### PR TITLE
Added way to exit the game.

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -32,6 +32,9 @@
 //#include <GL/gl.h>
 //#include <GL/glu.h>
 
+void game_end() { exit(0); } //TODO: Fire game end event.
+void action_end_game() { game_end(); }
+
 using namespace std;
 
 #include "Universal_System/CallbackArrays.h" // For those damn vk_ constants.

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.h
@@ -20,6 +20,9 @@
 #include <string>
 using std::string;
 
+void game_end();
+void action_end_game();
+
 void gmw_init();
 
 void Sleep(int ms);

--- a/ENIGMAsystem/SHELL/Universal_System/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/actions.h
@@ -280,12 +280,6 @@ static inline void action_show_info() {show_info();}
 
 #define action_restart_game game_restart
 #define action_message(message) show_message(message)
-
-void exit_real_exit(int i) {
-    exit(i);
-    return;
-}
-
 #define exit return 0;
 #define globalvar global var
 


### PR DESCRIPTION
This commit is mainly added such that there is a way to call the C exit function instead of the GML exit. It was introduced to enable a way of quitting the game when game_end has not been implemented yet for some platform.
