### PR TITLE
Changed collision event to support multiple collisions.

### DIFF
--- a/events.res
+++ b/events.res
@@ -274,7 +274,8 @@ collision: 4
 	Mode: Stacked
 	Super Check: instance_number(%1)
 	Sub Check: (instance_other = enigma::place_meeting_inst(x,y,%1)) # Parenthesize assignment used as truth
-	prefix: for (enigma::iterator it = enigma::fetch_inst_iter_by_int(%1); it; ++it) if (((instance_other = *it) || true) && (((solid ||  enigma::glaccess(int(other))->solid) && ((x = xprevious) || true) && ((y = yprevious) || true)) || true) && enigma::place_meeting_inst(x,y,instance_other->id))//if (solid ||  enigma::glaccess(int(other))->solid) {x = xprevious; y = yprevious;}
+	prefix: for (enigma::iterator it = enigma::fetch_inst_iter_by_int(%1); it; ++it) {instance_other = *it; if (enigma::place_meeting_inst(x,y,instance_other->id)) {if (enigma::glaccess(int(other))->solid) x = xprevious, y = yprevious;
+	suffix: }}
 # Check for detriment from collision events above
 
 nomorelives: 7


### PR DESCRIPTION
The previous handling of collision events only performed each event for the first colliding instance, instead of performing an event for all colliding instances. This fix performs an event for all instances that the given instance collides with. Furthermore, if the position of any of the involved instances changes as a result of one or more performances of the event during collision handling, the collision detection uses the new positions.

The fix is a bit hacky, in that it moves assignment inside the condition of an if-statement.

I don't know if the fix works correctly in regards to instance creation or destruction during the collision phase. Someone who understands creation, destruction and iterators should probably look at the fix before accepting this request. The fix has of this writing been tested in one game.
