### PR TITLE
show_question and some stuff

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -141,8 +141,24 @@ namespace enigma
 
 int show_message(string str)
 {
-    MessageBox(enigma::hWnd,str.c_str(),"Message",MB_OK);
+    MessageBox(enigma::hWnd,str.c_str(), window_get_caption().c_str(), MB_OK);
     return 0;
+}
+
+// TODO There's no easy way to do this. Creating a custom form is the only
+// solution I could find.
+int show_message_ext(string msg, string but1, string but2, string but3)
+{
+    return 1;
+}
+
+bool show_question(string str)
+{
+    if(MessageBox(enigma::hWnd, str.c_str(), window_get_caption().c_str(), MB_YESNO) == IDYES)
+    {
+        return true;
+    }
+    return false;
 }
 
 int window_get_x()
@@ -432,86 +448,86 @@ int display_get_frequency()
 void display_reset()
 {
 	DEVMODE devMode;
-	
+
 	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
 		return;
-	
+
 	if (displayInitialBitdepth != 0)
 	{
 		devMode.dmFields |= DM_BITSPERPEL;
 		devMode.dmBitsPerPel = displayInitialBitdepth;
 	}
-	
+
 	if (displayInitialFrequency != 0)
 	{
 		devMode.dmFields |= DM_DISPLAYFREQUENCY;
 		devMode.dmDisplayFrequency = displayInitialFrequency;
 	}
-	
+
 	if (displayInitialResolutionWidth != 0)
 	{
 		devMode.dmFields |= DM_PELSWIDTH;
 		devMode.dmPelsWidth = displayInitialResolutionWidth;
 	}
-	
+
 	if (displayInitialResolutionHeight != 0)
 	{
 		devMode.dmFields |= DM_PELSHEIGHT;
 		devMode.dmPelsHeight = displayInitialResolutionHeight;
 	}
-	
+
 	ChangeDisplaySettings(&devMode, 0);
 }
 
 void display_set_colordepth(int depth)
 {
 	DEVMODE devMode;
-	
+
 	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
 		return;
-	
+
 	if (displayInitialBitdepth == 0)
 		displayInitialBitdepth = devMode.dmBitsPerPel;
-	
+
 	devMode.dmFields = DM_BITSPERPEL;
 	devMode.dmBitsPerPel = depth;
-	
+
 	ChangeDisplaySettings(&devMode, 0);
 }
 
 void display_set_size(int w, int h)
 {
 	DEVMODE devMode;
-	
+
 	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
 		return;
-	
+
 	if (displayInitialResolutionWidth == 0)
 		displayInitialResolutionWidth = devMode.dmPelsWidth;
-	
+
 	if (displayInitialResolutionHeight == 0)
 		displayInitialResolutionHeight = devMode.dmPelsHeight;
-	
+
 	devMode.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
 	devMode.dmPelsWidth = w;
 	devMode.dmPelsHeight = h;
-	
+
 	ChangeDisplaySettings(&devMode, 0);
 }
 
 void display_set_frequency(int freq)
 {
 	DEVMODE devMode;
-	
+
 	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
 		return;
-	
+
 	if (displayInitialFrequency == 0)
 		displayInitialFrequency = devMode.dmBitsPerPel;
-	
+
 	devMode.dmFields = DM_DISPLAYFREQUENCY;
 	devMode.dmDisplayFrequency = freq;
-	
+
 	ChangeDisplaySettings(&devMode, 0);
 }
 
@@ -521,43 +537,43 @@ bool display_set_all(int w, int h, int freq, int bitdepth)
 
 	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
 		return false;
-	
+
 	if (w != -1)
 	{
 		if (displayInitialResolutionWidth == 0)
 			displayInitialResolutionWidth = devMode.dmPelsWidth;
-		
+
 		devMode.dmFields |= DM_PELSWIDTH;
 		devMode.dmPelsWidth = w;
 	}
-	
+
 	if (h != -1)
 	{
 		if (displayInitialResolutionHeight == 0)
 			displayInitialResolutionHeight = devMode.dmPelsHeight;
-		
+
 		devMode.dmFields |= DM_PELSHEIGHT;
 		devMode.dmPelsHeight = h;
 	}
-	
+
 	if (freq != -1)
 	{
 		if (displayInitialFrequency == 0)
 			displayInitialFrequency = devMode.dmDisplayFrequency;
-		
+
 		devMode.dmFields |= DM_DISPLAYFREQUENCY;
 		devMode.dmDisplayFrequency = freq;
 	}
-	
+
 	if (bitdepth != -1)
 	{
 		if (displayInitialBitdepth == 0)
 			displayInitialBitdepth = devMode.dmBitsPerPel;
-		
+
 		devMode.dmFields |= DM_BITSPERPEL;
 		devMode.dmBitsPerPel = bitdepth;
 	}
-	
+
 	return ChangeDisplaySettings(&devMode, 0) == DISP_CHANGE_SUCCESSFUL;
 }
 
@@ -567,43 +583,43 @@ bool display_test_all(int w, int h, int freq, int bitdepth)
 
 	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
 		return false;
-	
+
 	if (w != -1)
 	{
 		if (displayInitialResolutionWidth == 0)
 			displayInitialResolutionWidth = devMode.dmPelsWidth;
-		
+
 		devMode.dmFields |= DM_PELSWIDTH;
 		devMode.dmPelsWidth = w;
 	}
-	
+
 	if (h != -1)
 	{
 		if (displayInitialResolutionHeight == 0)
 			displayInitialResolutionHeight = devMode.dmPelsHeight;
-		
+
 		devMode.dmFields |= DM_PELSHEIGHT;
 		devMode.dmPelsHeight = h;
 	}
-	
+
 	if (freq != -1)
 	{
 		if (displayInitialFrequency == 0)
 			displayInitialFrequency = devMode.dmDisplayFrequency;
-		
+
 		devMode.dmFields |= DM_DISPLAYFREQUENCY;
 		devMode.dmDisplayFrequency = freq;
 	}
-	
+
 	if (bitdepth != -1)
 	{
 		if (displayInitialBitdepth == 0)
 			displayInitialBitdepth = devMode.dmBitsPerPel;
-		
+
 		devMode.dmFields |= DM_BITSPERPEL;
 		devMode.dmBitsPerPel = bitdepth;
 	}
-	
+
 	return ChangeDisplaySettings(&devMode, CDS_TEST) == DISP_CHANGE_SUCCESSFUL;
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.h
@@ -58,6 +58,8 @@ void keyboard_clear(const int key);
 void mouse_clear(const int button);
 
 int show_message(string str);
+//int show_message_ext(string msg, string but1, string but2, string but3)
+bool show_question(string str);
 int window_get_x();
 int window_get_y();
 int window_get_width();


### PR DESCRIPTION
If you couldn't guess from the modified files, this commit is Windows only

This commit implements show_question

This commit includes a skeleton for the function (obsolete in GM) show_message_ext. Actually implementing show_message_ext doesn't appear to be easy, because to get custom buttons it looks like you'd need to create a custom form for the job. Too lazy, but I thought I'd include the function header for someone else.

This commit changes the caption "Message" in show_message to the window's caption. show_question also has its caption set to the window caption. This behavior is what is in GM:S.

What might be confusing, is that it doesn't use room_caption. However, even though I cannot  find any reference to room_caption being obsolete or deprecated in the manual in GM:S, it is removed from the room editor and changing room_caption does not change the window caption. However, in GM if you window_set_caption and show_message or show_question, those dialog boxes will have the window caption as their own title as well.

Of course this is personal preference as well. You can do whatever the hell you want with the caption. You could rip the show_question code, modify it to change the caption, and commit it yourself and reject this pull request. I dedicate my code to the public domain.

I have no idea what the hell is wrong with the diff. Maybe despite my best efforts, C::B or git ate your line endings? Points of interest. In the CPP file, lines 142-162. In the header, 60-62.
