### PR TITLE
Model Drawing Overload's

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GLmesh.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GLmesh.cpp
@@ -356,12 +356,22 @@ bool d3d_model_load(const unsigned int id, string fname)
   return true;
 }
 
-void d3d_model_draw(const unsigned int id, double x, double y, double z, int texId)
+void d3d_model_draw(const unsigned int id) // overload for no additional texture or transformation call's
 {
-    texture_use(get_texture(texId));
+    meshes[id]->Draw();
+}
+
+void d3d_model_draw(const unsigned int id, double x, double y, double z) // overload for no additional texture call's
+{
     glTranslatef(x, y, z);
     meshes[id]->Draw();
     glTranslatef(-x, -y, -z);
+}
+
+void d3d_model_draw(const unsigned int id, double x, double y, double z, int texId)
+{
+    texture_use(get_texture(texId));
+    d3d_model_draw(id, x, y, z);
 }
 
 void d3d_model_primitive_begin(const unsigned int id, int kind)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GLmesh.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GLmesh.h
@@ -26,6 +26,8 @@ bool d3d_model_exists(const unsigned int id);
 void d3d_model_clear(const unsigned int id);
 void d3d_model_save(const unsigned int id, std::string fname);
 bool d3d_model_load(const unsigned int id, std::string fname);
+void d3d_model_draw(const unsigned int id);
+void d3d_model_draw(const unsigned int id, double x, double y, double z);
 void d3d_model_draw(const unsigned int id, double x, double y, double z, int texId);
 void d3d_model_primitive_begin(const unsigned int id, int kind);
 void d3d_model_primitive_end(const unsigned int id);


### PR DESCRIPTION
Added overload's to d3d_model_draw so that no additional texture or transformation call's are needed.
