### PR TITLE
Reverted Earlier Changes

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
@@ -62,9 +62,9 @@ namespace enigma
       glAlphaFunc(GL_ALWAYS,0);
 
       // enable vertex array's for fast vertex processing
-      //glEnableClientState(GL_VERTEX_ARRAY);
-      //glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-      //glEnableClientState(GL_NORMAL_ARRAY);
+      glEnableClientState(GL_VERTEX_ARRAY);
+      glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+      glEnableClientState(GL_NORMAL_ARRAY);
 
       glColor4f(0,0,0,1);
       glBindTexture(GL_TEXTURE_2D,0);


### PR DESCRIPTION
Reverted my earlier changes to the new graphic's system, the problem was not
a segmentation fault, polygonz hardware doesn't support VBO's, that's why it
works for me and Harri but not him.
