### PR TITLE
OpenGL3 Patch

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -329,7 +329,7 @@ void screen_redraw()
 #include "binding.h"
 void screen_init()
 {
-    untexture()
+    texture_reset();
     if (!view_enabled)
     {
         glMatrixMode(GL_PROJECTION);


### PR DESCRIPTION
Quick patch related to untexture macro being renamed to texture_reset
