### PR TITLE
D3D9 Blend Modes and Textures *Please Merge*

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9TextureStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9TextureStruct.h
@@ -1,0 +1,33 @@
+/** Copyright (C) 2008-2013 Josh Ventura, Robert B. Colton
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#ifndef _DXTEXTURESTRUCT__H
+#define _DXTEXTURESTRUCT__H
+
+#include "Direct3D9Headers.h"
+
+#include <vector>
+using std::vector;
+
+struct GmTexture {
+	LPDIRECT3DTEXTURE9 gTexture;
+	GmTexture(LPDIRECT3DTEXTURE9 gTex);
+	~GmTexture();
+};
+extern vector<GmTexture*> GmTextures;
+
+#endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9blend.cpp
@@ -15,6 +15,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "Bridges/General/DX9Device.h"
 #include "Direct3D9Headers.h"
 #include "../General/GSblend.h"
 
@@ -40,7 +41,7 @@ int draw_set_blend_mode(int mode){
 }
 
 int draw_set_blend_mode_ext(int src, int dest){
-  const static enum blendequivs[11] = {
+  const static D3DBLEND blendequivs[11] = {
 	  D3DBLEND_ZERO, D3DBLEND_ONE, D3DBLEND_SRCCOLOR, D3DBLEND_INVSRCCOLOR, D3DBLEND_SRCALPHA,
 	  D3DBLEND_INVSRCALPHA, D3DBLEND_DESTALPHA, D3DBLEND_INVDESTALPHA, D3DBLEND_DESTCOLOR,
 	  D3DBLEND_INVDESTCOLOR, D3DBLEND_SRCALPHASAT

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
@@ -61,6 +61,12 @@ using std::string;
     const enigma::sprite *const spr = enigma::spritestructarray[id];
 #endif
 
+#include "Direct3D9Headers.h"
+#include "Bridges/General/DX9Device.h"
+#include "DX9TextureStruct.h"
+
+	LPD3DXSPRITE sprite=NULL;
+	
 namespace enigma_user
 {
 
@@ -70,7 +76,30 @@ bool sprite_exists(int spr) {
 
 void draw_sprite(int spr,int subimg, gs_scalar x, gs_scalar y)
 {
+    get_spritev(spr2d,spr);
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
+    const float tbx = spr2d->texbordxarray[usi], tby = spr2d->texbordyarray[usi],
+                xvert1 = x-spr2d->xoffset, xvert2 = xvert1 + spr2d->width,
+                yvert1 = y-spr2d->yoffset, yvert2 = yvert1 + spr2d->height;
+	
+
+	if (sprite == NULL) {
+	if (SUCCEEDED(D3DXCreateSprite(d3ddev,&sprite)))
+	{
+		// created OK
+	}
+	}
+	
+	D3DXVECTOR3 pos;
+
+	pos.x = x;
+	pos.y = y;
+	pos.z = 0.0f;
+
+	sprite->Begin(D3DXSPRITE_ALPHABLEND);
+	sprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture,NULL,NULL,&pos,0xFFFFFFFF);
+	sprite->End();
 }
 
 void draw_sprite_stretched(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -17,9 +17,11 @@
 
 #include <stdio.h>
 #include "Direct3D9Headers.h"
+#include "Bridges/General/DX9Device.h"
 #include <string.h>
 //using std::string;
 #include "../General/GStextures.h"
+#include "DX9TextureStruct.h"
 #include "Universal_System/backgroundstruct.h"
 #include "Universal_System/spritestruct.h"
 #include "Graphics_Systems/graphics_mandatory.h"
@@ -34,9 +36,9 @@ namespace enigma {
   extern size_t background_idmax;
 }
 
-GmTexture::GmTexture(unsigned gtex)
+GmTexture::GmTexture(LPDIRECT3DTEXTURE9 gTex)
 {
-
+	gTexture = gTex;
 }
 
 GmTexture::~GmTexture()
@@ -64,7 +66,31 @@ namespace enigma
 
   int graphics_create_texture(int fullwidth, int fullheight, void* pxdata)
   {
+    LPDIRECT3DTEXTURE9 texture = NULL;
+	HRESULT hr;
 
+	hr = d3ddev->CreateTexture(
+		fullwidth,
+		fullheight,
+		1,
+		D3DUSAGE_DYNAMIC,
+		D3DFMT_A8R8G8B8,
+		D3DPOOL_DEFAULT,
+		&texture,
+		0
+	);
+ 
+	D3DLOCKED_RECT rect;
+
+	texture->LockRect( 0, &rect, NULL, D3DLOCK_DISCARD);
+	
+	unsigned char* dest = static_cast<unsigned char*>(rect.pBits);
+	memcpy(dest, pxdata, sizeof(unsigned char) * fullwidth * fullheight * 4);
+
+	texture->UnlockRect(0);
+	
+    GmTextures.push_back(new GmTexture(texture));
+    return GmTextures.size()-1;
   }
 
   int graphics_duplicate_texture(int tex)
@@ -99,7 +125,9 @@ void texture_set_enabled(bool enable)
 
 void texture_set_interpolation(int enable)
 {
-
+	d3ddev->SetSamplerState( 0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR );
+	d3ddev->SetSamplerState( 0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR );
+	d3ddev->SetSamplerState( 0, D3DSAMP_MIPFILTER, D3DTEXF_LINEAR );
 }
 
 bool texture_get_interpolation()

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GLTextureStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GLTextureStruct.h
@@ -1,0 +1,33 @@
+/** Copyright (C) 2008-2013 Josh Ventura, Robert B. Colton
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include "Universal_System/scalar.h"
+
+#ifndef _GLTEXTURESTRUCT__H
+#define _GLTEXTURESTRUCT__H
+
+#include <vector>
+using std::vector;
+
+struct GmTexture {
+	unsigned gltex;
+	GmTexture(unsigned gtex);
+	~GmTexture();
+};
+extern vector<GmTexture*> GmTextures;
+
+#endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.h
@@ -34,17 +34,6 @@ namespace enigma
 #define GL_TEXTURE_MAX_ANISOTROPY_EXT 0x84FE
 #define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
 
-#include <vector>
-using std::vector;
-
-struct GmTexture {
-	unsigned gltex;
-	GmTexture(unsigned gtex);
-	~GmTexture();
-};
-extern vector<GmTexture*> GmTextures;
-
-
 namespace enigma_user {
 enum {
   tx_none,

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
@@ -20,6 +20,7 @@
 #include <math.h>
 #include "../General/OpenGLHeaders.h"
 #include "../General/GSbackground.h"
+#include "../General/GLTextureStruct.h"
 #include "Universal_System/backgroundstruct.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Universal_System/spritestruct.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLfont.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLfont.cpp
@@ -22,6 +22,7 @@
 #include "libEGMstd.h"
 #include "../General/GScolors.h"
 #include "../General/GSfont.h"
+#include "../General/GLTextureStruct.h"
 #include "../General/GStextures.h"
 #include "../General/GLbinding.h"
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
@@ -22,6 +22,7 @@ using std::string;
 
 #include "../General/OpenGLHeaders.h"
 #include "../General/GSsprite.h"
+#include "../General/GLTextureStruct.h"
 #include "../General/GStextures.h"
 #include "../General/GLbinding.h"
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtextures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtextures.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 //using std::string;
 #include "../General/GStextures.h"
+#include "../General/GLTextureStruct.h"
 #include "Universal_System/backgroundstruct.h"
 #include "Universal_System/spritestruct.h"
 #include "Graphics_Systems/graphics_mandatory.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtiles.cpp
@@ -21,6 +21,7 @@
 #include "../General/GSbackground.h"
 #include "Universal_System/backgroundstruct.h"
 #include "../General/GStextures.h"
+#include "../General/GLTextureStruct.h"
 #include "../General/GStiles.h"
 #include "../General/GLtilestruct.h"
 #include "../General/GLbinding.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
@@ -20,6 +20,7 @@
 #include <math.h>
 #include "../General/OpenGLHeaders.h"
 #include "../General/GSbackground.h"
+#include "../General/GLTextureStruct.h"
 #include "Universal_System/backgroundstruct.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Universal_System/spritestruct.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3font.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3font.cpp
@@ -18,6 +18,7 @@
 #include <math.h>
 #include <string>
 #include "../General/OpenGLHeaders.h"
+#include "../General/GLTextureStruct.h"
 #include "Universal_System/var4.h"
 #include "libEGMstd.h"
 #include "../General/GScolors.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
@@ -23,6 +23,7 @@ using std::string;
 #include "../General/OpenGLHeaders.h"
 #include "../General/GSsprite.h"
 #include "../General/GStextures.h"
+#include "../General/GLTextureStruct.h"
 #include "../General/GLbinding.h"
 
 #include "Universal_System/spritestruct.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 //using std::string;
 #include "../General/GStextures.h"
+#include "../General/GLTextureStruct.h"
 #include "Universal_System/backgroundstruct.h"
 #include "Universal_System/spritestruct.h"
 #include "Graphics_Systems/graphics_mandatory.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3tiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3tiles.cpp
@@ -21,6 +21,7 @@
 #include "../General/GSbackground.h"
 #include "Universal_System/backgroundstruct.h"
 #include "../General/GStextures.h"
+#include "../General/GLTextureStruct.h"
 #include "../General/GStiles.h"
 #include "../General/GLtilestruct.h"
 #include "../General/GLbinding.h"

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_OpenGL1.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_OpenGL1.h
@@ -21,6 +21,7 @@
 #include "Graphics_Systems/General/GSsprite.h"
 #include "Graphics_Systems/General/GLbinding.h"
 #include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GLTextureStruct.h"
 #include "Graphics_Systems/General/GScolors.h"
 #include "PS_particle_instance.h"
 #include "PS_particle_sprites.h"

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_OpenGL3.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_OpenGL3.h
@@ -21,6 +21,7 @@
 #include "Graphics_Systems/General/GSsprite.h"
 #include "Graphics_Systems/General/GLbinding.h"
 #include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GLTextureStruct.h"
 #include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSd3d.h"
 #include "PS_particle_instance.h"


### PR DESCRIPTION
Implemented texture loading so backgrounds and sprites get created as
textures now and also implemented the blend mode functions. Merge when
ready. 

There are however a few things needing discussed about ENIGMA being RGBA and DX being ARGB and other things...
http://enigma-dev.org/forums/index.php?topic=1379.msg13798#msg13798
