### PR TITLE
Direct3D 9.0 Sprite and Background Tiles

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
@@ -112,12 +112,37 @@ void draw_background_part(int back, gs_scalar left, gs_scalar top, gs_scalar wid
 
 void draw_background_tiled(int back, gs_scalar x, gs_scalar y)
 {
+    get_background(bck2d,back);
 
+    const float
+    tbx = bck2d->texbordx,tby=bck2d->texbordy;
+
+    const int
+    hortil = int (ceil(room_width/(bck2d->width*tbx))) + 1,
+    vertil = int (ceil(room_height/(bck2d->height*tby))) + 1;
+
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSW, D3DTADDRESS_WRAP );
+
+	D3DXVECTOR3 pos(x, y, 0);
+	tagRECT rect;
+	rect.left = 0; rect.top = 0; rect.right = hortil * bck2d->width; rect.bottom = vertil * bck2d->height;
+	dsprite->Draw(GmTextures[bck2d->texture]->gTexture, &rect, NULL, &pos, 0xFFFFFFFF);
 }
 
 void draw_background_tiled_area(int back, gs_scalar x, gs_scalar y, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2)
 {
+	get_background(bck2d,back);
 
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSW, D3DTADDRESS_WRAP );
+
+	D3DXVECTOR3 pos(x1, y1, 0);
+	tagRECT rect;
+	rect.left = x1 + x; rect.top = y1 + y; rect.right = x2 + x; rect.bottom = y2 + y;
+	dsprite->Draw(GmTextures[bck2d->texture]->gTexture, &rect, NULL, &pos, 0xFFFFFFFF);
 }
 
 void draw_background_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int color, double alpha)
@@ -202,12 +227,71 @@ void draw_background_part_ext(int back, gs_scalar left, gs_scalar top, gs_scalar
 
 void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, double alpha)
 {
+    get_background(bck2d,back);
 
+    const float
+    tbx = bck2d->texbordx,tby=bck2d->texbordy;
+
+    const int
+    hortil = int (ceil(room_width/(bck2d->width*tbx))) + 1,
+    vertil = int (ceil(room_height/(bck2d->height*tby))) + 1;
+
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSW, D3DTADDRESS_WRAP );
+	
+	// Screen position of the sprite
+	D3DXVECTOR2 trans = D3DXVECTOR2(x, y);
+
+	// Build our matrix to rotate, scale and position our sprite
+	D3DXMATRIX mat;
+
+	D3DXVECTOR2 scaling(xscale, yscale);
+
+	// out, scaling centre, scaling rotation, scaling, rotation centre, rotation, translation
+	D3DXMatrixTransformation2D(&mat,NULL,0.0,&scaling,NULL,0,&trans);
+	
+	// Tell the sprite about the matrix
+	dsprite->SetTransform(&mat);
+
+	tagRECT rect;
+	rect.left = 0; rect.top = 0; rect.right = hortil * bck2d->width; rect.bottom = vertil * bck2d->height;
+	dsprite->Draw(GmTextures[bck2d->texture]->gTexture, &rect, NULL, NULL,
+		D3DCOLOR_ARGB(char(alpha*255), __GETR(color), __GETG(color), __GETB(color)));
+		
+	D3DXMatrixTransformation2D(&mat,NULL,0.0,0,NULL,0,0);
+	dsprite->SetTransform(&mat);
 }
 
 void draw_background_tiled_area_ext(int back, gs_scalar x, gs_scalar y, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar xscale, gs_scalar yscale, int color, double alpha)
 {
+	get_background(bck2d,back);
 
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSW, D3DTADDRESS_WRAP );
+
+	// Screen position of the sprite
+	D3DXVECTOR2 trans = D3DXVECTOR2(x1, y1);
+
+	// Build our matrix to rotate, scale and position our sprite
+	D3DXMATRIX mat;
+
+	D3DXVECTOR2 scaling(xscale, yscale);
+
+	// out, scaling centre, scaling rotation, scaling, rotation centre, rotation, translation
+	D3DXMatrixTransformation2D(&mat,NULL,0.0,&scaling,NULL,0,&trans);
+	
+	// Tell the sprite about the matrix
+	dsprite->SetTransform(&mat);
+	
+	tagRECT rect;
+	rect.left = x1 + x; rect.top = y1 + y; rect.right = x2 + x; rect.bottom = y2 + y;
+	dsprite->Draw(GmTextures[bck2d->texture]->gTexture, &rect, NULL, NULL,
+		D3DCOLOR_ARGB(char(alpha*255), __GETR(color), __GETG(color), __GETB(color)));
+		
+	D3DXMatrixTransformation2D(&mat,NULL,0.0,0,NULL,0,0);
+	dsprite->SetTransform(&mat);
 }
 
 void draw_background_general(int back, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int c1, int c2, int c3, int c4, double a1, double a2, double a3, double a4)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
@@ -77,9 +77,9 @@ void draw_sprite(int spr,int subimg, gs_scalar x, gs_scalar y)
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 				
-	D3DXVECTOR3 center(spr2d->xoffset, spr2d->yoffset, 0);
+	D3DXVECTOR3 offset(spr2d->xoffset, spr2d->yoffset, 0);
 	D3DXVECTOR3 pos(x, y, 0);
-	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, &center, &pos, 0xFFFFFFFF);
+	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, &offset, &pos, 0xFFFFFFFF);
 }
 
 void draw_sprite_stretched(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height)
@@ -105,7 +105,10 @@ void draw_sprite_stretched(int spr, int subimg, gs_scalar x, gs_scalar y, gs_sca
 	// Tell the sprite about the matrix
 	dsprite->SetTransform(&mat);
 	
-	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, NULL, NULL, 0xFFFFFFFF);
+	// Screen position of the sprite
+	D3DXVECTOR3 offset = D3DXVECTOR3(spr2d->xoffset, spr2d->yoffset, 0);
+	
+	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, &offset, NULL, 0xFFFFFFFF);
 	
 	D3DXMatrixTransformation2D(&mat,NULL,0.0,0,NULL,0,0);
 	dsprite->SetTransform(&mat);
@@ -115,7 +118,7 @@ void draw_sprite_part(int spr, int subimg, gs_scalar left, gs_scalar top, gs_sca
 {
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
-				
+
 	D3DXVECTOR3 pos(x, y, 0);
 	tagRECT rect;
 	rect.left = left; rect.top = top; rect.right = left + width; rect.bottom = top + height;
@@ -127,11 +130,11 @@ void draw_sprite_part_offset(int spr, int subimg, gs_scalar left, gs_scalar top,
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 				
-	D3DXVECTOR3 center(spr2d->xoffset, spr2d->yoffset, 0);
+	D3DXVECTOR3 offset(spr2d->xoffset, spr2d->yoffset, 0);
 	D3DXVECTOR3 pos(x, y, 0);
 	tagRECT rect;
 	rect.left = left; rect.top = top; rect.right = left + width; rect.bottom = top + height;
-	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, &rect, &center, &pos, 0xFFFFFFFF);
+	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, &rect, &offset, &pos, 0xFFFFFFFF);
 }
 
 void draw_sprite_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int color, double alpha)
@@ -155,7 +158,10 @@ void draw_sprite_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xs
 	// Tell the sprite about the matrix
 	dsprite->SetTransform(&mat);
 	
-	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, NULL, NULL, 
+	// Screen position of the sprite
+	D3DXVECTOR3 offset = D3DXVECTOR3(spr2d->xoffset, spr2d->yoffset, 0);
+	
+	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, &offset, NULL, 
 		D3DCOLOR_ARGB(char(alpha*255), __GETR(color), __GETG(color), __GETB(color)));
 		
 	D3DXMatrixTransformation2D(&mat,NULL,0.0,0,NULL,0,0);
@@ -181,10 +187,13 @@ void draw_sprite_part_ext(int spr, int subimg, gs_scalar left, gs_scalar top, gs
 	// Tell the sprite about the matrix
 	dsprite->SetTransform(&mat);
 	
+	// Screen position of the sprite
+	D3DXVECTOR3 offset = D3DXVECTOR3(spr2d->xoffset, spr2d->yoffset, 0);
+	
 	tagRECT rect;
 	rect.left = left; rect.top = top; rect.right = left + width; rect.bottom = top + height;
 				
-	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, NULL, NULL,
+	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, &offset, NULL,
 		D3DCOLOR_ARGB(char(alpha*255), __GETR(color), __GETG(color), __GETB(color)));
 }
 
@@ -214,10 +223,13 @@ void draw_sprite_stretched_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs
 	// out, scaling centre, scaling rotation, scaling, rotation centre, rotation, translation
 	D3DXMatrixTransformation2D(&mat,NULL,0.0,&scaling,&center,0,&trans);
 	
+	// Screen position of the sprite
+	D3DXVECTOR3 offset = D3DXVECTOR3(spr2d->xoffset, spr2d->yoffset, 0);
+	
 	// Tell the sprite about the matrix
 	dsprite->SetTransform(&mat);
 	
-	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, NULL, NULL, 
+	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, NULL, &offset, NULL, 
 		D3DCOLOR_ARGB(char(alpha*255), __GETR(color), __GETG(color), __GETB(color)));
 		
 	D3DXMatrixTransformation2D(&mat,NULL,0.0,0,NULL,0,0);
@@ -239,12 +251,68 @@ namespace enigma_user
 
 void draw_sprite_tiled(int spr, int subimg, gs_scalar x, gs_scalar y)
 {
+    get_spritev(spr2d,spr);
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
+	const float
+    tbx  = spr2d->texbordxarray[usi], tby  = spr2d->texbordyarray[usi];
+	
+    const int
+    hortil = int(ceil((view_enabled ? int(view_xview[view_current] + view_wview[view_current]) : room_width) / (spr2d->width*tbx))) + 1,
+    vertil = int(ceil((view_enabled ? int(view_yview[view_current] + view_hview[view_current]) : room_height) / (spr2d->height*tby))) + 1;
+	
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSW, D3DTADDRESS_WRAP );
+
+	D3DXVECTOR3 offset(spr2d->xoffset, spr2d->yoffset, 0);
+	D3DXVECTOR3 pos(x, y, 0);
+	tagRECT rect;
+	rect.left = 0; rect.top = 0; rect.right = hortil * spr2d->width; rect.bottom = vertil * spr2d->height;
+	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, &rect, &offset, &pos, 0xFFFFFFFF);
 }
 
 void draw_sprite_tiled_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, double alpha)
 {
+    get_spritev(spr2d,spr);
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
+	const float
+    tbx  = spr2d->texbordxarray[usi], tby  = spr2d->texbordyarray[usi];
+	
+    const int
+    hortil = int(ceil((view_enabled ? int(view_xview[view_current] + view_wview[view_current]) : room_width) / (spr2d->width*tbx))) + 1,
+    vertil = int(ceil((view_enabled ? int(view_yview[view_current] + view_hview[view_current]) : room_height) / (spr2d->height*tby))) + 1;
+	
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP );
+	d3ddev->SetSamplerState( 0, D3DSAMP_ADDRESSW, D3DTADDRESS_WRAP );
+
+	// Screen position of the sprite
+	D3DXVECTOR2 center = D3DXVECTOR2(spr2d->xoffset, spr2d->yoffset);
+	// Screen position of the sprite
+	D3DXVECTOR2 trans = D3DXVECTOR2(x, y);
+
+	D3DXVECTOR2 scaling(xscale, yscale);
+	
+	// Build our matrix to rotate, scale and position our sprite
+	D3DXMATRIX mat;
+
+	// out, scaling centre, scaling rotation, scaling, rotation centre, rotation, translation
+	D3DXMatrixTransformation2D(&mat,NULL,0.0,&scaling,&center,0,&trans);
+	
+	// Screen position of the sprite
+	D3DXVECTOR3 offset = D3DXVECTOR3(spr2d->xoffset, spr2d->yoffset, 0);
+	
+	dsprite->SetTransform(&mat);
+	
+	tagRECT rect;
+	rect.left = 0; rect.top = 0; rect.right = hortil * spr2d->width; rect.bottom = vertil * spr2d->height;
+	dsprite->Draw(GmTextures[spr2d->texturearray[usi]]->gTexture, &rect, &offset, NULL, 
+				D3DCOLOR_ARGB(char(alpha*255), __GETR(color), __GETG(color), __GETB(color)));
+				
+	D3DXMatrixTransformation2D(&mat,NULL,0.0,0,NULL,0,0);
+	dsprite->SetTransform(&mat);
 }
 
 }


### PR DESCRIPTION
Implemented the tiling functions for sprites and backgrounds, not the
actual tile functions. All I had to do was properly set the source
rectangle for repitition and enable texture wrapping on the D3D Device, I
love DX, especially its internal sprite batching. Merge when ready.
