### PR TITLE
D3D9 Sprites, Backgrounds, and Globals

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
@@ -58,7 +58,7 @@ namespace enigma {
   extern size_t background_idmax;
 }
 
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 #include <string.h> // needed for querying ARB extensions
 
 #include "Bridges/General/DX9Device.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9binding.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9binding.h
@@ -15,13 +15,24 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "Bridges/General/DX9Device.h"
+
+#ifndef __DX9_BINDING_H
+#define __DX9_BINDING_H
+
+LPDIRECT3DTEXTURE9 get_texture(int texid);
+
+// DirectX does not memorize the bound texture and significant slowdowns occur by constantly rebinding a texture
+// glBind calls clog up the pipeline avoid them at all costs, texture paging is good
 #define use_bound_texture_global
 #ifdef use_bound_texture_global
-  namespace enigma { extern unsigned bound_texture; }
-  #define texture_reset() if(enigma::bound_texture) 
-  #define texture_use(texid) if (enigma::bound_texture != unsigned(texid)) \
-    
+  namespace enigma { extern LPDIRECT3DTEXTURE9 bound_texture; }
+  #define texture_reset() if (enigma::bound_texture != NULL) d3ddev->SetTexture(0, enigma::bound_texture = 0);
+  #define texture_use(texid) if (enigma::bound_texture != get_texture(texid)) \
+	d3ddev->SetTexture(0, enigma::bound_texture = get_texture(texid));
 #else
-  #define texture_reset() 
-  #define texture_use(texid)
+  #define texture_reset() d3ddev->SetTexture(0, 0);
+  #define texture_use(texid) d3ddev->SetTexture(0, get_texture(texid));
+#endif
+
 #endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9curves.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9curves.cpp
@@ -22,7 +22,7 @@
 #include "Direct3D9Headers.h"
 #include "../General/GScolors.h"
 #include "../General/GScurves.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 
 #define __GETR(x) (((x & 0x0000FF))/255.0)
 #define __GETG(x) (((x & 0x00FF00)>>8)/255.0)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -18,7 +18,7 @@
 #include "../General/GSd3d.h"
 #include "Direct3D9Headers.h"
 #include "../General/GStextures.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 #include "DX9model.h"
 #include "DX9shapes.h"
 #include "Universal_System/var4.h"
@@ -310,7 +310,6 @@ void d3d_draw_ellipsoid(gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar x2, 
 }
 
 void d3d_draw_icosahedron(int texId) {
-    texture_use(get_texture(texId));
 }
 
 void d3d_draw_torus(gs_scalar x1, gs_scalar y1, gs_scalar z1, int texId, gs_scalar hrep, gs_scalar vrep, int csteps, int tsteps, double radius, double tradius, double TWOPI) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -18,7 +18,7 @@
 #include <math.h>
 #include "Direct3D9Headers.h"
 #include "../General/GSstdraw.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 #include <stdio.h>
 #include "Universal_System/roomsystem.h"
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9font.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9font.cpp
@@ -23,7 +23,7 @@
 #include "../General/GScolors.h"
 #include "../General/GSfont.h"
 #include "../General/GStextures.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 
 using namespace std;
 #include "Universal_System/fontstruct.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9material.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9material.cpp
@@ -17,7 +17,7 @@
 
 #include "Direct3D9Headers.h"
 #include "DX9material.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 #include <math.h>
 
 #include <vector>

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9model.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9model.cpp
@@ -23,7 +23,7 @@
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
 #include <math.h>
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 
 using namespace std;
 
@@ -317,13 +317,13 @@ void d3d_model_draw(const unsigned int id, gs_scalar x, gs_scalar y, gs_scalar z
 
 void d3d_model_draw(const unsigned int id, int texId)
 {
-    texture_use(get_texture(texId));
+    texture_use(texId);
     meshes[id]->Draw();
 }
 
 void d3d_model_draw(const unsigned int id, gs_scalar x, gs_scalar y, gs_scalar z, int texId)
 {
-    texture_use(get_texture(texId));
+    texture_use(texId);
     d3d_model_draw(id, x, y, z);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9primitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9primitives.cpp
@@ -19,7 +19,7 @@
 #include "../General/GSprimitives.h"
 #include "../General/GStextures.h"
 #include "DX9model.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 
 #include <string>
 #include "Widget_Systems/widgets_mandatory.h"
@@ -95,7 +95,7 @@ int draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar 
 int draw_primitive_end()
 {
   if (prim_draw_texture != -1) {
-    texture_use(get_texture(prim_draw_texture));
+    texture_use(prim_draw_texture);
   } else {
     texture_reset();
   }
@@ -127,7 +127,7 @@ void d3d_primitive_begin_texture(int kind, int texId)
 void d3d_primitive_end()
 {
   if (prim_d3d_texture != -1) {
-    texture_use(get_texture(prim_d3d_texture));
+    texture_use(prim_d3d_texture);
   } else {
     texture_reset();
   }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -21,7 +21,7 @@
 #include "../General/GSbackground.h"
 #include "../General/GSscreen.h"
 #include "../General/GSd3d.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 
 using namespace std;
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
@@ -23,7 +23,7 @@ using std::string;
 #include "Direct3D9Headers.h"
 #include "../General/GSsprite.h"
 #include "../General/GStextures.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 
 #include "Universal_System/spritestruct.h"
 #include "Universal_System/instance_system.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -21,7 +21,7 @@ using namespace std;
 #include <iostream>
 #include <math.h>
 
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 #include <stdio.h> //for file writing (surface_save)
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/spritestruct.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -25,7 +25,7 @@
 #include "Universal_System/backgroundstruct.h"
 #include "Universal_System/spritestruct.h"
 #include "Graphics_Systems/graphics_mandatory.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 
 vector<GmTexture*> GmTextures(0);
 
@@ -46,6 +46,10 @@ GmTexture::~GmTexture()
 
 }
 
+LPDIRECT3DTEXTURE9 get_texture(int texid) {
+
+}
+
 inline unsigned int lgpp2(unsigned int x){//Trailing zero count. lg for perfect powers of two
 	x =  (x & -x) - 1;
 	x -= ((x >> 1) & 0x55555555);
@@ -53,11 +57,6 @@ inline unsigned int lgpp2(unsigned int x){//Trailing zero count. lg for perfect 
 	x =  ((x >> 4) + x) & 0x0f0f0f0f;
 	x += x >> 8;
 	return (x + (x >> 16)) & 63;
-}
-
-unsigned get_texture(int texid) 
-{
-
 }
 
 namespace enigma
@@ -85,11 +84,11 @@ namespace enigma
 	texture->LockRect( 0, &rect, NULL, D3DLOCK_DISCARD);
 	
 	unsigned char* dest = static_cast<unsigned char*>(rect.pBits);
-	for(int x=0;x<fullwidth * fullheight*4;x+=4){
-		((char*)dest)[x]=((char*)pxdata)[x+2];//A
-		((char*)dest)[x+1]=((char*)pxdata)[x+1];//R
-		((char*)dest)[x+2]=((char*)pxdata)[x];//G
-		((char*)dest)[x+3]=((char*)pxdata)[x+3];//B
+	for(int x = 0; x < fullwidth * fullheight * 4; x += 4){
+		((unsigned char*)dest)[x]  =((unsigned char*)pxdata)[x + 2];   //A
+		((unsigned char*)dest)[x+1]=((unsigned char*)pxdata)[x + 1];   //R
+		((unsigned char*)dest)[x+2]=((unsigned char*)pxdata)[x];       //G
+		((unsigned char*)dest)[x+3]=((unsigned char*)pxdata)[x + 3];   //B
 	}
 
 	texture->UnlockRect(0);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9tiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9tiles.cpp
@@ -40,7 +40,7 @@
 #include "../General/GSbackground.h"
 #include "Universal_System/backgroundstruct.h"
 #include "../General/GStextures.h"
-#include "../General/DXbinding.h"
+#include "DX9binding.h"
 #include "Direct3D9Headers.h"
 #include "../General/GStiles.h"
 #include "../General/DXtilestruct.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GLbinding.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GLbinding.h
@@ -15,6 +15,13 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "../General/GLTextureStruct.h"
+
+#ifndef __GL_BINDING_H
+#define __GL_BINDING_H
+
+unsigned get_texture(int texid);
+
 // OpenGL does not memorize the bound texture and significant slowdowns occur by constantly rebinding a texture
 // glBind calls clog up the pipeline avoid them at all costs, texture paging is good
 #define use_bound_texture_global
@@ -26,4 +33,6 @@
 #else
   #define texture_reset() glBindTexture(GL_TEXTURE_2D, 0)
   #define texture_use(texid) glBindTexture(GL_TEXTURE_2D, texid)
+#endif
+
 #endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.h
@@ -43,8 +43,6 @@ enum {
 };
 }
 
-unsigned get_texture(int texid); // fail safe macro
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtextures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtextures.cpp
@@ -46,6 +46,10 @@ GmTexture::~GmTexture()
 	glDeleteTextures(1, &gltex);
 }
 
+unsigned get_texture(int texid) {
+	return (size_t(texid) >= GmTextures.size())? -1 : GmTextures[texid]->gltex;
+}
+
 inline unsigned int lgpp2(unsigned int x){//Trailing zero count. lg for perfect powers of two
 	x =  (x & -x) - 1;
 	x -= ((x >> 1) & 0x55555555);
@@ -53,10 +57,6 @@ inline unsigned int lgpp2(unsigned int x){//Trailing zero count. lg for perfect 
 	x =  ((x >> 4) + x) & 0x0f0f0f0f;
 	x += x >> 8;
 	return (x + (x >> 16)) & 63;
-}
-
-unsigned get_texture(int texid) {
-	return (size_t(texid) >= GmTextures.size())? -1 : GmTextures[texid]->gltex;
 }
 
 namespace enigma


### PR DESCRIPTION
My little tile trick for sprites and backgrounds didn't work with NONPOT
textures. Also mouse_x and mouse_y and other globals are not getting
updated under D3D 9, added mouse_x and mouse_y temporarily to
screen_redraw, will file another bug report seperately. Merge when ready.
