### PR TITLE
Direct3D 9 Globals *Merge*

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -99,9 +99,6 @@ namespace enigma_user
 
 void screen_redraw()
 {
-	mouse_x = window_mouse_get_x();
-	mouse_y = window_mouse_get_y();
-	
     d3ddev->BeginScene();    // begins the 3D scene
 	dsprite->Begin(D3DXSPRITE_ALPHABLEND);
 	if (!view_enabled)
@@ -315,6 +312,7 @@ void screen_redraw()
     d3ddev->EndScene();    // ends the 3D scene
 	
     d3ddev->Present(NULL, NULL, NULL, NULL);    // displays the created frame
+	screen_refresh();
 }
 
 void screen_init()


### PR DESCRIPTION
Fixed the updating of globals in D3D9 it was because I did not have a call
to screen_refresh at the end of the screen_redraw. Merge when ready.
