### PR TITLE
Outlined DirectSound effect functions. *Merge*

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -217,4 +217,80 @@ bool sound_replace(int sound, string fname, int kind, bool preload)
 
 }
 
+void sound_3d_set_sound_cone(int sound, float x, float y, float z, double anglein, double angleout, long voloutside) {
+}
+
+void sound_3d_set_sound_distance(int sound, float mindist, float maxdist) {
+}
+
+void sound_3d_set_sound_position(int sound, float x, float y, float z) {
+}
+
+void sound_3d_set_sound_velocity(int sound, float x, float y, float z) {
+}
+
+void sound_effect_chorus(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay, long phase) {
+	/*
+	DSFXChorus pcDsFxChorus;
+	IDirectSoundFXChorus::SetAllParameters(pcDsFxChorus);
+	*/
+}
+
+void sound_effect_compressor(int sound, float gain, float attack, float release, float threshold, float ratio, float delay) {
+}
+
+void sound_effect_echo(int sound, float wetdry, float feedback, float leftdelay, float rightdelay, long pandelay) {
+}
+
+void sound_effect_equalizer(int sound, float center, float bandwidth, float gain) {
+}
+
+void sound_effect_flanger(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay, long phase) {
+}
+
+void sound_effect_gargle(int sound, unsigned rate, unsigned wave) {
+}
+
+void sound_effect_reverb(int sound, float gain, float mix, float time, float ratio) {
+}
+
+//const _GUID& sound_effect_types[8] = { GUID_DSFX_STANDARD_CHORUS, GUID_DSFX_STANDARD_ECHO, GUID_DSFX_STANDARD_FLANGER, GUID_DSFX_STANDARD_GARGLE, 
+	//GUID_DSFX_WAVES_REVERB, GUID_DSFX_STANDARD_COMPRESSOR, GUID_DSFX_STANDARD_PARAMEQ };
+	
+void sound_effect_set(int sound, int effect) {
+/*
+  HRESULT hr;
+  DWORD dwResults[1];  // One element for each effect.
+ 
+  // Describe the effect.
+  DSEFFECTDESC dsEffect;
+  memset(&dsEffect, 0, sizeof(DSEFFECTDESC));
+  dsEffect.dwSize = sizeof(DSEFFECTDESC);
+  dsEffect.dwFlags = 0;
+  dsEffect.guidDSFXClass = sound_effect_types[effect];
+ 
+  get_sound(snd, sound, 0);
+	
+  // Set the effect
+  if (SUCCEEDED(hr = snd->soundBuffer->SetFX(1, &dsEffect, dwResults)))
+  {
+    #ifdef DEBUG_MODE
+    switch (dwResults[0])
+    {
+      case DSFXR_LOCHARDWARE:
+        printf("Effect was placed in hardware.");
+        break;
+      case DSFXR_LOCSOFTWARE:
+        printf("Effect was placed in software.");
+        break;
+      case DSFXR_UNALLOCATED:
+        printf("Effect is not yet allocated to hardware or software.");
+        break;
+    }
+	#endif
+  }
+  return;
+  */
+}
+
 }

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.h
@@ -18,14 +18,29 @@
 #include "../General/ASbasic.h"
 
 namespace enigma_user {
-/* DirectSound provides the interface for these functions to be added as they originally were before deprecation
-    void sound_effect_chorus(int snd, wetdry, depth, feedback, frequency, wave, delay, phase);
-    void sound_effect_compressor(int snd, gain, attack, release, threshold, ratio, delay);
-    void sound_effect_echo(int snd, wetdry, feedback, leftdelay, rightdelay, pandelay);
-    void sound_effect_equalizer(int snd, center, bandwidth, gain);
-    void sound_effect_flanger(int snd, wetdry, depth, feedback, frequency, wave, delay, phase);
-    void sound_effect_gargle(int snd, rate, wave);
-    void sound_effect_reverb(int snd, gain, mix, time, ratio);
-    void sound_effect_set(int snd, effect);
-*/
+	// these functions can not be added for compatibility until we modify the dsound.h header from mingw
+	// and redistribute it, wait until someone requests them before adding them if they are not requested
+	// we will eventually deprecate them
+	enum {
+		se_none = 0,
+		se_chorus = 1,
+		se_echo = 2,
+		se_flanger = 3,
+		se_gargle = 4,
+		se_reverb = 5,
+		se_compressor = 6,
+		se_equalizer = 7
+	};
+    void sound_3d_set_sound_cone(int snd, float x, float y, float z, double anglein, double angleout, long voloutside);
+	void sound_3d_set_sound_distance(int snd, float mindist, float maxdist);
+	void sound_3d_set_sound_position(int snd, float x, float y, float z);
+	void sound_3d_set_sound_velocity(int snd, float x, float y, float z);
+    void sound_effect_chorus(int snd, float wetdry, float depth, float feedback, float frequency, long wave, float delay, long phase);
+    void sound_effect_compressor(int snd, float gain, float attack, float release, float threshold, float ratio, float delay);
+    void sound_effect_echo(int snd, float wetdry, float feedback, float leftdelay, float rightdelay, long pandelay);
+    void sound_effect_equalizer(int snd, float center, float bandwidth, float gain);
+    void sound_effect_flanger(int snd, float wetdry, float depth, float feedback, float frequency, long wave, float delay, long phase);
+    void sound_effect_gargle(int snd, unsigned rate, unsigned wave);
+    void sound_effect_reverb(int snd, float gain, float mix, float time, float ratio);
+    void sound_effect_set(int snd, int effect);
 }

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
@@ -43,6 +43,7 @@ enum load_state {
 struct SoundResource
 {
     IDirectSoundBuffer* soundBuffer;
+	//IDirectSoundFXChorus8* soundEffect;
     unsigned buf[3]; // The buffer-id of the sound data
     void (*cleanup)(void *userdata); // optional cleanup callback for streams
     void *userdata; // optional userdata for streams


### PR DESCRIPTION
They require a modification to the dsound.h WINE header in MinGW and for
us to redistribute it. Just wait and see if the functions ever even get
requested by someone, if they do then add them, if they don't we will
officially deprecate them. Please merge when ready.
