### PR TITLE
OpenGL 3 Min/Max Fix *Merge*

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.cpp
@@ -22,6 +22,10 @@
 #include <stdio.h>      /* printf, scanf, NULL */
 #include <stdlib.h>     /* malloc, free, rand */
 
+#include <iostream>
+#include <fstream>
+using namespace std;
+
 #include <vector>
 using std::vector;
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.h
@@ -18,9 +18,8 @@
 #ifndef _GLSHADER__H
 #define _GLSHADER__H
 
-#include <iostream>
-#include <fstream>
-using namespace std;
+#include <string>
+using std::string;
 
 namespace enigma_user
 {


### PR DESCRIPTION
I was accidentally including iostream and other std headers from
GL3shader.h, that was causing min/max not to work in OpenGL3. Please merge when ready.
