### PR TITLE
Git Ignore on Binaries *Merge*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ CompilerSource/bin/
 CompilerSource/JDI/dox/
 CompilerSource/JDI/test/defines_linux.txt
 CompilerSource/JDI/test/defines_mingw.txt
+CompilerSource/stupidity-buffer/obj
 Compilers/Windows/gcc.ey
 ENIGMAsystem/SHELL/ENIGMAengine
 *.cbTemp


### PR DESCRIPTION
Added CompilerSource/stupidity-buffer/obj to git ignore as it is just
binaries outputted by make for enigma.exe Please merge when ready.
