### PR TITLE
Fixed Windows Exe Info *Merge*

### DIFF
--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -329,7 +329,7 @@ int lang_CPP::compile(EnigmaStruct *es, const char* exe_filename, int mode)
   wto.open("ENIGMAsystem/SHELL/Preprocessor_Environment_Editable/Resources.rc",ios_base::out);
     wto << license;
     wto << "#include <windows.h>\n";
-	if (strlen(gameSet.gameIcon) > 0) {
+	if (gameSet.gameIcon != NULL && strlen(gameSet.gameIcon) > 0) {
 		wto << "IDI_MAIN_ICON ICON          \"" << string_replace_all(gameSet.gameIcon,"\\","/")  << "\"\n";
 	} else {
 		wto << "IDI_MAIN_ICON ICON          \"\"\n";
@@ -344,12 +344,11 @@ int lang_CPP::compile(EnigmaStruct *es, const char* exe_filename, int mode)
 	wto << "VALUE \"ProductName\",         \"" << gameSet.product << "\"\n";
 	wto << "VALUE \"ProductVersion\",      \"" << gameSet.version << "\\0\"\n";
 	wto << "VALUE \"LegalCopyright\",      \"" << gameSet.copyright << "\"\n";
-	if (strlen(es->filename) > 0) {
+	if (es->filename != NULL && strlen(es->filename) > 0) {
 		wto << "VALUE \"OriginalFilename\",         \"" << string_replace_all(es->filename,"\\","/") << "\"\n";
 	} else {
 		wto << "VALUE \"OriginalFilename\",         \"\"\n";
 	}
-	
 	wto << "END\nEND\nBLOCK \"VarFileInfo\"\nBEGIN\n";
 	wto << "VALUE \"Translation\", 0x409, 1252\n";
 	wto << "END\nEND";


### PR DESCRIPTION
You can now build with no icon, etc. an empty game wasn't working before
because I wasn't checking for some of the game settings to be a null
string. Please merge when ready.
