### PR TITLE
Fixed Primitive Functions

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9primitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9primitives.cpp
@@ -105,8 +105,6 @@ int draw_primitive_end()
 {
   if (prim_draw_texture != -1) {
     texture_use(prim_draw_texture);
-  } else {
-    texture_reset();
   }
   prim_draw_texture = -1;
   d3d_model_draw(prim_draw_model);
@@ -137,8 +135,6 @@ void d3d_primitive_end()
 {
   if (prim_d3d_texture != -1) {
     texture_use(prim_d3d_texture);
-  } else {
-    texture_reset();
   }
   prim_d3d_texture = -1;
   d3d_model_draw(prim_d3d_model);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLprimitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLprimitives.cpp
@@ -45,8 +45,7 @@ namespace enigma_user
 
 int draw_primitive_begin(int dink)
 {
-	texture_reset();
-	GLenum kind = ptypes_by_id[ dink & 15 ];
+  GLenum kind = ptypes_by_id[ dink & 15 ];
   glBegin(kind);
   return 0;
 }
@@ -54,8 +53,8 @@ int draw_primitive_begin(int dink)
 int draw_primitive_begin_texture(int dink,unsigned tex)
 {
   texture_use(tex);
-	GLenum kind = ptypes_by_id[ dink & 15 ];
-	glBegin(kind);
+  GLenum kind = ptypes_by_id[ dink & 15 ];
+  glBegin(kind);
   return 0;
 }
 
@@ -104,7 +103,6 @@ int draw_primitive_end()
 
 void d3d_primitive_begin(int kind)
 {
-    texture_reset();
     glBegin(ptypes_by_id[kind]);
 }
 void d3d_primitive_begin_texture(int kind, int texId)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3primitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3primitives.cpp
@@ -112,8 +112,6 @@ int draw_primitive_end()
 {
   if (prim_draw_texture != -1) {
     texture_use(get_texture(prim_draw_texture));
-  } else {
-    texture_reset();
   }
   prim_draw_texture = -1;
   d3d_model_draw(prim_draw_model);
@@ -144,8 +142,6 @@ void d3d_primitive_end()
 {
   if (prim_d3d_texture != -1) {
     texture_use(get_texture(prim_d3d_texture));
-  } else {
-    texture_reset();
   }
   prim_d3d_texture = -1;
   d3d_model_draw(prim_d3d_model);


### PR DESCRIPTION
Commenting out texture_reset() from draw_primitive and d3d_primitive() functions so that they work with shaders, not passing a texture means NO
ADDITIONAL BINDINGS
