### PR TITLE
Added missing include for atof() *Merge Immediately*

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9model.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9model.cpp
@@ -24,6 +24,7 @@
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
 #include <math.h>
+#include <stdlib.h>
 #include "DX9binding.h"
 
 using namespace std;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmodel.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmodel.cpp
@@ -25,6 +25,8 @@
 #include "Universal_System/roomsystem.h"
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
+
 
 #include "../General/GLbinding.h"
 using namespace std;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3model.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3model.cpp
@@ -25,6 +25,7 @@
 #include "Universal_System/roomsystem.h"
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "GL3binding.h"
 using namespace std;


### PR DESCRIPTION
Tizzio forgot the stdlib.h include, it didn't need it to compile on Windows. Please merge this immediately this is a serious bug and Linux does not work right now because of it.
