### PR TITLE
Direct3D 9.0 Segmentation Fault Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
@@ -99,18 +99,38 @@ namespace enigma
     }
 	
 	void WindowResized() {
-		LPDIRECT3DSWAPCHAIN9 sc;
-		d3ddev->GetSwapChain(0, &sc);
+		if (d3ddev == NULL) { return; }
+		IDirect3DSwapChain9 *sc;	
+		HRESULT hr = d3ddev->GetSwapChain(0, &sc);
+		if(FAILED(hr)){
+			MessageBox(hWnd,
+               "Failed to retrieve the Direct3D 9.0 Swap Chain",
+			   DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
+               MB_ICONERROR | MB_OK);
+		}
 		D3DPRESENT_PARAMETERS d3dpp;
 		sc->GetPresentParameters(&d3dpp);
 		d3dpp.BackBufferWidth = enigma_user::window_get_region_width_scaled();
 		d3dpp.BackBufferHeight = enigma_user::window_get_region_height_scaled();
 		sc->Release();
+		
+		bool spritenull = (dsprite == NULL);
+		if (!spritenull) {
+			dsprite->Release();
+		}
 
-		HRESULT hr = d3ddev->Reset(&d3dpp);
+		hr = d3ddev->Reset(&d3dpp);
 		if(FAILED(hr)){
 			MessageBox(hWnd,
                "Failed to reset Direct3D 9.0 Device",
+			   DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
+               MB_ICONERROR | MB_OK);
+		}
+		
+		if (FAILED(D3DXCreateSprite(d3ddev,&dsprite)))
+		{
+			MessageBox(enigma::hWnd,
+               "Failed to create Direct3D 9.0 Sprite Object",
 			   DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
                MB_ICONERROR | MB_OK);
 		}
@@ -133,6 +153,7 @@ int display_aa = 0;
 
 // Not really sure if you have to reset everything or if you can just reset a few things.
 void display_reset(int aa, bool vsync) {
+		if (d3ddev == NULL) { return; }
 		LPDIRECT3DSWAPCHAIN9 sc;
 		d3ddev->GetSwapChain(0, &sc);
 		D3DPRESENT_PARAMETERS d3dpp;
@@ -150,7 +171,10 @@ void display_reset(int aa, bool vsync) {
 			d3ddev->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE); 
 		}
 		sc->Release();
-		dsprite->Release();
+		bool spritenull = (dsprite == NULL);
+		if (!spritenull) {
+			dsprite->Release();
+		}
 
 		HRESULT hr = d3ddev->Reset(&d3dpp);
 		if(FAILED(hr)){
@@ -181,4 +205,3 @@ void set_synchronization(bool enable) //TODO: Needs to be rewritten
 }  
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
@@ -66,6 +66,18 @@ void draw_set_color(int color)
 	enigma::currentcolor[0] = __GETR(color);
 	enigma::currentcolor[1] = __GETG(color);
 	enigma::currentcolor[2] = __GETB(color);
+	
+	/*
+			//d3ddev->SetRenderState(D3DRS_LIGHTING, TRUE);    // enable/disable the 3D lighting
+	D3DMATERIAL9 mtrl;
+	ZeroMemory( &mtrl, sizeof(D3DMATERIAL9) );
+	mtrl.Emissive.r = mtrl.Ambient.r = __GETR(color);
+	mtrl.Emissive.g = mtrl.Ambient.g = __GETG(color);
+	mtrl.Emissive.b = mtrl.Ambient.b = __GETB(color);
+	mtrl.Emissive.a = mtrl.Ambient.a = 1.0f;
+	d3ddev->SetMaterial( &mtrl );
+	*/
+
 }
 
 void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -26,6 +26,9 @@
 #define __GETG(x) ((x & 0x00FF00) >> 8)
 #define __GETB(x) ((x & 0xFF0000) >> 16)
 
+#include <vector>
+using std::vector;
+
 namespace enigma {
   float circleprecision=24;
   extern unsigned char currentcolor[4];
@@ -133,9 +136,58 @@ float draw_get_circle_precision() {
     return enigma::circleprecision;
 }
 
+struct D3DTLVERTEX
+{
+	float fX;
+	float fY;
+	float fZ;
+};
+
+
+
 void draw_circle(gs_scalar x, gs_scalar y, float rad, bool outline)
 {
-
+    double pr = 2 * M_PI / enigma::circleprecision;
+	vector<float> Circle;
+	    d3ddev->SetFVF(D3DFVF_XYZ);
+    if(outline)
+    {
+        for (double i = 0; i <= 2*M_PI; i += pr)
+        {
+            double xc1=cos(i)*rad,yc1=sin(i)*rad;
+			//D3DTLVERTEX v; 
+			//v.fX = x+xc1; v.fY = y+yc1; v.fZ = 0;
+			//v.fRHW = RHW;
+			//v.Color = color;
+			//v.fU = U; v.fV = V;
+			//Circle.push_back(v);
+			
+			Circle.push_back(x+xc1); Circle.push_back(y+yc1); Circle.push_back(0);
+        }
+		d3ddev->DrawPrimitiveUP(D3DPT_LINESTRIP, enigma::circleprecision, &Circle[0], sizeof(float) * 3);
+    }
+    else
+    {
+		//D3DTLVERTEX v; 
+		//v.fX = x; v.fY = y; v.fZ = 0;
+		//v.fRHW = RHW;
+		//v.Color = color;
+		//v.fU = U; v.fV = V;
+		//Circle.push_back(v);
+		Circle.push_back(x); Circle.push_back(y); Circle.push_back(0);
+        for (double i = 0; i <= 2*M_PI; i += pr)
+        {
+            double xc1=cos(i)*rad,yc1=sin(i)*rad;
+			//D3DTLVERTEX v; 
+			//v.fX = x+xc1; v.fY = y+yc1; v.fZ = 0;
+			//v.fRHW = RHW;
+			//v.Color = color;
+			//v.fU = U; v.fV = V;
+			//Circle.push_back(v);
+			Circle.push_back(x+xc1); Circle.push_back(y+yc1); Circle.push_back(0);
+        }
+		d3ddev->DrawPrimitiveUP(D3DPT_TRIANGLEFAN, enigma::circleprecision, &Circle[0], sizeof(float) * 3);
+    }
 }
 
 void draw_circle_color(gs_scalar x, gs_scalar y, float rad, int c1, int c2, bool outline)


### PR DESCRIPTION
Fixed the segmentation fault on earlier versions of Windows, it was due to accessing null pointers. A much broader display reset needs worked out to prevent duplicating code so much for handling of all window messages.
