### PR TITLE
Fixed Plugin Issue

### DIFF
--- a/pluginsource/org/enigma/file/ApngIO.java
+++ b/pluginsource/org/enigma/file/ApngIO.java
@@ -503,6 +503,7 @@ public final class ApngIO
 						png.write(pngBase);
 						png.write(imageHeader);
 						hasData = false;
+						bais.close();
 						}
 					}
 				else if (genChunk.isType(IDAT.type))
@@ -521,6 +522,7 @@ public final class ApngIO
 					png.write(genChunk.getBytes());
 					ByteArrayInputStream bais = new ByteArrayInputStream(png.toByteArray());
 					ret.add(ImageIO.read(bais));
+					bais.close();
 					break;
 					}
 				else if (genChunk.isType(IHDR_Dummy.type)) {

--- a/pluginsource/org/enigma/file/EgmIO.java
+++ b/pluginsource/org/enigma/file/EgmIO.java
@@ -53,7 +53,14 @@ public class EgmIO extends FileView implements FileReader,FileWriter,GroupFilter
 
 	public ProjectFile read(InputStream in, URI uri, ResNode root) throws GmFormatException
 		{
-		return EFileReader.readEgmFile(new File(uri),root,true);
+		ProjectFile file = EFileReader.readEgmFile(new File(uri),root,true);
+		try {
+			in.close();
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return file;
 		}
 
 	//Writer
@@ -73,6 +80,7 @@ public class EgmIO extends FileView implements FileReader,FileWriter,GroupFilter
 	public void write(OutputStream out, ProjectFile gf, ResNode root) throws IOException
 		{
 		EFileWriter.writeEgmZipFile(out,gf,root);
+		out.close();
 		}
 
 	@Override


### PR DESCRIPTION
The plugin was not closing zip files streams and other input/output
streams. This was causing an error message when it went to move the file
to write a global back up because the operating system placed a lock on
the file. You people need to learn how to program.
