### PR TITLE
Direct3D 9.0 Improvements

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9primitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9primitives.cpp
@@ -15,6 +15,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "Bridges/General/DX9Device.h"
 #include "Direct3D9Headers.h"
 #include "../General/GSprimitives.h"
 #include "../General/GStextures.h"
@@ -48,136 +49,101 @@ namespace enigma {
   extern unsigned char currentcolor[4];
 }
 
-int prim_draw_model = -1;
-int prim_draw_texture = -1;
-int prim_d3d_model = -1;
-int prim_d3d_texture = -1;
-
 namespace enigma_user
 {
 
-int draw_primitive_begin(int kind)
+void draw_primitive_begin(int kind)
 {
-  prim_draw_texture = -1;
-  if (prim_draw_model == -1) {
-    prim_draw_model = d3d_model_create();
-  }
-  d3d_model_primitive_begin(prim_draw_model, kind);
-  return 0;
+  d3ddev->BeginShapesBatching(-1);
+  d3d_model_primitive_begin(d3ddev->GetShapesModel(), kind);
 }
 
-int draw_primitive_begin_texture(int kind,unsigned tex)
+void draw_primitive_begin_texture(int kind, int texId)
 {
-  if (prim_draw_model == -1) {
-    prim_draw_model = d3d_model_create();
-  }
-  prim_draw_texture = tex;
-  d3d_model_primitive_begin(prim_draw_model, kind);
-  return 0;
+  d3ddev->BeginShapesBatching(texId);
+  d3d_model_primitive_begin(d3ddev->GetShapesModel(), kind);
 }
 
-int draw_vertex(gs_scalar x, gs_scalar y)
+void draw_primitive_end()
 {
-  d3d_model_vertex(prim_draw_model, x, y, 0);
-  return 0;
+  d3d_model_primitive_end(d3ddev->GetShapesModel());
 }
 
-int draw_vertex_color(gs_scalar x, gs_scalar y, int col, float alpha)
+void draw_vertex(gs_scalar x, gs_scalar y)
 {
-  d3d_model_vertex_color(prim_draw_model, x, y, 0, col, alpha);
-  return 0;
+  d3d_model_vertex(d3ddev->GetShapesModel(), x, y, 0);
 }
 
-int draw_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty)
+void draw_vertex_color(gs_scalar x, gs_scalar y, int col, float alpha)
 {
-  d3d_model_vertex_texture(prim_draw_model, x, y, 0, tx, ty);
-  return 0;
+  d3d_model_vertex_color(d3ddev->GetShapesModel(), x, y, 0, col, alpha);
 }
 
-int draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty, int col, float alpha)
+void draw_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty)
 {
-  d3d_model_vertex_texture_color(prim_draw_model, x, y, 0, tx, ty, col, alpha);
-  return 0;
+  d3d_model_vertex_texture(d3ddev->GetShapesModel(), x, y, 0, tx, ty);
 }
 
-int draw_primitive_end()
+void draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty, int col, float alpha)
 {
-  if (prim_draw_texture != -1) {
-    texture_set(prim_draw_texture);
-  }
-  prim_draw_texture = -1;
-  d3d_model_draw(prim_draw_model);
-  d3d_model_clear(prim_draw_model);
-  return 0;
+  d3d_model_vertex_texture_color(d3ddev->GetShapesModel(), x, y, 0, tx, ty, col, alpha);
 }
 
 void d3d_primitive_begin(int kind)
 {
-  prim_draw_texture == -1;
-  if (prim_d3d_model = -1) {
-    prim_d3d_model = d3d_model_create();
-  }
-  d3d_model_primitive_begin(prim_d3d_model, kind);
-  return;
+  d3ddev->BeginShapesBatching(-1);
+  d3d_model_primitive_begin(d3ddev->GetShapesModel(), kind);
 }
 
 void d3d_primitive_begin_texture(int kind, int texId)
 {
-  if (prim_d3d_model == -1) {
-    prim_d3d_model = d3d_model_create();
-  }
-  prim_d3d_texture = texId;
-  d3d_model_primitive_begin(prim_d3d_model, kind);
+  d3ddev->BeginShapesBatching(texId);
+  d3d_model_primitive_begin(d3ddev->GetShapesModel(), kind);
 }
 
 void d3d_primitive_end()
 {
-  if (prim_d3d_texture != -1) {
-    texture_set(prim_d3d_texture);
-  }
-  prim_d3d_texture = -1;
-  d3d_model_draw(prim_d3d_model);
-  d3d_model_clear(prim_d3d_model);
+  d3d_model_primitive_end(d3ddev->GetShapesModel());
 }
 
 void d3d_vertex(gs_scalar x, gs_scalar y, gs_scalar z)
 {
-  d3d_model_vertex(prim_d3d_model, x, y, z);
+  d3d_model_vertex(d3ddev->GetShapesModel(), x, y, z);
 }
 
 void d3d_vertex_color(gs_scalar x, gs_scalar y, gs_scalar z, int color, double alpha)
 {
-  d3d_model_vertex_color(prim_d3d_model, x, y, z, color, alpha);
+  d3d_model_vertex_color(d3ddev->GetShapesModel(), x, y, z, color, alpha);
 }
 
 void d3d_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar tx, gs_scalar ty)
 {
-  d3d_model_vertex_texture(prim_d3d_model, x, y, z, tx, ty);
+  d3d_model_vertex_texture(d3ddev->GetShapesModel(), x, y, z, tx, ty);
 }
 
 void d3d_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar tx, gs_scalar ty, int color, double alpha)
 {
-  d3d_model_vertex_texture_color(prim_d3d_model, x, y, z, tx, ty, color, alpha);
+  d3d_model_vertex_texture_color(d3ddev->GetShapesModel(), x, y, z, tx, ty, color, alpha);
 }
 
 void d3d_vertex_normal(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_scalar ny, gs_scalar nz)
 {
-  d3d_model_vertex_normal(prim_d3d_model, x, y, z, nx, ny, nz);
+  d3d_model_vertex_normal(d3ddev->GetShapesModel(), x, y, z, nx, ny, nz);
 }
 
 void d3d_vertex_normal_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_scalar ny, gs_scalar nz, int color, double alpha)
 {
-  d3d_model_vertex_normal_color(prim_d3d_model, x, y, z, nx, ny, nz, color, alpha);
+  d3d_model_vertex_normal_color(d3ddev->GetShapesModel(), x, y, z, nx, ny, nz, color, alpha);
 }
 
 void d3d_vertex_normal_texture(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_scalar ny, gs_scalar nz, gs_scalar tx, gs_scalar ty)
 {
-  d3d_model_vertex_normal_texture(prim_d3d_model, x, y, z, nx, ny, nz, tx, ty);
+  d3d_model_vertex_normal_texture(d3ddev->GetShapesModel(), x, y, z, nx, ny, nz, tx, ty);
 }
 
 void d3d_vertex_normal_texture_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_scalar ny, gs_scalar nz, gs_scalar tx, gs_scalar ty, int color, double alpha)
 {
-  d3d_model_vertex_normal_texture_color(prim_d3d_model, x, y, z, nx, ny, nz, tx, ty, color, alpha);
+  d3d_model_vertex_normal_texture_color(d3ddev->GetShapesModel(), x, y, z, nx, ny, nz, tx, ty, color, alpha);
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSprimitives.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSprimitives.h
@@ -28,13 +28,13 @@ enum {
   pr_trianglefan    = 6      // GL_TRIANGLE_FAN      D3DPT_TRIANGLEFAN
 };
 
-int draw_primitive_begin(int kind);
-int draw_primitive_begin_texture(int kind,unsigned tex);
-int draw_vertex(gs_scalar x, gs_scalar y);
-int draw_vertex_color(gs_scalar x, gs_scalar y, int color, float alpha);
-int draw_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty);
-int draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty, int col, float alpha);
-int draw_primitive_end();
+void draw_primitive_begin(int kind);
+void draw_primitive_begin_texture(int kind, int texId);
+void draw_primitive_end();
+void draw_vertex(gs_scalar x, gs_scalar y);
+void draw_vertex_color(gs_scalar x, gs_scalar y, int color, float alpha);
+void draw_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty);
+void draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty, int col, float alpha);
 void d3d_primitive_begin(int kind);
 void d3d_primitive_begin_texture(int kind, int texId);
 void d3d_primitive_end();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLprimitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLprimitives.cpp
@@ -43,28 +43,25 @@ namespace enigma {
 namespace enigma_user
 {
 
-int draw_primitive_begin(int dink)
+void draw_primitive_begin(int dink)
 {
   GLenum kind = ptypes_by_id[ dink & 15 ];
   glBegin(kind);
-  return 0;
 }
 
-int draw_primitive_begin_texture(int dink,unsigned tex)
+void draw_primitive_begin_texture(int dink,unsigned tex)
 {
   texture_set(tex);
   GLenum kind = ptypes_by_id[ dink & 15 ];
   glBegin(kind);
-  return 0;
 }
 
-int draw_vertex(gs_scalar x, gs_scalar y)
+void draw_vertex(gs_scalar x, gs_scalar y)
 {
-	glVertex2f(x,y);
-	return 0;
+  glVertex2f(x,y);
 }
 
-int draw_vertex_color(gs_scalar x, gs_scalar y, int col, float alpha)
+void draw_vertex_color(gs_scalar x, gs_scalar y, int col, float alpha)
 {
   glPushAttrib(GL_CURRENT_BIT);
     glColor4f(
@@ -74,15 +71,15 @@ int draw_vertex_color(gs_scalar x, gs_scalar y, int col, float alpha)
       alpha);
     glVertex2f(x,y);
   glPopAttrib();
-	return 0;
 }
-int draw_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty)
+
+void draw_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty)
 {
     glTexCoord2f(tx,ty);
     glVertex2f(x,y);
-	return 0;
 }
-int draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty, int col, float alpha)
+
+void draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty, int col, float alpha)
 {
   glPushAttrib(GL_CURRENT_BIT);
     glColor4f(
@@ -93,18 +90,18 @@ int draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar 
     glTexCoord2f(tx,ty);
     glVertex2f(x,y);
   glPopAttrib();
-	return 0;
 }
-int draw_primitive_end()
+
+void draw_primitive_end()
 {
 	glEnd();
-	return 0;
 }
 
 void d3d_primitive_begin(int kind)
 {
     glBegin(ptypes_by_id[kind]);
 }
+
 void d3d_primitive_begin_texture(int kind, int texId)
 {
     texture_set(get_texture(texId));

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3primitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3primitives.cpp
@@ -61,53 +61,47 @@ unsigned get_texture(int texid);
 namespace enigma_user
 {
 
-int draw_primitive_begin(int kind)
+void draw_primitive_begin(int kind)
 {
   prim_draw_texture = -1;
   if (prim_draw_model == -1) {
     prim_draw_model = d3d_model_create();
   }
   d3d_model_primitive_begin(prim_draw_model, kind);
-  return 0;
 }
 
-int draw_primitive_begin_texture(int kind,unsigned tex)
+void draw_primitive_begin_texture(int kind,unsigned tex)
 {
   if (prim_draw_model == -1) {
     prim_draw_model = d3d_model_create();
   }
   prim_draw_texture = tex;
   d3d_model_primitive_begin(prim_draw_model, kind);
-  return 0;
 }
 
-int draw_vertex(gs_scalar x, gs_scalar y)
+void draw_vertex(gs_scalar x, gs_scalar y)
 {
   d3d_model_vertex(prim_draw_model, x, y, 0);
-  return 0;
 }
 
-int draw_vertex_color(gs_scalar x, gs_scalar y, int col, float alpha)
+void draw_vertex_color(gs_scalar x, gs_scalar y, int col, float alpha)
 {
   d3d_model_vertex_color(prim_draw_model, x, y, 0, col, alpha);
-  return 0;
 }
 
-int draw_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty)
+void draw_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty)
 {
   int col = enigma::currentcolor[0] | (enigma::currentcolor[1] << 8) | (enigma::currentcolor[2] << 16);
   float alpha = (float)enigma::currentcolor[3] / 255.0;
   d3d_model_vertex_texture_color(prim_draw_model, x, y, 0, tx, ty, col, alpha);
-  return 0;
 }
 
-int draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty, int col, float alpha)
+void draw_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar tx, gs_scalar ty, int col, float alpha)
 {
   d3d_model_vertex_texture_color(prim_draw_model, x, y, 0, tx, ty, col, alpha);
-  return 0;
 }
 
-int draw_primitive_end()
+void draw_primitive_end()
 {
   if (prim_draw_texture != -1) {
     texture_set(get_texture(prim_draw_texture));
@@ -115,7 +109,6 @@ int draw_primitive_end()
   prim_draw_texture = -1;
   d3d_model_draw(prim_draw_model);
   d3d_model_clear(prim_draw_model);
-  return 0;
 }
 
 void d3d_primitive_begin(int kind)


### PR DESCRIPTION
Added proper d3d_primitive_\* and draw_primitive_\* batching so no more
segfault. Also got the house effects demo working and added light state
memorization to the Direct3D 9.0 device manager.
