### PR TITLE
Implemented Background Scrolling Speed

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
@@ -262,7 +262,7 @@ void draw_background_part_ext(int back, gs_scalar left, gs_scalar top, gs_scalar
 	dsprite->SetTransform(&mat);
 }
 
-void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
+void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha, bool htiled, bool vtiled)
 {
     get_background(bck2d,back);
 
@@ -273,18 +273,28 @@ void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xsc
     x = width_scaled-fmod(x,width_scaled);
     y = height_scaled-fmod(y,height_scaled);
 
-    const int
-    hortil = int(ceil(room_width/(width_scaled*tbx))) + 1,
-    vertil = int(ceil(room_height/(height_scaled*tby))) + 1;
+    int hortil, vertil;
+	if (htiled) {
+		hortil = int(ceil(room_width/(width_scaled*tbx))) + 1;
+		x = -(width_scaled-fmod(x,width_scaled));
+	} else {
+		hortil = 1;
+	}
+	if (vtiled) { 
+		vertil = int(ceil(room_height/(height_scaled*tby))) + 1;
+		y = -(height_scaled-fmod(y,height_scaled));
+	} else {
+		vertil = 1;
+	}
 
-    float xvert1 = -x, xvert2 = xvert1 + width_scaled, yvert1, yvert2;
+    float xvert1 = x, xvert2 = xvert1 + width_scaled, yvert1, yvert2;
 	
 	// Build our matrix to rotate, scale and position our sprite
 	D3DXMATRIX mat;
 			
     for (int i=0; i<hortil; i++)
     {
-        yvert1 = -y; yvert2 = yvert1 + height_scaled;
+        yvert1 = y; yvert2 = yvert1 + height_scaled;
         for (int c=0; c<vertil; c++)
         {
 		

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -66,6 +66,8 @@ static inline void draw_back()
     using enigma_user::background_yscale;
     using enigma_user::background_htiled;
     using enigma_user::background_vtiled;
+	using enigma_user::background_hspeed;
+	using enigma_user::background_vspeed;
     using enigma_user::background_index;
     using enigma_user::background_coloring;
     using enigma_user::draw_background_tiled_ext;
@@ -75,8 +77,14 @@ static inline void draw_back()
     {
         if (background_visible[back_current] == 1)
         {
+			//NOTE: This has been double checked with Game Maker 8.1 to work exactly the same, the background_x/y is modified just as object locals are
+			//and also just as one would assume the system to work.
+			//TODO: This should probably be moved to room system.
+			background_x[back_current] += background_hspeed[back_current];
+			background_y[back_current] += background_vspeed[back_current];
             if (background_htiled[back_current] || background_vtiled[back_current])
-                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], background_xscale[back_current], background_coloring[back_current], background_alpha[back_current]);
+                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], 
+					background_xscale[back_current], background_coloring[back_current], background_alpha[back_current], background_htiled[back_current], background_vtiled[back_current]);
             else
                 draw_background_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], background_xscale[back_current], 0, background_coloring[back_current], background_alpha[back_current]);
         }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSbackground.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSbackground.h
@@ -34,7 +34,7 @@ void draw_background_tiled_area(int back,gs_scalar x, gs_scalar y,gs_scalar x1, 
 void draw_background_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int color, gs_scalar alpha);
 void draw_background_stretched_ext(int back, gs_scalar x, gs_scalar y, gs_scalar wid, gs_scalar hei, int color, gs_scalar alpha);
 void draw_background_part_ext(int back, gs_scalar left, gs_scalar top, gs_scalar wid, gs_scalar hei, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale,int color, gs_scalar alpha);
-void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha);
+void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha, bool htiled = true, bool vtiled = true);
 void draw_background_tiled_area_ext(int back, gs_scalar x, gs_scalar y, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha);
 void draw_background_general(int back, gs_scalar left, gs_scalar top, gs_scalar wid, gs_scalar hei, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int c1, int c2, int c3, int c4, gs_scalar a1, gs_scalar a2, gs_scalar a3, gs_scalar a4);
 int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload = true);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
@@ -323,7 +323,7 @@ void draw_background_part_ext(int back, gs_scalar left, gs_scalar top, gs_scalar
     glPopAttrib();
 }
 
-void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
+void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha, bool htiled, bool vtiled)
 {
     get_background(bck2d,back);
       texture_set(textureStructs[bck2d->texture]->gltex);
@@ -335,18 +335,25 @@ void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xsc
     tbx = bck2d->texbordx, tby = bck2d->texbordy,
     width_scaled = bck2d->width*xscale, height_scaled = bck2d->height*yscale;
 
-    x = width_scaled-fmod(x,width_scaled);
-    y = height_scaled-fmod(y,height_scaled);
-
-    const int
-    hortil = int(ceil(room_width/(width_scaled*tbx))) + 1,
-    vertil = int(ceil(room_height/(height_scaled*tby))) + 1;
+    int hortil, vertil;
+	if (htiled) {
+		hortil = int(ceil(room_width/(width_scaled*tbx))) + 1;
+		x = -(width_scaled-fmod(x,width_scaled));
+	} else {
+		hortil = 1;
+	}
+	if (vtiled) { 
+		vertil = int(ceil(room_height/(height_scaled*tby))) + 1;
+		y = -(height_scaled-fmod(y,height_scaled));
+	} else {
+		vertil = 1;
+	}
 
     glBegin(GL_QUADS);
-    float xvert1 = -x, xvert2 = xvert1 + width_scaled, yvert1, yvert2;
+    float xvert1 = x, xvert2 = xvert1 + width_scaled, yvert1, yvert2;
     for (int i=0; i<hortil; i++)
     {
-        yvert1 = -y; yvert2 = yvert1 + height_scaled;
+        yvert1 = y; yvert2 = yvert1 + height_scaled;
         for (int c=0; c<vertil; c++)
         {
             glTexCoord2f(0,0);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -63,6 +63,8 @@ static inline void draw_back()
     using enigma_user::background_yscale;
     using enigma_user::background_htiled;
     using enigma_user::background_vtiled;
+	using enigma_user::background_hspeed;
+	using enigma_user::background_vspeed;
     using enigma_user::background_index;
     using enigma_user::background_coloring;
     using enigma_user::draw_background_tiled_ext;
@@ -72,8 +74,14 @@ static inline void draw_back()
     {
         if (background_visible[back_current] == 1)
         {
+			//NOTE: This has been double checked with Game Maker 8.1 to work exactly the same, the background_x/y is modified just as object locals are
+			//and also just as one would assume the system to work.
+			//TODO: This should probably be moved to room system.
+			background_x[back_current] += background_hspeed[back_current];
+			background_y[back_current] += background_vspeed[back_current];
             if (background_htiled[back_current] || background_vtiled[back_current])
-                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], background_xscale[back_current], background_coloring[back_current], background_alpha[back_current]);
+                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], 
+					background_xscale[back_current], background_coloring[back_current], background_alpha[back_current], background_htiled[back_current], background_vtiled[back_current]);
             else
                 draw_background_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], background_xscale[back_current], 0, background_coloring[back_current], background_alpha[back_current]);
         }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
@@ -262,7 +262,7 @@ void draw_background_part_ext(int back, gs_scalar left, gs_scalar top, gs_scalar
     plane2D_rotated(data);
 }
 
-void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int blend, gs_scalar alpha)
+void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int blend, gs_scalar alpha, bool htiled, bool vtiled)
 {
     get_background(bck2d,back);
     texture_set(textureStructs[bck2d->texture]->gltex);
@@ -271,18 +271,25 @@ void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xsc
     tbx = bck2d->texbordx, tby = bck2d->texbordy,
     width_scaled = bck2d->width*xscale, height_scaled = bck2d->height*yscale;
 
-    x = width_scaled-fmod(x,width_scaled);
-    y = height_scaled-fmod(y,height_scaled);
+    int hortil, vertil;
+	if (htiled) {
+		hortil = int(ceil(room_width/(width_scaled*tbx))) + 1;
+		x = -(width_scaled-fmod(x,width_scaled));
+	} else {
+		hortil = 1;
+	}
+	if (vtiled) { 
+		vertil = int(ceil(room_height/(height_scaled*tby))) + 1;
+		y = -(height_scaled-fmod(y,height_scaled));
+	} else {
+		vertil = 1;
+	}
 
-    const int
-    hortil = int(ceil(room_width/(width_scaled*tbx))) + 1,
-    vertil = int(ceil(room_height/(height_scaled*tby))) + 1;
-
-    gs_scalar xvert1 = -x, xvert2 = xvert1 + width_scaled, yvert1, yvert2;
+    gs_scalar xvert1 = x, xvert2 = xvert1 + width_scaled, yvert1, yvert2;
     const gs_scalar r = __GETR(blend), g = __GETG(blend), b = __GETB(blend);
     for (int i=0; i<hortil; i++)
     {
-        yvert1 = -y; yvert2 = yvert1 + height_scaled;
+        yvert1 = y; yvert2 = yvert1 + height_scaled;
         for (int c=0; c<vertil; c++)
         {
             const gs_scalar data[4*8] = {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -75,6 +75,8 @@ static inline void draw_back()
     using enigma_user::background_yscale;
     using enigma_user::background_htiled;
     using enigma_user::background_vtiled;
+	using enigma_user::background_hspeed;
+	using enigma_user::background_vspeed;
     using enigma_user::background_index;
     using enigma_user::background_coloring;
     using enigma_user::draw_background_tiled_ext;
@@ -84,8 +86,14 @@ static inline void draw_back()
     {
         if (background_visible[back_current] == 1)
         {
+			//NOTE: This has been double checked with Game Maker 8.1 to work exactly the same, the background_x/y is modified just as object locals are
+			//and also just as one would assume the system to work.
+			//TODO: This should probably be moved to room system.
+			background_x[back_current] += background_hspeed[back_current];
+			background_y[back_current] += background_vspeed[back_current];
             if (background_htiled[back_current] || background_vtiled[back_current])
-                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], background_xscale[back_current], background_coloring[back_current], background_alpha[back_current]);
+                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], 
+					background_xscale[back_current], background_coloring[back_current], background_alpha[back_current], background_htiled[back_current], background_vtiled[back_current]);
             else
                 draw_background_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], background_xscale[back_current], 0, background_coloring[back_current], background_alpha[back_current]);
         }


### PR DESCRIPTION
Noticed that background speed settings were not added and tested Game
Maker 8.1 and GameMaker: Studio and found out it just modifies the background_x and background_y
just as one would assume object local x and y to work. Tested thoroughly
and all 3 graphics systems work with the fixes. Also fixed the issue so it
can only tile horizontally and not vertically and vice versa. Please merge
when ready I have tested very thoroughly to make sure I won't have to touch this again.
