### PR TITLE
fix cross compiling on linux

### DIFF
--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -326,7 +326,6 @@ int lang_CPP::compile(EnigmaStruct *es, const char* exe_filename, int mode)
   // FIRST FILE
   // Modes, settings and executable information.
   
-  #ifdef _WIN32
   GameSettings gameSet = es->gameSettings;
   edbg << "Writing executable information and resources." << flushl;
   wto.open("ENIGMAsystem/SHELL/Preprocessor_Environment_Editable/Resources.rc",ios_base::out);
@@ -356,7 +355,6 @@ int lang_CPP::compile(EnigmaStruct *es, const char* exe_filename, int mode)
 	wto << "VALUE \"Translation\", 0x409, 1252\n";
 	wto << "END\nEND";
   wto.close();
-  #endif
   
   edbg << "Writing modes and settings" << flushl;
   wto.open("ENIGMAsystem/SHELL/Preprocessor_Environment_Editable/GAME_SETTINGS.h",ios_base::out);


### PR DESCRIPTION
Cross compiling with mingw on linux was failing because the compiler didn't write Resource.rc.

make[1]: **\* No rule to make target '.eobjs/Linux/Windows/Run/Preprocessor_Environment_Editable/Resources.rc', needed by 'compile_game'.  Stop.

Resources.rc is needed on Win32 and linux cross compile and does nothing on normal linux builds. Tested on linux and linux mingw cross compile.
