### PR TITLE
remove useless ERROR( lines from compiler

### DIFF
--- a/CompilerSource/JDI/src/System/token.cpp
+++ b/CompilerSource/JDI/src/System/token.cpp
@@ -46,6 +46,9 @@ void token_t::report_error(error_handler *herr, std::string error) const
     p = pos
   );
   
+  #ifndef USELESS_ERRORS
+  return;
+  #endif
   herr->error(error, fn, l, p);
 }
 
@@ -141,7 +144,10 @@ void token_t::report_errorf(error_handler *herr, std::string error) const
     error.replace(f,2,str);
     f = error.find("%s");
   }
-  
+
+  #ifndef USELESS_ERRORS
+  return;
+  #endif
   #ifdef DEBUG_MODE
     if (herr)
   #endif


### PR DESCRIPTION
Removing useless lines speeds up Windows console and saves time looking for real errors. -DUSELESS_ERRORS in compiler Makefile to show useless error lines again.
