### PR TITLE
Default Color Change

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -23,6 +23,7 @@
 #include "../General/GSscreen.h"
 #include "../General/GSd3d.h"
 #include "../General/GStextures.h"
+#include "../General/GScolors.h"
 
 using namespace std;
 
@@ -538,13 +539,9 @@ void screen_init()
 	d3dmgr->SetRenderState(D3DRS_ALPHAREF, (DWORD)0x00000001);
 	d3dmgr->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE); 
 	d3dmgr->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
-	//glEnable(GL_BLEND);
-	//glEnable(GL_TEXTURE_2D);
-	//glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
 	d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
-	//glAlphaFunc(GL_ALWAYS,0);
-	//glColor4f(0,0,0,1);
+	draw_set_color(c_white);
 }
 
 int screen_save(string filename) //Assumes native integers are little endian

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -22,6 +22,7 @@
 #include "../General/GSbackground.h"
 #include "../General/GSscreen.h"
 #include "../General/GSd3d.h"
+#include "../General/GScolors.h"
 
 using namespace std;
 
@@ -476,8 +477,8 @@ void screen_init()
 	glEnable(GL_TEXTURE_2D);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glAlphaFunc(GL_ALWAYS,0);
-	glColor4f(0,0,0,1);
 	glBindTexture(GL_TEXTURE_2D,0);
+	draw_set_color(c_white);
 }
 
 int screen_save(string filename) { //Assumes native integers are little endian

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -22,6 +22,7 @@
 #include "../General/GSscreen.h"
 #include "../General/GSd3d.h"
 #include "../General/GStextures.h"
+#include "../General/GScolors.h"
 #include "Bridges/General/GL3Context.h"
 
 using namespace std;
@@ -463,8 +464,8 @@ void screen_init()
 	glEnable(GL_TEXTURE_2D);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glAlphaFunc(GL_ALWAYS,0);
-	glColor4f(0,0,0,1);
 	texture_reset();
+	draw_set_color(c_white);
 }
 
 int screen_save(string filename) //Assumes native integers are little endian


### PR DESCRIPTION
Setting the default color to white, was agreed upon by myself, Josh, and
polygonz. Most d3d games set the color to white at d3d start because
models were affected by color and alpha, and then they set color to black
when drawing text if they wanted it black, so default color black was
rather assinine. We can do things different then game maker.
