### PR TITLE
Fixed Working Directory

### DIFF
--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -162,6 +162,9 @@ void clear_ide_editables()
 // modes: 0=run, 1=debug, 2=design, 3=compile
 enum { emode_run, emode_debug, emode_design, emode_compile, emode_rebuild };
 
+// The games working directory, in run/debug it is the GMK/GMX location where the IDE is working with the project,
+// in compile mode it is the same as program_directory, or where the (*.exe executable) is located.
+string working_directory = "";
 
 dllexport int compileEGMf(EnigmaStruct *es, const char* exe_filename, int mode) {
   return current_language->compile(es, exe_filename, mode);
@@ -192,6 +195,19 @@ int lang_CPP::compile(EnigmaStruct *es, const char* exe_filename, int mode)
 	return 0;
   }
   edbg << "Building for mode (" << mode << ")" << flushl;
+  
+    string s;
+    if (!es->filename || mode == emode_compile) {
+        s = ".";
+    } else {
+        s = es->filename;
+        s = s.substr(0, s.find_last_of("/"));
+        s = s.substr(s.find("file:/",0) + 6);
+        s = string_replace_all(s, "/", "\\\\");
+        s = string_replace_all(s, "%20", " ");
+    }
+	
+	working_directory = s;
 
   // CLean up from any previous executions.
 

--- a/CompilerSource/compiler/components/write_globals.cpp
+++ b/CompilerSource/compiler/components/write_globals.cpp
@@ -43,6 +43,8 @@ using namespace std;
 
 int global_script_argument_count = 0;
 
+extern string working_directory;
+
 int lang_CPP::compile_writeGlobals(EnigmaStruct* es, parsed_object* global)
 {
   ofstream wto;
@@ -57,20 +59,9 @@ int lang_CPP::compile_writeGlobals(EnigmaStruct* es, parsed_object* global)
         wto << ", argument" << i << " = 0";
       wto << ";\n\n";
     }
-
-    string s;
-    if (!es->filename)
-        s = "";
-    else
-    {
-        s = es->filename;
-        s = s.substr(0, s.find_last_of("/"));
-        s = s.substr(s.find("file:/",0) + 6);
-        s = string_replace_all(s, "/", "\\\\");
-        s = string_replace_all(s, "%20", " ");
-    }
+	
     wto << "namespace enigma_user { " << endl;
-    wto << "  string working_directory = \"" << s << "\";" << endl;
+    wto << "  string working_directory = \"" << working_directory << "\";" << endl;
     wto << "  unsigned int game_id = " << es->gameSettings.gameId << ";" << endl;
     wto << "}" << endl;
 


### PR DESCRIPTION
It should simply be '.' when in compile mode, or in other words, the same
as program_directory. Should probably investigate how Game Maker handled it since I don't believe Game Maker simply returned '.', testing should also be done for program_directory. I believe Game Maker actually called the windows SetWorkingDirectory() call so that '' a null terminated string would simply be the local path.
