### PR TITLE
Fixed OpenGL3

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/GL3Context.h
+++ b/ENIGMAsystem/SHELL/Bridges/General/GL3Context.h
@@ -140,11 +140,9 @@ void ReadPixels() {
 }
 
 void BindTexture(GLenum target,  GLuint texture) {
-//GLint tex;
-//glGetIntegerv(target, &tex);
 if (bound_tex != texture) {
-EndShapesBatching();
-		glBindTexture(target, bound_tex = texture);
+	EndShapesBatching();
+	glBindTexture(target, bound_tex = texture);
 }
 		return;
 	// Update the texture state cache


### PR DESCRIPTION
Texture binding I had was all wrong and extremely slow, glGet is very bad. The map still needs fixed though, so that it includes the different texture stages as well as the different targets, eg. GL_TEXTURE_3D
