### PR TITLE
Direct3D Improvements

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
@@ -69,7 +69,7 @@ namespace enigma
 		hr = d3dobj->CreateDevice(D3DADAPTER_DEFAULT,
                       D3DDEVTYPE_HAL,
                       hWnd,
-                      D3DCREATE_HARDWARE_VERTEXPROCESSING,
+                      D3DCREATE_MIXED_VERTEXPROCESSING,
                       &d3dpp,
                       &d3dmgr->device);
 		if(FAILED(hr)){

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -83,6 +83,10 @@ void d3d_end()
 	d3d_set_hidden(false);
 }
 
+void d3d_set_software_vertex_processing(bool software) {
+	d3dmgr->device->SetSoftwareVertexProcessing(software);
+}
+
 void d3d_set_hidden(bool enable)
 {
 	//d3d_set_zwriteenable(enable);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
@@ -85,6 +85,7 @@ void d3d_set_hidden(bool enable);
 void d3d_set_zwriteenable(bool enable);
 void d3d_set_lighting(bool enable);
 
+void d3d_set_software_vertex_processing(bool software);
 void d3d_set_culling(int mode);
 void d3d_set_fill_mode(int fill);
 void d3d_set_line_width(float value);


### PR DESCRIPTION
Added d3d_set_software_vertex_processing and changed the default in
graphics bridge to mixed vertex processing which speeds up our dynamic
VBO's
