### PR TITLE
Moved Preprocessor

### DIFF
--- a/CompilerSource/workdir.cpp
+++ b/CompilerSource/workdir.cpp
@@ -16,7 +16,7 @@ std::string myReplace(std::string str, const std::string& oldStr, const std::str
   return nstr;
 }
 
-std::string workdir = (strstr(getenv("APPDATA")," "))?"ENIGMAsystem/SHELL/":myReplace(getenv("APPDATA"), "\\","/") + std::string("/ENIGMA/");
+std::string workdir = "C:/ProgramData/ENIGMA/";
 #else
 std::string workdir = getenv("HOME") + std::string("/.enigma/");
 #endif


### PR DESCRIPTION
Moving it to the ProgramData, which is a user directory introduced in Windows Vista I believe. This avoids both the %AppData% spaces issues and the admin privileges issue for all Windows platforms, it appears Studio also uses this directory to output debug logs and I believe may also be used to compile games and is automatically cleaned afterwards, though not quite sure.
