### PR TITLE
Normalized instance_activate/deactivate functions in the collision system

### DIFF
--- a/ENIGMAsystem/SHELL/Collision_Systems/BBox/coll_funcs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/BBox/coll_funcs.cpp
@@ -748,7 +748,7 @@ typedef std::pair<int,enigma::inst_iter*> inode_pair;
 namespace enigma_user
 {
 
-void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, int inside, bool notme) {
+void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bool inside, bool notme) {
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
         if (notme && (*it)->id == enigma::instance_event_iterator->inst->id) continue;
         enigma::object_collisions* const inst = ((enigma::object_collisions*)*it);
@@ -778,7 +778,7 @@ void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, in
     }
 }
 
-void instance_activate_region(int rleft, int rtop, int rwidth, int rheight, int inside) {
+void instance_activate_region(int rleft, int rtop, int rwidth, int rheight, bool inside) {
     std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
 
@@ -836,7 +836,7 @@ static bool line_ellipse_intersects(cs_scalar rx, cs_scalar ry, cs_scalar x, cs_
 namespace enigma_user
 {
 
-void instance_deactivate_circle(int x, int y, int r, int inside, bool notme)
+void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
 {
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
     {
@@ -881,7 +881,7 @@ void instance_deactivate_circle(int x, int y, int r, int inside, bool notme)
 }
 
 
-void instance_activate_circle(int x, int y, int r, int inside)
+void instance_activate_circle(int x, int y, int r, bool inside)
 {
     std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {

--- a/ENIGMAsystem/SHELL/Collision_Systems/General/coll_funcs.h
+++ b/ENIGMAsystem/SHELL/Collision_Systems/General/coll_funcs.h
@@ -76,10 +76,10 @@ inline bool move_bounce_solid(bool adv = true) {
     return move_bounce_object(all, adv, true);
 }
 
-void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, int inside = true, bool notme = true);
-void instance_activate_region(int left, int top, int width, int height, int inside = true);
-void instance_deactivate_circle(int x, int y, int r, int inside = true, bool notme = true);
-void instance_activate_circle(int x, int y, int r, int inside = true);
+void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bool inside = true, bool notme = true);
+void instance_activate_region(int left, int top, int width, int height, bool inside = true);
+void instance_deactivate_circle(int x, int y, int r, bool inside = true, bool notme = true);
+void instance_activate_circle(int x, int y, int r, bool inside = true);
 
 }
 

--- a/ENIGMAsystem/SHELL/Collision_Systems/Precise/coll_funcs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/Precise/coll_funcs.cpp
@@ -588,7 +588,7 @@ static bool line_ellipse_intersects(cs_scalar rx, cs_scalar ry, cs_scalar x, cs_
 namespace enigma_user
 {
 
-void instance_deactivate_circle(int x, int y, int r, int inside, bool notme)
+void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
 {
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
     {
@@ -632,7 +632,7 @@ void instance_deactivate_circle(int x, int y, int r, int inside, bool notme)
     }
 }
 
-void instance_activate_circle(int x, int y, int r, int inside)
+void instance_activate_circle(int x, int y, int r, bool inside)
 {
     std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {


### PR DESCRIPTION
I tested this with the BBox and Precision collision systems, and both compile/link to that point. 

Note that I cannot currently test this in the runtime, since the Linux versions of "keyboard_*" do not yet exist (so there are linker errors). If you look at the code below, however, you will see that these variables are clearly being used as booleans anyway.
