### PR TITLE
Many fixes for GL3 and GL1

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/GL3Context.h
+++ b/ENIGMAsystem/SHELL/Bridges/General/GL3Context.h
@@ -35,7 +35,7 @@ GLint bound_tex;
 
 protected:
   map< GLenum, GLuint > cacheTextureStates;    /// cached texture stages
-  
+
 public:
 
 float last_depth;
@@ -50,7 +50,7 @@ ContextManager() {
 	shapes_d3d_texture = -1;
 	last_stride = -1;
 	last_depth = 0.0f;
-	bound_tex = 0;
+	bound_tex = -1;
 }
 
 ~ContextManager() {
@@ -140,11 +140,11 @@ void ReadPixels() {
 }
 
 void BindTexture(GLenum target,  GLuint texture) {
-if (bound_tex != texture) {
-	EndShapesBatching();
-	glBindTexture(target, bound_tex = texture);
-}
-		return;
+    if (bound_tex != texture) {
+        EndShapesBatching();
+        glBindTexture(target, bound_tex = texture);
+    }
+    return;
 	// Update the texture state cache
     // If the return value is 'true', the command must be forwarded to OpenGL
 	map< GLenum, GLuint >::iterator it = cacheTextureStates.find( target );
@@ -165,6 +165,10 @@ void ResetTextureStates() {
 }
 
 void Viewport() {
+	EndShapesBatching();
+}
+
+void Transformation() { //Used when calling 3d transformations (translation, scaling etc.)
 	EndShapesBatching();
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.h
@@ -35,6 +35,10 @@ namespace enigma_user {
   void d3d_model_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z);
   void d3d_model_draw(int id, int texId);
   void d3d_model_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int texId);
+  void d3d_model_part_draw(int id, int vertex_count);
+  void d3d_model_part_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int vertex_count);
+  void d3d_model_part_draw(int id, int texId, int vertex_count);
+  void d3d_model_part_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int texId, int vertex_count);
   void d3d_model_primitive_begin(int id, int kind);
   void d3d_model_primitive_end(int id);
   bool d3d_model_calculate_normals(int id, bool smooth, bool invert);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
@@ -43,7 +43,7 @@ void draw_point(gs_scalar x, gs_scalar y)
 void draw_point_color(gs_scalar x, gs_scalar y, int col)
 {
 	draw_primitive_begin(pr_pointlist);
-	draw_vertex_color(x, y, col, 1.0);
+	draw_vertex_color(x, y, col, draw_get_alpha());
 	draw_primitive_end();
 }
 
@@ -57,20 +57,38 @@ void draw_line(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2)
 
 void draw_line_color(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, int c1, int c2)
 {
+    gs_scalar alpha = draw_get_alpha();
 	draw_primitive_begin(pr_linestrip);
-	draw_vertex_color(x1, y1, c1, 1.0);
-	draw_vertex_color(x2, y2, c2, 1.0);
+	draw_vertex_color(x1, y1, c1, alpha);
+	draw_vertex_color(x2, y2, c2, alpha);
 	draw_primitive_end();
 }
 
 void draw_line_width(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, float width)
 {
-	//TODO: Write this as a trianglestrip primitive
+    double dir = fmod(atan2(y1-y2,x2-x1)+2*M_PI,2*M_PI);
+    double cv = cos(dir-M_PI/2.0), sv = -sin(dir-M_PI/2.0);
+    double dw = width/2.0;
+    draw_primitive_begin(pr_trianglestrip);
+	draw_vertex(x1+dw*cv, y1+dw*sv);
+	draw_vertex(x1-dw*cv, y1-dw*sv);
+    draw_vertex(x2+dw*cv, y2+dw*sv);
+    draw_vertex(x2-dw*cv, y2-dw*sv);
+	draw_primitive_end();
 }
 
 void draw_line_width_color(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, float width, int c1, int c2)
 {
-	//TODO: Write this as a trianglestrip primitive
+    gs_scalar alpha = draw_get_alpha();
+    double dir = fmod(atan2(y1-y2,x2-x1)+2*M_PI,2*M_PI);
+    double cv = cos(dir-M_PI/2.0), sv = -sin(dir-M_PI/2.0);
+    double dw = width/2.0;
+    draw_primitive_begin(pr_trianglestrip);
+	draw_vertex_color(x1+dw*cv, y1+dw*sv, c1, alpha);
+	draw_vertex_color(x1-dw*cv, y1-dw*sv, c1, alpha);
+    draw_vertex_color(x2+dw*cv, y2+dw*sv, c2, alpha);
+    draw_vertex_color(x2-dw*cv, y2-dw*sv, c2, alpha);
+	draw_primitive_end();
 }
 
 void draw_rectangle(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, bool outline)
@@ -113,7 +131,7 @@ void draw_rectangle_angle(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2,
   float
     ldx2 = len*cos(dir),
     ldy2 = len*sin(dir);
-	
+
     if (outline) {
 		draw_primitive_begin(pr_linestrip);
 		draw_vertex(xm+ldx1, ym-ldy1);
@@ -134,20 +152,21 @@ void draw_rectangle_angle(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2,
 
 void draw_rectangle_color(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, int c1, int c2, int c3, int c4, bool outline)
 {
+    gs_scalar alpha = draw_get_alpha();
     if (outline) {
 		draw_primitive_begin(pr_linestrip);
-		draw_vertex_color(x1, y1, c1, 1.0);
-		draw_vertex_color(x2, y1, c2, 1.0);
-		draw_vertex_color(x2, y2, c3, 1.0);
-		draw_vertex_color(x1, y2, c4, 1.0);
-		draw_vertex_color(x1, y1, c1, 1.0);
+		draw_vertex_color(x1, y1, c1, alpha);
+		draw_vertex_color(x2, y1, c2, alpha);
+		draw_vertex_color(x2, y2, c3, alpha);
+		draw_vertex_color(x1, y2, c4, alpha);
+		draw_vertex_color(x1, y1, c1, alpha);
 		draw_primitive_end();
     } else {
 		draw_primitive_begin(pr_trianglestrip);
-		draw_vertex_color(x1, y1, c1, 1.0);
-		draw_vertex_color(x2, y1, c2, 1.0);
-		draw_vertex_color(x1, y2, c3, 1.0);
-		draw_vertex_color(x2, y2, c4, 1.0);
+		draw_vertex_color(x1, y1, c1, alpha);
+		draw_vertex_color(x2, y1, c2, alpha);
+		draw_vertex_color(x1, y2, c3, alpha);
+		draw_vertex_color(x2, y2, c4, alpha);
 		draw_primitive_end();
     }
 }
@@ -181,15 +200,16 @@ void draw_circle(gs_scalar x, gs_scalar y, float rad, bool outline)
 
 void draw_circle_color(gs_scalar x, gs_scalar y, float rad,int c1, int c2,bool outline)
 {
+    gs_scalar alpha = draw_get_alpha();
     if(outline) {
 		draw_primitive_begin(pr_linestrip);
     } else {
         draw_primitive_begin(pr_trianglefan);
-		draw_vertex_color(x, y, c1, 1.0);
+		draw_vertex_color(x, y, c1, alpha);
     }
 	float pr=2*M_PI/enigma::circleprecision;
 	for(float i=0;i<=2*M_PI;i+=pr)
-		draw_vertex_color(x+rad*cos(i),y-rad*sin(i), c2, 1.0);
+		draw_vertex_color(x+rad*cos(i),y-rad*sin(i), c2, alpha);
     draw_primitive_end();
 }
 
@@ -215,7 +235,7 @@ void draw_circle_perfect(gs_scalar x, gs_scalar y, float rad, bool outline)
 void draw_circle_color_perfect(gs_scalar x, gs_scalar y, float rad, int c1, int c2, bool outline)
 {
     gs_scalar r2=rad*rad;
-	gs_scalar alpha = draw_get_alpha();
+    gs_scalar alpha = draw_get_alpha();
     if (outline)
     {
 	  draw_primitive_begin(pr_pointlist);
@@ -341,18 +361,19 @@ void draw_triangle(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, gs_sca
 
 void draw_triangle_color(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, gs_scalar x3, gs_scalar y3, int col1, int col2, int col3, bool outline)
 {
+    gs_scalar alpha = draw_get_alpha();
     if (outline) {
 		draw_primitive_begin(pr_linestrip);
-		draw_vertex_color(x1, y1, col1, 1.0);
-		draw_vertex_color(x2, y2, col2, 1.0);
-		draw_vertex_color(x3, y3, col3, 1.0);
-		draw_vertex_color(x1, y1, col1, 1.0);
+		draw_vertex_color(x1, y1, col1, alpha);
+		draw_vertex_color(x2, y2, col2, alpha);
+		draw_vertex_color(x3, y3, col3, alpha);
+		draw_vertex_color(x1, y1, col1, alpha);
 		draw_primitive_end();
     } else {
 		draw_primitive_begin(pr_trianglestrip);
-		draw_vertex_color(x1, y1, col1, 1.0);
-		draw_vertex_color(x2, y2, col2, 1.0);
-		draw_vertex_color(x3, y3, col3, 1.0);
+		draw_vertex_color(x1, y1, col1, alpha);
+		draw_vertex_color(x2, y2, col2, alpha);
+		draw_vertex_color(x3, y3, col3, alpha);
 		draw_primitive_end();
     }
 }
@@ -375,16 +396,16 @@ void draw_arrow(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, gs_scalar
 	lw = ts*(line_size/2), lh = tc*(line_size/2);
 	double at = atan2(ys-y1,xs-x1);
 	if (fabs((dir<0?dir+2*M_PI:dir)-(at<0?at+2*M_PI:at)) < 0.01){
-		draw_primitive_begin(outline?pr_trianglestrip:pr_linestrip);
+		draw_primitive_begin(outline?pr_linestrip:pr_trianglestrip);
 		draw_vertex(x1+lw,y1-lh);
 		draw_vertex(x1-lw,y1+lh);
-		draw_vertex(xs+lw,ys-lh);
-		draw_vertex(xs-lw,ys+lh);
-		if (outline) { draw_vertex(x1+lw,y1-lh); }
+		if (!outline) { draw_vertex(xs+lw,ys-lh); }
+        draw_vertex(xs-lw,ys+lh);
+		if (outline) { draw_vertex(xs+lw,ys-lh); draw_vertex(x1+lw,y1-lh); }
 		draw_primitive_end();
 	}
- 
-	draw_primitive_begin(outline?pr_trianglestrip:pr_linestrip);
+
+	draw_primitive_begin(outline?pr_linestrip:pr_trianglestrip);
 	draw_vertex(x2,y2);
 	draw_vertex(xs-ts*(arrow_size/3),ys+tc*(arrow_size/3));
 	draw_vertex(xs+ts*(arrow_size/3),ys-tc*(arrow_size/3));
@@ -404,7 +425,7 @@ void draw_button(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, gs_scala
   }
   if (x2-x1<border_width*2){border_width=(x2-x1)/2;}
   if (y2-y1<border_width*2){border_width=(y2-y1)/2;}
-	
+
 	draw_primitive_begin(pr_trianglestrip);
 	draw_vertex(x1,y1);
 	draw_vertex(x2,y1);
@@ -422,7 +443,7 @@ void draw_button(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, gs_scala
 	draw_vertex_color(x1,y2,color,alpha);
 	draw_vertex_color(x2,y2,color,alpha);
 	draw_primitive_end();
-	
+
 	draw_primitive_begin(pr_trianglestrip);
 	draw_vertex_color(x2-border_width,y1+border_width,color,alpha);
 	draw_vertex_color(x2,y1,color,alpha);
@@ -437,8 +458,8 @@ void draw_button(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, gs_scala
 	draw_vertex_color(x1+border_width,y1+border_width,color,alpha);
 	draw_vertex_color(x2-border_width,y2+border_width,color,alpha);
 	draw_primitive_end();
-	
-	
+
+
 	draw_primitive_begin(pr_trianglestrip);
 	draw_vertex_color(x1,y1,color,alpha);
 	draw_vertex_color(x1+border_width,y1+border_width,color,alpha);
@@ -485,7 +506,7 @@ void draw_healthbar(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, float
 	draw_vertex_color(x1,y2,col,alpha);
 	draw_vertex_color(x2,y2,col,alpha);
 	draw_primitive_end();
-	
+
 	if (showborder) {
 		draw_primitive_begin(pr_linestrip);
 		draw_vertex_color(x1,y1,0,alpha);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStiles.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStiles.h
@@ -14,13 +14,15 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
+#ifndef ENIGMA_GSTILES__H
+#define ENIGMA_GSTILES__H
 
 #include "Universal_System/scalar.h"
 
 namespace enigma_user
 {
 
-int tile_add(int background, int left, int top, int width, int height, int x, int y, int depth, int alpha = 1, int color = 0xFFFFFF);
+int tile_add(int background, int left, int top, int width, int height, int x, int y, int depth, double xscale = 1.0, double yscale = 1.0, double alpha = 1, int color = 0xFFFFFF);
 bool tile_delete(int id);
 bool tile_exists(int id);
 double tile_get_alpha(int id);
@@ -53,4 +55,4 @@ bool tile_layer_show(int layer_depth);
 bool tile_layer_shift(int layer_depth, int x, int y);
 
 }
-
+#endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLModelStruct.h
@@ -46,7 +46,7 @@ unsigned get_texture(int texid);
 extern GLenum ptypes_by_id[16];
 namespace enigma {
   extern unsigned char currentcolor[4];
-  
+
   //split a string and convert to float
   vector<float> float_split(const string& str, const char& ch) {
     string next;
@@ -77,7 +77,7 @@ namespace enigma {
 	bool trimmed = false;
 	bool checknormal = false;
 	for (unsigned int i = 0; i < s->size() ; i++)
-	{ 
+	{
 		//comment
 		if ((*s)[i] == '#')
 		{
@@ -133,7 +133,7 @@ namespace enigma {
 union VertexElement {
 	unsigned long d;
 	gs_scalar f;
-	
+
 	VertexElement(gs_scalar v): f(v) {}
 	VertexElement(unsigned long v): d(v) {}
 };
@@ -154,37 +154,37 @@ class Mesh
   vector<VertexElement> pointVertices; // The vertices added to point primitives batched into a single point list to be sent to the GPU
   vector<VertexElement> pointIndexedVertices; // The vertices added to indexed point primitives batched into a single point list to be sent to the GPU
   vector<GLuint> pointIndices; // The point indices either concatenated by batching or supplied in the temporary container.
-  
+
   unsigned vertexStride; // whether the vertices are 2D or 3D
   bool useColors; // If colors have been added to the model
   bool useTextures; // If texture coordinates have been added
   bool useNormals; // If normals have been added
-  
+
   unsigned pointCount; // The number of vertices in the point container
   unsigned triangleCount; // The number of vertices in the triangle container
   unsigned lineCount; // The number of vertices in the line container
-  
+
   unsigned pointIndexedCount; // The number of point indices
   unsigned triangleIndexedCount; // The number of triangle indices
   unsigned lineIndexedCount; // The number of line indices
-  
+
   //NOTE: OpenGL 1.1 models are always dynamic since they utilize vertex arrays for software vertex processing and backwards compatibility.
   Mesh (bool dynamic) {
 	vertexStride = 0;
     useColors = false;
     useTextures = false;
     useNormals = false;
-	
+
 	pointCount = 0;
 	triangleCount = 0;
 	lineCount = 0;
-	
+
 	pointIndexedCount = 0;
 	triangleIndexedCount = 0;
 	lineIndexedCount = 0;
-	
+
     currentPrimitive = 0;
-	
+
 	triangleIndexedVertices.reserve(64000);
 	pointIndexedVertices.reserve(64000);
 	lineIndexedVertices.reserve(64000);
@@ -216,7 +216,7 @@ class Mesh
 
   void Clear() {
     ClearData();
-	
+
 	triangleIndexedVertices.reserve(64000);
 	pointIndexedVertices.reserve(64000);
 	lineIndexedVertices.reserve(64000);
@@ -228,12 +228,12 @@ class Mesh
 	triangleIndices.reserve(64000);
 	vertices.reserve(64000);
 	indices.reserve(64000);
-	
+
 	vertexStride = 0;
 	useColors = false;
     useTextures = false;
     useNormals = false;
-	
+
 	pointCount = 0;
 	triangleCount = 0;
 	lineCount = 0;
@@ -241,7 +241,7 @@ class Mesh
 	triangleIndexedCount = 0;
 	lineIndexedCount = 0;
   }
-  
+
   GLsizei GetStride() {
   	GLsizei stride = vertexStride;
     if (useNormals) stride += 3;
@@ -249,12 +249,12 @@ class Mesh
     if (useColors) stride += 1;
 	return stride;
   }
-  
+
   void Begin(int pt)
   {
     currentPrimitive = pt;
   }
-  
+
   void AddVertex(gs_scalar x, gs_scalar y)
   {
     vertices.push_back(x); vertices.push_back(y);
@@ -266,7 +266,7 @@ class Mesh
     vertices.push_back(x); vertices.push_back(y); vertices.push_back(z);
 	vertexStride = 3;
   }
-  
+
   void AddIndex(unsigned ind)
   {
     indices.push_back(ind);
@@ -285,12 +285,12 @@ class Mesh
   }
 
   void AddColor(int col, double alpha)
-  {               
+  {
 	unsigned long final = col + ((unsigned char)alpha*255 << 24);
-	vertices.push_back(final); 
+	vertices.push_back(final);
 	useColors = true;
   }
-  
+
   void Translate(gs_scalar x, gs_scalar y, gs_scalar z)
   {
 	unsigned int stride = GetStride();
@@ -302,7 +302,7 @@ class Mesh
 		triangleVertices[i+2].f += z;
 	}
   }
-     
+
   void RotateUV(gs_scalar angle)
   {
 	unsigned int stride = GetStride();
@@ -318,7 +318,7 @@ class Mesh
 		triangleVertices[i + 4 + 3*useNormals].f = x*_sin - y*_cos;
 	}
   }
-  
+
   /*
   void ScaleUV(gs_scalar xscale, gs_scalar yscale)
   {
@@ -331,7 +331,7 @@ class Mesh
 	}
   }
   */
-   
+
   void RotateX(gs_scalar angle)
   {
 	unsigned int stride = GetStride();
@@ -347,8 +347,8 @@ class Mesh
 		triangleVertices[i+2].f = y*_sin - z*_cos;
 	}
   }
-  
-  
+
+
   void RotateY(gs_scalar angle)
   {
 	unsigned int stride = GetStride();
@@ -364,7 +364,7 @@ class Mesh
 		triangleVertices[i+2].f = z*_cos - x*_sin;
 	}
   }
-  
+
   void RotateZ(gs_scalar angle)
   {
 	unsigned int stride = GetStride();
@@ -380,7 +380,7 @@ class Mesh
 		triangleVertices[i+1].f = x*_sin - y*_cos;
 	}
   }
-  
+
   /*
   void Scale(gs_scalar xscale, gs_scalar yscale, gs_scalar zscale)
   {
@@ -398,7 +398,7 @@ class Mesh
   bool CalculateNormals(bool smooth, bool invert)
   {
 	unsigned int stride = GetStride();
-	
+
 	int oft = useNormals * 3;
 	int ofc = oft + useTextures * 2 ;
 	vector<gs_scalar> tempVertices;
@@ -412,11 +412,11 @@ class Mesh
 		gs_scalar x2 = *(i +stride);
 		gs_scalar y2 = *(i+1 +stride);
 		gs_scalar z2 = *(i+2 +stride);
-		
+
 		gs_scalar x3 = *(i +stride*2);
 		gs_scalar y3 = *(i+1 +stride*2);
 		gs_scalar z3 = *(i+2 +stride*2);
-		
+
 		gs_scalar nX = (y2-y1)*(z3-z1)-(y3-y1)*(z2-z1);
 		gs_scalar nY = (z2-z1)*(x3-x1)-(z3-z1)*(x2-x1);
 		gs_scalar nZ = (x2-x1)*(y3-y1)-(x3-x1)*(y2-y1);
@@ -424,7 +424,7 @@ class Mesh
 		nX /= m;
 		nY /= m;
 		nZ /= m;
-		
+
 		for(int n = 0; n < 3; n++)
 		{
 			int v = n*stride;
@@ -466,7 +466,7 @@ class Mesh
   void SmoothNormals()
   {
 	unsigned int stride = GetStride();
-	
+
 	vector<vector<unsigned int> > groupList;
 	unsigned int n = 0;
 	//group all vertices
@@ -475,25 +475,25 @@ class Mesh
 		gs_scalar x1 = *(i+0);
 		gs_scalar y1 = *(i+1);
 		gs_scalar z1 = *(i+2);
-		
+
 		bool added = false;
-		//check each group 
+		//check each group
 		if (groupList.size() > 0)
 		for (vector< vector<unsigned int> >::iterator ig = groupList.begin(); ig != groupList.end(); ++ig)
 		{
-			
+
 			//compute first element and add it if has the same position
 			unsigned int index = (*ig)[0];
 			gs_scalar x2 = triangleVertices[index*stride + 0];
 			gs_scalar y2 = triangleVertices[index*stride + 1];
-			gs_scalar z2 = triangleVertices[index*stride + 2]; 
+			gs_scalar z2 = triangleVertices[index*stride + 2];
 			if( x1 == x2 && y1 == y2 && z1 == z2)
 			{
 				added = true;
 				(*ig).push_back(n);
 				break;
 			}
-			 
+
 		}
 		if (!added)
 		{
@@ -501,10 +501,10 @@ class Mesh
 			vec.push_back(n);
 			groupList.push_back(vec);
 		}
-		 
+
 		n++;
 	}
-	
+
 	//add average values
 	for (vector< vector<unsigned int> >::iterator ig = groupList.begin(); ig != groupList.end(); ++ig)
 	{
@@ -515,13 +515,13 @@ class Mesh
 			anx += triangleVertices[(*i)*stride+3];
 			any += triangleVertices[(*i)*stride+4];
 			anz += triangleVertices[(*i)*stride+5];
-			
+
 			count++;
 		}
 		anx /= count;
 		any /= count;
 		anz /= count;
-		
+
 		for (vector<unsigned int>::iterator i = (*ig).begin(); i != (*ig).end(); ++i)
 		{
 			triangleVertices[(*i)*stride+3] = anx;
@@ -531,15 +531,15 @@ class Mesh
 	}
   }
   */
-  
+
   void End()
   {
 	//NOTE: This batching only checks for degenerate primitives on triangle strips and fans since the GPU does not render triangles where the two
-	//vertices are exactly the same, triangle lists could also check for degenerates, it is unknown whether the GPU will render a degenerative 
+	//vertices are exactly the same, triangle lists could also check for degenerates, it is unknown whether the GPU will render a degenerative
 	//in a line strip primitive.
-	
+
 	unsigned stride = GetStride();
-	
+
 	// Primitive has ended so now we need to batch the vertices that were given into single lists, eg. line list, triangle list, point list
 	// Indices are optionally supplied, model functions can also be added for the end user to supply the indexing themselves for each primitive
 	// but the batching system does not care either way if they are not supplied it will automatically generate them.
@@ -645,16 +645,16 @@ class Mesh
 	vertices.clear();
 	indices.clear();
   }
-  
-  void DrawElements(GLenum mode, vector<VertexElement> &verts, vector<GLuint> &inds, GLsizei count) {
+
+  void DrawElements(GLenum mode, vector<VertexElement> &verts, vector<GLuint> &inds, GLsizei count, int vert_start = 0) {
 	if (!count) {
 		return;
 	}
-  
+
     // Calculate the number of bytes to get to the next vertex
 	GLsizei stride = GetStride() * sizeof( gs_scalar );
-	
-	#define OFFSET( P )  ( char* ) ( &verts[0] ) + ( ( sizeof( gs_scalar ) * ( P         ) ) ) 
+
+	#define OFFSET( P )  ( char* ) ( &verts[0] ) + ( ( sizeof( gs_scalar ) * ( P         ) ) )
 	GLsizei STRIDE = stride;
 
 	// Enable vertex array's for fast vertex processing
@@ -662,7 +662,7 @@ class Mesh
 	unsigned offset = 0;
 	glVertexPointer( vertexStride, GL_FLOAT, STRIDE, OFFSET(offset) ); // Set the vertex pointer
 	offset += vertexStride;
-	
+
     if (useNormals){
 		glEnableClientState(GL_NORMAL_ARRAY);
 		glNormalPointer( GL_FLOAT, STRIDE, OFFSET(offset) ); // Set the normal pointer to the offset in the array
@@ -674,24 +674,24 @@ class Mesh
 		glTexCoordPointer( 2, GL_FLOAT, STRIDE,  OFFSET(offset) ); // Set the texture pointer to the offset in the array
 		offset += 2;
 	}
-	
+
     if (useColors){
 		glEnableClientState(GL_COLOR_ARRAY);
         glColorPointer( 4, GL_UNSIGNED_BYTE, STRIDE, OFFSET(offset)); // Set the color pointer to the offset in the array
     }
-	
-	glDrawElements(mode, count, GL_UNSIGNED_INT, &inds[0]);
+
+	glDrawElements(mode, count, GL_UNSIGNED_INT, &inds[vert_start]);
   }
-  
-  void DrawArrays(GLenum mode, vector<VertexElement> &verts, GLsizei count) {
+
+  void DrawArrays(GLenum mode, vector<VertexElement> &verts, GLsizei count, int vert_start = 0) {
 	if (!count) {
 		return;
 	}
-  
+
     // Calculate the number of bytes to get to the next vertex
 	GLsizei stride = GetStride() * sizeof( gs_scalar );
-	
-	#define OFFSET( P )  ( char* ) ( &verts[0] ) + ( ( sizeof( gs_scalar ) * ( P         ) ) ) 
+
+	#define OFFSET( P )  ( char* ) ( &verts[0] ) + ( ( sizeof( gs_scalar ) * ( P         ) ) )
 	GLsizei STRIDE = stride;
 
 	// Enable vertex array's for fast vertex processing
@@ -699,7 +699,7 @@ class Mesh
 	unsigned offset = 0;
 	glVertexPointer( vertexStride, GL_FLOAT, STRIDE, OFFSET(offset) ); // Set the vertex pointer
 	offset += vertexStride;
-	
+
     if (useNormals){
 		glEnableClientState(GL_NORMAL_ARRAY);
 		glNormalPointer( GL_FLOAT, STRIDE, OFFSET(offset) ); // Set the normal pointer to the offset in the array
@@ -711,20 +711,21 @@ class Mesh
 		glTexCoordPointer( 2, GL_FLOAT, STRIDE,  OFFSET(offset) ); // Set the texture pointer to the offset in the array
 		offset += 2;
 	}
-	
+
     if (useColors){
 		glEnableClientState(GL_COLOR_ARRAY);
         glColorPointer( 4, GL_UNSIGNED_BYTE, STRIDE, OFFSET(offset)); // Set the color pointer to the offset in the array
     }
-	
-	glDrawArrays(mode, 0, count);
+
+	glDrawArrays(mode, vert_start, count);
   }
 
-  void Draw()
+  void Draw(int vertex_start = 0, int vertex_count = -1)
   {
+    //TODO: Right now vertex count override only works with triangles
 	// Draw the batched and indexed primitives
-	if (triangleIndexedCount > 0) { 
-		DrawElements(GL_TRIANGLES, triangleIndexedVertices, triangleIndices, triangleIndices.size());
+	if (triangleIndexedCount > 0) {
+		DrawElements(GL_TRIANGLES, triangleIndexedVertices, triangleIndices, (vertex_count==-1?triangleIndices.size():vertex_count), vertex_start);
 	}
 	if (lineIndexedCount > 0) {
 		DrawElements(GL_LINES, lineIndexedVertices, lineIndices, lineIndices.size());
@@ -732,10 +733,10 @@ class Mesh
 	if (pointIndexedCount > 0) {
 	    DrawElements(GL_POINTS, pointIndexedVertices, pointIndices, pointIndices.size());
 	}
-	
+
 	// Draw the unbatched and unindexed primitives
-	if (triangleCount > 0) { 
-		DrawArrays(GL_TRIANGLES, triangleVertices, triangleCount);
+	if (triangleCount > 0) {
+		DrawArrays(GL_TRIANGLES, triangleVertices, (vertex_count==-1?triangleCount:vertex_count), vertex_start);
 	}
 	if (lineCount > 0) {
 		DrawArrays(GL_LINES, lineVertices, lineCount);
@@ -743,7 +744,7 @@ class Mesh
 	if (pointCount > 0) {
 	    DrawArrays(GL_POINTS, pointVertices, pointCount);
 	}
-	
+
 	glDisableClientState(GL_VERTEX_ARRAY);
     if (useTextures) glDisableClientState(GL_TEXTURE_COORD_ARRAY);
     if (useNormals) glDisableClientState(GL_NORMAL_ARRAY);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -79,7 +79,7 @@ static inline void draw_back()
 			background_x[back_current] += background_hspeed[back_current];
 			background_y[back_current] += background_vspeed[back_current];
             if (background_htiled[back_current] || background_vtiled[back_current]) {
-                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], 
+                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current],
 					background_xscale[back_current], background_coloring[back_current], background_alpha[back_current], background_htiled[back_current], background_vtiled[back_current]);
             } else {
                 draw_background_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], background_xscale[back_current], 0, background_coloring[back_current], background_alpha[back_current]);
@@ -110,19 +110,22 @@ namespace enigma_user
 
 void screen_redraw()
 {
+    if (GLEW_EXT_framebuffer_object) {
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &enigma::FBO);
+    }
 	// Clean up any textures that ENIGMA may still think are binded but actually are not
 	texture_reset();
 	d3d_set_zwriteenable(true);
     if (!view_enabled)
     {
-        glViewport(0, 0, window_get_region_width_scaled(), window_get_region_height_scaled());
-        glLoadIdentity();
-        if (GLEW_EXT_framebuffer_object) {
-            glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &enigma::FBO);
-            glScalef(1, ((FBO==0||enigma::msaa_fbo!=0)?-1:1), 1);
-        } else {
-            glScalef(1, -1, 1);
+        if (FBO!=0){ //This fixes off-by-one error when rendering on surfaces. This should be checked to see if other GPU's have the same effect
+            glViewport(1, 1, window_get_region_width_scaled()+1, window_get_region_height_scaled()+1);
+        }else{
+            glViewport(0, 0, window_get_region_width_scaled(), window_get_region_height_scaled());
         }
+        glLoadIdentity();
+        glScalef(1, ((FBO==0||enigma::msaa_fbo!=0)?-1:1), 1);
+
         glOrtho(0, room_width, 0, room_height, 32000, -32000);
         glGetDoublev(GL_MODELVIEW_MATRIX,projection_matrix);
         glMultMatrixd(transformation_matrix);
@@ -280,14 +283,14 @@ void screen_redraw()
 				}
 			}
 
-			glViewport(view_xport[vc], view_yport[vc], window_get_region_width_scaled() - view_xport[vc], window_get_region_height_scaled() - view_yport[vc]);
+            if (FBO!=0){ //This fixes off-by-one error when rendering on surfaces. This should be checked to see if other GPU's have the same effect
+                glViewport(view_xport[vc]+1, view_yport[vc]+1, window_get_region_width_scaled() - view_xport[vc]+1, window_get_region_height_scaled() - view_yport[vc]+1);
+            }else{
+                glViewport(view_xport[vc], view_yport[vc], window_get_region_width_scaled() - view_xport[vc], window_get_region_height_scaled() - view_yport[vc]);
+            }
 			glLoadIdentity();
-			if (GLEW_EXT_framebuffer_object) {
-				glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &enigma::FBO);
-				glScalef(1, ((FBO==0||enigma::msaa_fbo!=0)?-1:1), 1);
-			} else {
-				glScalef(1, -1, 1);
-			}
+			glScalef(1, ((FBO==0||enigma::msaa_fbo!=0)?-1:1), 1);
+
 			glOrtho(int(view_xview[vc]), int(view_wview[vc] + view_xview[vc]), int(view_yview[vc]), int(view_hview[vc] + view_yview[vc]), 32000, -32000);
 			glGetDoublev(GL_MODELVIEW_MATRIX,projection_matrix);
 			glMultMatrixd(transformation_matrix);
@@ -423,7 +426,7 @@ void screen_redraw()
 		glBindFramebufferEXT(GL_DRAW_FRAMEBUFFER_EXT, fbo);
 		// glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, pixels);
 	}
-	
+
     ///TODO: screen_refresh() shouldn't be in screen_redraw(). They are separate functions for a reason.
     if (enigma::FBO == 0 || enigma::msaa_fbo != 0) { screen_refresh(); }
 }
@@ -435,7 +438,7 @@ void screen_init()
 
 	glClearColor(0,0,0,0);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-	
+
     if (!view_enabled)
     {
         glMatrixMode(GL_PROJECTION);
@@ -470,22 +473,22 @@ void screen_init()
             }
         }
     }
-	
+
 	glDisable(GL_DEPTH_TEST);
 	glEnable(GL_BLEND);
 	glEnable(GL_ALPHA_TEST);
 	glEnable(GL_TEXTURE_2D);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glAlphaFunc(GL_ALWAYS,0);
-	glBindTexture(GL_TEXTURE_2D,0);
+	texture_reset();
 	draw_set_color(c_white);
 }
 
 int screen_save(string filename) { //Assumes native integers are little endian
 	unsigned int w=window_get_width(),h=window_get_height(),sz=w*h;
-	
+
 	string ext = enigma::image_get_format(filename);
-	
+
 	unsigned char *rgbdata = new unsigned char[sz*4];
 	GLint prevFbo;
 	glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &prevFbo);
@@ -502,16 +505,16 @@ int screen_save(string filename) { //Assumes native integers are little endian
 	} else {
 		ret = image_save(filename, rgbdata, w, h, w, h);
 	}
-	
+
 	delete[] rgbdata;
 	return ret;
 }
 
 int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h) { //Assumes native integers are little endian
 	unsigned sz = w*h;
-	
+
 	string ext = enigma::image_get_format(filename);
-	
+
 	unsigned char *rgbdata = new unsigned char[sz*4];
 	GLint prevFbo;
 	glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &prevFbo);
@@ -519,7 +522,7 @@ int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h
  	glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
 	glReadPixels(x,window_get_region_height_scaled()-h-y,w,h, GL_RGBA, GL_UNSIGNED_BYTE, rgbdata);
 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
-	
+
 	int ret;
 	if (ext == ".png") {
 		unsigned char* data = image_reverse_scanlines(rgbdata, w, h, 4);
@@ -528,7 +531,7 @@ int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h
 	} else {
 		ret = image_save(filename, rgbdata, w, h, w, h);
 	}
-	
+
 	delete[] rgbdata;
 	return ret;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtiles.cpp
@@ -100,7 +100,7 @@ namespace enigma
     {
         glPushAttrib(GL_CURRENT_BIT);
         enigma_user::texture_reset();
-        for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++)
+        for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++){
             if (dit->second.tiles.size())
             {
                 if (dit->second.tiles[0].depth != layer_depth)
@@ -117,7 +117,9 @@ namespace enigma
                     draw_tile(t.bckid, t.bgx, t.bgy, t.width, t.height, t.roomX, t.roomY, t.xscale, t.yscale, t.color, t.alpha);
                 }
                 glEndList();
+                break;
             }
+        }
         glPopAttrib();
     }
 }
@@ -125,7 +127,7 @@ namespace enigma
 namespace enigma_user
 {
 
-int tile_add(int background, int left, int top, int width, int height, int x, int y, int depth, int alpha, int color)
+int tile_add(int background, int left, int top, int width, int height, int x, int y, int depth, double xscale, double yscale, double alpha, int color)
 {
     enigma::tile *ntile = new enigma::tile;
     ntile->id = enigma::maxtileid++;
@@ -137,6 +139,8 @@ int tile_add(int background, int left, int top, int width, int height, int x, in
     ntile->roomX = x;
     ntile->roomY = y;
     ntile->depth = depth;
+    ntile->xscale = xscale;
+    ntile->yscale = yscale;
     ntile->alpha = alpha;
     ntile->color = color;
     enigma::drawing_depths[ntile->depth].tiles.push_back(*ntile);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3ModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3ModelStruct.h
@@ -43,7 +43,7 @@ unsigned get_texture(int texid);
 extern GLenum ptypes_by_id[16];
 namespace enigma {
   extern unsigned char currentcolor[4];
-  
+
   //split a string and convert to float
   vector<float> float_split(const string& str, const char& ch) {
     string next;
@@ -74,7 +74,7 @@ namespace enigma {
 	bool trimmed = false;
 	bool checknormal = false;
 	for (unsigned int i = 0; i < s->size() ; i++)
-	{ 
+	{
 		//comment
 		if ((*s)[i] == '#')
 		{
@@ -130,7 +130,7 @@ namespace enigma {
 union VertexElement {
 	unsigned long d;
 	gs_scalar f;
-	
+
 	VertexElement(gs_scalar v): f(v) {}
 	VertexElement(unsigned long v): d(v) {}
 };
@@ -152,32 +152,32 @@ class Mesh
   vector<VertexElement> pointVertices; // The vertices added to point primitives batched into a single point list to be buffered to the GPU
   vector<VertexElement> pointIndexedVertices; // The vertices added to indexed point primitives batched into a single point list to be buffered to the GPU
   vector<GLuint> pointIndices; // The point indices either concatenated by batching or supplied in the temporary container.
-  
+
   unsigned vertexStride; // whether the vertices are 2D or 3D
   bool useColors; // If colors have been added to the model
   bool useTextures; // If texture coordinates have been added
   bool useNormals; // If normals have been added
-  
+
   unsigned pointCount; // The number of vertices in the point buffer
   unsigned triangleCount; // The number of vertices in the triangle buffer
   unsigned lineCount; // The number of vertices in the line buffer
-  
+
   unsigned indexedoffset; // The number of indexed vertices
   unsigned pointIndexedCount; // The number of point indices
   unsigned triangleIndexedCount; // The number of triangle indices
   unsigned lineIndexedCount; // The number of line indices
-  
+
   // Indexed primitives are first since the indices must be offset, and keeps them as small as possible.
   // INDEXEDTRIANGLES|INDEXEDLINES|INDEXEDPOINTS|TRIANGLES|LINES|POINTS
   GLuint vertexBuffer; // Interleaved vertex buffer object with triangles first since they are most likely to be used
   GLuint indexBuffer; // Interleaved index buffer object with triangles first since they are most likely to be used
-  
+
   bool vbodynamic; // Whether or not the buffer should be prepared for dynamic memory usage, eg. constantly changing vertex data
   bool ibogenerated;
   bool vbogenerated;
   bool vbobuffered; // Whether or not the buffer objects have been generated
   bool vboindexed; // Whether or not the model contains any indexed primitives or just regular lists
-  
+
   Mesh (bool dynamic)
   {
 	triangleIndexedVertices.reserve(64000);
@@ -191,27 +191,27 @@ class Mesh
 	triangleIndices.reserve(64000);
 	vertices.reserve(64000);
 	indices.reserve(64000);
-  
+
 	vbodynamic = false;
 	ibogenerated = false;
 	vbogenerated = false;
     vbobuffered = false;
 	vboindexed = false;
-	
+
 	vertexStride = 0;
     useColors = false;
     useTextures = false;
     useNormals = false;
-	
+
 	pointCount = 0;
 	triangleCount = 0;
 	lineCount = 0;
-	
+
 	indexedoffset = 0;
 	pointIndexedCount = 0;
 	triangleIndexedCount = 0;
 	lineIndexedCount = 0;
-	
+
     currentPrimitive = 0;
   }
 
@@ -239,7 +239,7 @@ class Mesh
   void Clear()
   {
     ClearData();
-	
+
 	triangleIndexedVertices.reserve(64000);
 	pointIndexedVertices.reserve(64000);
 	lineIndexedVertices.reserve(64000);
@@ -254,12 +254,12 @@ class Mesh
 
     vbobuffered = false;
 	vboindexed = false;
-	
+
 	vertexStride = 0;
 	useColors = false;
     useTextures = false;
     useNormals = false;
-	
+
 	pointCount = 0;
 	triangleCount = 0;
 	lineCount = 0;
@@ -268,7 +268,7 @@ class Mesh
 	triangleIndexedCount = 0;
 	lineIndexedCount = 0;
   }
-  
+
   unsigned GetStride() {
   	unsigned stride = vertexStride;
     if (useNormals) stride += 3;
@@ -276,7 +276,7 @@ class Mesh
     if (useColors) stride += 1;
 	return stride;
   }
-  
+
   void Begin(int pt)
   {
     vbobuffered = false;
@@ -294,7 +294,7 @@ class Mesh
     vertices.push_back(x); vertices.push_back(y); vertices.push_back(z);
 	vertexStride = 3;
   }
-  
+
   void AddIndex(unsigned ind)
   {
     indices.push_back(ind);
@@ -311,14 +311,14 @@ class Mesh
     vertices.push_back(tx); vertices.push_back(ty);
 	useTextures = true;
   }
-  
+
   void AddColor(int col, double alpha)
-  {               
-	unsigned long final = col + ((unsigned char)alpha*255 << 24);
-	vertices.push_back(final); 
+  {
+	unsigned long final = col + ((unsigned char)(alpha*255) << 24);
+	vertices.push_back(final);
 	useColors = true;
   }
-  
+
   void Translate(gs_scalar x, gs_scalar y, gs_scalar z)
   {
 	unsigned int stride = GetStride();
@@ -330,7 +330,7 @@ class Mesh
 		triangleVertices[i+2].f += z;
 	}
   }
-     
+
   void RotateUV(gs_scalar angle)
   {
 	unsigned int stride = GetStride();
@@ -346,7 +346,7 @@ class Mesh
 		triangleVertices[i + 4 + 3*useNormals].f = x*_sin - y*_cos;
 	}
   }
-  
+
   /*
   void ScaleUV(gs_scalar xscale, gs_scalar yscale)
   {
@@ -359,7 +359,7 @@ class Mesh
 	}
   }
   */
-   
+
   void RotateX(gs_scalar angle)
   {
 	unsigned int stride = GetStride();
@@ -375,8 +375,8 @@ class Mesh
 		triangleVertices[i+2].f = y*_sin - z*_cos;
 	}
   }
-  
-  
+
+
   void RotateY(gs_scalar angle)
   {
 	unsigned int stride = GetStride();
@@ -392,7 +392,7 @@ class Mesh
 		triangleVertices[i+2].f = z*_cos - x*_sin;
 	}
   }
-  
+
   void RotateZ(gs_scalar angle)
   {
 	unsigned int stride = GetStride();
@@ -408,7 +408,7 @@ class Mesh
 		triangleVertices[i+1].f = x*_sin - y*_cos;
 	}
   }
-  
+
   /*
   void Scale(gs_scalar xscale, gs_scalar yscale, gs_scalar zscale)
   {
@@ -422,12 +422,12 @@ class Mesh
 	}
   }
   */
-  
+
   /*
   bool CalculateNormals(bool smooth, bool invert)
   {
 	unsigned int stride = GetStride();
-	
+
 	int oft = useNormals * 3;
 	int ofc = oft + useTextures * 2 ;
 	vector<gs_scalar> tempVertices;
@@ -441,11 +441,11 @@ class Mesh
 		gs_scalar x2 = *(i +stride);
 		gs_scalar y2 = *(i+1 +stride);
 		gs_scalar z2 = *(i+2 +stride);
-		
+
 		gs_scalar x3 = *(i +stride*2);
 		gs_scalar y3 = *(i+1 +stride*2);
 		gs_scalar z3 = *(i+2 +stride*2);
-		
+
 		gs_scalar nX = (y2-y1)*(z3-z1)-(y3-y1)*(z2-z1);
 		gs_scalar nY = (z2-z1)*(x3-x1)-(z3-z1)*(x2-x1);
 		gs_scalar nZ = (x2-x1)*(y3-y1)-(x3-x1)*(y2-y1);
@@ -453,7 +453,7 @@ class Mesh
 		nX /= m;
 		nY /= m;
 		nZ /= m;
-		
+
 		for(int n = 0; n < 3; n++)
 		{
 			int v = n*stride;
@@ -495,7 +495,7 @@ class Mesh
   void SmoothNormals()
   {
 	unsigned int stride = GetStride();
-	
+
 	vector<vector<unsigned int> > groupList;
 	unsigned int n = 0;
 	//group all vertices
@@ -504,25 +504,25 @@ class Mesh
 		gs_scalar x1 = *(i+0);
 		gs_scalar y1 = *(i+1);
 		gs_scalar z1 = *(i+2);
-		
+
 		bool added = false;
-		//check each group 
+		//check each group
 		if (groupList.size() > 0)
 		for (vector< vector<unsigned int> >::iterator ig = groupList.begin(); ig != groupList.end(); ++ig)
 		{
-			
+
 			//compute first element and add it if has the same position
 			unsigned int index = (*ig)[0];
 			gs_scalar x2 = triangleVertices[index*stride + 0];
 			gs_scalar y2 = triangleVertices[index*stride + 1];
-			gs_scalar z2 = triangleVertices[index*stride + 2]; 
+			gs_scalar z2 = triangleVertices[index*stride + 2];
 			if( x1 == x2 && y1 == y2 && z1 == z2)
 			{
 				added = true;
 				(*ig).push_back(n);
 				break;
 			}
-			 
+
 		}
 		if (!added)
 		{
@@ -530,10 +530,10 @@ class Mesh
 			vec.push_back(n);
 			groupList.push_back(vec);
 		}
-		 
+
 		n++;
 	}
-	
+
 	//add average values
 	for (vector< vector<unsigned int> >::iterator ig = groupList.begin(); ig != groupList.end(); ++ig)
 	{
@@ -544,13 +544,13 @@ class Mesh
 			anx += triangleVertices[(*i)*stride+3];
 			any += triangleVertices[(*i)*stride+4];
 			anz += triangleVertices[(*i)*stride+5];
-			
+
 			count++;
 		}
 		anx /= count;
 		any /= count;
 		anz /= count;
-		
+
 		for (vector<unsigned int>::iterator i = (*ig).begin(); i != (*ig).end(); ++i)
 		{
 			triangleVertices[(*i)*stride+3] = anx;
@@ -563,11 +563,11 @@ class Mesh
   void End()
   {
 	//NOTE: This batching only checks for degenerate primitives on triangle strips and fans since the GPU does not render triangles where the two
-	//vertices are exactly the same, triangle lists could also check for degenerates, it is unknown whether the GPU will render a degenerative 
+	//vertices are exactly the same, triangle lists could also check for degenerates, it is unknown whether the GPU will render a degenerative
 	//in a line strip primitive.
-	
+
 	unsigned stride = GetStride();
-	
+
 	// Primitive has ended so now we need to batch the vertices that were given into single lists, eg. line list, triangle list, point list
 	// Indices are optionally supplied, model functions can also be added for the end user to supply the indexing themselves for each primitive
 	// but the batching system does not care either way if they are not supplied it will automatically generate them.
@@ -675,19 +675,19 @@ class Mesh
   {
 	vector<VertexElement> vdata;
 	vector<GLuint> idata;
-	
+
 	vdata.reserve(triangleVertices.size() + lineVertices.size() + pointVertices.size() + triangleIndexedVertices.size() + lineIndexedVertices.size() + pointIndexedVertices.size());
 	idata.reserve(triangleIndices.size() + lineIndices.size() + pointIndices.size());
-	
+
 	unsigned interleave = 0;
-	
+
 	triangleIndexedCount = triangleIndices.size();
 	if (triangleIndexedCount > 0) {
 		vdata.insert(vdata.end(), triangleIndexedVertices.begin(), triangleIndexedVertices.end());
 		idata.insert(idata.end(), triangleIndices.begin(), triangleIndices.end());
 		interleave += triangleIndexedVertices.size()/GetStride();
 	}
-	
+
 	lineIndexedCount = lineIndices.size();
 	if (lineIndexedCount > 0) {
 		vdata.insert(vdata.end(), lineIndexedVertices.begin(), lineIndexedVertices.end());
@@ -695,18 +695,18 @@ class Mesh
 		idata.insert(idata.end(), lineIndices.begin(), lineIndices.end());
 		interleave += lineIndexedVertices.size()/GetStride();
 	}
-	
+
 	pointIndexedCount = pointIndices.size();
 	if (pointIndexedCount > 0) {
 		vdata.insert(vdata.end(), pointIndexedVertices.begin(), pointIndexedVertices.end());
 		for (std::vector<GLuint>::iterator it = lineIndices.begin(); it != lineIndices.end(); ++it) { *it += interleave; }
 		idata.insert(idata.end(), pointIndices.begin(), pointIndices.end());
 	}
-	
+
 	if (idata.size() > 0) {
 		vboindexed = true;
 		indexedoffset += vdata.size();
-		
+
 		if (!ibogenerated) {
 			glGenBuffersARB( 1, &indexBuffer );
 			ibogenerated = true;
@@ -714,7 +714,7 @@ class Mesh
 			glBufferDataARB( GL_ELEMENT_ARRAY_BUFFER, idata.size() * sizeof(GLuint), &idata[0], vbodynamic ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW );
 		} else {
 			glBindBufferARB( GL_ELEMENT_ARRAY_BUFFER, indexBuffer );
-			
+
 			GLint nBufferSize = 0;
 			glGetBufferParameteriv(GL_ELEMENT_ARRAY_BUFFER, GL_BUFFER_SIZE, &nBufferSize);
 			if (idata.size() * sizeof(GLuint) / nBufferSize > 0.5 ) {
@@ -731,15 +731,15 @@ class Mesh
 	} else {
 		vboindexed = false;
 	}
-	
+
 	if (triangleCount > 0) {
 		vdata.insert(vdata.end(), triangleVertices.begin(), triangleVertices.end());
 	}
-	
+
 	if (lineCount > 0) {
 		vdata.insert(vdata.end(), lineVertices.begin(), lineVertices.end());
 	}
-	
+
 	if (pointCount > 0) {
 		vdata.insert(vdata.end(), pointVertices.begin(), pointVertices.end());
 	}
@@ -751,7 +751,7 @@ class Mesh
 		glBufferDataARB( GL_ARRAY_BUFFER, vdata.size() * sizeof(gs_scalar), &vdata[0], vbodynamic ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW );
 	} else {
 		glBindBufferARB( GL_ARRAY_BUFFER, vertexBuffer );
-		
+
 		GLint nBufferSize = 0;
 		glGetBufferParameteriv(GL_ARRAY_BUFFER, GL_BUFFER_SIZE, &nBufferSize);
 		if (vdata.size() * sizeof(gs_scalar) / nBufferSize > 0.5 ) {
@@ -760,26 +760,26 @@ class Mesh
 			glBufferSubDataARB( GL_ARRAY_BUFFER, 0, vdata.size() * sizeof(gs_scalar), &vdata[0]);
 		}
 	}
-	
+
 	// Unbind the buffer we do not need anymore
 	glBindBufferARB( GL_ARRAY_BUFFER, 0 );
 	// Clean up temporary interleaved data
 	vdata.clear();
-	
+
     // Clean up the data from RAM it is now safe on VRAM
     ClearData();
   }
 
-  void Draw()
+  void Draw(int vertex_start = 0, int vertex_count = -1)
   {
 	if (!GetStride()) { return; }
     if (!vbogenerated || !vbobuffered) {
 	  vbobuffered = true;
       BufferGenerate();
     }
-  
+
 	GLsizei stride = GetStride();
-	
+
 	#define OFFSET( P )  ( ( const GLvoid * ) ( sizeof( gs_scalar ) * ( P         ) ) )
 	GLsizei STRIDE = stride * sizeof( gs_scalar );
 
@@ -793,7 +793,7 @@ class Mesh
 	unsigned offset = 0;
 	glVertexPointer( vertexStride, GL_FLOAT, STRIDE, OFFSET(offset) ); // Set the vertex pointer to the offset in the buffer
 	offset += vertexStride;
-	
+
     if (useNormals){
 		glEnableClientState(GL_NORMAL_ARRAY);
 		glNormalPointer( GL_FLOAT, STRIDE, OFFSET(offset) ); // Set the normal pointer to the offset in the buffer
@@ -805,18 +805,18 @@ class Mesh
 		glTexCoordPointer( 2, GL_FLOAT, STRIDE, OFFSET(offset) ); // Set the texture pointer to the offset in the buffer
 		offset += 2;
 	}
-	
+
     if (useColors){
 		glEnableClientState(GL_COLOR_ARRAY);
         glColorPointer( 4, GL_UNSIGNED_BYTE, STRIDE, OFFSET(offset)); // Set The Color Pointer To The Color Buffer
     }
 
 	#define OFFSETE( P )  ( ( const GLvoid * ) ( sizeof( GLuint ) * ( P         ) ) )
-	offset = 0;
-	
+	offset = vertex_start;
+
 	// Draw the indexed primitives
-	if (triangleIndexedCount > 0) { 
-		glDrawElements(GL_TRIANGLES, triangleIndexedCount, GL_UNSIGNED_INT, OFFSETE(offset));
+	if (triangleIndexedCount > 0) {
+		glDrawElements(GL_TRIANGLES, (vertex_count==-1?triangleIndexedCount:vertex_count), GL_UNSIGNED_INT, OFFSETE(offset));
 		offset += triangleIndexedCount;
 	}
 	if (lineIndexedCount > 0) {
@@ -826,12 +826,12 @@ class Mesh
 	if (pointIndexedCount > 0) {
 		glDrawElements(GL_POINTS, pointIndexedCount, GL_UNSIGNED_INT, OFFSETE(offset));
 	}
-	
+
 	offset = indexedoffset/stride;
 
 	// Draw the unindexed primitives
-	if (triangleCount > 0) { 
-		glDrawArrays(GL_TRIANGLES, offset, triangleCount);
+	if (triangleCount > 0) {
+		glDrawArrays(GL_TRIANGLES, (vertex_start==0?offset:vertex_start), (vertex_count==-1?triangleCount:vertex_count));
 		offset += triangleCount;
 	}
 	if (lineCount > 0) {
@@ -841,12 +841,12 @@ class Mesh
 	if (pointCount > 0) {
 		glDrawArrays(GL_POINTS, offset, pointCount);
 	}
-	
+
 	glBindBufferARB( GL_ARRAY_BUFFER, 0 );
 	if (vboindexed) {
 		glBindBufferARB( GL_ELEMENT_ARRAY_BUFFER, 0 );
 	}
-	
+
 	glDisableClientState(GL_VERTEX_ARRAY);
     if (useTextures) glDisableClientState(GL_TEXTURE_COORD_ARRAY);
     if (useNormals) glDisableClientState(GL_NORMAL_ARRAY);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3blend.cpp
@@ -17,11 +17,13 @@
 
 #include "../General/OpenGLHeaders.h"
 #include "../General/GSblend.h"
+#include "Bridges/General/GL3Context.h"
 
 namespace enigma_user
 {
 
 int draw_set_blend_mode(int mode){
+    oglmgr->BlendFunc();
 	switch (mode)
 	{
     case bm_add:
@@ -40,6 +42,7 @@ int draw_set_blend_mode(int mode){
 }
 
 int draw_set_blend_mode_ext(int src, int dest){
+    oglmgr->BlendFunc();
 	const static GLenum blendequivs[11] = {
 	  GL_ZERO, GL_ONE, GL_SRC_COLOR, GL_ONE_MINUS_SRC_COLOR, GL_SRC_ALPHA,
 	  GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_DST_COLOR,

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -42,7 +42,7 @@ namespace enigma {
 double projection_matrix[16] = {1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1}, transformation_matrix[16] = {1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1};
 
 GLenum renderstates[6] = {
-  GL_FRONT, GL_BACK, GL_FRONT_AND_BACK, 
+  GL_FRONT, GL_BACK, GL_FRONT_AND_BACK,
   GL_NICEST, GL_FASTEST, GL_DONT_CARE
 };
 
@@ -222,7 +222,7 @@ void d3d_set_line_width(float value) {
 
 void d3d_set_point_size(float value) {
   glPointSize(value);
-} 
+}
 
 void d3d_set_depth_operator(int mode) {
   glDepthFunc(depthoperators[mode]);
@@ -320,127 +320,140 @@ void d3d_set_projection_perspective(gs_scalar x, gs_scalar y, gs_scalar width, g
 
 void d3d_transform_set_identity()
 {
-  transformation_matrix[0] = 1;
-  transformation_matrix[1] = 0;
-  transformation_matrix[2] = 0;
-  transformation_matrix[3] = 0;
-  transformation_matrix[4] = 0;
-  transformation_matrix[5] = 1;
-  transformation_matrix[6] = 0;
-  transformation_matrix[7] = 0;
-  transformation_matrix[8] = 0;
-  transformation_matrix[9] = 0;
-  transformation_matrix[10] = 1;
-  transformation_matrix[11] = 0;
-  transformation_matrix[12] = 0;
-  transformation_matrix[13] = 0;
-  transformation_matrix[14] = 0;
-  transformation_matrix[15] = 1;
-  glLoadMatrixd(projection_matrix);
+    oglmgr->Transformation();
+    transformation_matrix[0] = 1;
+    transformation_matrix[1] = 0;
+    transformation_matrix[2] = 0;
+    transformation_matrix[3] = 0;
+    transformation_matrix[4] = 0;
+    transformation_matrix[5] = 1;
+    transformation_matrix[6] = 0;
+    transformation_matrix[7] = 0;
+    transformation_matrix[8] = 0;
+    transformation_matrix[9] = 0;
+    transformation_matrix[10] = 1;
+    transformation_matrix[11] = 0;
+    transformation_matrix[12] = 0;
+    transformation_matrix[13] = 0;
+    transformation_matrix[14] = 0;
+    transformation_matrix[15] = 1;
+    glLoadMatrixd(projection_matrix);
 }
 
 void d3d_transform_add_translation(gs_scalar xt, gs_scalar yt, gs_scalar zt)
 {
-  glLoadIdentity();
-  glTranslatef(xt, yt, zt);
-  glMultMatrixd(transformation_matrix);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glTranslatef(xt, yt, zt);
+    glMultMatrixd(transformation_matrix);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_add_scaling(gs_scalar xs, gs_scalar ys, gs_scalar zs)
 {
-  glLoadIdentity();
-  glScalef(xs, ys, zs);
-  glMultMatrixd(transformation_matrix);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glScalef(xs, ys, zs);
+    glMultMatrixd(transformation_matrix);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_add_rotation_x(double angle)
 {
-  glLoadIdentity();
-  glRotatef(-angle,1,0,0);
-  glMultMatrixd(transformation_matrix);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glRotatef(-angle,1,0,0);
+    glMultMatrixd(transformation_matrix);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_add_rotation_y(double angle)
 {
-  glLoadIdentity();
-  glRotatef(-angle,0,1,0);
-  glMultMatrixd(transformation_matrix);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glRotatef(-angle,0,1,0);
+    glMultMatrixd(transformation_matrix);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_add_rotation_z(double angle)
 {
-  glLoadIdentity();
-  glRotatef(-angle,0,0,1);
-  glMultMatrixd(transformation_matrix);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glRotatef(-angle,0,0,1);
+    glMultMatrixd(transformation_matrix);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_add_rotation_axis(gs_scalar x, gs_scalar y, gs_scalar z, double angle)
 {
-  glLoadIdentity();
-  glRotatef(-angle,x,y,z);
-  glMultMatrixd(transformation_matrix);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glRotatef(-angle,x,y,z);
+    glMultMatrixd(transformation_matrix);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 
 void d3d_transform_set_translation(gs_scalar xt, gs_scalar yt, gs_scalar zt)
 {
-  glLoadIdentity();
-  glTranslatef(xt, yt, zt);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glTranslatef(xt, yt, zt);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_set_scaling(gs_scalar xs, gs_scalar ys, gs_scalar zs)
 {
-  glLoadIdentity();
-  glScalef(xs, ys, zs);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glScalef(xs, ys, zs);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_set_rotation_x(double angle)
 {
-  glLoadIdentity();
-  glRotatef(-angle,1,0,0);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glRotatef(-angle,1,0,0);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_set_rotation_y(double angle)
 {
-  glLoadIdentity();
-  glRotatef(-angle,0,1,0);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glRotatef(-angle,0,1,0);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_set_rotation_z(double angle)
 {
-  glLoadIdentity();
-  glRotatef(-angle,0,0,1);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glRotatef(-angle,0,0,1);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 void d3d_transform_set_rotation_axis(gs_scalar x, gs_scalar y, gs_scalar z, double angle)
 {
-  glLoadIdentity();
-  glRotatef(-angle,x,y,z);
-  glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
-  glLoadMatrixd(projection_matrix);
-  glMultMatrixd(transformation_matrix);
+    oglmgr->Transformation();
+    glLoadIdentity();
+    glRotatef(-angle,x,y,z);
+    glGetDoublev(GL_MODELVIEW_MATRIX,transformation_matrix);
+    glLoadMatrixd(projection_matrix);
+    glMultMatrixd(transformation_matrix);
 }
 
 }
@@ -455,6 +468,7 @@ namespace enigma_user
 bool d3d_transform_stack_push()
 {
     if (trans_stack_size == 31) return false;
+    oglmgr->Transformation();
     glPushMatrix();
     trans_stack.push(1);
     trans_stack_size++;
@@ -464,6 +478,7 @@ bool d3d_transform_stack_push()
 bool d3d_transform_stack_pop()
 {
     if (trans_stack_size == 0) return false;
+    oglmgr->Transformation();
     while (trans_stack.top() == 0)
     {
         glPopMatrix();
@@ -475,6 +490,7 @@ bool d3d_transform_stack_pop()
 
 void d3d_transform_stack_clear()
 {
+    oglmgr->Transformation();
     do
       glPopMatrix();
     while (trans_stack_size--);
@@ -489,6 +505,7 @@ bool d3d_transform_stack_empty()
 bool d3d_transform_stack_top()
 {
     if (trans_stack_size == 0) return false;
+    oglmgr->Transformation();
     while (trans_stack.top() == 0)
     {
         glPopMatrix();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3model.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3model.cpp
@@ -102,37 +102,37 @@ bool d3d_model_load(int id, string fname)
 {
   //TODO: this needs to be rewritten properly not using the file_text functions
   using namespace enigma_user;
-  
+
   int file = file_text_open_read(fname);
-  
+
   if (file == -1) {
 	return false;
   }
-  
+
   string fileExt = fname.substr(fname.find_last_of(".") + 1) ;
   if (fileExt == "obj")
   {
 	vector< float > vertices;
 	vector< float > uvs;
 	vector< float > normals;
-	
+
 	int faceCount = 0;
 	bool hasTexture = false;
 	bool hasNormals = false;
 	meshes[id]->Begin(pr_trianglelist);
-	
+
 	while (!file_text_eof(file))
 	{
 		string line = file_text_read_string(file);
 		file_text_readln(file);
-		enigma::string_parse(&line); 
+		enigma::string_parse(&line);
 		if (line.length() > 0)
 		{
 			if(line[0] == 'v')
 			{
 				vector<float> floats = enigma::float_split(line, ' ');
 				floats.erase( floats.begin());
-					
+
 				int n = 0;
 				switch(line[1])
 				{
@@ -168,45 +168,45 @@ bool d3d_model_load(int id, string fname)
 			}
 			else if(line[0] == 'f')
 			{
-				faceCount++; 
+				faceCount++;
 				vector<float> f = enigma::float_split(line, ' ');
 				f.erase( f.begin());
 				int faceVertices = f.size() / (1 + hasTexture + hasNormals);
 				int of = 1 + hasTexture + hasNormals;
-				
+
 				meshes[id]->AddVertex(vertices[(f[0]-1)*3],  vertices[(f[0]-1)*3 +1], vertices[(f[0]-1)*3 +2]);
 				if(hasNormals) meshes[id]->AddNormal(normals[(f[2]-1)*3], normals[(f[2]-1)*3 +1], normals[(f[2]-1)*3 +2]);
 				if(hasTexture) meshes[id]->AddTexture(uvs[(f[1]-1)*2], 1 - uvs[(f[1]-1)*2 +1]);
-				
+
 				meshes[id]->AddVertex(vertices[(f[1*of]-1)*3],  vertices[(f[1*of]-1)*3 +1] , vertices[(f[1*of]-1)*3 +2]);
 				if(hasNormals) meshes[id]->AddNormal(normals[(f[1*of + 2]-1)*3], normals[(f[1*of  + 2]-1)*3 +1], normals[(f[1*of  + 2]-1)*3 +2]);
 				if(hasTexture) meshes[id]->AddTexture(uvs[(f[1*of + 1]-1)*2], 1 - uvs[(f[1*of + 1]-1)*2 +1]);
-				
+
 				meshes[id]->AddVertex(vertices[(f[2*of]-1)*3],  vertices[(f[2*of]-1)*3 +1] , vertices[(f[2*of]-1)*3 +2]);
 				if(hasNormals) meshes[id]->AddNormal(normals[(f[2*of + 2]-1)*3], normals[(f[2*of  + 2]-1)*3 +1], normals[(f[2*of  + 2]-1)*3 +2]);
 				if(hasTexture) meshes[id]->AddTexture(uvs[(f[2*of + 1]-1)*2], 1 - uvs[(f[2*of + 1]-1)*2 +1]);
-				
+
 				//is a quad
 				if(faceVertices == 4)
 				{
 					meshes[id]->AddVertex(vertices[(f[2*of]-1)*3],  vertices[(f[2*of]-1)*3 +1] , vertices[(f[2*of]-1)*3 +2]);
 					if(hasNormals) meshes[id]->AddNormal(normals[(f[2*of + 2]-1)*3], normals[(f[2*of  + 2]-1)*3 +1], normals[(f[2*of  + 2]-1)*3 +2]);
 					if(hasTexture) meshes[id]->AddTexture(uvs[(f[2*of + 1]-1)*2], 1 - uvs[(f[2*of + 1]-1)*2 +1]);
-					
+
 					meshes[id]->AddVertex( vertices[(f[3*of]-1)*3],  vertices[(f[3*of]-1)*3 +1] , vertices[(f[3*of]-1)*3 +2]);
 					if(hasNormals) meshes[id]->AddNormal(normals[(f[3*of + 2]-1)*3], normals[(f[3*of  + 2]-1)*3 +1], normals[(f[3*of  + 2]-1)*3 +2]);
 					if(hasTexture) meshes[id]->AddTexture(uvs[(f[3*of + 1]-1)*2], 1 - uvs[(f[3*of + 1]-1)*2 +1]);
-					
+
 					meshes[id]->AddVertex(vertices[(f[0]-1)*3],  vertices[(f[0]-1)*3 +1], vertices[(f[0]-1)*3 +2]);
 					if(hasNormals) meshes[id]->AddNormal(normals[(f[2]-1)*3], normals[(f[2]-1)*3 +1], normals[(f[2]-1)*3 +2]);
 					if(hasTexture) meshes[id]->AddTexture(uvs[(f[0 + 1]-1)*2], 1 - uvs[(f[0 + 1]-1)*2 +1]);
 				}
-				
-			}	
+
+			}
 		}
 	}
-	meshes[id]->End();  
-	
+	meshes[id]->End();
+
   }
   else
   {
@@ -333,6 +333,32 @@ bool d3d_model_calculate_normals(int id, bool smooth, bool invert)
  // return meshes[id]->CalculateNormals(smooth, invert);
 }
 
+void d3d_model_part_draw(int id, int vertex_start, int vertex_count) // overload for no additional texture or transformation call's
+{
+    meshes[id]->Draw(vertex_start, vertex_count);
+}
+
+void d3d_model_part_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int vertex_start, int vertex_count) // overload for no additional texture call's
+{
+    glTranslatef(x, y, z);
+    meshes[id]->Draw(vertex_start, vertex_count);
+    glTranslatef(-x, -y, -z);
+}
+
+void d3d_model_part_draw(int id, int texId, int vertex_start, int vertex_count)
+{
+    texture_set(get_texture(texId));
+    meshes[id]->Draw(vertex_start, vertex_count);
+}
+
+void d3d_model_part_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int texId, int vertex_start, int vertex_count)
+{
+    texture_set(get_texture(texId));
+    glTranslatef(x, y, z);
+    meshes[id]->Draw(vertex_start, vertex_count);
+    glTranslatef(-x, -y, -z);
+}
+
 void d3d_model_draw(int id) // overload for no additional texture or transformation call's
 {
     meshes[id]->Draw();
@@ -354,7 +380,9 @@ void d3d_model_draw(int id, int texId)
 void d3d_model_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int texId)
 {
     texture_set(get_texture(texId));
-    d3d_model_draw(id, x, y, z);
+    glTranslatef(x, y, z);
+    meshes[id]->Draw();
+    glTranslatef(-x, -y, -z);
 }
 
 void d3d_model_primitive_begin(int id, int kind)
@@ -454,7 +482,7 @@ void d3d_model_floor(int id, gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar
   gs_scalar nX = (y2-y1)*(z2-z1)*(z2-z1);
   gs_scalar nY = (z2-z1)*(x2-x1)*(x2-x1);
   gs_scalar nZ = (x2-x1)*(y2-y1)*(y2-y1);
-  
+
   gs_scalar  m = sqrt(nX*nX + nY*nY + nZ*nZ);
   nX /= m; nY /= m; nZ /= m;
 
@@ -471,7 +499,7 @@ void d3d_model_wall(int id, gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar 
   gs_scalar nX = (y2-y1)*(z2-z1)*(z2-z1);
   gs_scalar nY = (z2-z1)*(x2-x1)*(x2-x1);
   gs_scalar nZ = (x2-x1)*(y2-y1)*(y2-y1);
-  
+
   gs_scalar  m = sqrt(nX*nX + nY*nY + nZ*nZ);
   nX /= m; nY /= m; nZ /= m;
 
@@ -502,7 +530,7 @@ void d3d_model_block(int id, gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar
 	d3d_model_vertex_normal_texture( id, x2,y2,z2, 1,0,0, 0,0 );
 	d3d_model_vertex_normal_texture( id, x2,y1,z2, 1,0,0, 1,0 );
 	d3d_model_primitive_end( id );
-	
+
 	// Negative Y
 	d3d_model_primitive_begin( id, pr_trianglefan );
 	d3d_model_vertex_normal_texture( id, x1,y1,z1, 0,-1,0, 0,1 );
@@ -518,7 +546,7 @@ void d3d_model_block(int id, gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar
 	d3d_model_vertex_normal_texture( id, x2,y2,z2, 0,1,0, 0,0 );
 	d3d_model_vertex_normal_texture( id, x2,y2,z1, 0,1,0, 0,1 );
 	d3d_model_primitive_end( id );
-	
+
 	if (closed) {
 		// Negative Z
 		d3d_model_primitive_begin( id, pr_trianglefan );
@@ -698,20 +726,20 @@ void d3d_model_ellipsoid(int id, gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_sc
 void d3d_model_icosahedron(int id, gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar x2, gs_scalar y2, gs_scalar z2, gs_scalar hrep, gs_scalar vrep, int steps)
 {
   gs_scalar width = (x2-x1), length = (y2-y1), height = (z2-z1);
-  static gs_scalar vdata[12][3] = {    
-   {0, 0.5, 1}, {1, 0.5, 1}, {0, 0.5, 0}, {1, 0.5, 0},    
-   {0.5, 1, 1}, {0.5, 1, 0}, {0.5, 0, 1}, {0.5, 0, 0},    
-   {1, 1, 0.5}, {0, 1, 0.5}, {1, 0, 0.5}, {0, 0, 0.5} 
+  static gs_scalar vdata[12][3] = {
+   {0, 0.5, 1}, {1, 0.5, 1}, {0, 0.5, 0}, {1, 0.5, 0},
+   {0.5, 1, 1}, {0.5, 1, 0}, {0.5, 0, 1}, {0.5, 0, 0},
+   {1, 1, 0.5}, {0, 1, 0.5}, {1, 0, 0.5}, {0, 0, 0.5}
   };
 
-  static int tindices[20][3] = { 
-   {0,4,1}, {0,9,4}, {9,5,4}, {4,5,8}, {4,8,1},    
-   {8,10,1}, {8,3,10}, {5,3,8}, {5,2,3}, {2,7,3},    
-   {7,10,3}, {7,6,10}, {7,11,6}, {11,0,6}, {0,1,6}, 
+  static int tindices[20][3] = {
+   {0,4,1}, {0,9,4}, {9,5,4}, {4,5,8}, {4,8,1},
+   {8,10,1}, {8,3,10}, {5,3,8}, {5,2,3}, {2,7,3},
+   {7,10,3}, {7,6,10}, {7,11,6}, {11,0,6}, {0,1,6},
    {6,1,10}, {9,0,11}, {9,11,2}, {9,2,5}, {7,2,11} };
 
   d3d_model_primitive_begin(id, pr_trianglelist);
-  for (unsigned i = 0; i < 20; i++) {    
+  for (unsigned i = 0; i < 20; i++) {
 	d3d_model_vertex(id, x1 + vdata[tindices[i][0]][0] * width, y1 + vdata[tindices[i][0]][1] * length, z1 + vdata[tindices[i][0]][2] * height);
 	d3d_model_vertex(id, x1 + vdata[tindices[i][1]][0] * width, y1 + vdata[tindices[i][1]][1] * length, z1 + vdata[tindices[i][1]][2] * height);
 	d3d_model_vertex(id, x1 + vdata[tindices[i][2]][0] * width, y1 + vdata[tindices[i][2]][1] * length, z1 + vdata[tindices[i][2]][2] * height);
@@ -724,19 +752,19 @@ void d3d_model_torus(int id, gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar
 {
   double TWOPI = 2 * (double)M_PI;
   for (int i = 0; i < csteps; i++) {
-    d3d_model_primitive_begin(id, pr_trianglestrip); 
+    d3d_model_primitive_begin(id, pr_trianglestrip);
     for (int j = 0; j <= tsteps; j++) {
       for (int k = 1; k >= 0; k--) {
 
         double s = (i + k) % csteps + 0.5;
         double t = j % tsteps;
-		
+
         double x = (radius + tradius * cos(s * TWOPI / csteps)) * cos(t * TWOPI / tsteps);
         double y = (radius + tradius * cos(s * TWOPI / csteps)) * sin(t * TWOPI / tsteps);
         double z = tradius * sin(s * TWOPI / csteps);
 		double u = ((i + k) / (float)csteps) * hrep;
 		double v = (j / (float)tsteps) * vrep;
-		
+
 		gs_scalar nX = cos(s * TWOPI / csteps) * cos(t * TWOPI / tsteps);
 		gs_scalar nY = cos(s * TWOPI / csteps) * sin(t * TWOPI / tsteps);
 		gs_scalar nZ = sin(s * TWOPI / csteps);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3surface.cpp
@@ -214,7 +214,7 @@ void surface_set_target(int id)
   glPushAttrib(GL_VIEWPORT_BIT); //same
   glViewport(0,0,surf->width,surf->height);
   glLoadIdentity();
-  glOrtho(0, surf->width, 0, surf->height, -1, 1);
+  glOrtho(-1, surf->width, -1, surf->height, -1, 1);
 }
 
 void surface_reset_target(void)
@@ -332,7 +332,7 @@ int surface_save(int id, string filename)
 	} else {
 		ret = enigma::image_save(filename, rgbdata, w, h, w, h);
 	}
-	
+
 	delete[] rgbdata;
 	return ret;
 }
@@ -345,7 +345,7 @@ int surface_save_part(int id, string filename, unsigned x, unsigned y, unsigned 
     string ext = enigma::image_get_format(filename);
 
     unsigned char *rgbdata = new unsigned char[sz*4];
-	
+
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, surf->fbo);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
 	glReadPixels(x,y,w,h,GL_RGBA,GL_UNSIGNED_BYTE,rgbdata);
@@ -359,7 +359,7 @@ int surface_save_part(int id, string filename, unsigned x, unsigned y, unsigned 
 	} else {
 		ret = enigma::image_save(filename, rgbdata, w, h, w, h);
 	}
-	
+
 	delete[] rgbdata;
 	return ret;
 }
@@ -368,7 +368,7 @@ int background_create_from_surface(int id, int x, int y, int w, int h, bool remo
 {
     get_surfacev(surf,id,-1);
     int full_width=nlpo2dc(w)+1, full_height=nlpo2dc(h)+1;
-    
+
     unsigned sz=full_width*full_height;
     unsigned char *surfbuf=new unsigned char[sz*4];
     glBindFramebuffer(GL_READ_FRAMEBUFFER, surf->fbo);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
@@ -82,7 +82,7 @@ namespace enigma
     glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_MIN_FILTER,interpolate?GL_LINEAR:GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_MAG_FILTER,interpolate?GL_LINEAR:GL_NEAREST);
     oglmgr->ResetTextureStates();
-	
+
 	TextureStruct* textureStruct = new TextureStruct(texture);
 	textureStruct->isFont = isfont;
     textureStructs.push_back(textureStruct);
@@ -236,6 +236,7 @@ void texture_set_stage(int stage, int texid) {
 void texture_reset() {
 	glActiveTexture(GL_TEXTURE0);
 	oglmgr->BindTexture(GL_TEXTURE_2D, 0);
+	oglmgr->EndShapesBatching();
 }
 
 void texture_set_repeat(bool repeat)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3tiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3tiles.cpp
@@ -25,6 +25,8 @@
 #include "../General/GStiles.h"
 #include "../General/GLtilestruct.h"
 #include "../General/OpenGLHeaders.h"
+#include "../General/GSprimitives.h" //pr_trianglestrip
+#include "../General/GSmodel.h" //For batcher
 
 #ifdef DEBUG_MODE
   #include <string>
@@ -47,90 +49,128 @@
 
 namespace enigma
 {
-    static void draw_tile(int back, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, double alpha)
+    static void draw_tile(int index, int back, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, double alpha)
     {
         if (!enigma_user::background_exists(back)) return;
         get_background(bck2d,back);
-        enigma_user::texture_set(textureStructs[bck2d->texture]->gltex);
-
-        glColor4ub(__GETR(color),__GETG(color),__GETB(color),char(alpha*255));
-
         float tbw = bck2d->width/(float)bck2d->texbordx, tbh = bck2d->height/(float)bck2d->texbordy,
               xvert1 = x, xvert2 = xvert1 + width*xscale,
               yvert1 = y, yvert2 = yvert1 + height*yscale,
               tbx1 = left/tbw, tbx2 = tbx1 + width/tbw,
               tby1 = top/tbh, tby2 = tby1 + height/tbh;
 
-        glBegin(GL_TRIANGLE_STRIP);
-        glTexCoord2f(tbx1,tby1);
-        glVertex2f(xvert1,yvert1);
-        glTexCoord2f(tbx2,tby1);
-        glVertex2f(xvert2,yvert1);
-        glTexCoord2f(tbx1,tby2);
-        glVertex2f(xvert1,yvert2);
-        glTexCoord2f(tbx2,tby2);
-        glVertex2f(xvert2,yvert2);
-        glEnd();
+        //TODO: The model should probably be populated manually along with indicies. The _end() calls a lot of useless code now. Upside is that this needs to be done once.
+        enigma_user::d3d_model_primitive_begin(index, enigma_user::pr_trianglestrip);
+        enigma_user::d3d_model_vertex_texture_color(index, xvert1, yvert1, tbx1, tby1, color, alpha);
+        enigma_user::d3d_model_vertex_texture_color(index, xvert2, yvert1, tbx2, tby1, color, alpha);
+        enigma_user::d3d_model_vertex_texture_color(index, xvert1, yvert2, tbx1, tby2, color, alpha);
+        enigma_user::d3d_model_vertex_texture_color(index, xvert2, yvert2, tbx2, tby2, color, alpha);
+        enigma_user::d3d_model_primitive_end(index);
     }
 
     void load_tiles()
     {
-        glPushAttrib(GL_CURRENT_BIT);
-        for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++)
+        int prev_bkid;
+        int vert_size = 0;
+        int vert_start = 0;
+        for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++){
             if (dit->second.tiles.size())
             {
-                enigma_user::texture_reset();
+                //TODO: Should they really be sorted by background? This may help batching, but breaks compatiblity. Nothing texture atlas wouldn't solve.
                 sort(dit->second.tiles.begin(), dit->second.tiles.end(), bkinxcomp);
-                int index = int(glGenLists(1));
+                int index = enigma_user::d3d_model_create(false);
                 drawing_depths[dit->second.tiles[0].depth].tilelist = index;
-                glNewList(index, GL_COMPILE);
-                for(std::vector<tile>::size_type i = 0; i !=  dit->second.tiles.size(); i++)
+                vert_size = 0;
+                vert_start = 0;
+                for(std::vector<tile>::size_type i = 0; i != dit->second.tiles.size(); ++i)
                 {
                     tile t = dit->second.tiles[i];
-                    draw_tile(t.bckid, t.bgx, t.bgy, t.width, t.height, t.roomX, t.roomY, t.xscale, t.yscale, t.color, t.alpha);
+                    if (i==0){ prev_bkid = t.bckid; }
+                    draw_tile(index, t.bckid, t.bgx, t.bgy, t.width, t.height, t.roomX, t.roomY, t.xscale, t.yscale, t.color, t.alpha);
+
+                    if (prev_bkid != t.bckid || i == dit->second.tiles.size()-1){ //Texture switch has happened. Create new batch
+                        get_background(bck2d,prev_bkid);
+                        drawing_depths[dit->second.tiles[0].depth].tilevector.push_back( vector< int >(3) );
+                        drawing_depths[dit->second.tiles[0].depth].tilevector.back()[0] = textureStructs[bck2d->texture]->gltex;
+                        drawing_depths[dit->second.tiles[0].depth].tilevector.back()[1] = vert_start;
+                        drawing_depths[dit->second.tiles[0].depth].tilevector.back()[2] = vert_size;
+                        //printf("Texture id = %i and vertices to render = %i and start = %i\n", prev_bkid, vert_size, vert_start );
+                        vert_start += vert_size;
+                        vert_size = 0;
+                        //printf("Texture switch at i = %i and now texture = %i\n", i, prev_bkid );
+                        prev_bkid = t.bckid;
+                    }
+                    vert_size+=6;
+                    //printf("Tile = %i, tile x = %i and tile y = %i\n", i, t.bgx, t.bgy);
                 }
-                glEndList();
+                drawing_depths[dit->second.tiles[0].depth].tilevector.back()[2] += 6; //Add last quad
             }
-        glPopAttrib();
+        }
     }
 
     void delete_tiles()
     {
-        for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++)
-            if (dit->second.tiles.size())
-                glDeleteLists(drawing_depths[dit->second.tiles[0].depth].tilelist, 1);
+        for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++){
+            if (dit->second.tiles.size()){
+                drawing_depths[dit->second.tiles[0].depth].tilevector.clear();
+                enigma_user::d3d_model_destroy( drawing_depths[dit->second.tiles[0].depth].tilelist );
+            }
+        }
     }
 
     void rebuild_tile_layer(int layer_depth)
     {
-        glPushAttrib(GL_CURRENT_BIT);
-        enigma_user::texture_reset();
-        for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++)
+        int prev_bkid;
+        for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++){
             if (dit->second.tiles.size())
             {
                 if (dit->second.tiles[0].depth != layer_depth)
                     continue;
 
-                enigma_user::texture_reset();
-                glDeleteLists(drawing_depths[dit->second.tiles[0].depth].tilelist, 1);
-                int index = int(glGenLists(1));
-                drawing_depths[dit->second.tiles[0].depth].tilelist = index;
-                glNewList(index, GL_COMPILE);
-                for(std::vector<tile>::size_type i = 0; i !=  dit->second.tiles.size(); i++)
+                //TODO: Should they really be sorted by background? This may help batching, but breaks compatiblity. Nothing texture atlas wouldn't solve.
+                //sort(dit->second.tiles.begin(), dit->second.tiles.end(), bkinxcomp);
+                int index = drawing_depths[dit->second.tiles[0].depth].tilelist;
+                if (enigma_user::d3d_model_exists( index )){
+                    enigma_user::d3d_model_clear( index );
+                    drawing_depths[dit->second.tiles[0].depth].tilevector.clear();
+                }else{
+                    index = enigma_user::d3d_model_create(false);
+                    drawing_depths[dit->second.tiles[0].depth].tilelist = index;
+                }
+                int vert_size = 0;
+                int vert_start = 0;
+                for(std::vector<tile>::size_type i = 0; i != dit->second.tiles.size(); ++i)
                 {
                     tile t = dit->second.tiles[i];
-                    draw_tile(t.bckid, t.bgx, t.bgy, t.width, t.height, t.roomX, t.roomY, t.xscale, t.yscale, t.color, t.alpha);
+                    if (i==0){ prev_bkid = t.bckid; }
+                    draw_tile(index, t.bckid, t.bgx, t.bgy, t.width, t.height, t.roomX, t.roomY, t.xscale, t.yscale, t.color, t.alpha);
+
+                    if (prev_bkid != t.bckid || i == dit->second.tiles.size()-1){ //Texture switch has happened. Create new batch
+                        get_background(bck2d,prev_bkid);
+                        drawing_depths[dit->second.tiles[0].depth].tilevector.push_back( vector< int >(3) );
+                        drawing_depths[dit->second.tiles[0].depth].tilevector.back()[0] = textureStructs[bck2d->texture]->gltex;
+                        drawing_depths[dit->second.tiles[0].depth].tilevector.back()[1] = vert_start;
+                        drawing_depths[dit->second.tiles[0].depth].tilevector.back()[2] = vert_size;
+                        //printf("Texture id = %i and vertices to render = %i and start = %i\n", prev_bkid, vert_size, vert_start );
+                        vert_start += vert_size;
+                        vert_size = 0;
+                        //printf("Texture switch at i = %i and now texture = %i\n", i, prev_bkid );
+                        prev_bkid = t.bckid;
+                    }
+                    vert_size+=6;
+                    //printf("Tile = %i, vertices = %i, prev_bkid = %i, t.bckid = %i, size() = %i\n", i, vert_size,prev_bkid, t.bckid, dit->second.tiles.size() );
                 }
-                glEndList();
+                drawing_depths[dit->second.tiles[0].depth].tilevector.back()[2] += 6; //Add last quad
+                break;
             }
-        glPopAttrib();
+        }
     }
 }
 
 namespace enigma_user
 {
 
-int tile_add(int background, int left, int top, int width, int height, int x, int y, int depth, int alpha, int color)
+int tile_add(int background, int left, int top, int width, int height, int x, int y, int depth, double xscale, double yscale, double alpha, int color)
 {
     enigma::tile *ntile = new enigma::tile;
     ntile->id = enigma::maxtileid++;
@@ -144,6 +184,8 @@ int tile_add(int background, int left, int top, int width, int height, int x, in
     ntile->depth = depth;
     ntile->alpha = alpha;
     ntile->color = color;
+    ntile->xscale = xscale;
+    ntile->yscale = yscale;
     enigma::drawing_depths[ntile->depth].tiles.push_back(*ntile);
     enigma::rebuild_tile_layer(ntile->depth);
     return ntile->id;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/include.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/include.h
@@ -1,6 +1,7 @@
 #include "OPENGL3Std.h"
-#include "Info/graphics_info.h" 
+#include "Info/graphics_info.h"
 #include "../General/GSsprite.h"
+#include "../General/GStiles.h"
 #include "../General/GSbackground.h"
 #include "GL3shader.h"
 #include "../General/GStextures.h"

--- a/ENIGMAsystem/SHELL/Universal_System/depth_draw.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/depth_draw.cpp
@@ -23,7 +23,7 @@
 #include "depth_draw.h"
 
 namespace enigma {
-  depth_layer::depth_layer(): draw_events(new event_iter("Draw")) {}
+  depth_layer::depth_layer(): draw_events(new event_iter("Draw")), tilelist(-1) {}
   map<double,depth_layer> drawing_depths;
   map<int,pair<double,double> > id_to_currentnextdepth;
 }

--- a/ENIGMAsystem/SHELL/Universal_System/depth_draw.h
+++ b/ENIGMAsystem/SHELL/Universal_System/depth_draw.h
@@ -28,6 +28,8 @@
 /// While the code that manages tiles and drawing is to be declared and managed
 /// by the files under Graphics_Systems, this file exists to provide a way to
 /// structure layers of depth, for both tiles and instances.
+#ifndef ENIGMA_DEPTH_DRAW_H
+#define ENIGMA_DEPTH_DRAW_H
 
 #include <map>
 #include <set>
@@ -40,15 +42,21 @@ using namespace std;
 #error This file is high-impact and should not be included from SHELLmain.cpp.
 #endif
 
-
 namespace enigma {
   struct depth_layer {
     vector<tile> tiles;
     event_iter* draw_events;
     int tilelist;
+
+    //TODO: This should probably be moved into graphics_systems/GENERAL?
+    vector<vector<int> > tilevector; //Tile vector holds several values, like number of vertices to render, texture to use and so on
+    //The structure is like this [render batch][batch info]
+    //batch info - 0 = texture to use, 1 = vertices to render,
+
     depth_layer();
   };
   extern map<double,depth_layer> drawing_depths;
   extern map<int,pair<double,double> > id_to_currentnextdepth;
   typedef map<double,depth_layer>::reverse_iterator diter;
 }
+#endif

--- a/ENIGMAsystem/SHELL/Universal_System/fontinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fontinit.cpp
@@ -77,8 +77,10 @@ namespace enigma
 		  int* pixels=new int[size+1]; //FYI: This variable was once called "cpixels." When you do compress them, change it back.
 
 		  unsigned int sz2;
-		  for (sz2 = 0; !feof(exe) and sz2 < size; sz2++)
-		    pixels[sz2] = 0x00FFFFFF | ((unsigned char)fgetc(exe) << 24);
+		  for (sz2 = 0; !feof(exe) and sz2 < size; sz2++){
+            pixels[sz2] = 0x00FFFFFF | ((unsigned char)fgetc(exe) << 24);
+		    if (pixels[sz2] == 0x00FFFFFF) pixels[sz2] = 0;
+		  }
 
 		  if (size!=sz2) {
 			  show_error("Failed to load font: Data is truncated before exe end. Read "+toString(sz2)+" out of expected "+toString(size),0);

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -152,9 +152,10 @@ namespace enigma
 
     //Load tiles
     delete_tiles();
-	for (int i = 0; i < tilecount; i++) {
-        tile t = tiles[i];
-		drawing_depths[t.depth].tiles.clear();
+    for (enigma::diter dit = drawing_depths.rbegin(); dit != drawing_depths.rend(); dit++){
+        if (dit->second.tiles.size()){
+            dit->second.tiles.clear();
+        }
     }
     for (int i = 0; i < tilecount; i++) {
         tile t = tiles[i];
@@ -170,25 +171,25 @@ namespace enigma
     }
 
     instance_event_iterator = new inst_iter(NULL,NULL,NULL);
-	
+
 	// Fire the create event of all the new instances
     for (int i = 0; i < instancecount; i++)
       is[i]->myevent_create();
-	  
-	// instance create code should be added here or occur at this exact moment in time, but guess what the code 
+
+	// instance create code should be added here or occur at this exact moment in time, but guess what the code
 	// isn't here, so where the fuck is it? and no not the create event, the instance create code from the room editor
 	// WHERE THE FUCK IS IT?
-	 
-	// Fire the game start event for all the new instances, persistent objects don't matter since this is the first time 
+
+	// Fire the game start event for all the new instances, persistent objects don't matter since this is the first time
 	// the game ran they won't even exist yet
     if (gamestart)
     for (int i = 0; i < instancecount; i++)
       is[i]->myevent_gamestart();
-	  
+
 	// Fire the rooms creation code
 	if (createcode)
        createcode();
-	   
+
 	// Fire the room start event for all persistent objects still kept alive and all the new instances
 	for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
     {

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.h
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.h
@@ -108,8 +108,8 @@ namespace enigma
     int id,obj,x,y;
   };
     struct tile {
-        int id,bckid,bgx,bgy,depth,height,width,roomX,roomY,xscale,yscale;
-        double alpha;
+        int id,bckid,bgx,bgy,depth,height,width,roomX,roomY;
+        double alpha, xscale, yscale;
         int color;
     };
   struct viewstruct


### PR DESCRIPTION
Now they both at least partly work. GL3 was so broken it didn't run any
examples. GL1 failed with tiles during room changes as well with other
things.

-Implemented tile system for GL3 so it works with VBO's now. It actually
uses d3d_model functions, so it should be graphics system independent.
This means with little more changes the whole thing can be put in
General and that would automatically implement tiles for D3D as well.
There of course might be a better way to do it in D3D, so maybe it can
stay separate.
-Tile system now actually allows runtime tile addition and deletion in
both GL1 and GL3.
-Fixed so shapes functions actually take into account bound alpha.
-Implemented draw_line_width and draw_line_width_color.
-Fixed draw_arrow.
-Fixed tile struct so scaling and alpha is a double, not an int. Also
added scaling to tile_add.
-Added d3d_model_part_draw which is used in the tile system. It allows
drawing only part of the model by specifying start indices and number to
draw.
-Fixed off-by-one error when drawing screen to surfaces. Should be
tested with other GPU's (tested here with Nvidia).
-Blend functions in GL3 now calls batch flush.
-Transformation functions in GL3 now calls batch flush.
-When loading fonts pixels with alpha = 0 now are black. This fixes
blending bugs. But something still needs to be done with AA.

Tile system and batching is still sometimes buggy in GL3. An example can
be seen here: https://dl.dropboxusercontent.com/u/21117924/tile_test.gmk
. It will work fine in GL1, but will be buggy in GL3.
Examples like the shadow engine still don't work in GL1 and GL3.
