### PR TITLE
Implemented undefined keyboard functions in Xlib backend.

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -46,7 +46,7 @@ namespace enigma_user {
 namespace enigma
 {
   extern char keymap[512];
-  extern char usermap[256];
+  //extern char usermap[256];
   void ENIGMA_events(void); //TODO: Synchronize this with Windows by putting these two in a single header.
   bool gameFroze = false;
   extern bool freezeOnLoseFocus;
@@ -70,8 +70,8 @@ namespace enigma
               if (gk==NoSymbol)
                 return 0;
 
-              if (!(gk & 0xFF00)) actualKey = enigma::usermap[(int)enigma::keymap[gk & 0xFF]];
-              else actualKey = enigma::usermap[(int)enigma::keymap[gk & 0x1FF]];
+              if (!(gk & 0xFF00)) actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0xFF]);
+              else actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0x1FF]);
               { // Set keyboard_lastchar. Seems to work without 
                   char str[1];
                   int len = XLookupString(&e.xkey, str, 1, NULL, NULL);
@@ -94,8 +94,8 @@ namespace enigma
             if (gk == NoSymbol)
               return 0;
 
-            if (!(gk & 0xFF00)) actualKey = enigma::usermap[(int)enigma::keymap[gk & 0xFF]];
-            else actualKey = enigma::usermap[(int)enigma::keymap[gk & 0x1FF]];
+            if (!(gk & 0xFF00)) actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0xFF]);
+            else actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0x1FF]);
 
             enigma::last_keybdstatus[actualKey]=enigma::keybdstatus[actualKey];
             enigma::keybdstatus[actualKey]=0;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -25,6 +25,7 @@
 #include <unistd.h> //usleep
 #include <time.h> //clock
 #include <string> //Return strings without needing a GC
+#include <map>
 #include <X11/Xlib.h>
 //#include <X11/Xutil.h>
 //#include <X11/Xos.h>
@@ -305,8 +306,11 @@ short curs[] = { 68, 68, 68, 130, 52, 152, 135, 116, 136, 108, 114, 150, 90, 68,
 
 namespace enigma
 {
+  //Replacing usermap array with keybdmap map, to align code with Windows implementation.
+  std::map<int,int> keybdmap;
+  //unsigned char usermap[256];
+
   unsigned char keymap[512];
-  unsigned char usermap[256];
   void initkeymap()
   {
     using namespace enigma_user;
@@ -365,8 +369,8 @@ namespace enigma
     keymap[0x163] = vk_insert;
 
     // Set up identity map...
-    for (int i = 0; i < 255; i++)
-      usermap[i] = i;
+    //for (int i = 0; i < 255; i++)
+    //  usermap[i] = i;
 
     for (int i = 0; i < 255; i++)
       keymap[i] = i;
@@ -437,6 +441,37 @@ void keyboard_wait()
     usleep(10000); // Sleep 1/100 second
   }
 }
+
+void keyboard_set_map(int key1, int key2) 
+{
+  std::map< int, int >::iterator it = enigma::keybdmap.find( key1 );
+  if ( enigma::keybdmap.end() != it ) {
+    it->second = key2;
+  } else {
+    enigma::keybdmap.insert( map< int, int >::value_type(key1, key2) );
+  }
+}
+
+int keyboard_get_map(int key) 
+{
+  std::map< int, int >::iterator it = enigma::keybdmap.find( key );
+  if ( enigma::keybdmap.end() != it ) {
+    return it->second;
+  } else {
+    return key;
+  }
+}
+
+void keyboard_unset_map() 
+{
+  enigma::keybdmap.clear();
+}
+
+void keyboard_clear(const int key)
+{
+  enigma::keybdstatus[key] = enigma::last_keybdstatus[key] = 0;
+}
+
 
 void window_set_region_scale(double scale, bool adaptwindow) {}
 double window_get_region_scale() {return 1;}


### PR DESCRIPTION
keyboard_set_map and related functions. Tested with this sample game:
https://drive.google.com/file/d/0B1P7NepPcOslbkZJQk5VUVdCdmc/edit?usp=sharing

keyboard_clear. Tested with this sample game:
https://drive.google.com/file/d/0B1P7NepPcOslanpWcE11eDBJWTQ/edit?usp=sharing

All implementations are the same as their Win32 equivalents. I removed usermap and replaced it with keybdmap, as usermap was currently only returning identity values. The shared code could easily be pulled out into the General shared code, but I am not sure what your plans are for Android, etc., so I kept it separate. 

Note the behavior of keyboard_clear according to this bug report; it is somewhat counter-intuitive, but my test case behaves the same in Enigma and GM Studio:
http://bugs.yoyogames.com/view.php?id=07055
