### PR TITLE
Cleaned Up Win32 Cursor Hit Test

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -54,7 +54,6 @@ namespace enigma
     extern void setchildsize(bool adapt);
 	extern void WindowResized();
     extern bool freezeOnLoseFocus, gameFroze, treatCloseAsEscape;
-	bool hitTestClientArea = false;
     static short hdeltadelta = 0, vdeltadelta = 0;
     int tempLeft = 0, tempTop = 0, tempRight = 0, tempBottom = 0, tempWidth, tempHeight;
     RECT tempWindow;
@@ -141,19 +140,12 @@ namespace enigma
         case WM_SETCURSOR:
 			// Set the user cursor if the mouse is in the client area of the window, otherwise let Windows handle setting the cursor
 			// since it knows how to set the gripper cursor for window resizing. This is exactly how GM handles it.
-			if (hitTestClientArea) {
+			if (LOWORD(lParam) == HTCLIENT) {
 				SetCursor(LoadCursor(NULL, currentCursor));
 			} else {
 				DefWindowProc(hWnd, message, wParam, lParam);
 			}
             return 0;
-			
-		case WM_NCHITTEST: {
-			// This is to check when a hit test is needed on the window, so we can see if the mouse is in the client area.
-			LRESULT res = DefWindowProc(hWnd, message, wParam, lParam);
-			hitTestClientArea = (res == HTCLIENT);
-			return res;
-		}
         case WM_CHAR:
             keyboard_lastchar = string(1,wParam);
 			keyboard_string += keyboard_lastchar;


### PR DESCRIPTION
It was actually much easier than I coded it in my last commit (#602), lParam contains whether the mouse is in the client area, so less code, and this method works better than the other way which was glitchy.
