### PR TITLE
Bugfix: Closing brace of scope was lost in some room scripts.

### DIFF
--- a/CompilerSource/compiler/components/parse_and_link.cpp
+++ b/CompilerSource/compiler/components/parse_and_link.cpp
@@ -202,7 +202,7 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[])
         
         pr->instance_create_codes[es->rooms[i].instances[ii].id].object_index = es->rooms[i].instances[ii].objectId;
         parsed_event* icce = pr->instance_create_codes[es->rooms[i].instances[ii].id].pe = new parsed_event(-1,-1,parsed_objects[es->rooms[i].instances[ii].objectId]);
-        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + es->rooms[i].instances[ii].creationCode + "}", icce);
+        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + es->rooms[i].instances[ii].creationCode + "\n/* */}", icce);
       }
     }
   }


### PR DESCRIPTION
For example:
//test = 1;

...would be constructed as:
"{" + "//test=1;" + "}"

...which would cause the final closing brace to be lost. I added a newline to fix this, but also added a "/\* */" after the newline, since I noticed a similar fix earlier in the same source file and figured that was probably done for a reason.
