### PR TITLE
Bugfix: += and related operators now properly "hint" the type.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/var4.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.cpp
@@ -57,6 +57,8 @@ template<>           inline bool varzero(double x) { return codebloxt(x >= 0 && 
 #  define div0c(x)
 #endif
 
+void variant::type_hint(int h_type) { if (type==-1) { type=h_type; } }
+
 variant::operator int()       { ccast(0); return int  (rval.d); }
 variant::operator bool()      { ccast(0); return lrint(rval.d) > 0; }
 variant::operator char()      { ccast(0); return char (rval.d); }
@@ -103,27 +105,27 @@ types_extrapolate_real_p  (variant& variant::operator=, { rval.d = x; type = rea
 types_extrapolate_string_p(variant& variant::operator=, { sval   = x; type = tstr; return *this; })
 variant& variant::operator=(const variant x)            { rval.d = x.rval.d; if ((type = x.type) == tstr) sval = x.sval; return *this; }
 variant& variant::operator=(const var &x)               { return *this = *x; }
-types_extrapolate_real_p  (variant& variant::operator+=, { terror(real); rval.d += x; return *this; })
-types_extrapolate_string_p(variant& variant::operator+=, { terror(tstr); sval   += x; return *this; })
+types_extrapolate_real_p  (variant& variant::operator+=, { terror(real); type_hint(real); rval.d += x; return *this; })
+types_extrapolate_string_p(variant& variant::operator+=, { terror(tstr); type_hint(tstr); sval   += x; return *this; })
 variant& variant::operator+=(const variant x)            { terror(x.type); if (x.type == real) rval.d += x.rval.d; else sval += x.sval; return *this; }
 variant& variant::operator+=(const var &x)               { return *this += *x; }
 
-types_extrapolate_real_p  (variant& variant::operator-=, { terror(real); rval.d -= x; return *this; })
+types_extrapolate_real_p  (variant& variant::operator-=, { terror(real); type_hint(real); rval.d -= x; return *this; })
 types_extrapolate_string_p(variant& variant::operator-=, { terrortrue(); return *this; })
 variant& variant::operator-=(const variant x)            { terror2(real); rval.d -= x.rval.d; return *this; }
 variant& variant::operator-=(const var &x)               { return *this -= *x; }
 
-types_extrapolate_real_p  (variant& variant::operator*=, { terror(real); rval.d *= x; return *this; })
+types_extrapolate_real_p  (variant& variant::operator*=, { terror(real); type_hint(real); rval.d *= x; return *this; })
 types_extrapolate_string_p(variant& variant::operator*=, { terrortrue(); return *this; })
 variant& variant::operator*=(const variant x)            { terror2(real); rval.d *= x.rval.d; return *this; }
 variant& variant::operator*=(const var &x)               { return *this *= *x; }
 
-types_extrapolate_real_p  (variant& variant::operator/=, { terror(real); rval.d /= x; return *this; })
+types_extrapolate_real_p  (variant& variant::operator/=, { terror(real); type_hint(real); rval.d /= x; return *this; })
 types_extrapolate_string_p(variant& variant::operator/=, { terrortrue(); return *this; })
 variant& variant::operator/=(const variant x)            { terror2(real); rval.d /= x.rval.d; return *this; }
 variant& variant::operator/=(const var &x)               { return *this /= *x; }
 
-types_extrapolate_real_p  (variant& variant::operator%=, { terror(real); rval.d = fmod(rval.d, x); return *this; })
+types_extrapolate_real_p  (variant& variant::operator%=, { terror(real); type_hint(real); rval.d = fmod(rval.d, x); return *this; })
 types_extrapolate_string_p(variant& variant::operator%=, { terrortrue(); return *this; })
 variant& variant::operator%=(const variant x)            { terror2(real); rval.d = fmod(rval.d, x.rval.d); return *this; }
 variant& variant::operator%=(const var &x)               { div0c((*x).rval.d) rval.d = fmod(rval.d, (*x).rval.d); return *this; }

--- a/ENIGMAsystem/SHELL/Universal_System/var4.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.h
@@ -51,6 +51,9 @@ struct variant
   enigma::rvt rval;
   string sval;
   int type;
+
+  ///Hints at the expected type of the object. If the current type is undefined, set it to the hinted type.
+  void type_hint(int h_type);
   
   operator int();
   operator bool();


### PR DESCRIPTION
This fixes the following Issue:
https://github.com/enigma-dev/enigma-dev/issues/609

The motivation for this pull request is that, given "var x;" with no further initialization, the following statements have different effects:

```
x = x + 1;  //x is a "real" of value "1".
x += 1;      //x is a "-1" (type unknown) of value "1".
```

Note that the "variant" class actually treats "x += 1" as a real-valued addition, but the type is lost. Thus, "+=" and "= .. +" have different behavior.

This pull request fixes that, by "hinting" the type on +=, -=, and other self-setting operators when combined with a "real" type on the RHS (and, in the case of +=, a string). It does NOT overwrite the type if it is known; it only changes it if the type is unknown. I feel that this is reasonable, as it conforms to the way that "= ... +" resolves and doesn't affect any script that initializes its variables anyway.

Note that I did _not_ change "var += var", since it is not clear to me how often this niche comes up in practice.

This fixes a bug in Iji save-file checksum calculation.
