### PR TITLE
implemented draw_polygon()

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
@@ -102,5 +102,12 @@ int draw_getpixel_ext(int x, int y)
 
 }
 
+bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColor, bool allowHoles)
+{
+  //TODO: Complex polygon supported only in OpenGL1 at the moment. By returning false here, we fall back
+  //      on a convex-only polygon drawing routine that works on any platform.
+  return false;
+}
+
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -106,5 +106,12 @@ int draw_getpixel_ext(int x, int y)
 
 }
 
+bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColor, bool allowHoles)
+{
+  //TODO: Complex polygon supported only in OpenGL1 at the moment. By returning false here, we fall back
+  //      on a convex-only polygon drawing routine that works on any platform.
+  return false;
+}
+
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.h
@@ -71,8 +71,9 @@ struct PolyVertex {
 };
 
 ///The draw_polygon functions use this to fill in convex/self-intersecting polygons.
+///The return value indicates success; if false, a "backup" convex-only polygon drawing routine will be used.
 ///Its implementation is platform-specific.
-void fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColor, bool allowHoles);
+bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColor, bool allowHoles);
 
 
 void draw_polygon_begin();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
@@ -208,14 +208,14 @@ void vertexCallback(GLvoid *vertex)
 }
 }
 
-void fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColor, bool allowHoles)
+bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColor, bool allowHoles)
 {
   //Supposedly this is required; see notes in GLPrimities.cpp
   texture_reset();
 
   //Create a GLU tessellation object.
   GLUtesselator* tessObj = gluNewTess();
-  if (!tessObj) { return; }
+  if (!tessObj) { return false; }
 
   //Assign callback functions for vertex drawing and combining.
   gluTessCallback(tessObj, GLU_TESS_BEGIN,   (GLvoid (*) ( )) &glBegin);
@@ -252,31 +252,7 @@ void fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColo
   //Done, reclaim memory.
   gluDeleteTess(tessObj);
   clear_free_extra_vertex_list();
+  return true;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
@@ -158,5 +158,14 @@ int draw_getpixel_ext(int x,int y)
   #endif
 }
 
+
+bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColor, bool allowHoles)
+{
+  //TODO: Complex polygon supported only in OpenGL1 at the moment. By returning false here, we fall back
+  //      on a convex-only polygon drawing routine that works on any platform.
+  return false;
+}
+
+
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESstdraw.cpp
@@ -725,4 +725,11 @@ int draw_mandelbrot(int x, int y, float w, double Zx, double Zy, double Zw, unsi
 	return c;
 }
 
+bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColor, bool allowHoles)
+{
+  //TODO: Complex polygon supported only in OpenGL1 at the moment. By returning false here, we fall back
+  //      on a convex-only polygon drawing routine that works on any platform.
+  return false;
+}
+
 }


### PR DESCRIPTION
This implements polygon drawing. Unlike GL_POLYGON, this supports:
- concave
- self-intersecting

...polygons in addition to convex. Currently implemented in OpenGL1, with fallbacks to convex polygon drawing in DirectX, GL-ES, and GL3. Other backends will be improved in later commits. 

I've had a forum post open asking for comments about this feature for a week, and so far there have been no issues. Thus, I'm leaving the implementation in "Graphics_Systems/", since it seems generally useful to everyone, and mimics a feature found in older versions of GM:
http://enigma-dev.org/forums/index.php?topic=1704.0
