### PR TITLE
treatUninitializedAs0 works now.

### DIFF
--- a/CompilerSource/compiler/components/write_globals.cpp
+++ b/CompilerSource/compiler/components/write_globals.cpp
@@ -63,7 +63,10 @@ int lang_CPP::compile_writeGlobals(EnigmaStruct* es, parsed_object* global)
     wto << "namespace enigma_user { " << endl;
     wto << "  string working_directory = \"" << working_directory << "\";" << endl;
     wto << "  unsigned int game_id = " << es->gameSettings.gameId << ";" << endl;
-    wto << "}" << endl;
+    wto << "}" << endl <<endl;
+
+    wto << "//Default variable type: \"undefined\" or \"real\"" <<endl;
+    wto << "const int variant::default_type = " <<(es->gameSettings.treatUninitializedAs0 ? "enigma::vt_real" : "-1") <<";" <<endl <<endl;
 
     wto << "namespace enigma {" << endl;
     wto << "  bool interpolate_textures = " << es->gameSettings.interpolate << ";" << endl;

--- a/ENIGMAsystem/SHELL/Universal_System/var4.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.cpp
@@ -97,7 +97,7 @@ types_extrapolate_string_p(variant::variant,: rval(0), sval(x), type(tstr) {})
 //variant::variant(var x): rval(x[0].rval), sval(x[0].sval) { }
 variant::variant(const variant& x): rval(x.rval.d), sval(x.sval), type(x.type) { }
 variant::variant(const var& x): rval((*x).rval.d), sval((*x).sval), type((*x).type) { }
-variant::variant(): rval(0), sval( ), type(-1) { }
+variant::variant(): rval(0), sval( ), type(default_type) { }
 
 types_extrapolate_real_p  (variant& variant::operator=, { rval.d = x; type = real; return *this; })
 types_extrapolate_string_p(variant& variant::operator=, { sval   = x; type = tstr; return *this; })

--- a/ENIGMAsystem/SHELL/Universal_System/var4.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.h
@@ -48,6 +48,10 @@ struct var;
 
 struct variant
 {
+  //Default type (-1 or real), changes based on "assume_uninitialized_is_zero" flag.
+  //This variable is defined in a compiler-generated class.
+  static const int default_type;
+
   enigma::rvt rval;
   string sval;
   int type;


### PR DESCRIPTION
Hooked up treatUninitializedAs0 to a static variable inside the "variant" class. Confirmed that this fixes all the "default zero" errors in Iji (not just the += one). Tested with the flag off as well.
