### PR TITLE
Fixes keyboard_string

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -150,7 +150,7 @@ namespace enigma
         case WM_CHAR:
             keyboard_lastchar = string(1,wParam);
 			if (keyboard_lastkey == enigma_user::vk_backspace) {
-				keyboard_string = keyboard_string.substr(0, keyboard_string.length() - 2);
+				keyboard_string = keyboard_string.substr(0, keyboard_string.length() - 1);
 			} else {
 				keyboard_string += keyboard_lastchar;
 			}

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -79,7 +79,7 @@ namespace enigma
                       enigma_user::keyboard_lastchar = string(1,str[0]);
 					  enigma_user::keyboard_string += enigma_user::keyboard_lastchar;
 					  if (enigma_user::keyboard_lastkey == enigma_user::vk_backspace) {
-						enigma_user::keyboard_string = enigma_user::keyboard_string.substr(0, enigma_user::keyboard_string.length() - 2);
+						enigma_user::keyboard_string = enigma_user::keyboard_string.substr(0, enigma_user::keyboard_string.length() - 1);
 					  } else {
 						enigma_user::keyboard_string += enigma_user::keyboard_lastchar;
 					  }


### PR DESCRIPTION
Keyboard string is supposed to remove characters when the backspace key is hit, we still support the enter key being a new line which GM does not. If users have a problem with this they can remove it themselves, locally, in their games. I simply check if keyboard_lastkey is hit, which works fine because if it's a char it will be changed anyway, and then remove the last charater. It behaves exactly the same as 8.1 and Studio where the first time it's pressed it will remove one and then when it's held down it goes faster, same with adding characters, behavior is perfectly the same. Please merge when ready.
