### PR TITLE
Direct3D 9 Textures

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -1,4 +1,4 @@
-/** Copyright (C) 2013 Robert B. Colton
+/** Copyright (C) 2013-2014 Robert B. Colton
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***


### PR DESCRIPTION
Implements graphics_get_texture_rgba for Direct3D9 effectively
implementing all sprite_save/background_save functions for the system.

We should also consider switching all of our code to use BGRA instead of RGBA internally. An original contributor to ENIGMA's code was already aware of this, but some where along the way it was changed. This is more optimal since most x86 graphics hardware and graphics API's use BGRA internally including Direct3D and OpenGL. Most image formats use BGRA as well including bmp,jpg,tga and optimized png.
