### PR TITLE
Functionality for "image_single"

### DIFF
--- a/CompilerSource/compiler/components/write_object_data.cpp
+++ b/CompilerSource/compiler/components/write_object_data.cpp
@@ -609,7 +609,7 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global)
     "    instance->gravity=0;\n    instance->gravity_direction=270;\n    instance->friction=0;\n    \n"
     "    \n"
     "    instance->image_alpha = 1.0;\n    instance->image_angle = 0;\n    instance->image_blend = 0xFFFFFF;\n    instance->image_index = 0;\n"
-    "    instance->image_speed  = 1;\n    instance->image_xscale = 1;\n    instance->image_yscale = 1;\n    \n"
+    "    instance->image_speed  = 1;\n    instance->image_single = -1;\n    instance->image_xscale = 1;\n    instance->image_yscale = 1;\n    \n"
     "instancecount++;\n    instance_count++;\n  }\n}\n";
   wto.close();
 

--- a/ENIGMAsystem/SHELL/Collision_Systems/Precise/coll_impl.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/Precise/coll_impl.cpp
@@ -318,8 +318,8 @@ enigma::object_collisions* const collide_inst_inst(int object, bool solid_only, 
             enigma::sprite* sprite1 = enigma::spritestructarray[collsprite_index1];
             enigma::sprite* sprite2 = enigma::spritestructarray[collsprite_index2];
 
-            const int usi1 = ((int) inst1->image_index) % sprite1->subcount;
-            const int usi2 = ((int) inst2->image_index) % sprite2->subcount;
+            const int usi1 = ((int) inst1->get_image_index()) % sprite1->subcount;
+            const int usi2 = ((int) inst2->get_image_index()) % sprite2->subcount;
 
             unsigned char* pixels1 = (unsigned char*) (sprite1->colldata[usi1]);
             unsigned char* pixels2 = (unsigned char*) (sprite2->colldata[usi2]);
@@ -431,7 +431,7 @@ enigma::object_collisions* const collide_inst_rect(int object, bool solid_only, 
 
             enigma::sprite* sprite = enigma::spritestructarray[collsprite_index];
 
-            const int usi = ((int) inst->image_index) % sprite->subcount;
+            const int usi = ((int) inst->get_image_index()) % sprite->subcount;
 
             unsigned char* pixels = (unsigned char*) (sprite->colldata[usi]);
 
@@ -537,7 +537,7 @@ enigma::object_collisions* const collide_inst_line(int object, bool solid_only, 
 
                 enigma::sprite* sprite = enigma::spritestructarray[collsprite_index];
 
-                const int usi = ((int) inst->image_index) % sprite->subcount;
+                const int usi = ((int) inst->get_image_index()) % sprite->subcount;
 
                 unsigned char* pixels = (unsigned char*) (sprite->colldata[usi]);
 
@@ -611,7 +611,7 @@ enigma::object_collisions* const collide_inst_point(int object, bool solid_only,
 
             enigma::sprite* sprite = enigma::spritestructarray[collsprite_index];
 
-            const int usi = ((int) inst->image_index) % sprite->subcount;
+            const int usi = ((int) inst->get_image_index()) % sprite->subcount;
 
             unsigned char* pixels = (unsigned char*) (sprite->colldata[usi]);
 
@@ -709,7 +709,7 @@ enigma::object_collisions* const collide_inst_ellipse(int object, bool solid_onl
 
             enigma::sprite* sprite = enigma::spritestructarray[collsprite_index];
 
-            const int usi = ((int) inst->image_index) % sprite->subcount;
+            const int usi = ((int) inst->get_image_index()) % sprite->subcount;
 
             unsigned char* pixels = (unsigned char*) (sprite->colldata[usi]);
 
@@ -774,7 +774,7 @@ void destroy_inst_point(int object, bool solid_only, int x1, int y1)
 
             enigma::sprite* sprite = enigma::spritestructarray[collsprite_index];
 
-            const int usi = ((int) inst->image_index) % sprite->subcount;
+            const int usi = ((int) inst->get_image_index()) % sprite->subcount;
 
             unsigned char* pixels = (unsigned char*) (sprite->colldata[usi]);
 
@@ -835,7 +835,7 @@ void change_inst_point(int obj, bool perf, int x1, int y1)
 
             enigma::sprite* sprite = enigma::spritestructarray[collsprite_index];
 
-            const int usi = ((int) inst->image_index) % sprite->subcount;
+            const int usi = ((int) inst->get_image_index()) % sprite->subcount;
 
             unsigned char* pixels = (unsigned char*) (sprite->colldata[usi]);
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
@@ -68,7 +68,7 @@ namespace enigma_user
 void draw_sprite(int spr,int subimg, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
 	const gs_scalar tbx = spr2d->texbordxarray[usi], tby = spr2d->texbordyarray[usi],
 			xvert1 = x-spr2d->xoffset, xvert2 = xvert1 + spr2d->width,
@@ -85,7 +85,7 @@ void draw_sprite(int spr,int subimg, gs_scalar x, gs_scalar y, int color, gs_sca
 void draw_sprite_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
 	rot *= M_PI/180;
 
@@ -111,7 +111,7 @@ void draw_sprite_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xs
 void draw_sprite_pos(int spr, int subimg, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar x3, gs_scalar y3, gs_scalar x4, gs_scalar y4, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
     const gs_scalar tbx = spr2d->texbordxarray[usi], tby = spr2d->texbordyarray[usi];
 
@@ -126,7 +126,7 @@ void draw_sprite_pos(int spr, int subimg, gs_scalar x1, gs_scalar y1, gs_scalar 
 void draw_sprite_part(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
 	gs_scalar tbw = spr2d->width/(gs_scalar)spr2d->texbordxarray[usi], tbh = spr2d->height/(gs_scalar)spr2d->texbordyarray[usi],
 	  tbx1 = left/tbw, tbx2 = tbx1 + width/tbw,
@@ -143,7 +143,7 @@ void draw_sprite_part(int spr, int subimg, gs_scalar left, gs_scalar top, gs_sca
 void draw_sprite_part_offset(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
 	gs_scalar tbw = spr2d->width/spr2d->texbordxarray[usi], tbh = spr2d->height/spr2d->texbordyarray[usi],
 	  xvert1 = x-spr2d->xoffset, xvert2 = xvert1 + spr2d->width,
@@ -162,7 +162,7 @@ void draw_sprite_part_offset(int spr, int subimg, gs_scalar left, gs_scalar top,
 void draw_sprite_part_ext(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
 	gs_scalar tbw = spr2d->width/(gs_scalar)spr2d->texbordxarray[usi], tbh = spr2d->height/(gs_scalar)spr2d->texbordyarray[usi],
 	  xvert1 = x, xvert2 = xvert1 + width*xscale,
@@ -181,7 +181,7 @@ void draw_sprite_part_ext(int spr, int subimg, gs_scalar left, gs_scalar top, gs
 void draw_sprite_general(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int c1, int c2, int c3, int c4, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
 	const gs_scalar
 	  tbx = spr2d->texbordxarray[usi],  tby = spr2d->texbordyarray[usi],
@@ -212,7 +212,7 @@ void draw_sprite_general(int spr, int subimg, gs_scalar left, gs_scalar top, gs_
 void draw_sprite_stretched(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
     const gs_scalar tbx = spr2d->texbordxarray[usi], tby = spr2d->texbordyarray[usi],
                 xvert1 = x-spr2d->xoffset, xvert2 = xvert1 + width,
@@ -229,7 +229,7 @@ void draw_sprite_stretched(int spr, int subimg, gs_scalar x, gs_scalar y, gs_sca
 void draw_sprite_stretched_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
     const gs_scalar tbx = spr2d->texbordxarray[usi], tby = spr2d->texbordyarray[usi],
                 xvert1 = x-spr2d->xoffset, xvert2 = xvert1 + width,
@@ -246,7 +246,7 @@ void draw_sprite_stretched_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs
 void d3d_draw_sprite(int spr,int subimg, gs_scalar x, gs_scalar y, gs_scalar z)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
 	const gs_scalar tbx = spr2d->texbordxarray[usi], tby = spr2d->texbordyarray[usi],
 			xvert1 = x-spr2d->xoffset, xvert2 = xvert1 + spr2d->width,
@@ -276,7 +276,7 @@ namespace enigma_user
 void draw_sprite_tiled(int spr, int subimg, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
     x = ((spr2d->xoffset+x)<0?0:spr2d->width)-fmod(spr2d->xoffset+x,spr2d->width);
     y = ((spr2d->yoffset+y)<0?0:spr2d->height)-fmod(spr2d->yoffset+y,spr2d->height);
@@ -310,7 +310,7 @@ void draw_sprite_tiled(int spr, int subimg, gs_scalar x, gs_scalar y, int color,
 void draw_sprite_tiled_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
 {
     get_spritev(spr2d,spr);
-    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
+    const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr2d->subcount;
 
     const gs_scalar
     tbx  = spr2d->texbordxarray[usi], tby  = spr2d->texbordyarray[usi],

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/actions.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/actions.h
@@ -55,6 +55,7 @@ inline void action_sprite_set(const double spritep, const  double subimage, cons
     inst->sprite_index=spritep;
 	if ((int)subimage !=-1) inst->image_index=subimage;
 	inst->image_speed=speed;
+	inst->image_single=-1; 
 }
 
 inline void action_draw_text(const string text, const gs_scalar x, const gs_scalar y) {
@@ -252,7 +253,7 @@ inline bool action_replace_background(int ind, std::string filename)
 inline int draw_self()
 {
     enigma::object_collisions* const inst = ((enigma::object_collisions*)enigma::instance_event_iterator->inst);
-    draw_sprite_ext(inst->sprite_index, inst->image_index, inst->x, inst->y, inst->image_xscale, inst->image_yscale, inst->image_angle, inst->image_blend, inst->image_alpha);
+    draw_sprite_ext(inst->sprite_index, inst->get_image_index(), inst->x, inst->y, inst->image_xscale, inst->image_yscale, inst->image_angle, inst->image_blend, inst->image_alpha);
     return 0;
 }  //actions seemed the best place for this
 

--- a/ENIGMAsystem/SHELL/Universal_System/graphics_object.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/graphics_object.cpp
@@ -31,6 +31,8 @@ namespace enigma
   object_graphics::object_graphics(unsigned _x, int _y): object_planar(_x,_y) {}
   object_graphics::~object_graphics() {}
 
+  int object_graphics::get_image_index() const { return image_single<0 ? image_index : fmod(image_single, enigma_user::sprite_get_number(sprite_index)); }
+
   INTERCEPT_DEFAULT_COPY(enigma::depthv)
   void depthv::function(variant oldval) {
     rval.d = floor(rval.d);

--- a/ENIGMAsystem/SHELL/Universal_System/graphics_object.h
+++ b/ENIGMAsystem/SHELL/Universal_System/graphics_object.h
@@ -52,6 +52,9 @@ namespace enigma
       gs_scalar image_index;
       gs_scalar image_speed;
 
+      //Older combination of image_index and image_speed. DO NOT USE for new games.
+      int image_single;
+
       //Depth
       enigma::depthv  depth;
       bool visible;
@@ -60,6 +63,9 @@ namespace enigma
       gs_scalar image_xscale;
       gs_scalar image_yscale;
       gs_scalar image_angle;
+
+      //Helper: Retrieve the image_index taking image_single into account.
+      int get_image_index() const;
 
     //Accessors
       #ifdef JUST_DEFINE_IT_RUN

--- a/ENIGMAsystem/SHELL/Universal_System/instance_create.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_create.h
@@ -36,6 +36,7 @@ namespace enigma
       double  xstart=inst->xstart, ystart=inst->ystart;
       double image_index=inst->image_index;
       double image_speed=inst->image_speed;
+      int image_single = inst->image_single;
       bool visible=inst->visible;
       double image_xscale=inst->image_xscale;
       double image_yscale=inst->image_yscale;
@@ -68,7 +69,7 @@ namespace enigma
       if (perf) newinst->myevent_create();
       newinst->x=x; newinst->y=y; newinst->yprevious=yprevious; newinst->xprevious=xprevious;
       newinst->xstart=xstart; newinst->ystart=ystart;
-      newinst->image_index=image_index; newinst->image_speed=image_speed;
+      newinst->image_index=image_index; newinst->image_speed=image_speed; newinst->image_single=image_single;
       newinst->visible=visible; newinst->image_xscale=image_xscale; newinst->image_yscale=image_yscale; newinst->image_angle=image_angle;
       newinst->hspeed=hspeed; newinst->vspeed=vspeed;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/spritestruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/spritestruct.cpp
@@ -564,7 +564,7 @@ int sprite_get_texture(int sprite,int subimage)
     if (!get_sprite(spr,sprite))
         return 0;
 
-    const int usi = subimage >= 0 ? (subimage % spr->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr->subcount;
+    const int usi = subimage >= 0 ? (subimage % spr->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->get_image_index()) % spr->subcount;
     return spr->texturearray[usi];
 }
 

--- a/events.res
+++ b/events.res
@@ -87,7 +87,7 @@ beginstep: 3
 	Name: Begin Step
 	Mode: Special
 	Case: 1
-	Constant: {xprevious = x; yprevious = y; if (sprite_index != -1) image_index = fmod((image_speed < 0)?(sprite_get_number(sprite_index) + image_index - fmod(abs(image_speed),sprite_get_number(sprite_index))):(image_index + image_speed), sprite_get_number(sprite_index));}
+	Constant: {xprevious = x; yprevious = y; if (sprite_index != -1) if (image_single < 0) image_index = fmod((image_speed < 0)?(sprite_get_number(sprite_index) + image_index - fmod(abs(image_speed),sprite_get_number(sprite_index))):(image_index + image_speed), sprite_get_number(sprite_index));}
 
 alarm: 2
 	Group: Alarm
@@ -372,7 +372,7 @@ draw: 8
 	Iterator-initialize: /* Draw is initialized in the constructor */
 	Iterator-remove: depth.remove();
 	Iterator-delete: /* Draw will destruct with this */
-	Default: if (visible && sprite_index != -1) draw_sprite_ext(sprite_index,image_index,x,y,image_xscale,image_yscale,image_angle,image_blend,image_alpha);
+	Default: if (visible && sprite_index != -1) draw_sprite_ext(sprite_index,get_image_index(),x,y,image_xscale,image_yscale,image_angle,image_blend,image_alpha);
 	Instead: if (automatic_redraw) screen_redraw(); # We never want to iterate draw; we let screen_redraw() handle it.
 	
 #Draw GUI event is processed after all draw events iterating objects by depth and first resetting the projection to orthographic, ignoring views
@@ -396,7 +396,7 @@ animationend: 7
 	Name: Animation End
 	Mode: Special
 	Case: 7
-	Sub Check: {if (image_index + image_speed < sprite_get_number(sprite_index)) return 0; }
+	Sub Check: {if (image_index + image_speed < sprite_get_number(sprite_index)) return 0; if (image_single >= 0) return 0; }
 
 
 # End of in-linked events


### PR DESCRIPTION
(NOTE: Do not merge yet; see comments for dicussion.)

As I'm sure you know, image_single is still supported in GM:S (even though they don't document it). A previous commit attempted to add this to Enigma via a macro, but in fact the semantics of image_single are more complicated than that. This patch adds in image_single; it was tested with GM 5 and GM:S.

There are only two things I am not 100% sure about.

First, this seems to return early if the current animation is "not done". I also had it return early if image_single was non-negative (i.e., active).

```
//events.res
animationend: 7
    Name: Animation End
    Mode: Special
    Case: 7
    Sub Check: {if (image_index + image_speed < sprite_get_number(sprite_index)) return 0; if (image_single >= 0) return 0; }
```

Second, this seems to check if image_index is not zero (with a modulus check thrown in). I did not add any check for image_single here.

```
//CompilerSource/compiler/event_reader/events.res
animationend: 7
    Name: Animation End
    Mode: Special
    Case: 7
    Sub Check: !(int(image_index) % image_count)
```

Image_single will only affect things if it's set to >=0, so existing behavior should be safe (that's why I filed the pull request). However, I'd like to understand what those two events.res examples are doing, if anyone could fill me in.
