### PR TITLE
Implements program_directory for Win32

### DIFF
--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -730,8 +730,7 @@ wto << "namespace enigma_user {\nstring shader_get_name(int i) {\n switch (i) {\
   {
     // The games working directory, in run/debug it is the GMK/GMX location where the IDE is working with the project,
     // in compile mode it is the same as program_directory, or where the (*.exe executable) is located.
-    // If you have not saved your file in the IDE or the mode is set to regular compile mode, the working directory is set
-    // using the platform specific function in the platforms main() when working_directory is of 0 length
+    // The working_directory global is set in the main() of each platform using the platform specific function.
     // This the exact behaviour of GM8.1
     char prevdir[4096];
     string newdir = (es->filename != NULL && strlen(es->filename) > 0) ? string(es->filename) : string( exe_filename );

--- a/ENIGMAsystem/SHELL/Platforms/Android/Androidfilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Android/Androidfilemanip.cpp
@@ -45,8 +45,6 @@ void export_include_file_location(string fname,string location);
 void discard_include_file(string fname);
 
 extern unsigned game_id;
-extern string working_directory;
-extern string program_directory;
 extern string temp_directory;
 
 

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -23,6 +23,7 @@ namespace enigma_user
 {
 
 extern std::string working_directory;
+extern std::string program_directory;
 
 void game_end(int ret=0);
 void action_end_game();

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -76,6 +76,7 @@ unsigned long current_time_mcs = 0; // microseconds since the start of the game
 
 namespace enigma_user {
   std::string working_directory = "";
+  std::string program_directory = "";
   extern double fps;
   unsigned long current_time = 0; // milliseconds since the start of the game
   unsigned long delta_time = 0; // microseconds since the last step event
@@ -195,6 +196,12 @@ int WINAPI WinMain (HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine,
     char buffer[MAX_PATH];
     GetCurrentDirectory( MAX_PATH, buffer );
     enigma_user::working_directory = string( buffer );
+    
+    // Set the program_directory
+    memset(&buffer[0], 0, MAX_PATH); 
+    GetModuleFileName( NULL, buffer, MAX_PATH );
+    enigma_user::program_directory = string( buffer );
+    enigma_user::program_directory = enigma_user::program_directory.substr( 0, enigma_user::program_directory.find_last_of( "\\/" ));
 
     LPWSTR *argv;
     if ((argv = CommandLineToArgvW(GetCommandLineW(), &enigma::main_argc)))

--- a/ENIGMAsystem/SHELL/Platforms/iPhone/Cocoafilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/iPhone/Cocoafilemanip.cpp
@@ -47,8 +47,6 @@ void export_include_file_location(string fname,string location);
 void discard_include_file(string fname);
 
 extern unsigned game_id;
-extern string working_directory;
-extern string program_directory;
 extern string temp_directory;
 
 

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBfilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBfilemanip.cpp
@@ -112,8 +112,6 @@ void export_include_file_location(string fname,string location);
 void discard_include_file(string fname);
 
 extern unsigned game_id;
-extern string working_directory;
-extern string program_directory;
 extern string temp_directory;
 
 

--- a/ENIGMAsystem/SHELL/Universal_System/GAME_GLOBALS.h
+++ b/ENIGMAsystem/SHELL/Universal_System/GAME_GLOBALS.h
@@ -82,7 +82,6 @@ int transition_steps=80;
 global:  working_directory*/
 namespace enigma_user {
 bool automatic_redraw = true;
-string program_directory="";
 int gamemaker_version=0;
 }
 //int transition_steps;


### PR DESCRIPTION
This also behaves exactly as GM8.1 it is always the executable directory
regardless of the OS working directory. So in run/debug/design it is
usually the temp folder and in compile mode when being executed it is
always exactly where the exe is located. The only problem is now there is
no Linux/*nix equivalent of Win32's GetModuleFilename, and it is variable so we can not have it in the compiler like Polygonz previously had working_directory. I also went back
and tested working_directory and I can confirm that mine works EXACTLY the
same as GM8,1, I created a show_message(working_directory) example in both
GM8.1 and ENIGMA and launched them from different directories than where
they are located at, and ENIGMA and GM8.1 always reported the OS working
directory. So the behavior of these functions is 100% correct now.
