### PR TITLE
Fixes Direct3D11

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
@@ -67,7 +67,7 @@ namespace enigma
 
   }
 
-  unsigned char* graphics_get_texture_rgba(unsigned texture, unsigned* fillwidth, unsigned* fullheight)
+  unsigned char* graphics_get_texture_pixeldata(unsigned texture, unsigned* fullwidth, unsigned* fullheight)
   {
 
   }


### PR DESCRIPTION
Function definition was never updated, now builds and clears background
color again.
