### PR TITLE
Fixes half pixel alignment.

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmatrix.cpp
@@ -107,8 +107,10 @@ void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, g
 
 void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-    // This is half-pixel alignment, 0.5 only works for some graphics cards, 0.25 works best for Nvidia, AMD, and other common graphics cards and drivers.
-    x += 0.25f; y += 0.25f;
+    // This is half-pixel alignment, the values used for the model view matrix in conjunction with the ortho projection have been tested on Nvidia and AMD graphics cards.
+    // 0.375,0.375 is suggested by Microsoft, however we have discovered the offsets 0.375,0.375 and 0.175,0.175 combined between the projection and model view matrix
+    // yields the best results.
+    x += 0.375f; y += 0.375f;
     enigma::projection_matrix.InitScaleTransform(1, -1, 1);
     enigma::projection_matrix.rotateZ(angle);
 
@@ -124,8 +126,10 @@ void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scal
     glLoadMatrix(enigma::projection_matrix);
 
     glMatrixMode(GL_MODELVIEW);
-    // We must half-pixel align the model view matrix as well for full screen games.
-    enigma::mv_matrix.translate(0.25f, 0.25f, 0.0f);
+    // This is half-pixel alignment, the values used for the model view matrix in conjunction with the ortho projection have been tested on Nvidia and AMD graphics cards.
+    // 0.375,0.375 is suggested by Microsoft, however we have discovered the offsets 0.375,0.375 and 0.175,0.175 combined between the projection and model view matrix
+    // yields the best results.
+    enigma::mv_matrix.translate(0.175f, 0.175f, 0.0f);
     glLoadMatrix(enigma::mv_matrix);
 
     enigma::d3d_light_update_positions();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3ModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3ModelStruct.h
@@ -570,8 +570,10 @@ class Mesh
     if (enigma::transformation_update == true){
         //Recalculate matrices
         enigma::mv_matrix = enigma::view_matrix * enigma::model_matrix;
-        // We must half-pixel align the model view matrix as well for full screen games.
-        enigma::mv_matrix.translate(0.25f, 0.25f, 0.0f);
+        // This is half-pixel alignment, the values used for the model view matrix in conjunction with the ortho projection have been tested on Nvidia and AMD graphics cards.
+        // 0.375,0.375 is suggested by Microsoft, however we have discovered the offsets 0.375,0.375 and 0.175,0.175 combined between the projection and model view matrix
+        // yields the best results.
+        enigma::mv_matrix.translate(0.175f, 0.175f, 0.0f);
         enigma::mvp_matrix = enigma::projection_matrix * enigma::mv_matrix;
 
         //normal_matrix = invert(transpose(mv_submatrix)), where mv_submatrix is modelview top-left 3x3 matrix

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.cpp
@@ -98,8 +98,10 @@ void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, g
 
 void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-    // This is half-pixel alignment, 0.5 only works for some graphics cards, 0.25 works best for Nvidia, AMD, and other common graphics cards and drivers.
-    x += 0.25f; y += 0.25f;
+    // This is half-pixel alignment, the values used for the model view matrix in conjunction with the ortho projection have been tested on Nvidia and AMD graphics cards.
+    // 0.375,0.375 is suggested by Microsoft, however we have discovered the offsets 0.375,0.375 and 0.175,0.175 combined between the projection and model view matrix
+    // yields the best results.
+    x += 0.375f; y += 0.375f;
     oglmgr->Transformation();
     enigma::projection_matrix.InitScaleTransform(1, -1, 1);
     enigma::projection_matrix.rotateZ(angle);


### PR DESCRIPTION
Uses the values reported by Darkstar2 on the forums, tested and can
confirm they work for me in all scenarios as well. When fullscreen
is fixed for Direct3D we should also ensure that pixel alignment
works in that system as well. Can be merged.
