### PR TITLE
Removes Pixel Alignment for OGL

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmatrix.cpp
@@ -107,10 +107,6 @@ void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, g
 
 void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-    // This is half-pixel alignment, the values used for the model view matrix in conjunction with the ortho projection have been tested on Nvidia and AMD graphics cards.
-    // 0.375,0.375 is suggested by Microsoft, however we have discovered the offsets 0.375,0.375 and 0.175,0.175 combined between the projection and model view matrix
-    // yields the best results.
-    x += 0.375f; y += 0.375f;
     enigma::projection_matrix.InitScaleTransform(1, -1, 1);
     enigma::projection_matrix.rotateZ(angle);
 
@@ -126,10 +122,6 @@ void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scal
     glLoadMatrix(enigma::projection_matrix);
 
     glMatrixMode(GL_MODELVIEW);
-    // This is half-pixel alignment, the values used for the model view matrix in conjunction with the ortho projection have been tested on Nvidia and AMD graphics cards.
-    // 0.375,0.375 is suggested by Microsoft, however we have discovered the offsets 0.375,0.375 and 0.175,0.175 combined between the projection and model view matrix
-    // yields the best results.
-    enigma::mv_matrix.translate(0.175f, 0.175f, 0.0f);
     glLoadMatrix(enigma::mv_matrix);
 
     enigma::d3d_light_update_positions();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3ModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3ModelStruct.h
@@ -570,10 +570,6 @@ class Mesh
     if (enigma::transformation_update == true){
         //Recalculate matrices
         enigma::mv_matrix = enigma::view_matrix * enigma::model_matrix;
-        // This is half-pixel alignment, the values used for the model view matrix in conjunction with the ortho projection have been tested on Nvidia and AMD graphics cards.
-        // 0.375,0.375 is suggested by Microsoft, however we have discovered the offsets 0.375,0.375 and 0.175,0.175 combined between the projection and model view matrix
-        // yields the best results.
-        enigma::mv_matrix.translate(0.175f, 0.175f, 0.0f);
         enigma::mvp_matrix = enigma::projection_matrix * enigma::mv_matrix;
 
         //normal_matrix = invert(transpose(mv_submatrix)), where mv_submatrix is modelview top-left 3x3 matrix

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.cpp
@@ -98,10 +98,6 @@ void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, g
 
 void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-    // This is half-pixel alignment, the values used for the model view matrix in conjunction with the ortho projection have been tested on Nvidia and AMD graphics cards.
-    // 0.375,0.375 is suggested by Microsoft, however we have discovered the offsets 0.375,0.375 and 0.175,0.175 combined between the projection and model view matrix
-    // yields the best results.
-    x += 0.375f; y += 0.375f;
     oglmgr->Transformation();
     enigma::projection_matrix.InitScaleTransform(1, -1, 1);
     enigma::projection_matrix.rotateZ(angle);


### PR DESCRIPTION
OGL does not have pixel alignment issues, the issues are in the sampler
for certain cards, I have never once seen blurry text and noone else has.

I've only experienced blurry text/images drawn at fractional pixels when using Direct3D.
