### PR TITLE
Fix infinite loop due to size/unsigned mismatch.

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmodel.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmodel.cpp
@@ -46,8 +46,8 @@ namespace enigma {
 
 unsigned int split(const std::string &txt, std::vector<std::string> &strs, char ch)
 {
-	unsigned int pos = txt.find( ch );
-	unsigned int initialPos = 0;
+	size_t pos = txt.find( ch );
+	size_t initialPos = 0;
 	strs.clear();
 
 	// Decompose statement
@@ -59,7 +59,7 @@ unsigned int split(const std::string &txt, std::vector<std::string> &strs, char 
 	}
 
 	// Add the last one
-	strs.push_back( txt.substr( initialPos, std::min( pos, (unsigned)txt.size() ) - initialPos + 1 ) );
+	strs.push_back( txt.substr( initialPos, std::min( pos, txt.size() ) - initialPos + 1 ) );
 
 	return strs.size();
 }


### PR DESCRIPTION
So fun story. size_t is "long unsigned int" on Linux 64-bit. That meas casting it to an unsigned int can lead to an infinite loop when checking against string::npos (since the cast value will always be truncated).

This was the only instance I came across, but it causes games that use d3d_model_load() with GL1 on Linux to spin forever and thrash my system. 
