### PR TITLE
Fixes window_center *DO NOT MERGE*

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -234,8 +234,8 @@ void window_center()
 {
     int screen_width = GetSystemMetrics(SM_CXSCREEN);
     int screen_height = GetSystemMetrics(SM_CYSCREEN);
-    enigma::windowX = (screen_width - enigma::scaledWidth)/2;
-    enigma::windowY = (screen_height - enigma::scaledHeight)/2;
+    enigma::windowX = (screen_width - enigma::regionWidth)/2;
+    enigma::windowY = (screen_height - enigma::regionHeight)/2;
     enigma::clampparent();
     enigma::centerchild();
 }


### PR DESCRIPTION
GM centers using the unscaled region dimensions to center the window so
that window_default or window_center will work in fullscreen mode making
the window centered if the user returns to windowed mode. Tested and
confirmed on GM8.1
