### PR TITLE
Linux: Fixing issue where last path in PATH isn't used.

### DIFF
--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -261,17 +261,19 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
       a = b;
 
       struct stat st;
-      for (char* c = b; *b; b++) if (*b == ':')
+      const char delim[] = ":";
+      char *c = strtok(b, delim);
+      while(c)
       {
-        *b = 0;
         string fn = string(c) + "/" + ename;
         if (!stat(fn.c_str(), &st))
         {
           ename = fn;
           break;
         }
-        c = b + 1;
+        c = strtok(NULL, delim);
       }
+
       free(a);
     }
 


### PR DESCRIPTION
My PATH looks like /bin:/usr/bin and /usr/bin wasn't getting prepended to things like cpp and g++ so execve later in the file was failing.  Without this the user will see errors like "Call to 'defines' toolchain executable returned non-zero!" if their executables happen to be last in the PATH environment variable.
