### PR TITLE
Keyboard Fixes

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -36,6 +36,7 @@ using std::map;
 extern short mouse_hscrolls;
 extern short mouse_vscrolls;
 namespace enigma_user {
+extern int keyboard_key;
 extern int keyboard_lastkey;
 extern string keyboard_lastchar;
 extern string keyboard_string;
@@ -43,6 +44,7 @@ extern string keyboard_string;
 
 namespace enigma
 {
+    using enigma_user::keyboard_key;
     using enigma_user::keyboard_lastkey;
     using enigma_user::keyboard_lastchar;
     using enigma_user::keyboard_string;
@@ -157,13 +159,14 @@ namespace enigma
         case WM_KEYDOWN: {
           int key = enigma_user::keyboard_get_map(wParam);
           keyboard_lastkey = key;
+          keyboard_key = key;
           last_keybdstatus[key]=keybdstatus[key];
           keybdstatus[key]=1;
           return 0;
         }
         case WM_KEYUP: {
           int key = enigma_user::keyboard_get_map(wParam);
-          keyboard_lastkey = key;
+          keyboard_key = 0;
           last_keybdstatus[key]=keybdstatus[key];
           keybdstatus[key]=0;
           return 0;
@@ -171,6 +174,7 @@ namespace enigma
         case WM_SYSKEYDOWN: {
           int key = enigma_user::keyboard_get_map(wParam);
           keyboard_lastkey = key;
+          keyboard_key = key;
           last_keybdstatus[key]=keybdstatus[key];
           keybdstatus[key]=1;
           if (key!=18)
@@ -183,7 +187,7 @@ namespace enigma
         }
         case WM_SYSKEYUP: {
           int key = enigma_user::keyboard_get_map(wParam);
-          keyboard_lastkey = key;
+          keyboard_key = 0;
           last_keybdstatus[key]=keybdstatus[key];
           keybdstatus[key]=0;
           if (key!=(unsigned int)18)

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -234,8 +234,8 @@ void window_center()
 {
     int screen_width = GetSystemMetrics(SM_CXSCREEN);
     int screen_height = GetSystemMetrics(SM_CYSCREEN);
-    enigma::windowX = (screen_width - enigma::regionWidth)/2;
-    enigma::windowY = (screen_height - enigma::regionHeight)/2;
+    enigma::windowX = (screen_width - enigma::scaledWidth)/2;
+    enigma::windowY = (screen_height - enigma::scaledHeight)/2;
     enigma::clampparent();
     enigma::centerchild();
 }

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -40,7 +40,10 @@
 
 namespace enigma_user {
   const int os_type = os_linux;
+  extern int keyboard_key;
   extern int keyboard_lastkey;
+  extern string keyboard_lastchar;
+  extern string keyboard_string;
 }
 
 namespace enigma
@@ -88,6 +91,7 @@ namespace enigma
                 }
               }
               enigma_user::keyboard_lastkey = actualKey;
+              enigma_user::keyboard_key = actualKey;
               if (enigma::last_keybdstatus[actualKey]==1 && enigma::keybdstatus[actualKey]==0) {
                 enigma::keybdstatus[actualKey]=1;
                 return 0;
@@ -97,6 +101,7 @@ namespace enigma
               return 0;
         }
         case KeyRelease: {
+            enigma_user::keyboard_key = 0;
             gk=XLookupKeysym(&e.xkey,0);
             if (gk == NoSymbol)
               return 0;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.h
@@ -41,7 +41,3 @@ namespace enigma {
   }
 }
 
-namespace enigma_user {
-  extern string keyboard_string;
-}
-


### PR DESCRIPTION
Implements keyboard_key and also fixes keyboard_lastkey so that they both behave the same as GM8.1, also tested multiple keyboard key combinations and releases to ensure the behavior is implemented properly. Also fixed for XLIB.

Tested on Win32 and XLIB (Ubuntu) with the following code in an object's draw event. I can confirm the changes work on both systems and behave the same as GM as expected now.

``` cpp
draw_text(0,0,string(keyboard_key) + ":" + string(keyboard_lastkey));
```

This pull request can be merged.

Note: Ignore the window_center commit, nothing was actually changed yet, I did it then undid it. Waiting to have a further discussion on the forums regarding removing the child window.
