### PR TITLE
Attempt to fix delayed deactivation by delaying the command itself. **DO NOT MERGE**

### DIFF
--- a/ENIGMAsystem/SHELL/Collision_Systems/BBox/BBOXfuncs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/BBox/BBOXfuncs.cpp
@@ -745,12 +745,25 @@ bool move_bounce_object(int object, bool adv, bool solid_only)
 
 typedef std::pair<int,enigma::inst_iter*> inode_pair;
 
-namespace enigma_user
+static bool line_ellipse_intersects(cs_scalar rx, cs_scalar ry, cs_scalar x, cs_scalar ly1, cs_scalar ly2)
 {
+    // Formula: x^2/a^2 + y^2/b^2 = 1   <=>   y = +/- sqrt(b^2*(1 - x^2/a^2))
 
-void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bool inside, bool notme) {
+    const cs_scalar inner = ry*ry*(1 - x*x/(rx*rx));
+    if (inner < 0) {
+        return false;
+    }
+    else {
+        const cs_scalar y1 = -sqrt(inner), y2 = sqrt(inner);
+        return y1 <= ly2 && ly1 <= y2;
+    }
+}
+
+namespace enigma 
+{
+void instance_deactivate_region_except(int exid, int rleft, int rtop, int rwidth, int rheight, bool inside) {
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
-        if (notme && (*it)->id == enigma::instance_event_iterator->inst->id) continue;
+        if (exid>=0 && (*it)->id == exid) continue;
         enigma::object_collisions* const inst = ((enigma::object_collisions*)*it);
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) //no sprite/mask then no collision
@@ -778,7 +791,69 @@ void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bo
     }
 }
 
+void instance_deactivate_circle_except(int exid, int x, int y, int r, bool inside) {
+    for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
+    {
+        if (exid>=0 && (*it)->id == exid) continue;
+        enigma::object_collisions* const inst = ((enigma::object_collisions*)*it);
+
+        if (inst->sprite_index == -1 && (inst->mask_index == -1)) //no sprite/mask then no collision
+            continue;
+
+        const bbox_rect_t &box = inst->$bbox_relative();
+        const double x1 = inst->x, y1 = inst->y,
+        xscale = inst->image_xscale, yscale = inst->image_yscale,
+        ia = inst->image_angle;
+
+        int left, top, right, bottom;
+        get_border(&left, &right, &top, &bottom, box.left, box.top, box.right, box.bottom, x1, y1, xscale, yscale, ia);
+
+        const bool intersects = line_ellipse_intersects(r, r, left-x, top-y, bottom-y) ||
+                                 line_ellipse_intersects(r, r, right-x, top-y, bottom-y) ||
+                                 line_ellipse_intersects(r, r, top-y, left-x, right-x) ||
+                                 line_ellipse_intersects(r, r, bottom-y, left-x, right-x) ||
+                                 (x >= left && x <= right && y >= top && y <= bottom); // Circle inside bbox.
+
+        if (intersects)
+        {
+            if (inside)
+            {
+                inst->deactivate();
+                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+            }
+        }
+        else
+        {
+            if (!inside)
+            {
+                inst->deactivate();
+                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+            }
+        }
+    }
+}
+}
+
+
+namespace enigma_user
+{
+
+void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bool inside, bool notme) {
+    int exid = notme ? enigma::instance_event_iterator->inst->id : -1;
+    if (enigma::InstDelayCmd::IsDelay) {
+      enigma::instance_delayed_commands.push_back(enigma::InstDelayCmd(enigma::InstDelayCmd::DeactReg, exid, rleft, rtop, rwidth, rheight, inside));
+      return;
+    }
+
+    enigma::instance_deactivate_region_except(exid, rleft, rtop, rwidth, rheight, inside);
+}
+
 void instance_activate_region(int rleft, int rtop, int rwidth, int rheight, bool inside) {
+    if (enigma::InstDelayCmd::IsDelay) {
+      enigma::instance_delayed_commands.push_back(enigma::InstDelayCmd(enigma::InstDelayCmd::ActReg, 0, rleft, rtop, rwidth, rheight, inside));
+      return;
+    }
+
     std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
 
@@ -819,70 +894,29 @@ void instance_activate_region(int rleft, int rtop, int rwidth, int rheight, bool
 
 }
 
-static bool line_ellipse_intersects(cs_scalar rx, cs_scalar ry, cs_scalar x, cs_scalar ly1, cs_scalar ly2)
-{
-    // Formula: x^2/a^2 + y^2/b^2 = 1   <=>   y = +/- sqrt(b^2*(1 - x^2/a^2))
-
-    const cs_scalar inner = ry*ry*(1 - x*x/(rx*rx));
-    if (inner < 0) {
-        return false;
-    }
-    else {
-        const cs_scalar y1 = -sqrt(inner), y2 = sqrt(inner);
-        return y1 <= ly2 && ly1 <= y2;
-    }
-}
 
 namespace enigma_user
 {
 
 void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
 {
-    for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
-    {
-        if (notme && (*it)->id == enigma::instance_event_iterator->inst->id)
-            continue;
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)*it);
-
-        if (inst->sprite_index == -1 && (inst->mask_index == -1)) //no sprite/mask then no collision
-            continue;
-
-        const bbox_rect_t &box = inst->$bbox_relative();
-        const double x1 = inst->x, y1 = inst->y,
-        xscale = inst->image_xscale, yscale = inst->image_yscale,
-        ia = inst->image_angle;
-
-        int left, top, right, bottom;
-        get_border(&left, &right, &top, &bottom, box.left, box.top, box.right, box.bottom, x1, y1, xscale, yscale, ia);
-
-        const bool intersects = line_ellipse_intersects(r, r, left-x, top-y, bottom-y) ||
-                                 line_ellipse_intersects(r, r, right-x, top-y, bottom-y) ||
-                                 line_ellipse_intersects(r, r, top-y, left-x, right-x) ||
-                                 line_ellipse_intersects(r, r, bottom-y, left-x, right-x) ||
-                                 (x >= left && x <= right && y >= top && y <= bottom); // Circle inside bbox.
-
-        if (intersects)
-        {
-            if (inside)
-            {
-                inst->deactivate();
-                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
-            }
-        }
-        else
-        {
-            if (!inside)
-            {
-                inst->deactivate();
-                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
-            }
-        }
+    int exid = notme ? enigma::instance_event_iterator->inst->id : -1;
+    if (enigma::InstDelayCmd::IsDelay) {
+      enigma::instance_delayed_commands.push_back(enigma::InstDelayCmd(enigma::InstDelayCmd::DeactCirc, exid, x, y, r, inside));
+      return;
     }
+
+    enigma::instance_deactivate_circle_except(exid, x, y, r, inside);
 }
 
 
 void instance_activate_circle(int x, int y, int r, bool inside)
 {
+    if (enigma::InstDelayCmd::IsDelay) {
+      enigma::instance_delayed_commands.push_back(enigma::InstDelayCmd(enigma::InstDelayCmd::ActCirc, 0, x, y, r, inside));
+      return;
+    }
+
     std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
         enigma::object_collisions* const inst = ((enigma::object_collisions*)(iter->second->inst));

--- a/ENIGMAsystem/SHELL/Universal_System/instance.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance.h
@@ -39,6 +39,63 @@ enigma::instance_t instance_create(int x,int y,int object);
 
 namespace enigma {
   object_basic *instance_create_id(int x,int y,int object,int idg); //This is for use by the system only. Please leave be.
+
+  //These are also required by the system (called for delayed deactivation).
+  void instance_deactivate_region_except(int exid, int rleft, int rtop, int rwidth, int rheight, bool inside);
+  void instance_deactivate_circle_except(int exid, int x, int y, int r, bool inside);
+
+  //Flag when we are within a "delayed deactivation" zone. This includes room creation and object creation code, and delays 
+  //instance_deactivate*() calls until the "clear" function is called. It also delays instance_activate*() calls, since 
+  //they would be out-of-order with respect to the deactivates.
+  void instance_flag_delay_deact();
+  void instance_flag_clear_and_run();
+
+  //This struct is used internally to when and how to "delay" instance deactivation commands.
+  struct InstDelayCmd {
+    static bool IsDelay; //If true, we are in a "delayed deactivation zone" (room creation code).
+
+    enum Cmd { //The type of command we are delaying.
+      DeactObj = 0,  //instance_deactivate_object()
+      DeactAll,      //instance_deactivate_all()
+      DeactReg,      //instance_deactivate_region()
+      DeactCirc,     //instance_deactivate_circle()
+      ActObj,        //instance_activate_object()
+      ActAll,        //instance_activate_all()
+      ActReg,        //instance_activate_region()
+      ActCirc,       //instance_activate_circle()
+    } cmd;
+
+    //Params for each delayed command type.
+    int id; //For the *all() commands, this is the id *not* to delete, or -1 if notme == false.
+    union {
+      int left; //for region()
+      int x;    //for circle()
+    };
+    union {
+      int top; //for region()
+      int y;    //for circle()
+    };
+    union {
+      int width; //for region()
+      int r;    //for circle()
+    };
+    int height;
+    bool inside;
+
+    //Most commands only take the command type and an id. (This is also the no-args constructor, for storage in a vector).
+    explicit InstDelayCmd(Cmd cmd=DeactObj, int id=0) : cmd(cmd), id(id), left(0), top(0), width(0), height(0), inside(false) {}
+
+    //Region commands take left/top/width/height/inside.
+    InstDelayCmd(Cmd cmd, int id, int left, int top, int width, int height, bool inside)
+      : cmd(cmd), id(id), left(left), top(top), width(width), height(height), inside(inside) {}
+
+    //Circle commands take x/y/r/inside.
+    InstDelayCmd(Cmd cmd, int id, int x, int y, int r, bool inside)
+      : cmd(cmd), id(id), x(x), y(y), r(r), height(0), inside(inside) {}
+  };
+
+  //Our list of delayed commands. If InstDelayCmd::IsDelay is true, then append to this. Else, execute the command.
+  static std::vector<InstDelayCmd> instance_delayed_commands;
 }
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -167,6 +167,9 @@ namespace enigma
     load_tiles();
     //Tiles end
 
+    //Delay deactivation/activation events.
+    enigma::instance_flag_delay_deact();
+
     object_basic* is[instancecount];
     for (int i = 0; i < instancecount; i++) {
       inst *obj = &instances[i];
@@ -192,6 +195,9 @@ namespace enigma
   // Fire the rooms creation code
   if (createcode)
        createcode();
+
+  //Fire off any saved instance events. (NOTE: The roomstart event below does *not* fire for these).
+  enigma::instance_flag_clear_and_run();
 
   // Fire the room start event for all persistent objects still kept alive and all the new instances
   for (enigma::iterator it = enigma::instance_list_first(); it; ++it)


### PR DESCRIPTION
This command fixes a nasty bug I ran into regarding instance_deactivate_*() and room events. From the GM docs:

```
NOTE: If you deactivate an instance on room start (ie:from the room creation code, or from an instance create event of an instance within the room) all instances that are placed within the room from the room editor will still run their create event before being deactivated.
```

The following game demonstrates this:
https://drive.google.com/file/d/0B1P7NepPcOslSjhaZFMzdE80ems

If run in GM:S, the following messages are shown. In Enigma, only the first message is shown.

```
show_message: CREATE OK
show_message: ROOM INST OK
```

The first message is an object's "create()" message, and the second is a room's instance_create method for a given instance. Note that one of the objects in the room calls "instance_destroy_all()" in its create() code --this is the source of the problem!

To solve this, I created a command structure that allows instance_deactivate_() and instance_activate_() commands to be delayed until after room loading is complete. This was the simplest, most robust way I could find for fixing this bug; other options include leaving the object in the active list but setting a "toBeDisabled" flag (it needs to be in the active list because with(object){} must still work), but this seems more likely to lead to esoteric bugs. Finally, it should be obvious that delaying deactivation events necessitates delaying activation events.

I've tested that this pull request fixes the observed bug, on both the Precise and BBox collision systems, bringing behavior in line to what was observed in GM5 and GM:S.
