### PR TITLE
Bug fixes and code cleanup identified by valgrind and clang.

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
@@ -122,10 +122,10 @@ int audio_play_sound(int sound, double priority, bool loop)
     alSourcef(sound_channels[src]->source, AL_GAIN, snd->volume);
     sound_channels[src]->priority = priority;
     sound_channels[src]->soundIndex = sound;
-    !(snd->idle = !(snd->playing = !snd->stream ?
+    snd->idle = !(snd->playing = !snd->stream ?
       alurePlaySource(sound_channels[src]->source, enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE :
       alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1, enigma::eos_callback,
-        (void*)(ptrdiff_t)sound) != AL_FALSE));
+        (void*)(ptrdiff_t)sound) != AL_FALSE);
     return src + 200000;
   } else {
     return -1;
@@ -147,10 +147,10 @@ int audio_play_sound_at(int sound, as_scalar x, as_scalar y, as_scalar z, as_sca
     alSourcef(sound_channels[src]->source, AL_GAIN, snd->volume);
     sound_channels[src]->priority = priority;
     sound_channels[src]->soundIndex = sound;
-    !(snd->idle = !(snd->playing = !snd->stream ?
+    snd->idle = !(snd->playing = !snd->stream ?
       alurePlaySource(sound_channels[src]->source, enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE :
       alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1, enigma::eos_callback,
-        (void*)(ptrdiff_t)sound) != AL_FALSE));
+        (void*)(ptrdiff_t)sound) != AL_FALSE);
     return src + 200000;
   } else {
     return -1;
@@ -344,7 +344,7 @@ int audio_add(string fname)
   // Decode sound
   int rid = enigma::sound_allocate();
   bool fail = enigma::sound_add_from_buffer(rid,fdata,flen);
-  delete fdata;
+  delete [] fdata;
   
   if (fail)
     return -1;

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALbasic.cpp
@@ -289,7 +289,7 @@ int sound_add(string fname, int kind, bool preload) //At the moment, the latter 
   // Decode sound
   int rid = enigma::sound_allocate();
   bool fail = enigma::sound_add_from_buffer(rid,fdata,flen);
-  delete fdata;
+  delete [] fdata;
 
   if (fail)
     return -1;
@@ -325,7 +325,7 @@ bool sound_replace(int sound, string fname, int kind, bool preload)
   
   // Decode sound
   bool fail = enigma::sound_add_from_buffer(sound,fdata,flen);
-  delete fdata;
+  delete [] fdata;
   return fail;
 }
 

--- a/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECfuncs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECfuncs.cpp
@@ -545,14 +545,15 @@ void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bo
 }
 
 void instance_activate_region(int rleft, int rtop, int rwidth, int rheight, bool inside) {
-    for (std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
-         iter != enigma::instance_deactivated_list.end();
-         ++iter) {
+    std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
+    while (iter != enigma::instance_deactivated_list.end()) {
 
         enigma::object_collisions* const inst = ((enigma::object_collisions*)(iter->second->inst));
 
-        if (inst->sprite_index == -1 && (inst->mask_index == -1)) //no sprite/mask then no collision
+        if (inst->sprite_index == -1 && (inst->mask_index == -1)) {//no sprite/mask then no collision
+            ++iter;
             continue;
+        }
 
         const bbox_rect_t &box = inst->$bbox_relative();
         const double x = inst->x, y = inst->y,
@@ -564,7 +565,9 @@ void instance_activate_region(int rleft, int rtop, int rwidth, int rheight, bool
 
         if ((left <= (rleft+rwidth) && rleft <= right && top <= (rtop+rheight) && rtop <= bottom) == inside) {
             inst->activate();
-            enigma::instance_deactivated_list.erase(iter);
+            enigma::instance_deactivated_list.erase(iter++);
+        } else {
+            ++iter;
         }
     }
 }

--- a/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECimpl.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECimpl.cpp
@@ -26,6 +26,7 @@
 
 #include "PRECimpl.h"
 #include <cmath>
+#include <utility>
 
 static inline void get_border(int *leftv, int *rightv, int *topv, int *bottomv, int left, int top, int right, int bottom, double x, double y, double xscale, double yscale, double angle)
 {
@@ -399,9 +400,9 @@ enigma::object_collisions* const collide_inst_inst(int object, bool solid_only, 
 enigma::object_collisions* const collide_inst_rect(int object, bool solid_only, bool prec, bool notme, int x1, int y1, int x2, int y2)
 {
     if (x1 > x2)
-        x1 ^= (x2 ^= (x1 ^= x2));
+        std::swap(x1, x2);
     if (y1 > y2)
-        y1 ^= (y2 ^= (y1 ^= y2));
+        std::swap(y1, y2);
 
     for (enigma::iterator it = enigma::fetch_inst_iter_by_int(object); it; ++it)
     {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmath.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmath.h
@@ -189,8 +189,8 @@ public:
             for (unsigned int j = 0 ; j < 3; ++j) {
                 Ret.m[i][j] = m[i][0] * Right.m[0][j] +
                               m[i][1] * Right.m[1][j] +
-                              m[i][2] * Right.m[2][j] +
-                              m[i][3] * Right.m[3][j];
+                              m[i][2] * Right.m[2][j];
+                              //m[i][3] * Right.m[3][j]; //CHECK THIS
             }
         }
         return Ret;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
@@ -569,8 +569,8 @@ void draw_button(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, gs_scala
 	draw_vertex(x2,y2);
 	draw_primitive_end();
 
-	int color, alpha;
-	alpha = 0.5;
+	int color;
+	float alpha = 0.5;
     if (up == true){ color = make_color_rgb(127,127,127); } else { color = make_color_rgb(255,255,255); }
 
 	draw_primitive_begin(pr_trianglestrip);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
@@ -15,11 +15,11 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-using namespace std;
 #include <cstddef>
 #include <iostream>
 #include <math.h>
 
+using namespace std;
 
 #include <stdio.h> //for file writing (surface_save)
 #include "Universal_System/nlpo2.h"

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
@@ -78,7 +78,7 @@ namespace enigma
 
     iterator::iterator(inst_iter*_it, bool tmp): it(_it), temp(tmp) { addme(); }
     iterator::iterator(const iterator&other): it(other.it?new inst_iter(*other.it):NULL), temp(true) { addme(); }
-    iterator::iterator(iterator&other): it(other.it), temp(other.temp) { other.temp = NULL; }
+    iterator::iterator(iterator&other): it(other.it), temp(other.temp) { other.temp = false; }
     iterator::iterator(object_basic*ob): it(new inst_iter(ob,NULL,NULL)), temp(true) { }
     iterator::iterator(): it(NULL), temp(true) { }
     iterator:: ~iterator() {


### PR DESCRIPTION
This contains some fixes for memory corruption or other risky code identified by valgrind/clang. I tried to avoid being pedantic by limiting the errors fixed only to those I thought could cause real damage.

Please check the "CHECK THIS" comment in GSmath.h; I'm 99% sure this is a bug, but perhaps there is some weird GL thing I am overlooking.

Note: The "x1 ^= (x2 ^= (x1 ^= x2));" line uses sequence points incorrectly, and is a very confusing way of writing "swap" in the first place. 
