### PR TITLE
Fix for obj_1.depth = 10; crashing when obj_1 isn't in the room.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/graphics_object.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/graphics_object.cpp
@@ -33,6 +33,8 @@ namespace enigma
 
   INTERCEPT_DEFAULT_COPY(enigma::depthv)
   void depthv::function(variant oldval) {
+    if (!myiter) { return; }
+
     rval.d = floor(rval.d);
     if (fequal(oldval.rval.d, rval.d)) return;
 
@@ -57,6 +59,8 @@ namespace enigma
     }
     myiter = NULL;
   }
+
+  depthv::depthv() : myiter(0) {}
   depthv::~depthv() {}
 
   int object_graphics::$sprite_width()  const { return sprite_index == -1? 0 : enigma_user::sprite_get_width(sprite_index)*image_xscale; }

--- a/ENIGMAsystem/SHELL/Universal_System/graphics_object.h
+++ b/ENIGMAsystem/SHELL/Universal_System/graphics_object.h
@@ -43,6 +43,7 @@ namespace enigma
     void function(variant oldval);
     void init(gs_scalar depth, object_basic* who);
     void remove();
+    depthv();
     ~depthv();
   };
   struct object_graphics: object_timelines


### PR DESCRIPTION
Say you have the following in any object except obj_1:

```
obj_1.depth = 100;
```

The default object returned does not have a valid iterator set in depth, so depthv::function() will segfault. I fixed this by adding a default constructor that nulls out "myiter", and then just checking that.

I also tested various other "multifunction_variants", such as speedv, hspeedv, etc. None of them seemed to crash.

This crash occurs because the default variable never has init() called for its depth parameter. I don't think tracking depth for the default variant makes a whole lot of sense, so I just had the function return early if no object was bound.
