### PR TITLE
Bugfix: alarm check decrements first.

### DIFF
--- a/events.res
+++ b/events.res
@@ -93,7 +93,7 @@ alarm: 2
 	Group: Alarm
 	Name: Alarm %1
 	Mode: Stacked
-	Sub Check: { alarm[%1] = (int)alarm[%1]; return !((alarm[%1] == -1) or (alarm[%1]--)); }
+	Sub Check: { alarm[%1] = (int)alarm[%1]; return alarm[%1]<=0 ? false : !(--alarm[%1]); }
 
 
 # Keyboard events. These are simple enough.


### PR DESCRIPTION
So, test case first:
https://drive.google.com/file/d/0B1P7NepPcOslRjlLMnZWSnhsOXM/edit?usp=sharing

...and here's what it looks like in GM:S:
http://i.imgur.com/FAznkmZ.png

In ENIGMA, however, the alarm counter is post-decremented, so the alarm actually fires off one tick later. This is bad for objects that rely on precise alarm timing. (The test case tests this by setting alarm[0] to 1 in begin_step, and then in step.)

In fact, ENIGMA's event ordering code is very sophisticated, so it only took one tiny fix: changing alarm[%1]-- to --alarm[%1] in the sub-check. However, this led to the alarm triggering one tick too often (due to the way the logical or is used to check -1), so I had to replace the sub-check with the code you see in this patch.

As always, I welcome discussion. In this case, I'm very confident in this fix, because upon applying it, every single timing glitch in Iji disappeared. 
