### PR TITLE
Resolves #772 to allow access to inherited vars

### DIFF
--- a/CompilerSource/compiler/components/write_object_access.cpp
+++ b/CompilerSource/compiler/components/write_object_access.cpp
@@ -114,12 +114,20 @@ int lang_CPP::compile_writeObjAccess(map<int,parsed_object*> &parsed_objects, pa
 
       for (po_i it = parsed_objects.begin(); it != parsed_objects.end(); it++)
       {
-        map<string,dectrip>::iterator x = it->second->locals.find(pmember);
-        if (x != it->second->locals.end())
+        po_i parent = it;
+        while(parent != parsed_objects.end())
         {
-          string tot = x->second.type != "" ? x->second.type : "var";
-          if (tot == dait->second.type and x->second.prefix == dait->second.prefix and x->second.suffix == dait->second.suffix)
-            wto << "      case " << it->second->name << ": return ((OBJ_" << it->second->name << "*)inst)->" << pmember << ";" << endl;
+          map<string,dectrip>::iterator x = parent->second->locals.find(pmember);
+          if (x != parent->second->locals.end())
+          {
+            string tot = x->second.type != "" ? x->second.type : "var";
+            if (tot == dait->second.type and x->second.prefix == dait->second.prefix and x->second.suffix == dait->second.suffix)
+            {
+              wto << "      case " << it->second->name << ": return ((OBJ_" << it->second->name << "*)inst)->" << pmember << ";" << endl;
+              break;
+            }
+          }
+          parent = parsed_objects.find(parent->second->parent);
         }
       }
 


### PR DESCRIPTION
As mentioned in issue #772, there is a minor issue when attempting to access a variable from a child object in which the parent contains the actual variable's definition.

It can be resolved either with the compiler change I suggest, or by adding something like "some_var = some_var" in the child's code somewhere (assuming that "some_var" was actually defined in the parent object.)

My solution adds a very small amount of compilation overhead and may not be an ideal fix, but I think it is sufficient.  Let me know your thoughts otherwise.
