### PR TITLE
Depth(1000000,1000001) fix.

### DIFF
--- a/CompilerSource/compiler/components/write_object_data.cpp
+++ b/CompilerSource/compiler/components/write_object_data.cpp
@@ -537,13 +537,14 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
 		parsed.push_back(i->first);
 		i++;
       }
-      wto << "\n  objectstruct objs[] = {\n  ";
+      wto << "\n  objectstruct objs[] = {\n  " <<std::fixed;
       int objcunt = 0, obmx = 0;
       for (po_i i = parsed_objects.begin(); i != parsed_objects.end(); i++, objcunt++)
       {
         wto << "{" << i->second->sprite_index << "," << i->second->solid << "," << i->second->visible << "," << i->second->depth << "," << i->second->persistent << "," << i->second->mask_index << "," << i->second->parent << "," << i->second->id << "}, ";
         if (i->second->id >= obmx) obmx = i->second->id;
       }
+      wto.unsetf(ios_base::floatfield);
       wto << "  };\n";
       wto << "  int objectcount = " << objcunt << ";\n";
       wto << "  int obj_idmax = " << obmx+1 << ";\n";


### PR DESCRIPTION
Test case; the red square should appear over the blue square.
https://drive.google.com/file/d/0B1P7NepPcOslR2pjOVpmVkdyZ3c/edit?usp=sharing

Large values of depth are common (GM5 starts you off at 1000000). Unfortunately, we were printing scientific notation (e.g., 1+e6 for BOTH 1000000 and 1000001), which led to objects being printed out of order. 

I fixed this by adding a <<std::fixed to the object print code. I unset it after the loop so that nothing else is affected.
