### PR TITLE
Fixes sprite_add when subimages > 1

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/spritestruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/spritestruct.cpp
@@ -324,7 +324,7 @@ namespace enigma
 					tmpcell += 4;
 				}
 			}
-			unsigned texture = graphics_create_texture(cellwidth, height, fullcellwidth, fullheight, pxdata, mipmap);
+			unsigned texture = graphics_create_texture(cellwidth, height, fullcellwidth, fullheight, pixels, mipmap);
 			ns->texturearray.push_back(texture);
 			ns->texbordxarray.push_back((double) cellwidth/fullcellwidth);
 			ns->texbordyarray.push_back((double) height/fullheight);


### PR DESCRIPTION
When loading external resources using a subimages argument greater than 1, the resulting image appears interlaced and incorrect.  I think the issue is a simple result of a typo.
