### PR TITLE
Fixes for timelines that are set from with(other){} type blocks

### DIFF
--- a/CompilerSource/compiler/components/write_object_data.cpp
+++ b/CompilerSource/compiler/components/write_object_data.cpp
@@ -91,13 +91,10 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
     }
     wto << "\n";
 
-    //Write timeline/moment names. Timelines are like scripts, but we don't have to worry about arguments or return types.
-    map<string, int> revTlineLookup; //We'll need this lookup later.
+    //Build a reverse lookup for timeline names.
+    map<string, int> revTlineLookup;
     for (int i=0; i<es->timelineCount; i++) {
       revTlineLookup[es->timelines[i].name] = es->timelines[i].id;
-      for (int j=0; j<es->timelines[i].momentCount; j++) {
-        wto << "void TLINE_" <<es->timelines[i].name <<"_MOMENT_" <<es->timelines[i].moments[j].stepNo <<"();\n";
-      }
     }
 
     wto << "\n";
@@ -252,23 +249,25 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
 
 
         // Next, we write the list of all the timelines this object will hoard a copy of for itself.
+        // NOTE: See below; we actually need to assume this object has the potential to call any timeline. 
+        //       BUT we only locally-copy the ones we know about for sure here.
+        bool hasKnownTlines = false;
         wto << "\n    //Timelines called by this object\n    ";
-        bool hasTlines = false;
         for (parsed_object::tlineit it = t->tlines.begin(); it != t->tlines.end(); it++) //For each timeline potentially set by this object.
         {
           map<string, int>::iterator timit = revTlineLookup.find(it->first); //Check if it's a timeline
           if (timit != revTlineLookup.end()) // If we've got ourselves a script
           //and subscr->second->pev_global) // And it has distinct code for use at the global scope (meaning it's more efficient locally) //NOTE: It seems all timeline MUST be copied locally.
           {
-            hasTlines = true;
+            hasKnownTlines = true;
             for (int j=0; j<es->timelines[timit->second].momentCount; j++) {
               wto << "void TLINE_" <<es->timelines[timit->second].name <<"_MOMENT_" <<es->timelines[timit->second].moments[j].stepNo <<"();\n    ";
             }
           }
         } wto << "\n    ";
 
-        //If at least one timeline is called by this object, override timeline_call_moment_script() to properly dispatch it.
-        if (hasTlines) {
+        //If at least one timeline is called by this object, override timeline_call_moment_script() to properly dispatch it to the local instance.
+        if (hasKnownTlines) {
           wto <<"//Dispatch timelines properly for this object..\n    ";
           wto <<"virtual void timeline_call_moment_script(int timeline_index, int moment_index);\n\n    ";
         }
@@ -581,9 +580,9 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
       //Super-hacky
       std::string override_code = "";
       std::string override_synt = "";
-      if (upev.code.find("with((self)){")==0 && upev.code.find("};")==upev.code.size()-2) {
-        override_code = upev.code.substr(13, upev.code.size()-13-2);
-        override_synt = upev.synt.substr(13, upev.synt.size()-13-2);
+      if (upev.code.find("with((self))")==0) {
+        override_code = upev.code.substr(12, std::string::npos);
+        override_synt = upev.synt.substr(12, std::string::npos);
       }
       print_to_file(
         override_code.empty() ? upev.code : override_code,
@@ -604,7 +603,21 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
         parsed_script* scr = tline_lookup[es->timelines[i].name][j];
         wto << "void TLINE_" <<es->timelines[i].name <<"_MOMENT_" <<es->timelines[i].moments[j].stepNo <<"()\n{\n";
         parsed_event& upev = scr->pev_global?*scr->pev_global:scr->pev;
-        print_to_file(upev.code,upev.synt,upev.strc,upev.strs,2,wto);
+
+        std::string override_code = "";
+        std::string override_synt = "";
+        if (upev.code.find("with((self))")==0) {
+          override_code = upev.code.substr(12, std::string::npos);
+          override_synt = upev.synt.substr(12, std::string::npos);
+        }
+        print_to_file(
+          override_code.empty() ? upev.code : override_code,
+          override_synt.empty() ? upev.synt : override_synt,
+          upev.strc,
+          upev.strs,
+          2,wto
+        );
+
         wto << "\n}\n\n";
       }
     }
@@ -693,14 +706,14 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
 
 
       //Write local object copies of timelines
-      bool hasTlines = false;
+      bool hasKnownTlines = false;
       for (parsed_object::tlineit it = t->tlines.begin(); it != t->tlines.end(); it++) //For each timeline potentially set by this object
       {
         map<string, int>::iterator timit = revTlineLookup.find(it->first); //Check if it's a timeline
         if (timit != revTlineLookup.end()) // If we've got ourselves a script
         //and subscr->second->pev_global) // And it has distinct code for use at the global scope (meaning it's more efficient locally) //NOTE: It seems all timeline MUST be copied locally.
         {
-          hasTlines = true;
+          hasKnownTlines = true;
           for (int j=0; j<es->timelines[timit->second].momentCount; j++) {
             parsed_script* scr = tline_lookup[timit->first][j];
             wto << "void enigma::OBJ_" <<i->second->name <<"::TLINE_" <<es->timelines[timit->second].name <<"_MOMENT_" <<es->timelines[timit->second].moments[j].stepNo <<"() {\n    ";
@@ -710,8 +723,9 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
         } wto << "\n";
       }
 
-      //If no timelines are ever used by this script, it has no use for a lookup table.
-      if (hasTlines) {
+      //If no timelines are ever used by this script, it can rely on the default lookup table.
+      //NOTE: We have to allow it to fall through to the default in cases where instances (by id) are given a timeline.
+      if (hasKnownTlines) {
         wto <<"void enigma::OBJ_" <<i->second->name <<"::timeline_call_moment_script(int timeline_index, int moment_index) {\n";
         wto <<"  switch (timeline_index) {\n";
         for (parsed_object::tlineit it = t->tlines.begin(); it != t->tlines.end(); it++) {
@@ -727,9 +741,11 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
             }
             wto <<"      }\n";
             wto <<"      break;\n";
-            wto <<"    }\n";
+           wto <<"    }\n";
           }
         }
+        //Fall through to the default case.
+        wto <<"    default: event_parent::timeline_call_moment_script(timeline_index, moment_index);\n";
         wto <<"  }\n";
         wto <<"}\n\n";
       }


### PR DESCRIPTION
Essentially, using the following would lead to an error:

```
with(other) {
  timeline_index = tline_0;
}
```

There were a few problems behind this. First, since "other" didn't know that tline_0 was a valid index, it would silently fail to update that timeline. (This is a bug in the parser that applies to with(other) in general with I intend to fix at some point in the future.) There are some cases that we will never be able to tag correctly; for example, "with(1000001){}". So, I wrote a "default:" case in all timeline lookup switches that would call the parent class's lookup method (the parent class contains a definitive lookup of all timelines).

Following this, timelines would trigger but glitched like crazy. In fact, it looked a lot like (https://github.com/enigma-dev/enigma-dev/pull/781), and was in fact the same bug --except applied to timelines instead of global scripts. This only happens when the default case is called. So, I applied the same fix as in the linked bug.

This fixes a few glitches with Iji's timeline-driven cutscenes (not the intro).
