### PR TITLE
Fix for chained iterators when a single instance is requested.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
@@ -239,7 +239,7 @@ namespace enigma
       return iterator();
 
     iliter a = instance_list.find(x);
-    return a != instance_list.end() ? a->second : NULL;
+    return a != instance_list.end() ? iterator(a->second->inst) : iterator();
   }
 
   iterator fetch_roominst_iter_by_id(int x)


### PR DESCRIPTION
I'm about 50% sure this is a bug, so please double-check.

Basically, returning the iterator directly (in fetch_inst_iter_by_id) instead of wrapping the object means that we receive an iterator with links to the other instances, instead of an isolated iterator as requested.

I am fairly sure of this because the other function (fetch_inst_iter_by_int) returns a wrapped iterator. 

If this is correct, please merge this branch (it fixes an observed bug in Iji). If not, I can always migrate this "fix" into fetch_roominst_iter_by_id(), which would also fix my problem but would leave the original function untouched.

By the way, I am fairly sure I am the only one using this function (even though I didn't write it). See:

```
grep -r fetch_inst_iter_by_id enigma-dev/*
enigma-dev/ENIGMAsystem/SHELL/Universal_System/instance_system_base.h:  inst_iter*    fetch_inst_iter_by_id(int id);
enigma-dev/ENIGMAsystem/SHELL/Universal_System/instance_iterator.h:  iterator fetch_inst_iter_by_id(int id);
enigma-dev/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp:  iterator fetch_inst_iter_by_id(int x)
enigma-dev/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp:    return fetch_inst_iter_by_id(x);
```
