### PR TITLE
The instance_deactivated list is never cleared between rooms.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -107,6 +107,9 @@ namespace enigma
       reset_lives();
     }
 
+    //We may still be holding on to deactivated instances; they can interact badly with existing instances in certain cases.
+    instance_deactivated_list.clear();
+
     // Initialize background variants so they do not throw uninitialized variable access errors.
     for (unsigned i=0;i<8;i++)
     {


### PR DESCRIPTION
**EDIT**: Further testing is required; don't merge just yet.

From my tests, the instance_deactivated list is never cleared between rooms. That means deactivated instances can, in some cases, overwrite new (correct) instances after changing rooms. This pull request fixes a few room-related bugs in Iji, all of which involve visiting the same room twice (hence the 

My only concern with this pull request is that I am not 100% clear on the memory management that takes place for instances. In other words: does clearing instance_deactivated create a memory leak?
