### PR TITLE
Reset the "default" variable for each use if "treat uninitialized variables as 0"

### DIFF
--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -576,7 +576,7 @@ wto << "namespace enigma_user {\nstring shader_get_name(int i) {\n switch (i) {\
   irrr();
 
   edbg << "Writing local accessors" << flushl;
-  res = current_language->compile_writeObjAccess(parsed_objects, &EGMglobal);
+  res = current_language->compile_writeObjAccess(parsed_objects, &EGMglobal, es->gameSettings.treatUninitializedAs0);
   irrr();
 
   edbg << "Writing font data" << flushl;

--- a/CompilerSource/compiler/components/write_object_access.cpp
+++ b/CompilerSource/compiler/components/write_object_access.cpp
@@ -65,7 +65,7 @@ string REFERENCE_POSTFIX(string ref) {
 #include "languages/lang_CPP.h"
 
 struct usedtype { int uc; dectrip original; usedtype(): uc(0) {} }; // uc is the use count, then after polling, the dummy number.
-int lang_CPP::compile_writeObjAccess(map<int,parsed_object*> &parsed_objects, parsed_object* global)
+int lang_CPP::compile_writeObjAccess(map<int,parsed_object*> &parsed_objects, parsed_object* global, bool treatUninitAs0)
 {
   ofstream wto;
   wto.open((makedir +"Preprocessor_Environment_Editable/IDE_EDIT_objectaccess.h").c_str(),ios_base::out);
@@ -135,6 +135,9 @@ int lang_CPP::compile_writeObjAccess(map<int,parsed_object*> &parsed_objects, pa
       if (dait->second.type == "var")
         wto << "      default: return map_var(&(((enigma::object_locals*)inst)->vmap), \"" << pmember << "\");"  << endl;
       wto << "    }" << endl;
+      if (treatUninitAs0) { //Can't keep re-using the same dummy variable.
+        wto << "    dummy_" <<(usedtypes[dait->second.type + " " + dait->second.prefix + dait->second.suffix].uc) <<" = var();" << endl;
+      }
       wto << "    return dummy_" << usedtypes[dait->second.type + " " + dait->second.prefix + dait->second.suffix].uc << ";" << endl;
       wto << "  }" << endl;
     }

--- a/CompilerSource/languages/lang_CPP.h
+++ b/CompilerSource/languages/lang_CPP.h
@@ -45,7 +45,7 @@ struct lang_CPP: language_adapter {
   int compile_parseSecondary(map<int,parsed_object*>&,parsed_script*[],int scrcount, vector<parsed_script*>& tlines, map<int,parsed_room*>&,parsed_object*, const std::set<std::string>&);
   int compile_writeGlobals(EnigmaStruct*,parsed_object*);
   int compile_writeObjectData(EnigmaStruct*,parsed_object*,int mode);
-  int compile_writeObjAccess(map<int,parsed_object*>&,parsed_object*);
+  int compile_writeObjAccess(map<int,parsed_object*>&,parsed_object*, bool treatUninitAs0);
   int compile_writeFontInfo(EnigmaStruct* es);
   int compile_writeRoomData(EnigmaStruct* es, parsed_object *EGMglobal,int mode);
   int compile_writeShaderData(EnigmaStruct* es, parsed_object *EGMglobal);

--- a/CompilerSource/languages/language_adapter.h
+++ b/CompilerSource/languages/language_adapter.h
@@ -41,7 +41,7 @@ struct language_adapter {
   virtual int compile_parseSecondary(map<int,parsed_object*>&,parsed_script*[],int scrcount, vector<parsed_script*>& tlines, map<int,parsed_room*>&,parsed_object*, const std::set<std::string>&) = 0;
   virtual int compile_writeGlobals(EnigmaStruct*,parsed_object*) = 0;
   virtual int compile_writeObjectData(EnigmaStruct*,parsed_object*,int mode) = 0;
-  virtual int compile_writeObjAccess(map<int,parsed_object*>&,parsed_object*) = 0;
+  virtual int compile_writeObjAccess(map<int,parsed_object*>&,parsed_object*, bool treatUninitAs0) = 0;
   virtual int compile_writeFontInfo(EnigmaStruct* es) = 0;
   virtual int compile_writeRoomData(EnigmaStruct* es,parsed_object *EGMglobal,int mode) = 0;
   virtual int compile_writeShaderData(EnigmaStruct* es,parsed_object *EGMglobal) = 0;


### PR DESCRIPTION
**_NOTE**_: This fix only affects games where "treat uninitialized variables as 0" is set.

Let's say you have this:

```
obj_1.myvar = 10;
show_message(string(obj_1.myvar));
```

...but there are no active instances of obj_1. On GM:S and ENIGMA, the behavior doesn't matter ---except if the variable "treat uninitialized variables as 0" is set. If so, we cannot keep any state. The message must always print "0". (This was confirmed on GM5.)

To fix that, I changed all the object access calls to reset the default like so:

```
//Previously.
return dummy_0;

//Now:
dummy_0 = var();
return dummy_0;
```

Otherwise, the dummy variable can carry state between different "default" calls.

Note that there are other possible solutions to this problem, but this seemed the easiest (and it doesn't affect games which don't use this particular flag, which most games shouldn't). If there is a solution you prefer, let me know.
