### PR TITLE
Fix for bad polygons crashing the game.

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
@@ -200,10 +200,10 @@ void CALLBACK combineCallback(GLdouble coords[3], GLdouble* vertex_data[4], GLfl
     vertex[2] = coords[2];
 
     for (int i = 3; i < 6; i++) {
-      vertex[i] = weight[0] * vertex_data[0][i]
-                + weight[1] * vertex_data[1][i]
-                + weight[2] * vertex_data[2][i]
-                + weight[3] * vertex_data[3][i];
+      vertex[i] = (weight[0] ? weight[0] * vertex_data[0][i] : 0)
+                + (weight[1] ? weight[1] * vertex_data[1][i] : 0)
+                + (weight[2] ? weight[2] * vertex_data[2][i] : 0)
+                + (weight[3] ? weight[3] * vertex_data[3][i] : 0);
     }
   }
 


### PR DESCRIPTION
The draw_polygon_begin()/vertext()/end() code (which is ONLY used from the GM5 compat plugin, but is accessible globally) will crash if you define a polygon with multiple consecutive points the same. For example:
https://drive.google.com/file/d/0B1P7NepPcOslekJxMTRNdHpsWTA

The tessellation algorithm is working correctly; it just returns a null pointer and a 0 weight if the edge in question has no effect on the total shape. This patch accounts for that that and fixes the bug; shapes now display properly and, more importantly, the game won't segfault if you define bogus polygons.

This also fixes a crash in the final boss on Iji.
