### PR TITLE
Added preCreationCode

### DIFF
--- a/CompilerSource/backend/sub/Instance.c
+++ b/CompilerSource/backend/sub/Instance.c
@@ -2,12 +2,13 @@
 #define boolean int
 
 typedef struct {
-	int x;
-	int y;
-	GmObject *object;
-	int id;
-	String creationCode;
-	boolean locked;
+  int x;
+  int y;
+  GmObject *object;
+  int id;
+  String creationCode;
+  String preCreationCode;
+  boolean locked;
 
-	Room *room;
+  Room *room;
 } Instance, *pInstance;

--- a/CompilerSource/backend/sub/Instance.h
+++ b/CompilerSource/backend/sub/Instance.h
@@ -13,12 +13,13 @@
 
 struct Instance
 {
-	int x;
-	int y;
-	int objectId;
-	int id;
-	String creationCode;
-	boolean locked;
+  int x;
+  int y;
+  int objectId;
+  int id;
+  String creationCode;
+  String preCreationCode;
+  boolean locked;
 };
 
 #endif

--- a/CompilerSource/compiler/components/parse_and_link.cpp
+++ b/CompilerSource/compiler/components/parse_and_link.cpp
@@ -298,13 +298,30 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
       {
         int a = syncheck::syntacheck(es->rooms[i].instances[ii].creationCode);
         if (a != -1) {
-          cout << "Syntax error in room creation code for room " << es->rooms[i].id << " (`" << es->rooms[i].name << "'):" << endl << syncheck::syerr << flushl;
+          cout << "Syntax error in instance creation code for instance " << es->rooms[i].instances[ii].id <<" in room " << es->rooms[i].id << " (`" << es->rooms[i].name << "'):" << endl << syncheck::syerr << flushl;
           return E_ERROR_SYNTAX;
         }
         
         pr->instance_create_codes[es->rooms[i].instances[ii].id].object_index = es->rooms[i].instances[ii].objectId;
         parsed_event* icce = pr->instance_create_codes[es->rooms[i].instances[ii].id].pe = new parsed_event(-1,-1,parsed_objects[es->rooms[i].instances[ii].objectId]);
-        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + es->rooms[i].instances[ii].creationCode + "\n/* */}", icce, script_names);
+        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + es->rooms[i].instances[ii].creationCode + "\n/* */}", icce, script_names);     
+      }
+    }
+    
+    //PreCreate code
+    for (int ii = 0; ii < es->rooms[i].instanceCount; ii++)
+    {
+      if (es->rooms[i].instances[ii].preCreationCode and *(es->rooms[i].instances[ii].preCreationCode))
+      {
+        int a = syncheck::syntacheck(es->rooms[i].instances[ii].preCreationCode);
+        if (a != -1) {
+          cout << "Syntax error in instance preCreation code for instance " << es->rooms[i].instances[ii].id <<" in room " << es->rooms[i].id << " (`" << es->rooms[i].name << "'):" << endl << syncheck::syerr << flushl;
+          return E_ERROR_SYNTAX;
+        }
+        
+        pr->instance_precreate_codes[es->rooms[i].instances[ii].id].object_index = es->rooms[i].instances[ii].objectId;
+        parsed_event* icce = pr->instance_precreate_codes[es->rooms[i].instances[ii].id].pe = new parsed_event(-1,-1,parsed_objects[es->rooms[i].instances[ii].objectId]);
+        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + es->rooms[i].instances[ii].preCreationCode + "\n/* */}", icce, script_names);     
       }
     }
   }

--- a/CompilerSource/compiler/components/parse_secondary.cpp
+++ b/CompilerSource/compiler/components/parse_secondary.cpp
@@ -79,6 +79,11 @@ int lang_CPP::compile_parseSecondary(map<int,parsed_object*> &parsed_objects, pa
       oto = parsed_objects[ici->second.object_index];
       parser_secondary(ici->second.pe->code,ici->second.pe->synt,EGMglobal,oto,ici->second.pe, script_names);
     }
+    for (map<int,parsed_room::parsed_icreatecode>::iterator ici = it->second->instance_precreate_codes.begin(); ici != it->second->instance_precreate_codes.end(); ici++)
+    {
+      oto = parsed_objects[ici->second.object_index];
+      parser_secondary(ici->second.pe->code,ici->second.pe->synt,EGMglobal,oto,ici->second.pe, script_names);
+    }
   }
   
   return 0;

--- a/CompilerSource/parser/object_storage.h
+++ b/CompilerSource/parser/object_storage.h
@@ -128,6 +128,8 @@ struct parsed_script
 struct parsed_room: parsed_object {
   struct parsed_icreatecode { parsed_event* pe; int object_index; };
   map<int,parsed_icreatecode> instance_create_codes;
+  //PreCreate code uses the same struct, as nothing is really different 
+  map<int,parsed_icreatecode> instance_precreate_codes;
 };
 extern map<int,parsed_room*> parsed_rooms;
 typedef map<int,parsed_object*> :: iterator po_i;

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -175,28 +175,29 @@ namespace enigma
 
     instance_event_iterator = new inst_iter(NULL,NULL,NULL);
 
+    // Fire the rooms preCreation code. This code includes instance sprite transformations added in the room editor.
+    // (NOTE: This code uses instance_deactivated_list to look up instances by ID, in addition to the normal lookup approach).
+    if (precreatecode)
+      precreatecode();
+    
     // Fire the create event of all the new instances.
     for (int i = 0; i < instancecount; i++) {
       is[i]->myevent_create();
     }
 
-  // instance create code should be added here or occur at this exact moment in time, but guess what the code
-  // isn't here, so where the fuck is it? and no not the create event, the instance create code from the room editor
-  // WHERE THE FUCK IS IT?
+    // Fire the game start event for all the new instances, persistent objects don't matter since this is the first time
+    // the game ran they won't even exist yet
+    if (gamestart)
+      for (int i = 0; i < instancecount; i++)
+        is[i]->myevent_gamestart();
 
-  // Fire the game start event for all the new instances, persistent objects don't matter since this is the first time
-  // the game ran they won't even exist yet
-  if (gamestart)
-    for (int i = 0; i < instancecount; i++)
-      is[i]->myevent_gamestart();
+    // Fire the rooms creation code. This includes instance creation code.
+    // (NOTE: This code uses instance_deactivated_list to look up instances by ID, in addition to the normal lookup approach).
+    if (createcode)
+      createcode();
 
-  // Fire the rooms creation code.
-  // (NOTE: This code uses instance_deactivated_list to look up instances by ID, in addition to the normal lookup approach).
-  if (createcode)
-       createcode();
-
-  // Fire the room start event for all persistent objects still kept alive and all the new instances
-  for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
+    // Fire the room start event for all persistent objects still kept alive and all the new instances
+    for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
     {
       it->myevent_roomstart();
     }
@@ -538,6 +539,7 @@ int room_add()
     rm->persistent = false;
     rm->views_enabled = false;
     rm->createcode = NULL;
+    rm->precreatecode = NULL;
 
     enigma::inst *newinst = new enigma::inst[1];
     rm->instances = newinst;
@@ -617,7 +619,8 @@ int room_duplicate(int indx, bool ass, int assroom)
     rm->persistent = copyrm->persistent;
     rm->views_enabled = copyrm->views_enabled;
     rm->createcode = copyrm->createcode;
-
+    rm->precreatecode = copyrm->precreatecode;
+    
     enigma::inst *newinst = new enigma::inst[copyrm->instancecount];
     rm->instances = newinst;
     rm->instancecount = copyrm->instancecount;

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.h
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.h
@@ -140,6 +140,7 @@ namespace enigma
     int backcolor;
     bool drawbackcolor;
     void(*createcode)();
+    void(*precreatecode)();
     int width, height, spd, persistent;
     int views_enabled;
     viewstruct views[10];


### PR DESCRIPTION
Implemented preCreationCode in backend (compiler) and the engine. This allows calling code before the create event is called. Now only used for setting the transformations settings chosen in the room editor (rotation, scale, color etc.).

Please test with the new LGM+plugin (http://enigma-dev.org/forums/index.php?topic=2082.60).
