### PR TITLE
Resolves #822 globalvar variable access in scripts

### DIFF
--- a/CompilerSource/parser/parser.cpp
+++ b/CompilerSource/parser/parser.cpp
@@ -404,6 +404,11 @@ int parser_secondary(string& code, string& synt,parsed_object* glob,parsed_objec
           repstr = "enigma::glaccess(int("   + exp +   "))->" + member;
           repsyn = "nnnnnnnnnnnnnnnn(ccc(" + expsynt + "))->" + string(member.length(),'n');
         }
+        else if(glob->globals.find(member) != glob->globals.end()) //Remove object access to globals
+        {
+          repstr = member;
+          repsyn = string(member.length(),'n');
+        }
         else
         {
           repstr = "enigma::varaccess_";


### PR DESCRIPTION
It seems that using globalvar works fairly well already, but when accessing a globalvar from a script, the <code>self.</code> part it places in front of variables was causing all of the issues.  Since variables defined with globalvar are placed in the highest scope already, there should not be any varaccess calls necessary to get the value.  My change basically forces the <code>self.</code> part to disappear, which should resolve the issue noted in #822.

Note that local variables that temporarily override globals still work, so long as varaccess is not necessary.  The only problematic situation I can think of is a case like <code>other.globvar</code> where the <code>other.</code> part will get deleted despite the programmer's intended access to the object's version of <code>globvar</code>, but that is an unlikely situation because the ambiguous scope would be dangerous anyway.
