### PR TITLE
Patch OpenGL Views

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -465,7 +465,7 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   sx = (window_get_width() - window_get_region_width_scaled()) / 2;
   sy = (window_get_height() - window_get_region_height_scaled()) / 2;
   //NOTE: OpenGL viewports are bottom left unlike Direct3D viewports which are top left
-	glViewport(sx + x, window_get_height() - (sy + y) - height, width, height);
+  glViewport(sx + x, window_get_height() - (sy + y) - height, width, height);
   glScissor(sx + x, window_get_height() - (sy + y) - height, width, height);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -474,7 +474,7 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   sx = (window_get_width() - window_get_region_width_scaled()) / 2;
   sy = (window_get_height() - window_get_region_height_scaled()) / 2;
   //NOTE: OpenGL viewports are bottom left unlike Direct3D viewports which are top left
-	glViewport(sx + x, window_get_height() - (sy + y) - height, width, height);
+  glViewport(sx + x, window_get_height() - (sy + y) - height, width, height);
   glScissor(sx + x, window_get_height() - (sy + y) - height, width, height);
 }
 


### PR DESCRIPTION
They are bottom left not top right like Direct3D, I forgot.

_Note: I do not like the implications of this patch because it is GLerror prone_
