### PR TITLE
Ability to blacklist keywords; they will be replaced by valid alternatives.

### DIFF
--- a/CompilerSource/compiler/components/parse_and_link.cpp
+++ b/CompilerSource/compiler/components/parse_and_link.cpp
@@ -54,21 +54,22 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
   //First we just parse the scripts to add semicolons and collect variable names
   for (int i = 0; i < es->scriptCount; i++)
   {
-    int a = syncheck::syntacheck(es->scripts[i].code);
+    std::string newcode;
+    int a = syncheck::syntacheck(es->scripts[i].code, newcode);
     if (a != -1) {
       user << "Syntax error in script `" << es->scripts[i].name << "'\n" << syncheck::syerr << flushl;
       return E_ERROR_SYNTAX;
     }
     // Keep a parsed record of this script
     scr_lookup[es->scripts[i].name] = scripts[i] = new parsed_script;
-    parser_main(es->scripts[i].code,&scripts[i]->pev, script_names);
+    parser_main(newcode,&scripts[i]->pev, script_names);
     edbg << "Parsed `" << es->scripts[i].name << "': " << scripts[i]->obj.locals.size() << " locals, " << scripts[i]->obj.globals.size() << " globals" << flushl;
     
     // If the script accesses variables from outside its scope implicitly
     if (scripts[i]->obj.locals.size() or scripts[i]->obj.globallocals.size()) {
       parsed_object temporary_object = *scripts[i]->pev.myObj;
       scripts[i]->pev_global = new parsed_event(&temporary_object);
-      parser_main(string("with (self) {\n") + es->scripts[i].code + "\n/* */}",scripts[i]->pev_global, script_names);
+      parser_main(string("with (self) {\n") + newcode + "\n/* */}",scripts[i]->pev_global, script_names);
       scripts[i]->pev_global->myObj = NULL;
     }
     fflush(stdout);
@@ -80,7 +81,8 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
   {
     for (int j=0; j<es->timelines[i].momentCount; j++) 
     {
-      int a = syncheck::syntacheck(es->timelines[i].moments[j].code);
+      std::string newcode;
+      int a = syncheck::syntacheck(es->timelines[i].moments[j].code, newcode);
       if (a != -1) {
         user << "Syntax error in timeline `" << es->timelines[i].name <<", moment: " <<es->timelines[i].moments[j].stepNo << "'\n" << syncheck::syerr << flushl;
         return E_ERROR_SYNTAX;
@@ -91,14 +93,14 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
 
       // Keep a parsed record of this timeline
       tline_lookup[es->timelines[i].name].push_back(tlines.back());
-      parser_main(es->timelines[i].moments[j].code, &tlines.back()->pev, script_names);
+      parser_main(newcode, &tlines.back()->pev, script_names);
       edbg << "Parsed `" << es->timelines[i].name <<", moment: " <<es->timelines[i].moments[j].stepNo << "': " << tlines.back()->obj.locals.size() << " locals, " << tlines.back()->obj.globals.size() << " globals" << flushl;
 
       // If the timeline accesses variables from outside its scope implicitly
       if (tlines.back()->obj.locals.size() or tlines.back()->obj.globallocals.size()) {
         parsed_object temporary_object = *tlines.back()->pev.myObj;
         tlines.back()->pev_global = new parsed_event(&temporary_object);
-        parser_main(string("with (self) {\n") + es->timelines[i].moments[j].code + "\n/* */}",tlines.back()->pev_global, script_names);
+        parser_main(string("with (self) {\n") + newcode + "\n/* */}",tlines.back()->pev_global, script_names);
         tlines.back()->pev_global->myObj = NULL;
       }
       fflush(stdout);
@@ -258,7 +260,7 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
           edbg << "Check `" << es->gmObjects[i].name << "::" << event_get_function_name(es->gmObjects[i].mainEvents[ii].id,es->gmObjects[i].mainEvents[ii].events[iii].id) << "...";
         
         // Check the code
-        int sc = syncheck::syntacheck(code);
+        int sc = syncheck::syntacheck(code, code);
         if (sc != -1)
         {
           // Error. Report it.
@@ -286,18 +288,19 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
     parsed_event &pev = pr->events[0]; //Make sure each sub event knows its main event's event ID.
     pev.mainId = 0, pev.id = 0, pev.myObj = pr;
     
-    int sc = syncheck::syntacheck(es->rooms[i].creationCode);
+    std::string newcode;
+    int sc = syncheck::syntacheck(es->rooms[i].creationCode, newcode);
     if (sc != -1) {
       cout << "Syntax error in room creation code for room " << es->rooms[i].id << " (`" << es->rooms[i].name << "'):" << endl << syncheck::syerr << flushl;
       return E_ERROR_SYNTAX;
     }
-    parser_main(es->rooms[i].creationCode,&pev,script_names);
+    parser_main(newcode,&pev,script_names);
     
     for (int ii = 0; ii < es->rooms[i].instanceCount; ii++)
     {
       if (es->rooms[i].instances[ii].creationCode and *(es->rooms[i].instances[ii].creationCode))
       {
-        int a = syncheck::syntacheck(es->rooms[i].instances[ii].creationCode);
+        int a = syncheck::syntacheck(es->rooms[i].instances[ii].creationCode, newcode);
         if (a != -1) {
           cout << "Syntax error in instance creation code for instance " << es->rooms[i].instances[ii].id <<" in room " << es->rooms[i].id << " (`" << es->rooms[i].name << "'):" << endl << syncheck::syerr << flushl;
           return E_ERROR_SYNTAX;
@@ -305,7 +308,7 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
         
         pr->instance_create_codes[es->rooms[i].instances[ii].id].object_index = es->rooms[i].instances[ii].objectId;
         parsed_event* icce = pr->instance_create_codes[es->rooms[i].instances[ii].id].pe = new parsed_event(-1,-1,parsed_objects[es->rooms[i].instances[ii].objectId]);
-        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + es->rooms[i].instances[ii].creationCode + "\n/* */}", icce, script_names);     
+        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + newcode + "\n/* */}", icce, script_names);     
       }
     }
     
@@ -314,7 +317,8 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
     {
       if (es->rooms[i].instances[ii].preCreationCode and *(es->rooms[i].instances[ii].preCreationCode))
       {
-        int a = syncheck::syntacheck(es->rooms[i].instances[ii].preCreationCode);
+        std::string newcode;
+        int a = syncheck::syntacheck(es->rooms[i].instances[ii].preCreationCode, newcode);
         if (a != -1) {
           cout << "Syntax error in instance preCreation code for instance " << es->rooms[i].instances[ii].id <<" in room " << es->rooms[i].id << " (`" << es->rooms[i].name << "'):" << endl << syncheck::syerr << flushl;
           return E_ERROR_SYNTAX;
@@ -322,7 +326,7 @@ int lang_CPP::compile_parseAndLink(EnigmaStruct *es,parsed_script *scripts[], ve
         
         pr->instance_precreate_codes[es->rooms[i].instances[ii].id].object_index = es->rooms[i].instances[ii].objectId;
         parsed_event* icce = pr->instance_precreate_codes[es->rooms[i].instances[ii].id].pe = new parsed_event(-1,-1,parsed_objects[es->rooms[i].instances[ii].objectId]);
-        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + es->rooms[i].instances[ii].preCreationCode + "\n/* */}", icce, script_names);     
+        parser_main(string("with (") + tostring(es->rooms[i].instances[ii].id) + ") {" + newcode + "\n/* */}", icce, script_names);     
       }
     }
   }

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -152,7 +152,8 @@ dllexport syntax_error *syntaxCheck(int script_count, const char* *script_names,
     quickmember_script(&globals_scope,script_names[i]);
   
   cout << "Starting syntax check." << endl;
-  ide_passback_error.absolute_index = syncheck::syntacheck(code);
+  std::string newcode;
+  ide_passback_error.absolute_index = syncheck::syntacheck(code, newcode);
   cout << "Syntax checking complete." << endl;
   error_sstring = syncheck::syerr;
   

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -87,6 +87,7 @@ void parse_ide_settings(const char* eyaml)
   setting::inherit_objects   = settree.get("inherit-objects").toBool();
   setting::make_directory = settree.get("make-directory").toString();
   setting::compliance_mode = settree.get("compliance-mode").toInt()==1 ? setting::COMPL_GM5 : setting::COMPL_STANDARD;
+  setting::keyword_blacklist = settree.get("keyword-blacklist").toString();
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
 	setMakeDirectory(myReplace(escapeEnv(setting::make_directory), "\\","/"));

--- a/CompilerSource/settings.cpp
+++ b/CompilerSource/settings.cpp
@@ -46,6 +46,7 @@ namespace setting
   bool inherit_objects = 0;  // Determines whether objects should automatically inherit locals and events from their parents
   string make_directory = "";
   COMPLIANCE_LVL compliance_mode = COMPL_STANDARD;
+  string keyword_blacklist = "";
 };
 
 

--- a/CompilerSource/settings.h
+++ b/CompilerSource/settings.h
@@ -69,6 +69,7 @@ namespace setting
   extern bool inherit_objects;  // Determines whether objects should automatically inherit locals and events from their parents
   extern string make_directory; // Where to output make objects and preprocessor.
   extern COMPLIANCE_LVL compliance_mode; // How to resolve differences between GM versions.
+  extern string keyword_blacklist; //Words to blacklist from user scripts, separated by commas.
 }
 
 #endif

--- a/CompilerSource/syntax/checkfile.cpp
+++ b/CompilerSource/syntax/checkfile.cpp
@@ -81,10 +81,11 @@ int file_check(string filename)
     else if (*in2=='\n') in2++;
     else { puts("An error occurred during syntax check. No newline following list of script names."); return 0; }
 
-    int retval=syncheck::syntacheck(in2);
+    std::string newcode;
+    int retval=syncheck::syntacheck(in2, newcode);
     if (retval==-1)
     {
-      string code=parser_main(in2);
+      string code=parser_main(newcode);
       FILE* o=fopen("C:\\PARSERESULT.TXT","wb");
       if (o)
       {

--- a/CompilerSource/syntax/syncheck.h
+++ b/CompilerSource/syntax/syncheck.h
@@ -31,7 +31,7 @@
 namespace syncheck
 {
   extern string syerr;
-  int syntacheck(string code);
+  int syntacheck(string code, string& newcode);
   void addscr(string name);
 }
 

--- a/settings.ey
+++ b/settings.ey
@@ -33,6 +33,10 @@
         Type: Combobox
         Label: Compliance Mode: 
         Options: "Standard, GM5"
+    -keyword-blacklist:
+        Type: Textfield
+        Label: Keyword Blacklist: 
+        Default: ""
 
 		
 


### PR DESCRIPTION
A major problem porting GM games has to do with C++ keywords ("try") or even just global namespace garbage ("time") interfering with GM variable names. In many cases, there are hundreds of these variables to change in hard-to-reach places (like map initialization).

This adds a setting to the "Compatibility" panel called "keyword blacklist". Any variable (e.g., "test") in this comma-separated list will be replaced by, e.g., "test______".  By default this list is empty.

At the moment, this switch is done in syntacheck(), so it would, for example, be a bad idea to blacklist "var". I think this is sufficient for the V1 parser; the new parser can probably do a more intelligent variable-only replacement, if that is in fact needed.
