### PR TITLE
Disabled make_directory

### DIFF
--- a/CompilerSource/makedir.cpp
+++ b/CompilerSource/makedir.cpp
@@ -82,4 +82,6 @@ void setMakeDirectory(string dir) {
 	  std::cout << "Created make directory: \"" << makedir << "\"" << endl;
 	}
 #endif
+
+	std::cout << "Make directory is: \"" << makedir << "\"" << endl;
 }

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -85,13 +85,23 @@ void parse_ide_settings(const char* eyaml)
   setting::use_gml_equals    = !settree.get("inherit-equivalence-from").toInt();
   setting::literal_autocast  = settree.get("treat-literals-as").toInt();
   setting::inherit_objects   = settree.get("inherit-objects").toBool();
-  setting::make_directory = settree.get("make-directory").toString();
   setting::compliance_mode = settree.get("compliance-mode").toInt()==1 ? setting::COMPL_GM5 : setting::COMPL_STANDARD;
 
+  // Use a platform-specific make directory.
+  std::string make_directory = "./ENIGMA/";
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-	setMakeDirectory(myReplace(escapeEnv(setting::make_directory), "\\","/"));
+  make_directory = "%PROGRAMDATA%/ENIGMA/";
+#elif CURRENT_PLATFORM_ID == OS_LINUX
+  make_directory = "%HOME%/.enigma/";
+#elif CURRENT_PLATFORM_ID == OS_MACOSX
+  make_directory = "./ENIGMA/";
+#endif
+
+  //Now actually set it, taking backslashes into account.
+#if CURRENT_PLATFORM_ID == OS_WINDOWS
+	setMakeDirectory(myReplace(escapeEnv(make_directory), "\\","/"));
 #else
-	setMakeDirectory(escapeEnv(setting::make_directory));
+	setMakeDirectory(escapeEnv(make_directory));
 #endif
 
   //ide_dia_open();

--- a/CompilerSource/settings.cpp
+++ b/CompilerSource/settings.cpp
@@ -44,7 +44,6 @@ namespace setting
   bool use_incrementals = 0; // Defines how operators ++ and -- are treated.         0 = GML,               1 = C++
   bool literal_autocast = 0; // Determines how literals are treated.                 0 = enigma::variant,   1 = C++ scalars
   bool inherit_objects = 0;  // Determines whether objects should automatically inherit locals and events from their parents
-  string make_directory = "";
   COMPLIANCE_LVL compliance_mode = COMPL_STANDARD;
 };
 

--- a/CompilerSource/settings.h
+++ b/CompilerSource/settings.h
@@ -67,7 +67,6 @@ namespace setting
   extern bool use_incrementals; // Defines how operators ++ and -- are treated.         0 = GML,               1 = C++
   extern bool literal_autocast; // Determines how literals are treated.                 0 = enigma::variant,   1 = C++ scalars
   extern bool inherit_objects;  // Determines whether objects should automatically inherit locals and events from their parents
-  extern string make_directory; // Where to output make objects and preprocessor.
   extern COMPLIANCE_LVL compliance_mode; // How to resolve differences between GM versions.
 }
 


### PR DESCRIPTION
The current use of make_directory won't ever work right for cross-platform projects. Essentially, there are two problems:
1. Different platforms put the make_directory in fundamentally different places. So on Windows it's in ProgramData, while on Linux it's in ~/.enigma. This will crash LGM if you, say, save a game in EGM format on Windows and load it in Linux.
2. Changing the default make directory doesn't even work within a single platform. At least on OS-X, changing the default make directory will cause plugins to fail to load for mysterious reasons.

(2) could be fixed, but (1) will be a pain. I propose a simpler solution: just don't expose make_directory to the user at all. It will still be platform-specific, but don't let the user see it.

If this is acceptable, let me know and I will remove the make_directory from LGM's dialog box as well (for now the user-supplied setting is simply ignored). We could also leave it there with a "<DEFAULT>" value or something.
