### PR TITLE
Fix for requesting a high-score that is out of range; fixes off-by-one on highscores.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/highscore_functions.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/highscore_functions.cpp
@@ -155,11 +155,13 @@ void highscore_add_current() {
 }
 
 int highscore_value(int place) {
-    return enigma::highscore_list.at(place).player_score;
+    size_t act = static_cast<size_t>(place) - 1;
+    return act<enigma::highscore_list.size() ? enigma::highscore_list[act].player_score : 0;
 }
 
 std::string highscore_name(int place) {
-    return enigma::highscore_list[place].player_name;
+    size_t act = static_cast<size_t>(place) - 1;
+    return act<enigma::highscore_list.size() ? enigma::highscore_list[act].player_name : "Unknown";
 }
 
 }


### PR DESCRIPTION
There were two problems with high-scores. First, highscore_value() and highscore_name() are both 1-indexed. Second, if a high-score is requested but not available, the program should return 0 for the value and "Unknown" for the name (rather than crashing).

This commit fixes both of these issues.
