### PR TITLE
Adds basic constant support.

### DIFF
--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -296,6 +296,10 @@ int lang_CPP::compile(EnigmaStruct *es, const char* exe_filename, int mode)
   for (int i = 0; i < es->roomCount; i++)
     quickmember_variable(&globals_scope,jdi::builtin_type__int,es->rooms[i].name);
 
+  edbg << "Copying constant names [" << es->constantCount << "]" << flushl;
+  for (int i = 0; i < es->constantCount; i++)
+    quickmember_variable(&globals_scope,jdi::builtin_type__int,es->constants[i].name);
+
 
   /// Next we do a simple parse of the code, scouting for some variable names and adding semicolons.
 

--- a/CompilerSource/compiler/components/write_globals.cpp
+++ b/CompilerSource/compiler/components/write_globals.cpp
@@ -78,6 +78,13 @@ int lang_CPP::compile_writeGlobals(EnigmaStruct* es, parsed_object* global)
     wto << "  unsigned int game_id = " << es->gameSettings.gameId << ";" << endl;
     wto << "}" << endl <<endl;
 
+    wto << "namespace enigma_user {" << endl;
+    for (int i=0; i<es->constantCount; i++) {
+      const Constant& con = es->constants[i];
+      wto << "  #define " << con.name << " " << con.value << endl;
+    }
+    wto << "}" << endl;
+
     wto << "//Default variable type: \"undefined\" or \"real\"" <<endl;
     wto << "const int variant::default_type = " <<(es->gameSettings.treatUninitializedAs0 ? "enigma::vt_real" : "-1") <<";" <<endl <<endl;
 


### PR DESCRIPTION
This adds compile-time support for constants (which is accomplished by defining each constant as a macro, and then informing JDI about them). Tested to work with simple constant substitution.

Note that LGM still does not save constants (in EGM). I'm hoping we can at least add the Default configuration, and maybe focus on multiple configurations later? Anyway, I'd like to at least get a discussion started on constants.
