### PR TITLE
Wraps constant defines in parens.

### DIFF
--- a/CompilerSource/compiler/components/write_globals.cpp
+++ b/CompilerSource/compiler/components/write_globals.cpp
@@ -81,7 +81,7 @@ int lang_CPP::compile_writeGlobals(EnigmaStruct* es, parsed_object* global)
     wto << "namespace enigma_user {" << endl;
     for (int i=0; i<es->constantCount; i++) {
       const Constant& con = es->constants[i];
-      wto << "  #define " << con.name << " " << con.value << endl;
+      wto << "  #define " << con.name << " (" << con.value <<")" << endl;
     }
     wto << "}" << endl;
 


### PR DESCRIPTION
This fixes an error pointed out by @kvanberendonck  in https://github.com/enigma-dev/enigma-dev/commit/74ce8ea462c204ef4d826f63a40374edc9547957#commitcomment-8590490
