### PR TITLE
Fixes a crash when a background is visible but unspecified.

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -30,6 +30,7 @@ using namespace std;
 
 #include "Universal_System/var4.h"
 #include "Universal_System/estring.h"
+#include "Universal_System/backgroundstruct.h"
 
 #define __GETR(x) (((unsigned int)x & 0x0000FF))/255.0
 #define __GETG(x) (((unsigned int)x & 0x00FF00) >> 8)/255.0
@@ -80,7 +81,7 @@ static inline void draw_back()
     // Draw the rooms backgrounds
     for (int back_current = 0; back_current < 8; back_current++) {
         if (background_visible[back_current] == 1) {
-          if (int(background_index[back_current]) >= 0) {
+          if (enigma_user::background_exists(background_index[back_current])) {
 				//NOTE: This has been double checked with Game Maker 8.1 to work exactly the same, the background_x/y is modified just as object locals are
 				//and also just as one would assume the system to work.
 				//TODO: This should probably be moved to room system.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -29,6 +29,7 @@
 using namespace std;
 
 #include "Universal_System/image_formats.h"
+#include "Universal_System/backgroundstruct.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/estring.h"
 
@@ -96,7 +97,7 @@ static inline void draw_back()
   // Draw the rooms backgrounds
   for (int back_current = 0; back_current < 8; back_current++) {
     if (background_visible[back_current] == 1) {
-      if (int(background_index[back_current]) >= 0) {
+      if (enigma_user::background_exists(background_index[back_current])) {
         //NOTE: This has been double checked with Game Maker 8.1 to work exactly the same, the background_x/y is modified just as object locals are
         //and also just as one would assume the system to work.
         //TODO: This should probably be moved to room system.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -28,6 +28,7 @@
 using namespace std;
 
 #include "Universal_System/image_formats.h"
+#include "Universal_System/backgroundstruct.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/estring.h"
 
@@ -92,7 +93,7 @@ static inline void draw_back()
   // Draw the rooms backgrounds
   for (int back_current = 0; back_current < 8; back_current++) {
     if (background_visible[back_current] == 1) {
-      if (int(background_index[back_current]) >= 0) {
+      if (enigma_user::background_exists(background_index[back_current])) {
         //NOTE: This has been double checked with Game Maker 8.1 to work exactly the same, the background_x/y is modified just as object locals are
         //and also just as one would assume the system to work.
         //TODO: This should probably be moved to room system.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -29,6 +29,7 @@
 using namespace std;
 
 #include "Universal_System/image_formats.h"
+#include "Universal_System/backgroundstruct.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/estring.h"
 
@@ -92,7 +93,7 @@ static inline void draw_back()
   // Draw the rooms backgrounds
   for (int back_current = 0; back_current < 8; back_current++) {
     if (background_visible[back_current] == 1) {
-      if (int(background_index[back_current]) >= 0) {
+      if (enigma_user::background_exists(background_index[back_current])) {
         //NOTE: This has been double checked with Game Maker 8.1 to work exactly the same, the background_x/y is modified just as object locals are
         //and also just as one would assume the system to work.
         //TODO: This should probably be moved to room system.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESscreen.cpp
@@ -25,6 +25,7 @@ int screen_redraw(int dontswap)
 
 using namespace std;
 
+#include "Universal_System/backgroundstruct.h"
 #include "Universal_System/var4.h"
 
 #define __GETR(x) (((unsigned int)x & 0x0000FF))
@@ -57,7 +58,7 @@ static inline void draw_back()
     for (int back_current=0; back_current<7; back_current++)
     {
         if (background_visible[back_current] == 1) {
-          if (int(background_index[back_current]) >= 0) {
+          if (enigma_user::background_exists(background_index[back_current])) {
               // if (background_stretched) draw_background_stretched(back, x, y, w, h);
               draw_background_tiled(background_index[back_current], background_x[back_current], background_y[back_current]);
           }


### PR DESCRIPTION
Test case:
1. Make a new game.
2. Make a new room.
3. In the room, set background 0 to "visible", but don't actually assign a background.
4. Run game; it segfaults.

GM:S runs just fine, and I don't see any reason to consider unspecified backgrounds an error. This patch adds the following check to draw_back() in each Graphics_System:

```
if (int(background_index[back_current]) >= 0) {
  //normal code.
}
```

Tested on Linux with GL1 and GL3. Please test on Windows/DirectX (but it's a small change, so it should be fine.)
