### PR TITLE
Fixes two bugs with keyboard_string (double-letters and backspace lag)

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -89,8 +89,7 @@ namespace enigma
                 int len = XLookupString(&e.xkey, str, 1, NULL, NULL);
                 if (len > 0) {
                   enigma_user::keyboard_lastchar = string(1,str[0]);
-                  enigma_user::keyboard_string += enigma_user::keyboard_lastchar;
-                  if (enigma_user::keyboard_lastkey == enigma_user::vk_backspace) {
+                  if (actualKey == enigma_user::vk_backspace) {
                     enigma_user::keyboard_string = enigma_user::keyboard_string.substr(0, enigma_user::keyboard_string.length() - 1);
                   } else {
                     enigma_user::keyboard_string += enigma_user::keyboard_lastchar;


### PR DESCRIPTION
These are pretty easy to grok:
1) Line 92 was clearly left over by accident; line 96 does the work in the "else" branch. This led to letters being "typed" twice.
2) Line 93 checked keyboard_lastkey, but that hadn't actually been set yet. Thus, vk_backspace wouldn't work, or it _would_ work, but 1 letter too late (which is super confusing).
