### PR TITLE
Fixes a bug with reparenting window managers on xlib.

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -52,8 +52,7 @@ namespace enigma
   extern char keymap[512];
   void ENIGMA_events(void); //TODO: Synchronize this with Windows by putting these two in a single header.
   bool gameWindowFocused = false;
-  extern int windowX, windowY, windowWidth, windowHeight;
-  extern void setwindowsize();
+  extern int windowWidth, windowHeight;
   extern bool freezeOnLoseFocus;
   unsigned int pausedSteps = 0;
   
@@ -142,8 +141,6 @@ namespace enigma
           return 0;
         }
         case ConfigureNotify: {
-          enigma::windowX = e.xconfigure.x;
-          enigma::windowY = e.xconfigure.y;
           enigma::windowWidth = e.xconfigure.width;
           enigma::windowHeight = e.xconfigure.height;
 

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -44,12 +44,12 @@ using namespace enigma::x11;
 
 namespace enigma {
   bool isVisible = true, isMinimized = false, stayOnTop = false, windowAdapt = true;
-  int regionWidth = 0, regionHeight = 0, windowWidth = 0, windowHeight = 0, windowX = 0, windowY = 0;
+  int regionWidth = 0, regionHeight = 0, windowWidth = 0, windowHeight = 0;
   double scaledWidth = 0, scaledHeight = 0;
   extern bool isSizeable, showBorder, showIcons, freezeOnLoseFocus, isFullScreen;
   extern int viewScale, windowColor;
     
-  void setwindowsize()
+  void setwindowsize(int forceX=-1, int forceY=-1)
   {
       if (!regionWidth)
           return;
@@ -91,9 +91,12 @@ namespace enigma {
               if (scaledHeight > windowHeight)
                   windowHeight = scaledHeight;
           }
-
           //Now actually set the window's position and size:
-          enigma_user::window_set_rectangle(windowX, windowY, windowWidth, windowHeight);
+          if (forceX==-1 || forceY==-1) {
+            enigma_user::window_set_size(windowWidth, windowHeight);
+          } else {
+            enigma_user::window_set_rectangle(forceX, forceY, windowWidth, windowHeight);
+          }
       } else {
           enigma_user::window_set_rectangle(0, 0, windowWidth, windowHeight);
       }
@@ -345,13 +348,15 @@ void window_default(bool center_size)
   enigma::windowWidth = enigma::regionWidth = xm;
   enigma::windowHeight = enigma::regionHeight = ym;
 
+  int forceX = -1;
+  int forceY = -1;
   if (center) {
-    enigma::windowX = display_get_width()/2 - enigma::windowWidth/2;
-    enigma::windowY = display_get_height()/2 - enigma::windowHeight/2;
+    forceX = display_get_width()/2 - enigma::windowWidth/2;
+    forceY = display_get_height()/2 - enigma::windowHeight/2;
     //window_center();
   }
   
-  enigma::setwindowsize();
+  enigma::setwindowsize(forceX, forceY);
 }
 
 void window_mouse_set(int x,int y) {
@@ -401,8 +406,8 @@ void window_set_position(int x,int y)
 }
 void window_set_size(unsigned int w,unsigned int h) {
 	XResizeWindow(disp,win, w, h);
-  enigma::windowWidth = w;
-  enigma::windowHeight = h;
+  //enigma::windowWidth = w;
+  //enigma::windowHeight = h;
   //enigma::setwindowsize(); //NOTE: I think this will also infinitely loop.
 }
 void window_set_rectangle(int x,int y,int w,int h) {
@@ -417,9 +422,9 @@ void window_center()
 	uint w,h,b,d;
 	XGetGeometry(disp,win,&r,&x,&y,&w,&h,&b,&d);
 	Screen *s = DefaultScreenOfDisplay(disp);
-   enigma::windowX = s->width/2-w/2;
-   enigma::windowY = s->height/2-h/2;
-	XMoveWindow(disp,win,enigma::windowX,enigma::windowY);
+   int windowX = s->width/2-w/2;
+   int windowY = s->height/2-h/2;
+	XMoveWindow(disp,win,windowX,windowY);
 }
 
 }


### PR DESCRIPTION
So the current windowing code is actually a bit broken on xlib; if you transition between windows of the same size or drag windows around, you'll get wild inaccuracies in windowX/windowY. I read up on this a bit, and it turns out that reparenting window managers (that is, almost any modern Linux desktop) will do a whole lot of magic to manage windowX/Y for you, and they get all confused if you try to track it. 

Thus, this fix removes windowX/Y entirely, and accomplishes the same thing by recalculating them only when needed. Tested on An Untitled Story, and it fixes the bugs I was seeing there relating to window positioning.
