### PR TITLE
Fix memory corruption from instance_deactivate_object()

### DIFF
--- a/CompilerSource/compiler/components/write_object_data.cpp
+++ b/CompilerSource/compiler/components/write_object_data.cpp
@@ -100,7 +100,7 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
 
     wto << "\n";
     wto << "namespace enigma\n{\n\n";
-    wto << "  extern std::map<int,inst_iter*> instance_deactivated_list;\n";
+    wto << "  extern std::map<int,object_basic*> instance_deactivated_list;\n";
     wto << "  extern objectstruct** objectdata;\n";
       wto << "  struct object_locals: event_parent";
         for (unsigned i = 0; i < parsed_extensions.size(); i++)
@@ -420,7 +420,7 @@ int lang_CPP::compile_writeObjectData(EnigmaStruct* es, parsed_object* global, i
 
           //This is the actual call to remove the current instance from all linked records before destroying it.
           wto << "\n    void unlink()\n    {\n";
-          wto << "      instance_iter_queue_for_destroy(ENOBJ_ITER_me); // Queue for delete while we're still valid\n";
+          wto << "      instance_iter_queue_for_destroy(this); // Queue for delete while we're still valid\n";
           wto << "      if (enigma::instance_deactivated_list.erase(id)==0) {\n";
           wto << "        //If it's not in the deactivated list, then it's active (so deactivate it).\n";
           wto << "        deactivate();\n";

--- a/ENIGMAsystem/SHELL/Collision_Systems/BBox/BBOXfuncs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/BBox/BBOXfuncs.cpp
@@ -743,7 +743,7 @@ bool move_bounce_object(int object, bool adv, bool solid_only)
 
 }
 
-typedef std::pair<int,enigma::inst_iter*> inode_pair;
+typedef std::pair<int,enigma::object_basic*> inode_pair;
 
 namespace enigma_user
 {
@@ -751,7 +751,7 @@ namespace enigma_user
 void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bool inside, bool notme) {
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
         if (notme && (*it)->id == enigma::instance_event_iterator->inst->id) continue;
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)*it);
+        enigma::object_collisions* const inst = (enigma::object_collisions*) *it;
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) //no sprite/mask then no collision
             continue;
@@ -767,22 +767,22 @@ void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bo
         if (left <= (rleft+rwidth) && rleft <= right && top <= (rtop+rheight) && rtop <= bottom) {
             if (inside) {
             inst->deactivate();
-            enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+            enigma::instance_deactivated_list.insert(inode_pair(inst->id,inst));
             }
         } else {
             if (!inside) {
                 inst->deactivate();
-                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+                enigma::instance_deactivated_list.insert(inode_pair(inst->id,inst));
             }
         }
     }
 }
 
 void instance_activate_region(int rleft, int rtop, int rwidth, int rheight, bool inside) {
-    std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
+    std::map<int,enigma::object_basic*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
 
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)(iter->second->inst));
+        enigma::object_collisions* const inst = (enigma::object_collisions*) iter->second;
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) { //no sprite/mask then no collision
             ++iter;
@@ -842,7 +842,7 @@ void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
     {
         if (notme && (*it)->id == enigma::instance_event_iterator->inst->id)
             continue;
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)*it);
+        enigma::object_collisions* const inst = (enigma::object_collisions*) *it;
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) //no sprite/mask then no collision
             continue;
@@ -866,7 +866,7 @@ void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
             if (inside)
             {
                 inst->deactivate();
-                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+                enigma::instance_deactivated_list.insert(inode_pair(inst->id, inst));
             }
         }
         else
@@ -874,7 +874,7 @@ void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
             if (!inside)
             {
                 inst->deactivate();
-                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+                enigma::instance_deactivated_list.insert(inode_pair(inst->id, inst));
             }
         }
     }
@@ -883,9 +883,9 @@ void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
 
 void instance_activate_circle(int x, int y, int r, bool inside)
 {
-    std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
+    std::map<int,enigma::object_basic*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)(iter->second->inst));
+        enigma::object_collisions* const inst = (enigma::object_collisions*) iter->second;
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) { //no sprite/mask then no collision
             ++iter;

--- a/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECfuncs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECfuncs.cpp
@@ -517,7 +517,7 @@ bool move_bounce_object(int object, bool adv, bool solid_only)
 
 }
 
-typedef std::pair<int,enigma::inst_iter*> inode_pair;
+typedef std::pair<int,enigma::object_basic*> inode_pair;
 
 namespace enigma_user
 {
@@ -525,7 +525,7 @@ namespace enigma_user
 void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bool inside, bool notme) {
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
         if (notme && (*it)->id == enigma::instance_event_iterator->inst->id) continue;
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)*it);
+        enigma::object_collisions* const inst = (enigma::object_collisions*) *it;
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) //no sprite/mask then no collision
             continue;
@@ -540,16 +540,15 @@ void instance_deactivate_region(int rleft, int rtop, int rwidth, int rheight, bo
 
         if ((left <= (rleft+rwidth) && rleft <= right && top <= (rtop+rheight) && rtop <= bottom) == inside) {
             inst->deactivate();
-            enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+            enigma::instance_deactivated_list.insert(inode_pair(inst->id,inst));
         }
     }
 }
 
 void instance_activate_region(int rleft, int rtop, int rwidth, int rheight, bool inside) {
-    std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
+    std::map<int,enigma::object_basic*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
-
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)(iter->second->inst));
+        enigma::object_collisions* const inst = (enigma::object_collisions*) iter->second;
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) {//no sprite/mask then no collision
             ++iter;
@@ -598,7 +597,7 @@ void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
     {
         if (notme && (*it)->id == enigma::instance_event_iterator->inst->id)
             continue;
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)*it);
+        enigma::object_collisions* const inst = (enigma::object_collisions*) *it;
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) //no sprite/mask then no collision
             continue;
@@ -622,7 +621,7 @@ void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
             if (inside)
             {
                 inst->deactivate();
-                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+                enigma::instance_deactivated_list.insert(inode_pair(inst->id,inst));
             }
         }
         else
@@ -630,7 +629,7 @@ void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
             if (!inside)
             {
                 inst->deactivate();
-                enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+                enigma::instance_deactivated_list.insert(inode_pair(inst->id,inst));
             }
         }
     }
@@ -638,9 +637,9 @@ void instance_deactivate_circle(int x, int y, int r, bool inside, bool notme)
 
 void instance_activate_circle(int x, int y, int r, bool inside)
 {
-    std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
+    std::map<int,enigma::object_basic*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
-        enigma::object_collisions* const inst = ((enigma::object_collisions*)(iter->second->inst));
+        enigma::object_collisions* const inst = (enigma::object_collisions*)iter->second;
 
         if (inst->sprite_index == -1 && (inst->mask_index == -1)) { //no sprite/mask then no collision
             ++iter;

--- a/ENIGMAsystem/SHELL/Universal_System/instance.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance.cpp
@@ -43,7 +43,7 @@ namespace enigma
   int destroycalls = 0, createcalls = 0;
 }
 
-typedef std::pair<int,enigma::inst_iter*> inode_pair;
+typedef std::pair<int,enigma::object_basic*> inode_pair;
 
 namespace enigma_user
 {
@@ -52,31 +52,31 @@ void instance_deactivate_all(bool notme) {
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
         if (notme && (*it)->id == enigma::instance_event_iterator->inst->id) continue;
 
-        ((enigma::object_basic*)*it)->deactivate();
-        enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+        (*it)->deactivate();
+        enigma::instance_deactivated_list.insert(inode_pair((*it)->id,*it));
     }
 }
 
 void instance_activate_all() {
 
-    std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
+    std::map<int,enigma::object_basic*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
-        ((enigma::object_basic*)(iter->second->inst))->activate();
+        iter->second->activate();
         enigma::instance_deactivated_list.erase(iter++);
     }
 }
 
 void instance_deactivate_object(int obj) {
     for (enigma::iterator it = enigma::fetch_inst_iter_by_int(obj); it; ++it) {
-        ((enigma::object_basic*)*it)->deactivate();
-        enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));
+        (*it)->deactivate();
+        enigma::instance_deactivated_list.insert(inode_pair((*it)->id,*it));
     }
 }
 
 void instance_activate_object(int obj) {
-    std::map<int,enigma::inst_iter*>::iterator iter = enigma::instance_deactivated_list.begin();
+    std::map<int,enigma::object_basic*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
-        enigma::object_basic* const inst = ((enigma::object_basic*)(iter->second->inst));
+        enigma::object_basic* const inst = iter->second;
         if (obj == all || (obj < 100000? inst->object_index == obj : inst->id == unsigned(obj))) {
             inst->activate();
             enigma::instance_deactivated_list.erase(iter++);

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
@@ -137,7 +137,7 @@ namespace enigma
 
   // This is the all-inclusive, centralized list of instances.
   map<int,inst_iter*> instance_list;
-  map<int,inst_iter*> instance_deactivated_list;
+  map<int,object_basic*> instance_deactivated_list;
   typedef map<int,inst_iter*>::iterator iliter;
   typedef pair<int,inst_iter*> inode_pair;
     
@@ -239,9 +239,9 @@ namespace enigma
       return iterator();
 
     //Check if it's a deactivated instance first.
-    std::map<int,enigma::inst_iter*>::iterator rIt = enigma::instance_deactivated_list.find(x);
+    std::map<int,enigma::object_basic*>::iterator rIt = enigma::instance_deactivated_list.find(x);
     if (rIt!=enigma::instance_deactivated_list.end()) {
-      return iterator(((enigma::object_basic*)(rIt->second->inst)));
+      return iterator(rIt->second);
     }
 
     //Else, it's still live (or was null). Use normal dispatch.
@@ -289,9 +289,9 @@ namespace enigma
     return objects[oid].add_inst(who);
   }
 
-  void instance_iter_queue_for_destroy(pinstance_list_iterator whop)
+  void instance_iter_queue_for_destroy(object_basic* inst)
   {
-    enigma::cleanups.insert((object_basic*)whop->w->second->inst);
+    enigma::cleanups.insert(inst);
     enigma::instancecount--;
     enigma_user::instance_count--;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system.h
@@ -36,7 +36,7 @@
 namespace enigma {
   typedef std::map<int,inst_iter*>::iterator instance_list_iterator;
   extern std::map<int,inst_iter*> instance_list;
-  extern std::map<int,inst_iter*> instance_deactivated_list;
+  extern std::map<int,object_basic*> instance_deactivated_list;
   extern std::set<object_basic*> cleanups;
   
   void unlink_main(instance_list_iterator who);

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system_frontend.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system_frontend.h
@@ -38,7 +38,7 @@ namespace enigma
   inst_iter *link_obj_instance(object_basic* who, int oid);
 
   // Unlinking/Destroying
-  void instance_iter_queue_for_destroy(pinstance_list_iterator whop);
+  void instance_iter_queue_for_destroy(object_basic*);
   void dispose_destroyed_instances();
   void unlink_main(pinstance_list_iterator);
   void unlink_object_id_iter(inst_iter*,int);


### PR DESCRIPTION
A while ago, someone fixed the massive memory leak in iterator's object_basic constructor. This is a good thing! However, it lead to this issue in instance_deactivate_object:

```
//Paraphrased:
enigma::iterator it = enigma::fetch_inst_iter_by_int(obj);
enigma::instance_deactivated_list.insert(inode_pair((*it)->id,it.it));

//In fetch_inst_iter_by_int():
iterator ret = iterator(a->second->inst);
return a != instance_list.end() ? iterator(a->second->inst) : iterator();

//In iterator::iterator(object_basic*):
iterator::iterator(object_basic* ob) : temp_iter(ob, NULL, NULL), it(&temp_iter) {}

//And, finally, in the iterator class definition:
struct iterator {
  inst_iter temp_iter;
  struct inst_iter* it;
};
```

So, correct me if I am wrong (which is entirely possible!), but fetch_inst_iter_by_int() is returning a temporary as a pointer (the it(&temp_iter)), which will eventually blow up. I noticed this occurring somewhat-predictably in both Iji and An Untitled Story.

To fix this, I noted that any object_basic\* is manually unlinked before being inserted into instance_deactivated_list, so I turned instance_deactivated_list into a map of object_basic\* rather than inst_iter*. 

This led to a bug with `instance_iter_queue_for_destroy(ENOBJ_ITER_me)` queueing up the wrong object, so I just replaced it with `instance_iter_queue_for_destroy(this)`, which seems more correct anyway. I am not sure how ENOBJ_ITER_me gets corrupted (I know it happens if a destroy() event creates and links a new object of a different type), but I suspect the instance system in general.
