### PR TITLE
Added override flag to CXXFLAGS/CFLAGS/LDFLAGS

### DIFF
--- a/ENIGMAsystem/SHELL/Makefile
+++ b/ENIGMAsystem/SHELL/Makefile
@@ -58,21 +58,21 @@ CC := gcc
 DEPENDENCIES :=
 
 ifeq ($(GMODE), Debug)
-	CXXFLAGS += -Wall -g -DDEBUG_MODE
-	CFLAGS += -Wall -g -DDEBUG_MODE
+	override CXXFLAGS += -Wall -g -DDEBUG_MODE
+	override CFLAGS += -Wall -g -DDEBUG_MODE
 else ifeq ($(GMODE), Compile)
-	CXXFLAGS += -Wall -s -O3 -fno-rtti -fno-exceptions -flto -fdata-sections -ffunction-sections
-	CFLAGS += -Wall -s -O3 -flto -fno-exceptions -fdata-sections -ffunction-sections
-	LDFLAGS += -flto -s -O3
+	override CXXFLAGS += -Wall -s -O3 -fno-rtti -fno-exceptions -flto -fdata-sections -ffunction-sections
+	override CFLAGS += -Wall -s -O3 -flto -fno-exceptions -fdata-sections -ffunction-sections
+	override LDFLAGS += -flto -s -O3
 else
-	CXXFLAGS += -Wall -s -O3 -fno-rtti -fno-exceptions
-	CFLAGS += -Wall -s -O3 -fno-exceptions
+	override CXXFLAGS += -Wall -s -O3 -fno-rtti -fno-exceptions
+	override CFLAGS += -Wall -s -O3 -fno-exceptions
 endif
 
 ifeq ($(PLATFORM), Win32)
-	LDFLAGS += -L../Additional/i686-w64-mingw32/lib -static-libgcc -static-libstdc++
+	override LDFLAGS += -L../Additional/i686-w64-mingw32/lib -static-libgcc -static-libstdc++
 	ifeq ($(GMODE), Compile)
-		LDFLAGS += -static-libgcc -Wl,-subsystem,windows
+		override LDFLAGS += -static-libgcc -Wl,-subsystem,windows
 	endif
 endif
 

--- a/ENIGMAsystem/SHELL/Platforms/iPhone/Makefile
+++ b/ENIGMAsystem/SHELL/Platforms/iPhone/Makefile
@@ -1,3 +1,3 @@
 SOURCES += $(wildcard Platforms/iPhone/*.cpp) Platforms/General/UNIXfilemanip.cpp
 SOURCES += $(wildcard Platforms/iPhone/*.m)
-LDFLAGS += -framework UIKit -framework Foundation -framework CoreGraphics -framework QuartzCore -framework OpenGLES
+override LDFLAGS += -framework UIKit -framework Foundation -framework CoreGraphics -framework QuartzCore -framework OpenGLES

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Json/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Json/Makefile
@@ -1,2 +1,2 @@
 SOURCES += $(wildcard Universal_System/Extensions/Json/*.cpp) 
-CFLAGS += -fexceptions
+override CFLAGS += -fexceptions

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/Makefile
@@ -1,2 +1,2 @@
 SOURCES += $(wildcard Universal_System/Extensions/Paths/*.cpp)
-CXXFLAGS+= -DPATH_EXT_SET
+override CXXFLAGS+= -DPATH_EXT_SET

--- a/ENIGMAsystem/SHELL/Widget_Systems/GTK+/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/GTK+/Makefile
@@ -1,5 +1,5 @@
 SOURCES += $(wildcard Widget_Systems/GTK+/*.cpp)
-CFLAGS += $(shell pkg-config --cflags gtk+-2.0)
+override CFLAGS += $(shell pkg-config --cflags gtk+-2.0)
 LDLIBS += $(shell pkg-config --libs gtk+-2.0) -lgthread-2.0
 
 ifeq ($(PLATFORM), xlib)


### PR DESCRIPTION
If you define anything in the cxxflags field in gcc.ey:

```
   cxxflags: -std=c++11 
```

...then, the following statement in Makefile will have NO EFFECT:

```
CXXFLAGS += -Wall -s -O3 -fno-rtti -fno-exceptions -flto -fdata-sections -ffunction-sections
```

You actually need to force make to accept this via the "override" flag. This patch does this for CXXFLAGS, CFLAGS, and LDFLAGS. For example:

```
override CXXFLAGS += -Wall -s -O3 -fno-rtti -fno-exceptions -flto -fdata-sections -ffunction-sections
```

This fixes extensions (most notably the Paths extension), and various other things (like re-enabling optimizations).
