### PR TITLE
Potential fix for anything relying on self to be single.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
@@ -209,7 +209,7 @@ namespace enigma
     if (x < 0) switch (x) // Keyword-based lookup
     {
       case self:
-      case local:  return instance_event_iterator;
+      case local:  return iterator(instance_event_iterator->inst);
       case other:  return instance_other ? iterator(instance_other) : iterator();
       case all:    return instance_list_first();
       case global: return &ENIGMA_global_instance_iterator;


### PR DESCRIPTION
NEEDS COMMENT: please read

As reported by egofree:

> Here is a test case : https://dl.dropboxusercontent.com/u/29802501/object_deactivate.egm
> 
> When the project starts, you have a black square which goes to the right and collides with a red square. In the red square object, i've a collision event with the following line : instance_deactivate_object(self); As you can see, when it collides with the red square, all red squares disappear. This is not the case in GM studio. (You can export the project as a gmx project and test it with GM Studio).

From my tests, this will also cause `with(self) {}` to fire for every instance of that object type.

I tracked this down to fetch_inst_iter_by_int()  ---it seems that we should really be returning an iterator that wraps the instance inside instance_event_iterator, rather than the iterator itself (which contains next/prev pointers to the siblings in the event hierarchy). I am not 100% sure this is the right thing to do, hence the "potential" fix. This patch does fix the behavior egofree reported, though.
