### PR TITLE
Fix instance_activate_object() not finding subclasses.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/instance.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance.cpp
@@ -41,6 +41,8 @@
 namespace enigma
 {
   int destroycalls = 0, createcalls = 0;
+
+  bool can_cast(object_basic* inst, int objType);
 }
 
 typedef std::pair<int,enigma::object_basic*> inode_pair;
@@ -77,7 +79,7 @@ void instance_activate_object(int obj) {
     std::map<int,enigma::object_basic*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
         enigma::object_basic* const inst = iter->second;
-        if (obj == all || (obj < 100000? inst->object_index == obj : inst->id == unsigned(obj))) {
+        if (obj == all || (obj < 100000 ? (inst->object_index==obj || can_cast(inst, obj)) : inst->id == unsigned(obj))) {
             inst->activate();
             enigma::instance_deactivated_list.erase(iter++);
         }


### PR DESCRIPTION
As reported by egofree:

> I don't know if you would be interested to fix this bug also, but there is a problem with the instance_activate_object function. It is not working correctly with objects inheritance. If you are interested, here is a test case : https://dl.dropboxusercontent.com/u/29802501/object_activate.egm
> There are two objects : black_square and red_square which inherits from the object square. In the room 'creation code', i put the following lines : instance_deactivate_object(square); instance_activate_object(square);. It deactivates correctly the objects, but it doesn't activate the objects again. This is not the case in GM Studio.

This is because the instance deactivated list contains unlinked objects. There are two solutions:
1. Track and link deactivated objects the same way we do activated ones.
2. Do a manual check against children (and children-of-children, etc.) when instance_activate_object() is called.

(1) seems like a lot of wasted effort and unnecessary slowdown; deactivated objects are usually restored by collision masks or by _all(), and tracking them involves lots of memory allocations. Therefore, I chose to implement (2), which adds a "can_cast()" method to IDE_EDIT_objectaccess. Most of the complexity is resolved at compile time, and image_activate_object() contains an optimization (checking `inst->object_index==obj` first) that avoids calling the function if the base class is exactly the same as the requested class.
