### PR TITLE
Fix Window Flags

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -56,11 +56,11 @@ namespace enigma
               newlong |= WS_SIZEBOX;
         }
         if (showIcons)
-            newlong |= WS_POPUPWINDOW;
+            newlong |= WS_SYSMENU;
         if (isVisible)
             newlong |= WS_VISIBLE;
 
-        return newlong;
+        return newlong | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
     }
     
     void centerwindow() {


### PR DESCRIPTION
I had them almost perfect in my last refactor, I used the wrong flag for hiding the icons in the window, WS_POPUPWINDOW is WS_SYSMENU | WS_POPUP, GM8 only uses WS_SYSMENU

The two additional flags are necessary for extensions like Ultimate3D and GMOgre to be able to render on top of our window.

I've tested all the flags using CLutterBuddy and can confirm they are exactly the same as GM8 now and existing games and settings work perfectly fine.
http://enigma-dev.org/software/clb/clutterbuddy.php

Explanation of the flags is available from Microsoft:
http://msdn.microsoft.com/en-us/library/windows/desktop/ms632600%28v=vs.85%29.aspx
