### PR TITLE
Fix mouse_x/mouse_y on OS-X

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
@@ -26,6 +26,11 @@
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL3 version.
 
+extern "C" {
+  void cocoa_screen_refresh();
+  void cocoa_flush_opengl();
+}
+
 namespace enigma {
   GLuint msaa_fbo = 0;
   
@@ -58,9 +63,11 @@ namespace enigma_user {
     //TODO: Copy over from the Win32 bridge
   }
     
-  //void screen_refresh() {
-
-  //}
+  void screen_refresh() {
+    cocoa_screen_refresh();
+    enigma::update_mouse_variables();
+    cocoa_flush_opengl();
+  }
 
 }
 

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
@@ -26,6 +26,11 @@
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL3 version.
 
+extern "C" {
+  void cocoa_screen_refresh();
+  void cocoa_flush_opengl();
+}
+
 namespace enigma {
   GLuint msaa_fbo = 0;
   
@@ -58,9 +63,11 @@ namespace enigma_user {
     //TODO: Copy over from the Win32 bridge
   }
     
-  //void screen_refresh() {
-
-  //}
+  void screen_refresh() {
+    cocoa_screen_refresh();
+    enigma::update_mouse_variables();
+    cocoa_flush_opengl();
+  }
 
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaWindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaWindow.cpp
@@ -246,10 +246,11 @@ void window_default(bool center_size)
 }
 
 //TODO: Move OpenGL shit to graphics bridges for Cocoa, screen refresh is a platform and graphics system specific function
-void screen_refresh() {
-	cocoa_screen_refresh();
-    cocoa_flush_opengl();
-}
+/*void screen_refresh() {
+  cocoa_screen_refresh();
+  enigma::update_mouse_variables();
+  cocoa_flush_opengl();
+}*/
 
   void io_clear()
   {


### PR DESCRIPTION
This pull request fixes two things:
1) It moves screen_refresh() into the Bridges/ folder.
2) It fixes mouse_x and mouse_y always being 0 on OS-X.
