### PR TITLE
Fix for cross-compiling on OS-X with C++11

### DIFF
--- a/Compilers/Linux/AppleCross64.ey
+++ b/Compilers/Linux/AppleCross64.ey
@@ -16,9 +16,9 @@ searchdirs-start: "#include <...> search starts here:"
 searchdirs-end: "End of search list."
 resources: ./MacOS/build/Release/EnigmaXcode.app/Contents/MacOS/EnigmaXcode.res
 cppflags:
-cxxflags: 
+cxxflags: -std=c++11 -stdlib=libc++
 cflags:
-ldflags: 
+ldflags: -stdlib=libc++
 links: -lobjc -lz -framework Cocoa
 
 Build-Extension: .app


### PR DESCRIPTION
This is the first half of fixes for C++11 OSX cross-compiling. The -stdlib=libc++ is needed to work around OS-X's reliance on the gcc 4.2 codeline.
