### PR TITLE
Cleanup object_basic

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -165,7 +165,8 @@ void screen_redraw()
             enigma::inst_iter* push_it = enigma::instance_event_iterator;
             //loop instances
             for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-                enigma::instance_event_iterator->inst->myevent_draw();
+                enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+                inst->myevent_draw();
                 if (enigma::room_switching_id != -1) {
                     stop_loop = true;
                     break;
@@ -316,7 +317,8 @@ void screen_redraw()
 				enigma::inst_iter* push_it = enigma::instance_event_iterator;
 				//loop instances
 				for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-					enigma::instance_event_iterator->inst->myevent_draw();
+          enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+					inst->myevent_draw();
 					if (enigma::room_switching_id != -1) {
 						stop_loop = true;
 						break;
@@ -364,7 +366,8 @@ void screen_redraw()
             enigma::inst_iter* push_it = enigma::instance_event_iterator;
             //loop instances
             for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-				enigma::instance_event_iterator->inst->myevent_drawgui();
+                enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+                inst->myevent_drawgui();
                 if (enigma::room_switching_id != -1) {
                     stop_loop = true;
                     break;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -230,8 +230,9 @@ static inline int draw_tiles()
     enigma::inst_iter* push_it = enigma::instance_event_iterator;
     //loop instances
     for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-      if (enigma::instance_event_iterator->inst->myevent_draw_subcheck())
-        enigma::instance_event_iterator->inst->myevent_draw();
+      enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+      if (inst->myevent_draw_subcheck())
+        inst->myevent_draw();
       if (enigma::room_switching_id != -1)
         return 1;
     }
@@ -281,8 +282,9 @@ static inline void draw_gui()
     enigma::inst_iter* push_it = enigma::instance_event_iterator;
     //loop instances
     for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-      if (enigma::instance_event_iterator->inst->myevent_drawgui_subcheck())
-        enigma::instance_event_iterator->inst->myevent_drawgui();
+      enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+      if (inst->myevent_drawgui_subcheck())
+        inst->myevent_drawgui();
       if (enigma::room_switching_id != -1) {
         stop_loop = true;
         break;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -223,8 +223,9 @@ static inline int draw_tiles()
     enigma::inst_iter* push_it = enigma::instance_event_iterator;
     //loop instances
     for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-      if (enigma::instance_event_iterator->inst->myevent_draw_subcheck())
-        enigma::instance_event_iterator->inst->myevent_draw();
+      enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+      if (inst->myevent_draw_subcheck())
+        inst->myevent_draw();
       if (enigma::room_switching_id != -1)
         return 1;
     }
@@ -275,8 +276,9 @@ static inline void draw_gui()
     enigma::inst_iter* push_it = enigma::instance_event_iterator;
     //loop instances
     for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-      if (enigma::instance_event_iterator->inst->myevent_drawgui_subcheck())
-        enigma::instance_event_iterator->inst->myevent_drawgui();
+      enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+      if (inst->myevent_drawgui_subcheck())
+        inst->myevent_drawgui();
       if (enigma::room_switching_id != -1) {
         stop_loop = true;
         break;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -230,8 +230,9 @@ static inline int draw_tiles()
     enigma::inst_iter* push_it = enigma::instance_event_iterator;
     //loop instances
     for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-      if (enigma::instance_event_iterator->inst->myevent_draw_subcheck())
-        enigma::instance_event_iterator->inst->myevent_draw();
+      enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+      if (inst->myevent_draw_subcheck())
+        inst->myevent_draw();
       if (enigma::room_switching_id != -1)
         return 1;
     }
@@ -282,8 +283,9 @@ static inline void draw_gui()
     enigma::inst_iter* push_it = enigma::instance_event_iterator;
     //loop instances
     for (enigma::instance_event_iterator = dit->second.draw_events->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next) {
-      if (enigma::instance_event_iterator->inst->myevent_drawgui_subcheck())
-        enigma::instance_event_iterator->inst->myevent_drawgui();
+      enigma::object_graphics* inst = ((object_graphics*)enigma::instance_event_iterator->inst);
+      if (inst->myevent_drawgui_subcheck())
+        inst->myevent_drawgui();
       if (enigma::room_switching_id != -1) {
         stop_loop = true;
         break;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -122,7 +122,7 @@ namespace enigma
             instance_event_iterator = new inst_iter(NULL,NULL,NULL);
             for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
             {
-              it->myevent_drawresize();
+              ((object_graphics*)*it)->myevent_drawresize();
             }
           } else {
             DefWindowProc(hWndParameter, message, wParam, lParam);

--- a/ENIGMAsystem/SHELL/Universal_System/graphics_object.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/graphics_object.cpp
@@ -31,6 +31,12 @@ namespace enigma
   object_graphics::object_graphics() {}
   object_graphics::object_graphics(unsigned _x, int _y): object_timelines(_x,_y) {}
   object_graphics::~object_graphics() {}
+  
+  variant object_graphics::myevent_draw()      { return 0; }
+  bool object_graphics::myevent_draw_subcheck() { return 0; }
+  variant object_graphics::myevent_drawgui()   { return 0; }
+  bool object_graphics::myevent_drawgui_subcheck() { return 0; }
+  variant object_graphics::myevent_drawresize()   { return 0; }
 
   INTERCEPT_DEFAULT_COPY(enigma::depthv)
   void depthv::function(variant oldval) {

--- a/ENIGMAsystem/SHELL/Universal_System/graphics_object.h
+++ b/ENIGMAsystem/SHELL/Universal_System/graphics_object.h
@@ -63,6 +63,12 @@ namespace enigma
       gs_scalar image_yscale;
       gs_scalar image_angle;
 
+      virtual variant myevent_draw();
+      virtual bool myevent_draw_subcheck();
+      virtual variant myevent_drawgui();
+      virtual bool myevent_drawgui_subcheck();
+      virtual variant myevent_drawresize();
+      
     //Accessors
       #ifdef JUST_DEFINE_IT_RUN
         int sprite_width, sprite_height;

--- a/ENIGMAsystem/SHELL/Universal_System/object.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/object.cpp
@@ -67,11 +67,6 @@ namespace enigma
     variant object_basic::myevent_gamestart() { return 0; }
     variant object_basic::myevent_gameend() { return 0; }
     variant object_basic::myevent_closebutton() { return 0; }
-    variant object_basic::myevent_draw()      { return 0; }
-    bool object_basic::myevent_draw_subcheck() { return 0; }
-    variant object_basic::myevent_drawgui()   { return 0; }
-    bool object_basic::myevent_drawgui_subcheck() { return 0; }
-    variant object_basic::myevent_drawresize()   { return 0; }
     variant object_basic::myevent_roomstart()   { return 0; }
     variant object_basic::myevent_roomend()   { return 0; }
     variant object_basic::myevent_destroy()   { return 0; }

--- a/ENIGMAsystem/SHELL/Universal_System/object.h
+++ b/ENIGMAsystem/SHELL/Universal_System/object.h
@@ -70,11 +70,6 @@ namespace enigma
       virtual variant myevent_gamestart();
       virtual variant myevent_gameend();
       virtual variant myevent_closebutton();
-      virtual variant myevent_draw();
-      virtual bool myevent_draw_subcheck();
-      virtual variant myevent_drawgui();
-      virtual bool myevent_drawgui_subcheck();
-      virtual variant myevent_drawresize();
       virtual variant myevent_roomstart();
       virtual variant myevent_roomend();
       virtual variant myevent_destroy();


### PR DESCRIPTION
Move all the draw events to object_graphics where they belong and fix
casts in all graphics systems.
