### PR TITLE
Enable unicode rc support

### DIFF
--- a/ENIGMAsystem/SHELL/Makefile
+++ b/ENIGMAsystem/SHELL/Makefile
@@ -40,7 +40,7 @@ RESOURCES += Preprocessor_Environment_Editable/Resources.rc
 endif
 
 # Default windres
-WINDRES = windres.exe
+WINDRES = windres.exe --codepage=65001
 
 # Default find
 FIND = find


### PR DESCRIPTION
This fixes #886 by enabling unicode for our resource files allowing the user to enter copyright symbols and such into the LateralGM game settings dialog. LGM already had the UTF-8 encoding but this is not exactly the same as UTF-8 encoding the RC files.

This follows the same solution as a Code::Blocks project.
http://forums.codeblocks.org/index.php?topic=19354.0;wap2

![Unicode Incompatible with GM8](https://cloud.githubusercontent.com/assets/3212801/5424955/c02936c8-82d1-11e4-8136-567d1f324255.png)
![Unicode RC Working](https://cloud.githubusercontent.com/assets/3212801/5424956/c741eb62-82d1-11e4-9e11-c2f6fac170c5.png)

This fix enables full unicode support.
![Full Unicode Support](https://cloud.githubusercontent.com/assets/3212801/5425240/62d86d76-82dc-11e4-9231-241253f0cdcb.png)
