### PR TITLE
New fix for instance_activate_object and subclasses, done at the object level

### DIFF
--- a/CompilerSource/compiler/components/write_object_data.cpp
+++ b/CompilerSource/compiler/components/write_object_data.cpp
@@ -581,6 +581,9 @@ static inline void write_object_destructor(std::ostream &wto, parsed_object *obj
       wto << "      delete ENOBJ_ITER_myevent_" << event_stacked_get_root_name(it->first) << ";\n";
     }
     wto << "    }\n";
+
+    //We'll sneak this in here.
+    wto << "    virtual bool can_cast(int obj) const;\n";
 }
 
 static inline void write_object_class_body(parsed_object* object, lang_CPP *lcpp, std::ostream &wto, EnigmaStruct *es, parsed_object* global, robertmap &parent_undefinitions, map<string, int> &revTlineLookup, evpairmap &evmap) {
@@ -766,6 +769,7 @@ static inline void write_timeline_implementations(ofstream& wto, EnigmaStruct *e
 static inline void write_object_script_funcs(ofstream& wto, const parsed_object *const t);
 static inline void write_object_timeline_funcs(ofstream& wto, EnigmaStruct *es, const parsed_object *const t, const map<string, int>& revTlineLookup);
 static inline void write_object_event_funcs(ofstream& wto, const parsed_object *const object, int mode, const robertmap &parent_undefinitions);
+static inline void write_can_cast_func(ofstream& wto, const parsed_object *const pobj);
 
 static inline void write_event_bodies(ofstream& wto, EnigmaStruct *es, int mode, robertmap &parent_undefinitions, const map<string, int>& revTlineLookup) {
   // Export everything else
@@ -777,6 +781,9 @@ static inline void write_event_bodies(ofstream& wto, EnigmaStruct *es, int mode,
 
     // Write local object copies of timelines
      write_object_timeline_funcs(wto, es, i->second, revTlineLookup);
+
+    //Write the required "can_cast()" function.
+    write_can_cast_func(wto, i->second);
   }
 }
 
@@ -906,6 +913,15 @@ static inline void write_known_timelines(ofstream& wto, EnigmaStruct *es, const 
   wto <<"    default: event_parent::timeline_call_moment_script(timeline_index, moment_index);\n";
   wto <<"  }\n";
   wto <<"}\n\n";
+}
+
+static inline void write_can_cast_func(ofstream& wto, const parsed_object *const pobj) {
+  wto <<"bool enigma::OBJ_" << pobj->name <<"::can_cast(int obj) const {\n";
+  wto <<"  return false";
+  for (parsed_object* curr=pobj->parent; curr; curr=curr->parent) {
+    wto <<" || (obj==" <<curr->id <<")";
+  }
+  wto << ";\n" <<"}\n\n";
 }
 
 static inline void write_global_script_array(ofstream &wto, EnigmaStruct *es) {

--- a/ENIGMAsystem/SHELL/Universal_System/instance.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance.cpp
@@ -77,7 +77,7 @@ void instance_activate_object(int obj) {
     std::map<int,enigma::object_basic*>::iterator iter = enigma::instance_deactivated_list.begin();
     while (iter != enigma::instance_deactivated_list.end()) {
         enigma::object_basic* const inst = iter->second;
-        if (obj == all || (obj < 100000? inst->object_index == obj : inst->id == unsigned(obj))) {
+        if (obj == all || (obj < 100000 ? (inst->object_index==obj || inst->can_cast(obj)) : inst->id == unsigned(obj))) {
             inst->activate();
             enigma::instance_deactivated_list.erase(iter++);
         }

--- a/ENIGMAsystem/SHELL/Universal_System/object.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/object.cpp
@@ -74,6 +74,7 @@ namespace enigma
     object_basic::object_basic(): id(-4), object_index(-4) {}
     object_basic::object_basic(int uid, int uoid): id(DEBUG_ID_CHECK(uid, uoid)), object_index(uoid) {}
     object_basic::~object_basic() {}
+    bool object_basic::can_cast(int obj) const { return false; }
 
     extern objectstruct objs[];
     extern int obj_idmax;

--- a/ENIGMAsystem/SHELL/Universal_System/object.h
+++ b/ENIGMAsystem/SHELL/Universal_System/object.h
@@ -77,6 +77,9 @@ namespace enigma
       object_basic();
       object_basic(int uid, int uoid);
       virtual ~object_basic();
+
+      //Can we cast this instance to an object of type "obj". (NOTE: This only checks parents; you can never can_cast(this->id).)
+      virtual bool can_cast(int obj) const;
     };
 
     struct objectstruct


### PR DESCRIPTION
This pull request fixes the bug reported in https://github.com/enigma-dev/enigma-dev/pull/878 and #753
It takes Josh's recommendations into account, and uses object inheritance rather than a global switch function.
