### PR TITLE
Fixes Array Subscript Coercion *DO NOT MERGE*

### DIFF
--- a/CompilerSource/parser/parser.cpp
+++ b/CompilerSource/parser/parser.cpp
@@ -1,4 +1,4 @@
-/** Copyright (C) 2008 Josh Ventura
+/** Copyright (C) 2008,2014 Josh Ventura
 *** Copyright (C) 2014 Seth N. Hetu
 *** Copyright (C) 2014 Robert B. Colton
 ***


### PR DESCRIPTION
This fully resolves #904 and activates the old array type coercing during the secondary parse phase, with a slight modification to use the coerced string type since the exp_typeof functionality was commented by fundies and then removed by Josh in 2012 when the new JDI was merged. This fix also enables n-d multi-dimensional arrays of primitive types.

``` cpp
int a[5];
a[0] = 10;
a[0] += 4;
show_message(string(a[0])); // 14

c[5] = 30;
c[5] += 4;
show_message(string(c[5])); // 34

a[0] = c[5];
show_message(string(a[0])); // 34

show_message(string(a[0] + c[5])); // 68

show_message(string(view_wview[0]/view_hview[0]));

int d[5][5][5];
d[5][5][5] = 4;
show_message(string(d[5][5][5])); // 4
int e[5][5];
e[5][5] = 4;
show_message(string(d[5][5][5]/e[5][5])); // 1
f[5,5] = 8;
show_message(string(d[5][5][5]/f[5,5])); // 0.5

e[get_integer("",string(f[5,5]))][0] = 5;
e[get_integer("",string(e[5][5]))][0] = 5;
e[get_integer("","")][0] = 5;
```

This is the codegen.

``` cpp
int a[5];
a[int(0)]= 10;
a[int(0)] += 4;
show_message(toString(a[int(0)] ));
c[int(5)]= 30;
c[int(5)] += 4;
show_message(toString(c[int(5)] ));
a[int(0)]= c[int(5)];
show_message(toString(a[int(0)] ));
show_message(toString(a[int(0)] + c[int(5)] ));
show_message(toString(view_wview[int(0)] / (double) view_hview[int(0)] ));
int d[5] [5] [5];
d[int(5)] [int(5)] [int(5)]= 4;
show_message(toString(d[int(5)] [int(5)] [int(5)] ));
int e[5] [5];
e[int(5)] [int(5)]= 4;
show_message(toString(d[int(5)] [int(5)] [int(5)] / (double) e[int(5)] [int(5)] ));
f(5, 5)= 8;
show_message(toString(d[int(5)] [int(5)] [int(5)] / (double) f(5, 5) ));
e[int(get_integer("", toString(f(5, 5) )))] [int(0)]= 5;
e[int(get_integer("", toString(e[int(5)] [int(5)] )))] [int(0)]= 5;
e[int(get_integer("", ""))] [int(0)]= 5;
```
