### PR TITLE
Fixes offset drift caused by multiple macros in the same sub-macro replacement

### DIFF
--- a/CompilerSource/JDI/src/System/lex_cpp.cpp
+++ b/CompilerSource/JDI/src/System/lex_cpp.cpp
@@ -173,6 +173,7 @@ string lexer_cpp::_flatten(const string param, const macro_map& macros, const to
   const char* s;
   string result = param;
   const char* begin = param.c_str();
+  int resOffset = 0;
   for (const char* i = begin; *i; ) {
     bool id = is_letterd(*i);
     s = i; while (is_letterd(*i)) ++i;
@@ -191,7 +192,8 @@ string lexer_cpp::_flatten(const string param, const macro_map& macros, const to
             char *buf=0, *bufe=0;
             mf->parse(arguments, buf, bufe, errep, herr);
             i = begin + p;
-            result.replace(s-begin, i-s, buf, bufe-buf);
+            result.replace(s-begin+resOffset, i-s+resOffset, buf, bufe-buf);
+            resOffset += (bufe-buf) - (i-s);
             delete[] buf;
           }
         }


### PR DESCRIPTION
This fixes https://github.com/enigma-dev/enigma-dev/issues/903

Basically, the _flatten() function (which is only called within an existing macro substitution) was failing to account for the fact that a macro's replacement text might have a different size than its original text. This would only affect the result if two macros existed inside another macro. While rare, it does happen from time to time.
