### PR TITLE
Compiler Settings

### DIFF
--- a/CompilerSource/compiler/components/parse_and_link.cpp
+++ b/CompilerSource/compiler/components/parse_and_link.cpp
@@ -407,6 +407,8 @@ int lang_CPP::link_globals(parsed_object *global, EnigmaStruct *es,parsed_script
 {
   for (po_i i = parsed_objects.begin(); i != parsed_objects.end(); i++)
     global->copy_from(*i->second,"object `"+i->second->name+"'","the Global Scope");
+  //TODO: because parsed_room inherits parsed_object it tries to use that as the name but it looks 
+  //like it never gets initialized, this is obviously a bug because this output never tells us the room name always just `'
   for (pr_i i = parsed_rooms.begin(); i != parsed_rooms.end(); i++)
     global->copy_from(*i->second,"room `"+i->second->name+"'","the Global Scope");
   for (int i = 0; i < es->scriptCount; i++)

--- a/CompilerSource/compiler/components/parse_and_link.cpp
+++ b/CompilerSource/compiler/components/parse_and_link.cpp
@@ -408,7 +408,7 @@ int lang_CPP::link_globals(parsed_object *global, EnigmaStruct *es,parsed_script
   for (po_i i = parsed_objects.begin(); i != parsed_objects.end(); i++)
     global->copy_from(*i->second,"object `"+i->second->name+"'","the Global Scope");
   for (pr_i i = parsed_rooms.begin(); i != parsed_rooms.end(); i++)
-    global->copy_from(*i->second,"object `"+i->second->name+"'","the Global Scope");
+    global->copy_from(*i->second,"room `"+i->second->name+"'","the Global Scope");
   for (int i = 0; i < es->scriptCount; i++)
     global->copy_from(scripts[i]->obj,"script `"+scripts[i]->obj.name+"'","the Global Scope");
   for (int i = 0; i < int(tlines.size()); i++)

--- a/CompilerSource/parser/parser.cpp
+++ b/CompilerSource/parser/parser.cpp
@@ -477,7 +477,7 @@ int parser_secondary(string& code, string& synt,parsed_object* glob,parsed_objec
       } else {
         //cout << "not a var array" << endl;
         const pt ep = end_of_brackets(synt,pos); // Get position of closing ']'
-        // see if there is actually something between the brackets
+        // see if there is actually something between the brackets because ISO C forbids 0 size arrays
         if (ep != pos + 1) {
           code.insert(ep, 1, ')');
           synt.insert(ep, 1, ')');

--- a/CompilerSource/parser/parser.cpp
+++ b/CompilerSource/parser/parser.cpp
@@ -477,11 +477,20 @@ int parser_secondary(string& code, string& synt,parsed_object* glob,parsed_objec
       } else {
         //cout << "not a var array" << endl;
         const pt ep = end_of_brackets(synt,pos); // Get position of closing ']'
-        code.insert(ep, 1, ')');
-        synt.insert(ep, 1, ')');
-        pos++; // Move after the '['
-        code.insert(pos, "int(");
-        synt.insert(pos, "ccc(");
+        // see if there is actually something between the brackets
+        bool anything = false;
+        for (pt pot = pos + 1; pot < ep; pot++) {
+          if (!isspace(code[pot]) || isalnum(code[pot])) {
+            anything = true; break;
+          }
+        }
+        if (anything) {
+          code.insert(ep, 1, ')');
+          synt.insert(ep, 1, ')');
+          pos++; // Move after the '['
+          code.insert(pos, "int(");
+          synt.insert(pos, "ccc(");
+        }
       }
       level++;
     }

--- a/CompilerSource/parser/parser.cpp
+++ b/CompilerSource/parser/parser.cpp
@@ -185,8 +185,9 @@ string parser_main(string code, parsed_event* pev, const std::set<std::string>& 
   parser_reinterpret(code,synt);
 
 
-
-  parser_add_semicolons(code,synt);
+  if (setting::automatic_semicolons) {
+    parser_add_semicolons(code,synt);
+  }
 
 
   //cout << synt << endl;

--- a/CompilerSource/parser/parser.cpp
+++ b/CompilerSource/parser/parser.cpp
@@ -478,13 +478,7 @@ int parser_secondary(string& code, string& synt,parsed_object* glob,parsed_objec
         //cout << "not a var array" << endl;
         const pt ep = end_of_brackets(synt,pos); // Get position of closing ']'
         // see if there is actually something between the brackets
-        bool anything = false;
-        for (pt pot = pos + 1; pot < ep; pot++) {
-          if (!isspace(code[pot]) || isalnum(code[pot])) {
-            anything = true; break;
-          }
-        }
-        if (anything) {
+        if (ep != pos + 1) {
           code.insert(ep, 1, ')');
           synt.insert(ep, 1, ')');
           pos++; // Move after the '['

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -486,8 +486,10 @@ void parser_add_semicolons(string &code,string &synt)
   
   //Add the semicolons in obvious places
   stackif *sy_semi = new stackif(';');
+  bool assignment = false;
   for (pt pos=0; pos<code.length(); pos++)
   {
+    
     if (synt[pos]==' ') // Automatic semicolon
     {
       codebuf[bufpos] = *sy_semi;
@@ -498,7 +500,13 @@ void parser_add_semicolons(string &code,string &synt)
     {
       codebuf[bufpos]=code[pos];
       syntbuf[bufpos++]=synt[pos];
-      
+
+      if (synt[pos]=='=') {
+        assignment = true;
+      }
+      if (synt[pos]==';') {
+        assignment = false;
+      }
       if (synt[pos]=='(') {
         if (pos and (synt[pos-1]=='0' or synt[pos-1] == '\'' or synt[pos-1] == '"')) {
           codebuf[bufpos-1] = *sy_semi;
@@ -523,6 +531,7 @@ void parser_add_semicolons(string &code,string &synt)
           syntbuf[bufpos-1] = *sy_semi;
           codebuf[bufpos  ] = ';';
           syntbuf[bufpos++] = ';';
+          assignment = false;
           sy_semi = sy_semi->popif('s');
         }
         sy_semi = sy_semi->popif('s');
@@ -539,6 +548,7 @@ void parser_add_semicolons(string &code,string &synt)
           syntbuf[bufpos-1] = *sy_semi;
           codebuf[bufpos  ] = ';';
           syntbuf[bufpos++] = ';';
+          assignment = false;
           sy_semi = sy_semi->popif('s');
         }
         sy_semi=sy_semi->popif('s');
@@ -551,10 +561,12 @@ void parser_add_semicolons(string &code,string &synt)
         continue;
       }
 
-      if (pos and needs_semi(synt[pos-1],synt[pos],synt[pos+1]))
+      bool needssemi = assignment ? needs_semi(synt[pos-1],synt[pos],synt[pos+1]) : needs_semi(synt[pos-1],synt[pos]);
+      if (pos and needssemi)
       {
         codebuf[bufpos-1] = *sy_semi;
         syntbuf[bufpos-1] = *sy_semi;
+        assignment = false;
         codebuf[bufpos  ] = code[pos];
         syntbuf[bufpos++] = synt[pos];
         sy_semi=sy_semi->popif('s');
@@ -564,6 +576,7 @@ void parser_add_semicolons(string &code,string &synt)
       {
         codebuf[bufpos  ] = *sy_semi;
         syntbuf[bufpos++] = *sy_semi;
+        assignment = false;
         sy_semi=sy_semi->popif('s');
       }
     }
@@ -606,6 +619,7 @@ void parser_add_semicolons(string &code,string &synt)
       sy_semi=sy_semi->push(')','s');
       sy_semi=sy_semi->push(';','s');
       sy_semi=sy_semi->push(';','s');
+      assignment = false;
     }
   }
 

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -351,7 +351,7 @@ inline bool needs_semi(char c1,char c2,char c3)
 {
   if (c1 == c2) return 0; //if the two tokens are the same, we assume they are one word; if they are
   return (c1 == 'b' or c1 == 'n' or c1 == '0' or c1 == '"' or c1 == ')' or c1 == ']')
-  and (is_letterd(c2) or c2=='"' or c2=='{' or (c2=='}' and c3 != ';'));
+  and (is_letterd(c2) or c2=='"' or c2=='{' or (c2=='}' and c3 != ';' and c3 != ',' and c3 != '}'));
 }
 inline bool needs_semi_sepd(char c1,char c2)
 {
@@ -480,6 +480,9 @@ void parser_add_semicolons(string &code,string &synt)
   char *codebuf = new char[code.length()*2+1];
   char *syntbuf = new char[code.length()*2+1];
   int bufpos = 0;
+  
+  cout << code << "shitfuck" << endl;
+  cout << synt << "joshfuck" << endl;
   
   //Add the semicolons in obvious places
   stackif *sy_semi = new stackif(';');
@@ -612,6 +615,9 @@ void parser_add_semicolons(string &code,string &synt)
 
   code = string(codebuf,bufpos);
   synt = string(syntbuf,bufpos);
+  
+    cout << code << "shitfuck" << endl;
+  cout << synt << "joshfuck" << endl;
 
   //Free memory here, lest it leak.
   delete codebuf;

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -887,7 +887,7 @@ void print_to_file(string code,string synt,const unsigned int strc, const varray
             if (str_ind >= strc) cout << "What the string literal.\n";
             of << string_settings_escape(string_in_code[str_ind]).c_str();
             str_ind++;
-            if (synt[pos+1] == '+' and (synt[pos+2] == '"' or synt[pos+2] == '\''))
+            if (synt[pos+1] == '+' and synt[pos+2] == '"')
               synt[pos+1] = code[pos+1] = ' ';
         break;
       case 's':

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -249,7 +249,14 @@ int parser_ready_input(string &code,string &synt,unsigned int &strc, varray<stri
         str = (code.substr(spos,++pos-spos));
       }
       string_in_code[strc++] = str;
-      codo[bpos] = synt[bpos] = last_token = '"', bpos++;
+      if (setting::use_cpp_strings) {
+        codo[bpos] = '\'';
+        synt[bpos] = '\'';
+        last_token = '\'';
+      } else {
+        codo[bpos] = synt[bpos] = last_token = '\"';
+      }
+      bpos++;
       continue;
     }
     if (code[pos] == '/')
@@ -781,9 +788,15 @@ const char * indent_chars   =  "\n                                \
                                                                   ";
 static inline string string_settings_escape(string n)
 {
-  if (!n.length()) return "\"\"";
-  if (n[0] == '\'' and n[n.length()-1] == '\'')
-    n[0] = n[n.length() - 1] = '"';
+  if (!setting::use_cpp_strings) {
+    if (!n.length()) return "\"\"";
+    if (n[0] == '\'' and n[n.length()-1] == '\'')
+      n[0] = n[n.length() - 1] = '"';
+  } else {
+    if (!n.length()) {
+      return "\'\'";
+    }
+  }
   for (size_t pos = 1; pos < n.length()-1; pos++)
   {
     switch (n[pos])
@@ -875,12 +888,12 @@ void print_to_file(string code,string synt,const unsigned int strc, const varray
             }
           }
         break;
-      case '"':
+      case '"': case '\'':
           if (pars) pars--;
-            if (str_ind >= strc) cout << "What the crap.\n";
+            if (str_ind >= strc) cout << "What the string literal.\n";
             of << string_settings_escape(string_in_code[str_ind]).c_str();
             str_ind++;
-            if (synt[pos+1] == '+' and synt[pos+2] == '"')
+            if (synt[pos+1] == '+' and (synt[pos+2] == '"' or synt[pos+2] == '\''))
               synt[pos+1] = code[pos+1] = ' ';
         break;
       case 's':

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -347,12 +347,6 @@ inline bool needs_semi(char c1,char c2)
   return (c1 == 'b' or c1 == 'n' or c1 == '0' or c1 == '"' or c1 == ')' or c1 == ']')
   and (is_letterd(c2) or c2=='"' or c2=='{' or c2=='}');
 }
-inline bool needs_semi(char c1,char c2,char c3)
-{
-  if (c1 == c2) return 0; //if the two tokens are the same, we assume they are one word; if they are
-  return (c1 == 'b' or c1 == 'n' or c1 == '0' or c1 == '"' or c1 == ')' or c1 == ']')
-  and (is_letterd(c2) or c2=='"' or c2=='{' or (c2=='}' and c3 != ';' and c3 != ',' and c3 != '}'));
-}
 inline bool needs_semi_sepd(char c1,char c2)
 {
   if (c1 == c2) return 1; //if the two tokens are the same, we assume they are one word; if they are
@@ -481,15 +475,10 @@ void parser_add_semicolons(string &code,string &synt)
   char *syntbuf = new char[code.length()*2+1];
   int bufpos = 0;
   
-  cout << code << "shitfuck" << endl;
-  cout << synt << "joshfuck" << endl;
-  
   //Add the semicolons in obvious places
   stackif *sy_semi = new stackif(';');
-  bool assignment = false;
   for (pt pos=0; pos<code.length(); pos++)
   {
-    
     if (synt[pos]==' ') // Automatic semicolon
     {
       codebuf[bufpos] = *sy_semi;
@@ -500,13 +489,7 @@ void parser_add_semicolons(string &code,string &synt)
     {
       codebuf[bufpos]=code[pos];
       syntbuf[bufpos++]=synt[pos];
-
-      if (synt[pos]=='=') {
-        assignment = true;
-      }
-      if (synt[pos]==';') {
-        assignment = false;
-      }
+      
       if (synt[pos]=='(') {
         if (pos and (synt[pos-1]=='0' or synt[pos-1] == '\'' or synt[pos-1] == '"')) {
           codebuf[bufpos-1] = *sy_semi;
@@ -531,7 +514,6 @@ void parser_add_semicolons(string &code,string &synt)
           syntbuf[bufpos-1] = *sy_semi;
           codebuf[bufpos  ] = ';';
           syntbuf[bufpos++] = ';';
-          assignment = false;
           sy_semi = sy_semi->popif('s');
         }
         sy_semi = sy_semi->popif('s');
@@ -548,7 +530,6 @@ void parser_add_semicolons(string &code,string &synt)
           syntbuf[bufpos-1] = *sy_semi;
           codebuf[bufpos  ] = ';';
           syntbuf[bufpos++] = ';';
-          assignment = false;
           sy_semi = sy_semi->popif('s');
         }
         sy_semi=sy_semi->popif('s');
@@ -561,12 +542,10 @@ void parser_add_semicolons(string &code,string &synt)
         continue;
       }
 
-      bool needssemi = assignment ? needs_semi(synt[pos-1],synt[pos],synt[pos+1]) : needs_semi(synt[pos-1],synt[pos]);
-      if (pos and needssemi)
+      if (pos and needs_semi(synt[pos-1],synt[pos]))
       {
         codebuf[bufpos-1] = *sy_semi;
         syntbuf[bufpos-1] = *sy_semi;
-        assignment = false;
         codebuf[bufpos  ] = code[pos];
         syntbuf[bufpos++] = synt[pos];
         sy_semi=sy_semi->popif('s');
@@ -576,7 +555,6 @@ void parser_add_semicolons(string &code,string &synt)
       {
         codebuf[bufpos  ] = *sy_semi;
         syntbuf[bufpos++] = *sy_semi;
-        assignment = false;
         sy_semi=sy_semi->popif('s');
       }
     }
@@ -619,7 +597,6 @@ void parser_add_semicolons(string &code,string &synt)
       sy_semi=sy_semi->push(')','s');
       sy_semi=sy_semi->push(';','s');
       sy_semi=sy_semi->push(';','s');
-      assignment = false;
     }
   }
 
@@ -629,9 +606,6 @@ void parser_add_semicolons(string &code,string &synt)
 
   code = string(codebuf,bufpos);
   synt = string(syntbuf,bufpos);
-  
-    cout << code << "shitfuck" << endl;
-  cout << synt << "joshfuck" << endl;
 
   //Free memory here, lest it leak.
   delete codebuf;

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -249,13 +249,7 @@ int parser_ready_input(string &code,string &synt,unsigned int &strc, varray<stri
         str = (code.substr(spos,++pos-spos));
       }
       string_in_code[strc++] = str;
-      if (setting::use_cpp_strings) {
-        codo[bpos] = '\'';
-        synt[bpos] = '\'';
-        last_token = '\'';
-      } else {
-        codo[bpos] = synt[bpos] = last_token = '\"';
-      }
+      codo[bpos] = synt[bpos] = last_token = setting::use_cpp_strings? '\'' : '\"';
       bpos++;
       continue;
     }

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -127,7 +127,7 @@ int parser_ready_input(string &code,string &synt,unsigned int &strc, varray<stri
         last_token = '@';
         continue;
       }
-      
+
       jdi::macro_iter_c itm = main_context->get_macros().find(name);
       if (itm != main_context->get_macros().end())
       {
@@ -475,10 +475,14 @@ void parser_add_semicolons(string &code,string &synt)
   char *syntbuf = new char[code.length()*2+1];
   int bufpos = 0;
   
+
+  
   //Add the semicolons in obvious places
   stackif *sy_semi = new stackif(';');
   for (pt pos=0; pos<code.length(); pos++)
   {
+    cout << code[pos] << endl;
+    cout << synt[pos] << endl;
     if (synt[pos]==' ') // Automatic semicolon
     {
       codebuf[bufpos] = *sy_semi;
@@ -489,8 +493,9 @@ void parser_add_semicolons(string &code,string &synt)
     {
       codebuf[bufpos]=code[pos];
       syntbuf[bufpos++]=synt[pos];
-      
+      int parentheses = 0, brackets = 0, braces = 0;
       if (synt[pos]=='(') {
+        parentheses++;
         if (pos and (synt[pos-1]=='0' or synt[pos-1] == '\'' or synt[pos-1] == '"')) {
           codebuf[bufpos-1] = *sy_semi;
           syntbuf[bufpos-1] = *sy_semi;
@@ -501,7 +506,11 @@ void parser_add_semicolons(string &code,string &synt)
           sy_semi=sy_semi->push(',','(');
         continue;
       }
-      if (synt[pos]==')') { sy_semi=sy_semi->popif('(');    continue; }
+      if (synt[pos]==')') { parentheses--; sy_semi=sy_semi->popif('(');    continue; }
+      if (synt[pos]=='{') { braces++; }
+      else if (synt[pos]=='}') { braces--; }
+      if (synt[pos]=='[') { brackets++; }
+      else if (synt[pos]==']') { brackets--; }
       if (synt[pos]==';')
       {
         /*if (synt[pos+1] == ')') {
@@ -542,7 +551,7 @@ void parser_add_semicolons(string &code,string &synt)
         continue;
       }
 
-      if (pos and needs_semi(synt[pos-1],synt[pos]))
+      if (pos and needs_semi(synt[pos-1],synt[pos]) and !brackets and !braces and !parentheses)
       {
         codebuf[bufpos-1] = *sy_semi;
         syntbuf[bufpos-1] = *sy_semi;
@@ -600,6 +609,11 @@ void parser_add_semicolons(string &code,string &synt)
     }
   }
 
+    cout << code << "asscock"<< endl;
+  cout << synt << "cockfuck" << endl;
+      cout << codebuf << "asscockbuf"<< endl;
+  cout << syntbuf << "cockfuckbuf" << endl;
+  
   //Dump the semicolon stack at the end.
   do codebuf[bufpos] = syntbuf[bufpos] = *sy_semi, bufpos++;
   while (sy_semi->prev and (sy_semi = sy_semi->prev));

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -137,6 +137,7 @@ void parse_ide_settings(const char* eyaml)
   setting::use_gml_equals    = !settree.get("inherit-equivalence-from").toInt();
   setting::literal_autocast  = settree.get("treat-literals-as").toInt();
   setting::inherit_objects   = settree.get("inherit-objects").toBool();
+  setting::automatic_semicolons   = settree.get("automatic-semicolons").toBool();
   setting::compliance_mode = settree.get("compliance-mode").toInt()==1 ? setting::COMPL_GM5 : setting::COMPL_STANDARD;
   setting::keyword_blacklist = settree.get("keyword-blacklist").toString();
 

--- a/CompilerSource/settings.cpp
+++ b/CompilerSource/settings.cpp
@@ -44,6 +44,7 @@ namespace setting
   bool use_incrementals = 0; // Defines how operators ++ and -- are treated.         0 = GML,               1 = C++
   bool literal_autocast = 0; // Determines how literals are treated.                 0 = enigma::variant,   1 = C++ scalars
   bool inherit_objects = 0;  // Determines whether objects should automatically inherit locals and events from their parents
+  bool automatic_semicolons = 0; // Determines whether semicolons should automatically be added or if the user wants strict syntax
   COMPLIANCE_LVL compliance_mode = COMPL_STANDARD;
   string keyword_blacklist = "";
 }

--- a/CompilerSource/settings.h
+++ b/CompilerSource/settings.h
@@ -67,6 +67,7 @@ namespace setting
   extern bool use_incrementals; // Defines how operators ++ and -- are treated.         0 = GML,               1 = C++
   extern bool literal_autocast; // Determines how literals are treated.                 0 = enigma::variant,   1 = C++ scalars
   extern bool inherit_objects;  // Determines whether objects should automatically inherit locals and events from their parents
+  extern bool automatic_semicolons; // Determines whether semicolons should automatically be added or if the user wants strict syntax
   extern COMPLIANCE_LVL compliance_mode; // How to resolve differences between GM versions.
   extern string keyword_blacklist; //Words to blacklist from user scripts, separated by commas.
 }

--- a/settings.ey
+++ b/settings.ey
@@ -54,6 +54,10 @@
         Type: Checkbox
         Label: Object Inheritance
         Default: true
+    -automatic-semicolons:
+        Type: Checkbox
+        Label: Automatic Semicolons
+        Default: true
 		
 -Graphics:
     Layout: Grid


### PR DESCRIPTION
Adds a setting to ENIGMA settings to disable automatic semicolons during the main parsing phase. This allows the user to build projects faster with strict syntax. This will fall through syntax checking and it will be picked up by MinGW and displayed in LGM's console window, though scope is harder to determine because the user will need to know and make sense of what is written to PREPROCESSOR_ENVIRONMENT_EDITABLE in order to fix syntax errors. This is considered an advanced setting. This is a temporary way of addressing #916 as EDL may have its own syntax for initialization lists which may or may not be compatible with C++'s, though GM: Studio's might possibly be. Additionally because GM users like to omit semicolons in statements, some games may fail to build if this setting is disabled.

You can see how MinGW reports missing semicolons in LGM's output window in the following screenshot.
![MinGW Errors](https://cloud.githubusercontent.com/assets/3212801/5579802/5c9c7350-900e-11e4-9e50-71d5517887b6.png)

I also implemented the setting to use cpp strings, it looks like it hasn't been implemented since 2011 according to commit logs. This makes all of the following possible including char arrays with the setting above. I also made sure that concatenation works and empty strings as well, though MinGW will throw an error for empty character constants/literals. Another fix was also necessary to not cast array subscripts to int() when there's nothing between the brackets. This fully fixes #918
```cpp
char test = 'a';
char strarr[] = { 'a', 'b', 'c' };
char strarr2[3] = { 'a', 'b', 'c' };

show_message(string('a'));
show_message(string(test));

for (int i = 0; i < 3; i++) {
	show_message(string(strarr[i]));
	show_message(string(strarr2[i]));
}
```
It parses to the following.
```cpp
  char test ='a';
  char strarr[ ]=
  {
    'a', 'b', 'c'
  }
  ;
  char strarr2[3]=
  {
    'a', 'b', 'c'
  }
  ;
  show_message(toString('a'));
  show_message(toString(test));
  for(int i = 0; i < 3; i ++ )
  {
    show_message(toString(strarr[int(i)] ));
    show_message(toString(strarr2[int(i)] ));
    
  }
```
It also parses the following.
```cpp
int test[] = { 0, 1, 2, 3, 4, 5, 9, 8, 5, 4, 3, 9 };

for (int i = 0; i < 12; i++) {
    show_message(string(test[i]));
}

int test2[2][2] = { { 0, 1},
                    { 3, 4} };

for (int r = 0; r < 2; r++) {
    for (int c = 0; c < 2; c++) {
        show_message(string(test2[r][c]));
    }
}
```
Into this codegen.
```cpp
  int test[ ]=
  {
    0, 1, 2, 3, 4, 5, 9, 8, 5, 4, 3, 9
  }
  ;
  for(int i = 0; i < 12; i ++ )
  {
    show_message(toString(test[int(i)] ));
    
  }
  int test2[int(2)] [int(2)]=
  {
    
    {
      0, 1
    }
    ,
    {
      3, 4
    }
    
  }
  ;
  for(int r = 0; r < 2; r ++ )
  {
    for(int c = 0; c < 2; c ++ )
    {
      show_message(toString(test2[int(r)] [int(c)] ));
      
    }
    
  }
```

Here's the test cases as unit tests:
https://www.dropbox.com/s/r39c52ntxwc41fo/char_array_initialization.gm81?dl=0
https://www.dropbox.com/s/njmar1bll6x5a5o/int_array_initialization.gm81?dl=0