### PR TITLE
Implements the clipboard functions on OS-X.

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaWindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaWindow.cpp
@@ -54,7 +54,7 @@ extern "C" void cocoa_window_set_fullscreen(bool full);
 extern "C" int cocoa_window_get_fullscreen();
 extern "C" void cocoa_window_set_color(int bgrColor);
 extern "C" void cocoa_clipboard_set_text(const char* text);
-extern "C" const char* cocoa_clipboard_get_text();
+extern "C" char* cocoa_clipboard_get_text();
 extern "C" bool cocoa_clipboard_has_text();
 
 namespace enigma {
@@ -481,7 +481,10 @@ namespace enigma_user {
   }
 
   string clipboard_get_text() {
-    return std::string(cocoa_clipboard_get_text());
+    char* res = cocoa_clipboard_get_text();
+    std::string resStr(res);
+    free(res);
+    return resStr;
   }
 
   bool clipboard_has_text() {

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaWindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaWindow.cpp
@@ -53,6 +53,9 @@ extern "C" int cocoa_get_screen_size(int getWidth);
 extern "C" void cocoa_window_set_fullscreen(bool full);
 extern "C" int cocoa_window_get_fullscreen();
 extern "C" void cocoa_window_set_color(int bgrColor);
+extern "C" void cocoa_clipboard_set_text(const char* text);
+extern "C" const char* cocoa_clipboard_get_text();
+extern "C" bool cocoa_clipboard_has_text();
 
 namespace enigma {
     extern char keybdstatus[256];
@@ -471,6 +474,18 @@ namespace enigma_user {
 
   void keyboard_unset_map() {
     enigma::keybdmap.clear();
+  }
+
+  void clipboard_set_text(string text) {
+    cocoa_clipboard_set_text(text.c_str());
+  }
+
+  string clipboard_get_text() {
+    return std::string(cocoa_clipboard_get_text());
+  }
+
+  bool clipboard_has_text() {
+    return cocoa_clipboard_has_text();
   }
 
   void window_set_region_scale(double scale, bool adaptwindow) {}


### PR DESCRIPTION
Now you (on OS-X) can copy and paste stuff between ENIGMA apps and other apps with ease! Strings larger than 1MB will be safely truncated.