### PR TITLE
Windows Widgets for MinGW64

### DIFF
--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -202,7 +202,7 @@ static INT_PTR CALLBACK ShowMessageExtProc(HWND hwndDlg,UINT uMsg,WPARAM wParam,
   return 0;
 }
 
-static INT_PTR CALLBACK GetDirectoryAltProc(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM pData)
+static INT CALLBACK GetDirectoryAltProc(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM pData)
 {
 	if (uMsg == BFFM_INITIALIZED) 
 		SetWindowText(hwnd, gs_cap.c_str());


### PR DESCRIPTION
The directory chooser callback should have been INT all along and not INT_PTR like the other callsbacks.

The directory chooser signature should follow this:
https://msdn.microsoft.com/en-us/library/windows/desktop/bb762598%28v=vs.85%29.aspx

The other dialogs we show with DialogBox should follow the DialogProc signature:
https://msdn.microsoft.com/en-us/library/windows/desktop/ms645469%28v=vs.85%29.aspx

I tested this change with both MinGW 32 and 64 and it works fine, and now makes the widgets partially build on MinGW 64 with less errors.