### PR TITLE
Use C++11 and libc++ for Clang/Clang32.

### DIFF
--- a/Compilers/Linux/clang.ey
+++ b/Compilers/Linux/clang.ey
@@ -15,9 +15,10 @@ searchdirs: gcc -E -x c++ -v $blank
 searchdirs-start: "#include <...> search starts here:"
 searchdirs-end: "End of search list."
 resources: $exe
-cppflags: -Wall -O3
-cxxflags: -Wno-missing-declarations -Wno-parentheses-equality
-cflags: -Wall -O3
+cppflags: 
+cxxflags: -std=c++11 -stdlib=libc++ 
+cflags: 
+ldflags: -stdlib=libc++
 links:
 
 Build-Extension:

--- a/Compilers/Linux/clang32.ey
+++ b/Compilers/Linux/clang32.ey
@@ -16,9 +16,9 @@ searchdirs-start: "#include <...> search starts here:"
 searchdirs-end: "End of search list."
 resources: $exe
 cppflags:
-cxxflags: -m32 -Wno-missing-declarations -Wno-parentheses-equality
-cflags: -m32 -Wall -O3
-ldlags: -m32 -Wall -O3
+cxxflags: -m32 -std=c++11 -stdlib=libc++ 
+cflags: -m32 
+ldflags: -m32 -stdlib=libc++
 links:
 
 Build-Extension:


### PR DESCRIPTION
This switches clang to C++11, which is in line with GCC. In order to work around some other bugs, I have also switched libstdc++ to libc++ (the LLVM c++ standard library) for clang. 