### PR TITLE
write_object_unlink() was recently modified to check groupedevents, but ...

### DIFF
--- a/CompilerSource/compiler/components/write_object_data.cpp
+++ b/CompilerSource/compiler/components/write_object_data.cpp
@@ -578,7 +578,9 @@ static inline void write_object_destructor(std::ostream &wto, parsed_object *obj
         }
       }
     for (map<int, vector<int> >::iterator it = evgroup.begin(); it != evgroup.end(); it++) { // The stacked ones should have their root exported
-      wto << "      delete ENOBJ_ITER_myevent_" << event_stacked_get_root_name(it->first) << ";\n";
+      if (!object->parent || !parent_declares_groupedevent(object->parent, it->first)) {
+        wto << "      delete ENOBJ_ITER_myevent_" << event_stacked_get_root_name(it->first) << ";\n";
+      }
     }
     wto << "    }\n";
 


### PR DESCRIPTION
...write_object_destructor() was not similarly modified. This causes write_object_destructor() to attempt to delete an instance that is not even in the class definition. Fixed by copying the line from write_object_unlink() in the appropriate place.

Note: This fixes a bug I've run into, and I'm fairly sure it's correct. Whoever modified write_object_unlink() should probably give this a quick glance to make sure it doesn't do anything unexpected.