### PR TITLE
add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: cpp
+sudo: false
+compiler:
+  - clang
+  - gcc
+install: python install.py
+script: make

--- a/CompilerSource/Makefile
+++ b/CompilerSource/Makefile
@@ -29,7 +29,7 @@ endif
 ###########
 
 CXX := g++
-CXXFLAGS += -std=c++11 -Wall -g -I./JDI/src
+CXXFLAGS += -std=c++0x -Wall -g -I./JDI/src
 LDFLAGS += -shared
 
 SOURCES := $(shell find . -name "*.cpp" -and ! -name "standalone_*")


### PR DESCRIPTION
This change adds [Travis CI](https://travis-ci.org/) to enigma-dev. I have it set up to python install.py && make on both clang and gcc systems.