### PR TITLE
Fixes keyboard_lastkey and keyboard_key for OS-X

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaFunctions.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaFunctions.cpp
@@ -41,6 +41,12 @@ namespace enigma
 	extern int initialize_everything();
 }
 
+namespace enigma_user 
+{
+  extern int keyboard_key;
+  extern int keyboard_lastkey;
+}
+
 namespace enigma
 {
 	void initkeymap();
@@ -104,6 +110,8 @@ namespace enigma {
 void key_press(int keycode) {
     //printf("Keycode pressed: %d",keycode); //useful to create the keymap array
 	int actualKey = enigma::keymap[keycode];
+	enigma_user::keyboard_lastkey = actualKey;
+	enigma_user::keyboard_key = actualKey;
 	
 	if (cocoa_keybdstatus[actualKey]==1) {
 		cocoa_last_keybdstatus[actualKey]=1; //its already handeled the key press
@@ -119,6 +127,7 @@ void key_press(int keycode) {
 void key_release(int keycode) {
 	int actualKey =enigma::keymap[keycode];
 	cocoa_keybdstatus[actualKey]=0;
+	enigma_user::keyboard_key = 0;
 }
 
 extern int enigma_user::mouse_button;


### PR DESCRIPTION
Due to an oversight, keyboard_key and keyboard_lastkey were never hooked up on OS-X. This fixes that.