### PR TITLE
Added UK spellings of 'color' for GM:S compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ blank.txt
 *.db
 *.depend
 *.so
+start.sh
 *.dll
 *.dylib
 *.exe

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11colors.cpp
@@ -39,7 +39,7 @@ namespace enigma_user
 void draw_clear_alpha(int col, float alpha)
 {
 	float color[4];
-	
+
 	// Setup the color to clear the buffer to.
 	color[0] = __GETR(col)/255.0;
 	color[1] = __GETG(col)/255.0;
@@ -53,7 +53,7 @@ void draw_clear_alpha(int col, float alpha)
 void draw_clear(int col)
 {
 	float color[4];
-	
+
 	// Setup the color to clear the buffer to.
 	color[0] = __GETR(col)/255.0;
 	color[1] = __GETG(col)/255.0;
@@ -96,7 +96,7 @@ void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blu
 	enigma::currentcolor[0] = red;
 	enigma::currentcolor[1] = green;
 	enigma::currentcolor[2] = blue;
-	enigma::currentcolor[3] = bind_alpha(alpha);	
+	enigma::currentcolor[3] = bind_alpha(alpha);
 }
 
 void draw_set_color_write_enable(bool red, bool green, bool blue, bool alpha)
@@ -182,4 +182,3 @@ int make_color_hsv(int hue,int saturation,int value)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
@@ -81,7 +81,7 @@ void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blu
 	enigma::currentcolor[0] = red;
 	enigma::currentcolor[1] = green;
 	enigma::currentcolor[2] = blue;
-	enigma::currentcolor[3] = bind_alpha(alpha);	
+	enigma::currentcolor[3] = bind_alpha(alpha);
 	D3DCOLOR D3DColor = D3DCOLOR_RGBA(enigma::currentcolor[0],enigma::currentcolor[1],enigma::currentcolor[2], enigma::currentcolor[3]);
 }
 
@@ -170,4 +170,3 @@ int make_color_hsv(int hue,int saturation,int value)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
@@ -76,7 +76,73 @@ int color_get_saturation(int color);
 
 int make_color_hsv(int hue,int saturation,int value);
 
+//UK localisation
+//This has been done because GameMaker:Studio allows for both spellings of 'color'
+inline int merge_colour(int col1, int col2, double amount)
+{
+  return merge_color(col1, col2, amount);
+}
+inline void draw_set_colour(int col)
+{
+  draw_set_color(col);
+}
+inline void draw_set_colour_rgb(unsigned char red, unsigned char green, unsigned char blue)
+{
+  draw_set_color_rgb(red, green, blue);
+}
+inline void draw_set_colour_rgba(unsigned char red, unsigned char green, unsigned char blue, float alpha)
+{
+  draw_set_color_rgba(red, green, blue, alpha);
+}
+inline void draw_set_colour_write_enable(bool red, bool green, bool blue, bool alpha)
+{
+  draw_set_color_write_enable(red, green, blue, alpha);
+}
+inline int draw_get_colour()
+{
+  return draw_get_color();
+}
+inline int make_colour_rgb(unsigned char red, unsigned char green, unsigned char blue)
+{
+  return make_color_rgb(red, green, blue);
+}
+inline int make_colour_rgba(unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha)
+{
+  return make_color_rgba(red, green, blue, alpha);
+}
+inline int make_colour(unsigned char r, unsigned char g, unsigned char b)
+{
+    return make_color_rgb(r,g,b);
+}
+inline int colour_get_red(int color)
+{
+  return color_get_red(color);
+}
+inline int colour_get_green(int color)
+{
+  return color_get_green(color);
+}
+inline int colour_get_blue(int color)
+{
+  return color_get_blue(color);
+}
+inline int colour_get_hue(int color)
+{
+  return color_get_hue(color);
+}
+inline int colour_get_value(int color)
+{
+  return color_get_value(color);
+}
+inline int colour_get_saturation(int color)
+{
+  return color_get_saturation(color);
+}
+inline int make_colour_hsv(int hue,int saturation,int value)
+{
+  return make_color_hsv(hue,saturation,value);
+}
+
 }
 
 #endif // ENIGMA_GLCOLORS_H
-


### PR DESCRIPTION
Since GameMaker:Studio allows for both spellings of 'color' to be used (for some strange reason) I implemented this in Enigma to make importing GameMaker:Studio projects easier.