### PR TITLE
Update XLIBmain.cpp

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -49,7 +49,7 @@ namespace enigma_user {
 namespace enigma
 {
   int game_return = 0;
-  extern char keymap[512];
+  extern unsigned char keymap[512];
   void ENIGMA_events(void); //TODO: Synchronize this with Windows by putting these two in a single header.
   bool gameWindowFocused = false;
   extern int windowWidth, windowHeight;


### PR DESCRIPTION
* Note: Somebody on Linux please test and confirm this fixes the warnings.

This fixes the following warning:
```
Closing game module and running if requested.
Platforms/xlib/XLIBmain.cpp:52:15: warning: type of ‘keymap’ does not match original declaration
   extern char keymap[512];
               ^
Platforms/xlib/XLIBwindow.cpp:515:17: note: previously declared here
   unsigned char keymap[512];
^
```