### PR TITLE
Correct extension About.ey files

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Alarms/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Alarms/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: Alarms
-ID: Alarms
+Identifier: Alarms
 Description: Adds the local alarm variable and alarm-related DND tiles.
 Build-date: 6/17/2011
 Icon: alarm.png

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: Asynchronous
-ID: Asynchronous
+Identifier: Asynchronous
 Description: Asynchronous dialog support for GameMaker: Studio. Requires a set Widget System and the Data Structure extension enabled.
 Default: false
 Build-date: 1/30/2014

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BasicGUI/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BasicGUI/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: BasicGUI
-ID: BasicGUI
+Name: Basic GUI
+Identifier: BasicGUI
 Description: Adds basic GUI functions: buttons, labels, scrollbars etc.
 Build-date: 18/06/2014
 Icon: BasicGUI.png

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2D/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2D/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: Box2DPhysics
-ID: Box2D Physics
+Name: Box2D Physics
+Identifier: Box2DPhysics
 Description: Physics simulation of 2D rigid bodies, joints, and forces.
 Default: false
 Build-date: 5/05/2013

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: BulletDynamics
-ID: Bullet Dynamics
+Name: Bullet Dynamics
+Identifier: BulletDynamics
 Description: 3D physics simulation, collision detection, and real time destruction.
 Default: false
 Build-date: 6/18/2013

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: Data Structures
-ID: Data Structures
+Identifier: DataStructures
 Description: Adds data structures using generic collections.
 Build-date: 09/03/2011
 Icon: datastructures.png

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: DateTime
-ID: Date Time
+Name: Date Time
+Identifier: DateTime
 Description: Adds date and time functions.
 Build-date: 09/03/2011
 Icon: datetime.png

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DirectShow/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DirectShow/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: DirectShow
-ID: DirectShow
+Identifier: DirectShow
 Description: Video playback support on Windows platforms.
 Default: false
 Build-date: 10/26/2013

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/GM5Compat/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/GM5Compat/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: GM5Compat
-ID: GameMaker 5 Compatibility
+Name: GameMaker 5 Compatibility
+Identifier: GM5Compat
 Description: Compatibility function calls for Game Maker 5.
 Default: false
 Build-date: 01/18/2014

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/GME/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/GME/About.ey
@@ -1,8 +1,8 @@
 %e-yaml
 ---
 
-Name: GME
-ID: Game Music Emulator
+Name: Game Music Emulator
+Identifier: GME
 Author: Rusky
 Description: Loads emulator sounds and music using libgme.
 Default: false

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/About.ey
@@ -1,8 +1,8 @@
 %e-yaml
 ---
 
-Name: IniFilesystem
-ID: IniFilesystem
+Name: Ini Filesystem
+Identifier: IniFilesystem
 Author: Seth N. Hetu
 Description: Provides a consistent, performant, cross-platform, GM-compliant API for manipulating INI files.
 Default: false

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Json/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Json/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: Json
-ID: Json
+Identifier: Json
 Author: Ssss
 Description: Adds support for json_decode and json_encode.
 Default: false

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/MCI/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/MCI/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: Media Control Interface
-ID: Media Control Interface
+Identifier: MediaControlInterface
 Description: CD playback on Windows using the MCI.
 Default: false
 Build-date: 11/2/2013

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Matrix/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Matrix/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: MatrixMath
-ID: Matrix math
+Name: Matrix Math
+Identifier: MatrixMath
 Description: Adds templated matrix and quaternion classes.
 Build-date: 26/01/2014
 Default: false

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: MotionPlanning
-ID: Motion Planning
+Name: Motion Planning
+Identifier: MotionPlanning
 Description: Adds motion planning functions.
 Icon: mp.png
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: ParticleSystems
-ID: Particle Systems
+Name: Particle Systems
+Identifier: ParticleSystems
 Description: Adds particle systems functions.
 Default: true
 Icon: ps.png

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: Paths
-ID: Paths
+Identifier: Paths
 Description: Adds path functions and local variables.
 Icon: path.png
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/RegistrySpoof/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/RegistrySpoof/About.ey
@@ -1,8 +1,8 @@
 %e-yaml
 ---
 
-Name: RegistrySpoof
-ID: RegistrySpoof
+Name: Registry Spoof
+Identifier: RegistrySpoof
 Author: Seth N. Hetu
 Description: Provides a subset of Windows Registry functionality on other platforms. Requires INI.
 Default: false

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/StudioPhysics/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/StudioPhysics/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: StudioPhysics
-ID: Studio Physics
+Name: Studio Physics
+Identifier: StudioPhysics
 Description: Physics compatibility with GameMaker: Studio
 Default: false
 Build-date: 5/05/2013
@@ -10,4 +10,3 @@ Icon: spicon.png
 
 Depends: None
 Dependencies: None
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Timelines/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Timelines/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: Timelines
-ID: Timelines
+Identifier: Timelines
 Description: Adds timeline local variables and functions.
 Icon: timeline.png
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/WindowsTouch/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/WindowsTouch/About.ey
@@ -1,8 +1,8 @@
 %E-YAML
 ---
 
-Name: WindowsTouch
-ID: Windows Touch
+Name: Windows Touch
+Identifier: WindowsTouch
 Description: Touch support for Windows based environments.
 Default: false
 Build-date: 10/04/2014

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/XInput/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/XInput/About.ey
@@ -2,7 +2,7 @@
 ---
 
 Name: XInput
-ID: XInput
+Identifier: XInput
 Description: Input support including gamepads on Windows and Xbox 360.
 Default: false
 Build-date: 8/8/2013


### PR DESCRIPTION
There are two changes here. First, "ID" is being changed to "Identifier" for extensions as it is for the major systems so there is consistency. Second, "Name" was intended to be the human readable field as it is used in the major systems, but due to a bug that I just fixed in the plugin (https://github.com/enigma-dev/lgmplugin/commit/ccc750ac54745d05599299549c13a29d91b659d4) "Identifier" was being used instead. So this PR swaps the role of "Identifier" and "Name".

Once this is merged, everybody is going to need the new ENIGMA plugin. Read the topic for more information about this issue.
http://enigma-dev.org/forums/index.php?topic=2718