### PR TITLE
Cleanup string functions

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -103,7 +103,7 @@ string base64_decode(string const& str) {
 
   while (in_len-- && ( str[in_] != '=') && is_base64(str[in_])) {
     char_array_4[i++] = str[in_]; in_++;
-    if (i ==4) {
+    if (i == 4) {
       for (i = 0; i <4; i++)
         char_array_4[i] = base64_chars.find(char_array_4[i]);
 
@@ -235,7 +235,7 @@ string string_replace_all(string str,string substr,string newstr) {
 size_t string_count(string substr,string str) {
   size_t pos = 0, occ = 0;
   const size_t sublen = substr.length();
-  while ((pos=str.find(substr,pos)) != string::npos)
+  while ((pos = str.find(substr,pos)) != string::npos)
     occ++, pos += sublen;
   return occ;
 }
@@ -265,7 +265,7 @@ string string_repeat(string str,int count) {
 string string_letters(string str) {
   string ret;
   for (const char *c = str.c_str(); *c; c++)
-    if (ldgrs[(unsigned char)*c] & 3) ret+=*c;
+    if (ldgrs[(unsigned char)*c] & 3) ret += *c;
   return ret;
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -49,7 +49,7 @@ bool is_base64(unsigned char c) {
 }
 
 string base64_encode(string const& str) {
-  unsigned in_len = str.size();
+  size_t in_len = str.size();
   string ret;
   int i = 0;
   int j = 0;
@@ -65,15 +65,15 @@ string base64_encode(string const& str) {
       char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
       char_array_4[3] = char_array_3[2] & 0x3f;
 
-      for(i = 0; (i <4) ; i++)
+      for (i = 0; (i <4); i++)
         ret += base64_chars[char_array_4[i]];
+
       i = 0;
     }
   }
 
-  if (i)
-  {
-    for(j = i; j < 3; j++)
+  if (i) {
+    for (j = i; j < 3; j++)
       char_array_3[j] = '\0';
 
     char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
@@ -84,9 +84,8 @@ string base64_encode(string const& str) {
     for (j = 0; (j < i + 1); j++)
       ret += base64_chars[char_array_4[j]];
 
-    while((i++ < 3))
+    while (i++ < 3)
       ret += '=';
-
   }
 
   return ret;
@@ -94,17 +93,17 @@ string base64_encode(string const& str) {
 }
 
 string base64_decode(string const& str) {
-  unsigned in_len = str.size();
+  size_t in_len = str.size();
   int i = 0;
   int j = 0;
   int in_ = 0;
   unsigned char char_array_4[4], char_array_3[3];
   string ret;
 
-  while (in_len-- && ( str[in_] != '=') && is_base64(str[in_])) {
+  while (in_len-- && (str[in_] != '=') && is_base64(str[in_])) {
     char_array_4[i++] = str[in_]; in_++;
     if (i == 4) {
-      for (i = 0; i <4; i++)
+      for (i = 0; i < 4; i++)
         char_array_4[i] = base64_chars.find(char_array_4[i]);
 
       char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
@@ -113,15 +112,16 @@ string base64_decode(string const& str) {
 
       for (i = 0; (i < 3); i++)
         ret += char_array_3[i];
+
       i = 0;
     }
   }
 
   if (i) {
-    for (j = i; j <4; j++)
+    for (j = i; j < 4; j++)
       char_array_4[j] = 0;
 
-    for (j = 0; j <4; j++)
+    for (j = 0; j < 4; j++)
       char_array_4[j] = base64_chars.find(char_array_4[j]);
 
     char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -232,7 +232,7 @@ string string_replace_all(string str,string substr,string newstr) {
   return str;
 }
 
-int string_count(string substr,string str) {
+size_t string_count(string substr,string str) {
   size_t pos = 0, occ = 0;
   const size_t sublen = substr.length();
   while ((pos=str.find(substr,pos)) != string::npos)

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -322,7 +322,7 @@ string filename_dir(string fname)
 {
   size_t fp = fname.find_last_of("/\\");
   if (fp == string::npos)
-      return "";
+    return "";
   return fname.substr(0, fp);
 }
 
@@ -336,7 +336,7 @@ string filename_ext(string fname)
 {
   size_t fp = fname.find_last_of(".");
   if (fp == string::npos)
-      return "";
+    return "";
   return fname.substr(fp);
 }
 
@@ -344,7 +344,7 @@ string filename_change_ext(string fname, string newext)
 {
   size_t fp = fname.find_last_of(".");
   if (fp == string::npos)
-      return fname + newext;
+    return fname + newext;
   return fname.replace(fp,fname.length(),newext);
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -190,7 +190,7 @@ string string_set_byte_at(string str, int index, char byte) {
 }
 
 char string_byte_at(string str, int index) {
-  unsigned int n = index <= 1? 0 : (unsigned int)(index - 1);
+  unsigned int n = index <= 1 ? 0 : (unsigned int)(index - 1);
   #ifdef DEBUG_MODE
     if (n > str.length())
       show_error("Index " + toString(index) + " is outside range " + toString(str.length()) + " in the following string:\n\"" + str + "\".", false);
@@ -199,7 +199,7 @@ char string_byte_at(string str, int index) {
 }
 
 string string_char_at(string str,int index) {
-  unsigned int n = index <= 1? 0: (unsigned int)(index - 1);
+  unsigned int n = index <= 1 ? 0 : (unsigned int)(index - 1);
   #ifdef DEBUG_MODE
     if (n > str.length())
       show_error("Index " + toString(index) + " is outside range " + toString(str.length()) + " in the following string:\n\"" + str + "\".", false);

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -65,7 +65,7 @@ string base64_encode(string const& str) {
       char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
       char_array_4[3] = char_array_3[2] & 0x3f;
 
-      for (i = 0; (i <4); i++)
+      for (i = 0; (i < 4); i++)
         ret += base64_chars[char_array_4[i]];
 
       i = 0;
@@ -134,20 +134,16 @@ string base64_decode(string const& str) {
   return ret;
 }
 
+double real(variant str) { return str.type ? atof(((string)str).c_str()) : (double) str; }
+
 bool is_string(variant val) { return val.type;  }
 bool is_real(variant val)   { return !val.type; }
 string ansi_char(char byte) { return string(1,byte); }
 string chr(char val) { return string(1,val); }
 int ord(string str)  { return str[0]; }
 
-double real(variant str) { return str.type ? atof(((string)str).c_str()) : (double) str; }
-
 size_t string_length(string str) { return str.length(); }
-
-size_t string_length(const char* str)
-{
-  return strlen(str);
-}
+size_t string_length(const char* str) { return strlen(str); }
 
 size_t string_length_utf8(string str) {
   size_t res = 0;

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -165,9 +165,9 @@ size_t string_length_utf8(const char* str) {
   return res;
 }
 
-int string_pos(string substr,string str) {
-  const size_t res = str.find(substr,0)+1;
-  return res == string::npos ? -1 : (int)res;
+size_t string_pos(string substr,string str) {
+  const size_t res = str.find(substr,0) + 1;
+  return res == string::npos ? 0 : (int)res;
 }
 
 string string_format(double val, unsigned tot, unsigned dec)

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -37,7 +37,7 @@ static const char ldgrs[256] = {
   1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0
 };
 
-static const std::string base64_chars = 
+static const std::string base64_chars =
              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
              "abcdefghijklmnopqrstuvwxyz"
              "0123456789+/";
@@ -56,7 +56,7 @@ string base64_encode(string const& str) {
   int in_ = 0;
   unsigned char char_array_3[3];
   unsigned char char_array_4[4];
-  
+
   while (in_len--) {
     char_array_3[i++] = str[in_]; in_++;
     if (i == 3) {
@@ -146,206 +146,206 @@ size_t string_length(string str) { return str.length(); }
 
 size_t string_length(const char* str)
 {
-	return strlen(str);
+  return strlen(str);
 }
 
-size_t string_length_utf8(string str) { 
-	size_t res = 0; 
-	for (size_t i = 0; i < str.length(); ++i) 
-		if ((str[i] & 0xC0) != 0x80) 
-			++res; 
-	return res; 
+size_t string_length_utf8(string str) {
+  size_t res = 0;
+  for (size_t i = 0; i < str.length(); ++i)
+    if ((str[i] & 0xC0) != 0x80)
+      ++res;
+  return res;
 }
 
-size_t string_length_utf8(const char* str) { 
-	size_t res = 0; 
-	for (size_t i = 0; str[i]; ++i) 
-		if ((str[i] & 0xC0) != 0x80) 
-			++res; 
-	return res; 
+size_t string_length_utf8(const char* str) {
+  size_t res = 0;
+  for (size_t i = 0; str[i]; ++i)
+    if ((str[i] & 0xC0) != 0x80)
+      ++res;
+  return res;
 }
 
 int string_pos(string substr,string str) {
-	const size_t res = str.find(substr,0)+1;
-	return res == string::npos ? -1 : (int)res;
+  const size_t res = str.find(substr,0)+1;
+  return res == string::npos ? -1 : (int)res;
 }
 
 string string_format(double val, unsigned tot, unsigned dec)
 {
-    char sbuf[19]; sbuf[0] = 0;
-    sprintf(sbuf,"%0*.*f",tot,dec,val);
-    const string fstr = sbuf;
-    return fstr.c_str();
+  char sbuf[19]; sbuf[0] = 0;
+  sprintf(sbuf,"%0*.*f",tot,dec,val);
+  const string fstr = sbuf;
+  return fstr.c_str();
 }
 
 string string_copy(string str, int index, int count) {
-	index = index < 0 ? 0 : index;
-	return (size_t)index > str.length()? "": str.substr(index < 2? 0: index-1, count < 1? 0: count);
+  index = index < 0 ? 0 : index;
+  return (size_t)index > str.length() ? "" : str.substr(index < 2 ? 0 : index - 1, count < 1 ? 0 : count);
 }
 
 string string_set_byte_at(string str, int index, char byte) {
-	if (index<=1) return str + byte;
-	const size_t x = index-1;
-	return x>str.length()? str + byte: str.replace(x, 1, 1, byte);
+  if (index <= 1) return str + byte;
+  const size_t x = index - 1;
+  return x > str.length()? str + byte: str.replace(x, 1, 1, byte);
 }
 
 char string_byte_at(string str, int index) {
-	unsigned int n = index <= 1? 0: (unsigned int)index-1;
-	#ifdef DEBUG_MODE
-	  if (n > str.length())
-	    show_error("Index " + toString(index) + " is outside range " + toString(str.length()) + " in the following string:\n\"" + str + "\".", false);
+  unsigned int n = index <= 1? 0 : (unsigned int)(index - 1);
+  #ifdef DEBUG_MODE
+    if (n > str.length())
+      show_error("Index " + toString(index) + " is outside range " + toString(str.length()) + " in the following string:\n\"" + str + "\".", false);
   #endif
-	return str[n];
+  return str[n];
 }
 
 string string_char_at(string str,int index) {
-	unsigned int n = index <= 1? 0: (unsigned int)index-1;
-	#ifdef DEBUG_MODE
-	  if (n > str.length())
-	    show_error("Index " + toString(index) + " is outside range " + toString(str.length()) + " in the following string:\n\"" + str + "\".", false);
+  unsigned int n = index <= 1? 0: (unsigned int)(index - 1);
+  #ifdef DEBUG_MODE
+    if (n > str.length())
+      show_error("Index " + toString(index) + " is outside range " + toString(str.length()) + " in the following string:\n\"" + str + "\".", false);
   #endif
-	return string(1, str[n]);
+  return string(1, str[n]);
 }
 
 string string_delete(string str,int index,int count) {
-	return str.erase(index < 2? 0: index-1, count < 1? 0: count);
+  return str.erase(index < 2 ? 0 : index - 1, count < 1 ? 0 : count);
 }
 
 string string_insert(string substr,string str,int index) {
-	if (index<=1) return substr + str;
-	const size_t x = index-1;
-	return x>str.length()? str + substr: str.insert(x, substr);
+  if (index <= 1) return substr + str;
+  const size_t x = index - 1;
+  return x > str.length() ? str + substr : str.insert(x, substr);
 }
 
 string string_replace(string str,string substr,string newstr) {
-	size_t pos=str.find(substr,0);
-	return pos==(size_t)-1?str:str.replace(pos,substr.length(),newstr);
+  size_t pos = str.find(substr,0);
+  return pos == (size_t)-1 ? str : str.replace(pos,substr.length(),newstr);
 }
 
 string string_replace_all(string str,string substr,string newstr) {
-	size_t pos = 0;
-	const size_t sublen = substr.length(), newlen = newstr.length();
-    while((pos=str.find(substr,pos)) != string::npos) {
-		str.replace(pos,sublen,newstr);
-		pos += newlen;
-	}
-	return str;
+  size_t pos = 0;
+  const size_t sublen = substr.length(), newlen = newstr.length();
+  while ((pos = str.find(substr,pos)) != string::npos) {
+    str.replace(pos,sublen,newstr);
+    pos += newlen;
+  }
+  return str;
 }
 
 int string_count(string substr,string str) {
-	size_t pos = 0, occ = 0;
-	const size_t sublen = substr.length();
-  while((pos=str.find(substr,pos)) != string::npos)
+  size_t pos = 0, occ = 0;
+  const size_t sublen = substr.length();
+  while ((pos=str.find(substr,pos)) != string::npos)
     occ++, pos += sublen;
   return occ;
 }
 
 string string_lower(string str) {
-	const size_t len = str.length()-1;
-	for(size_t i = 0; i < len; i++)
-		if(ldgrs[(int)(unsigned char)str[i]] & 2)
-		  str[i] += 32;
-	return str;
+  const size_t len = str.length();
+  for (size_t i = 0; i < len; ++i)
+    if (ldgrs[(int)(unsigned char)str[i]] & 2)
+      str[i] += 32;
+  return str;
 }
 
 string string_upper(string str) {
-	int len=str.length()-1;
-	for(int i = 0; i < len; i++)
-		if(ldgrs[(unsigned char)str[i]]&1) str[i]-=32;
-	return str;
+  const size_t len = str.length();
+  for (size_t i = 0; i < len; ++i)
+    if (ldgrs[(unsigned char)str[i]] & 1)
+      str[i] -= 32;
+  return str;
 }
 
 string string_repeat(string str,int count) {
-	string ret; ret.reserve(str.length() * count);
-	for(int i = count; i; i--) ret.append(str);
-	return ret;
+  string ret; ret.reserve(str.length() * count);
+  for (int i = count; i; i--) ret.append(str);
+  return ret;
 }
 
 string string_letters(string str) {
-	string ret;
-	for(const char*c=str.c_str();*c;c++)
-		if(ldgrs[(unsigned char)*c]&3) ret+=*c;
-	return ret;
+  string ret;
+  for (const char *c = str.c_str(); *c; c++)
+    if (ldgrs[(unsigned char)*c] & 3) ret+=*c;
+  return ret;
 }
 
 string string_digits(string str) {
-	string ret;
-	for(const char*c=str.c_str();*c;c++)
-		if(ldgrs[(unsigned char)*c]&4) ret += *c;
-	return ret;
+  string ret;
+  for (const char *c = str.c_str(); *c; c++)
+    if (ldgrs[(unsigned char)*c] & 4) ret += *c;
+  return ret;
 }
 
 string string_lettersdigits(string str) {
-	string ret;
-	for(const char*c=str.c_str();*c;c++)
-		if(ldgrs[(unsigned char)*c]) ret += *c;
-	return ret;
+  string ret;
+  for (const char *c = str.c_str(); *c; c++)
+    if (ldgrs[(unsigned char)*c]) ret += *c;
+  return ret;
 }
 
 bool string_isletters(string str) {
-	for(const char*c = str.c_str(); *c; c++)
-		if(!(ldgrs[(unsigned char)*c] & 3))
+  for (const char *c = str.c_str(); *c; c++)
+    if (!(ldgrs[(unsigned char)*c] & 3))
       return false;
-	return true;
+  return true;
 }
 
 bool string_isdigits(string str) {
-	for(const char*c = str.c_str(); *c; c++)
-		if(!(ldgrs[(unsigned char)*c] & 4))
-		  return false;
-	return true;
+  for (const char *c = str.c_str(); *c; c++)
+    if (!(ldgrs[(unsigned char)*c] & 4))
+      return false;
+  return true;
 }
 
 bool string_islettersdigits(string str) {
-	for(const char*c=str.c_str(); *c; c++)
-		if(!ldgrs[(unsigned char)*c])
-		  return false;
-	return true;
+  for (const char *c = str.c_str(); *c; c++)
+    if (!ldgrs[(unsigned char)*c])
+      return false;
+  return true;
 }
 
 //filename fucntions place here as they are just string based
 
 string filename_name(string fname)
 {
-    size_t fp = fname.find_last_of("/\\");
-    return fname.substr(fp+1);
+  size_t fp = fname.find_last_of("/\\");
+  return fname.substr(fp+1);
 }
 
 string filename_path(string fname)
 {
-    size_t fp = fname.find_last_of("/\\");
-    return fname.substr(0,fp+1);
+  size_t fp = fname.find_last_of("/\\");
+  return fname.substr(0,fp+1);
 }
 
 string filename_dir(string fname)
 {
-    size_t fp = fname.find_last_of("/\\");
-    if (fp == string::npos)
-        return "";
-    return fname.substr(0, fp);
+  size_t fp = fname.find_last_of("/\\");
+  if (fp == string::npos)
+      return "";
+  return fname.substr(0, fp);
 }
 
 string filename_drive(string fname)
 {
-    size_t fp = fname.find("/\\");
-    return fname.substr(0, fp);
+  size_t fp = fname.find("/\\");
+  return fname.substr(0, fp);
 }
 
 string filename_ext(string fname)
 {
-    size_t fp = fname.find_last_of(".");
-    if (fp == string::npos)
-        return "";
-    return fname.substr(fp);
+  size_t fp = fname.find_last_of(".");
+  if (fp == string::npos)
+      return "";
+  return fname.substr(fp);
 }
 
 string filename_change_ext(string fname, string newext)
 {
-    size_t fp = fname.find_last_of(".");
-    if (fp == string::npos)
-        return fname + newext;
-    return fname.replace(fp,fname.length(),newext);
+  size_t fp = fname.find_last_of(".");
+  if (fp == string::npos)
+      return fname + newext;
+  return fname.replace(fp,fname.length(),newext);
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -38,23 +38,23 @@ size_t string_length(const char* str);
 #define string_byte_length(x) string_length(x)
 size_t string_length_utf8(string str);
 size_t string_length_utf8(const char* str);
-int string_pos(string substr,string str);
+size_t string_pos(string substr, string str);
 
 string string_format(double val, unsigned tot, unsigned dec);
-string string_copy(string str, int index,int count);
+string string_copy(string str, int index, int count);
 string string_set_byte_at(string str, int pos, char byte);
 char string_byte_at(string str, int index);
 string string_char_at(string str,int index);
-string string_delete(string str,int index,int count);
-string string_insert(string substr,string str,int index);
-string string_replace(string str,string substr,string newstr);
-string string_replace_all(string str,string substr,string newstr);
+string string_delete(string str, int index, int count);
+string string_insert(string substr, string str, int index);
+string string_replace(string str, string substr, string newstr);
+string string_replace_all(string str, string substr, string newstr);
 size_t string_count(string substr, string str);
 
 string string_lower(string str);
 string string_upper(string str);
 
-string string_repeat(string str,int count);
+string string_repeat(string str, int count);
 
 string string_letters(string str);
 string string_digits(string str);

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -72,4 +72,3 @@ string filename_ext(string fname);
 string filename_change_ext(string fname, string newext);
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -49,7 +49,7 @@ string string_delete(string str,int index,int count);
 string string_insert(string substr,string str,int index);
 string string_replace(string str,string substr,string newstr);
 string string_replace_all(string str,string substr,string newstr);
-int string_count(string substr, string str);
+size_t string_count(string substr, string str);
 
 string string_lower(string str);
 string string_upper(string str);


### PR DESCRIPTION
This PR fully fixes #955

Fixes the indentation and whitespace around the string functions to improve readability. Also corrects ``string_upper`` and ``string_lower`` to handle zero length strings. They actually were not working before and were missing the last character. After this PR they should work correctly, here is a test:

```gml
show_message(string_lower("")); // should be ""
show_message(string_lower("A")); // should be "a"
show_message(string_lower("AA")); // should be "aa"
show_message(string_upper("")); // should be ""
show_message(string_upper("a")); // should be "A"
show_message(string_upper("aa")); // should be "AA"
```

While I was in here I also fixed the behavior and return type of ``string_pos``

According to the GM 5 manual and the GMS manual as well as ENIGMA's Wiki it should return 0 when no occurrence is found, not -1 as it has been returning.

> string_pos(substr,str) Returns the position of substr in str (0=no occurrence).

http://www.wonko.info/ipt/sse/gamemaker/GameProgramming/GameMakerManual.pdf
http://gamemaker.info/en/manual/402_03_string
https://docs.yoyogames.com/source/dadiospice/002_reference/strings/string_pos.html
http://enigma-dev.org/docs/Wiki/String_pos

I updated the Wiki articles for ``string_pos`` and ``string_count`` to mention their new return types.
http://enigma-dev.org/docs/Wiki/String_Functions

Here is a test for these changes:
```gml
show_message(string(string_pos("es","test"))); // should be 2
show_message(string(string_pos("t","test"))); // should be 1
show_message(string(string_pos("j","test"))); // should be 0
```

I also cleaned up whitespace around the base64 functions and double checked they worked the same as GM Studio's.
```gml
var str = base64_encode("hello");
show_message(str); // should be aGVsbG8=
show_message(base64_decode(str)); // should be "hello"
```