### PR TITLE
Fixes compileEGMf always compiling to 32-bit rather than native.

### DIFF
--- a/CompilerSource/Makefile
+++ b/CompilerSource/Makefile
@@ -29,8 +29,8 @@ endif
 ###########
 
 CXX := g++
-CXXFLAGS += -std=c++11 -m32 -Wall -O3 -g -I./JDI/src
-LDFLAGS += -shared -m32 -O3 -g
+CXXFLAGS += -std=c++11 -Wall -O3 -g -I./JDI/src
+LDFLAGS += -shared -O3 -g
 
 # This implements a recursive wildcard allowing us to iterate in subdirs
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))


### PR DESCRIPTION
See:
https://github.com/enigma-dev/enigma-dev/pull/929#issuecomment-247857016
