### PR TITLE
Fix #944 (use of external inline function)

### DIFF
--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -47,7 +47,7 @@ using namespace std;
 
 string makedir = "";
 
-string fc(const char* fn);
+inline string fc(const char* fn);
 static void clear_ide_editables()
 {
   ofstream wto;


### PR DESCRIPTION
Partial fix for #944. Fixes compilation and dynamic linkage under Arch with GCC 6.2.1, but JDI is still crashing later on.