### PR TITLE
Fix careless unlink call in `instance_change()`

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/instance_create.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_create.h
@@ -36,13 +36,12 @@ namespace enigma
       //  visible,
 
       //the instance id is the same
-      int idn=inst->id;
+      int idn = inst->id;
 
-      //Destory the instance
-      if (perf) inst->myevent_destroy();
-      inst->unlink();
+      // Destroy the instance
+      instance_destroy(idn, perf);
 
-      //Create the instance
+      // Re-create the instance
       object_basic* ob = NULL;
       switch((int)obj)
       {


### PR DESCRIPTION
Use `instance_destroy(id, call_destroy)` instead, as this handles cleaning up dangling iterators. This function is still a major hack; not sure who wrote it. At least now it won't segfault.

Fixes #1045.