### PR TITLE
Fixed Box2D bodies not being destroyed

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2D/Box2DWorld.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2D/Box2DWorld.h
@@ -64,7 +64,7 @@ struct B2DBody {
 
   ~B2DBody()
   {
-
+    this->body->GetWorld()->DestroyBody(this->body);
   }
 
 }; 


### PR DESCRIPTION
Despite calling ```b2d_body_delete()``` Box2D objects wouldn't be destroyed, all that would happen would be that the memory for the struct that encapsulates Box2D objects would be freed, which would mean you would end up with ghost bodies in a Box2D world (Box2D bodies not attached to an ENIGMA object).