### PR TITLE
Cleanup and fix Direct3D graphics systems

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
+++ b/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
@@ -54,7 +54,7 @@ LPDIRECT3DSURFACE9 pBackBuffer;
 LPDIRECT3DSURFACE9 pRenderTarget;
 
 float last_depth;
-int last_stride;
+unsigned last_stride;
 bool hasdrawn;
 int shapes_d3d_model;
 int shapes_d3d_texture;
@@ -75,7 +75,7 @@ ContextManager() {
 	hasdrawn = false;
 	shapes_d3d_model = -1;
 	shapes_d3d_texture = -1;
-	last_stride = -1;
+	last_stride = 0;
 	vertexShader = NULL;
 	pixelShader = NULL;
 	last_depth = 0.0f;
@@ -183,9 +183,9 @@ int GetShapesModel() {
 void BeginShapesBatching(int texId) {
 	if (shapes_d3d_model == -1) {
 		shapes_d3d_model = d3d_model_create(model_dynamic);
-		last_stride = -1;
-	} else if (texId != shapes_d3d_texture || (d3d_model_get_stride(shapes_d3d_model) != last_stride && last_stride != -1)) {
-		last_stride = -1;
+		last_stride = 0;
+	} else if (texId != shapes_d3d_texture || (d3d_model_get_stride(shapes_d3d_model) != last_stride)) {
+		last_stride = 0;
 		if (!hasdrawn) {
 			d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
 			d3d_model_clear(shapes_d3d_model);
@@ -204,7 +204,7 @@ void EndShapesBatching() {
 	d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
 	d3d_model_clear(shapes_d3d_model);
 	shapes_d3d_texture = -1;
-	last_stride = -1;
+	last_stride = 0;
 }
 
 void Clear(DWORD Count, const D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil) {

--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
@@ -34,28 +34,28 @@ using namespace std;
 #include "Graphics_Systems/General/GScolors.h"
 
 // global declarations
-LPDIRECT3D9 d3dobj;    // the pointer to our Direct3D interface
-ContextManager* d3dmgr;    // the pointer to the device class
+LPDIRECT3D9 d3dobj; // the pointer to our Direct3D interface
+ContextManager* d3dmgr; // the pointer to the device class
 
 // the WindowProc function prototype
 LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 namespace enigma
 {
-	extern bool forceSoftwareVertexProcessing;
-	
+  extern bool forceSoftwareVertexProcessing;
+
   void OnDeviceLost() {
     for (vector<Surface*>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
       (*it)->OnDeviceLost();
     }
   }
-  
+
   void OnDeviceReset() {
     for (vector<Surface*>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
       (*it)->OnDeviceReset();
     }
   }
-  
+
   extern void (*WindowResizedCallback)();
   void WindowResized() {
     if (d3dmgr == NULL) { return; }
@@ -75,100 +75,99 @@ namespace enigma
     // clear the window color, viewport does not need set because backbuffer was just recreated
     enigma_user::draw_clear(enigma_user::window_get_color());
   }
-  
+
   void EnableDrawing (HGLRC *hRC)
   {
     WindowResizedCallback = &WindowResized;
-    
+
     d3dmgr = new ContextManager();
     HRESULT hr;
-    
-    D3DPRESENT_PARAMETERS d3dpp;    // create a struct to hold various device information
-    d3dobj = Direct3DCreate9(D3D_SDK_VERSION);    // create the Direct3D interface
-    D3DFORMAT format = D3DFMT_A8R8G8B8; //For simplicity we'll hard-code this for now.
-    
-    ZeroMemory(&d3dpp, sizeof(d3dpp));    // clear out the struct for use
-    d3dpp.Windowed = TRUE;    // program windowed, not fullscreen
+
+    D3DPRESENT_PARAMETERS d3dpp; // create a struct to hold various device information
+    d3dobj = Direct3DCreate9(D3D_SDK_VERSION); // create the Direct3D interface
+    D3DFORMAT format = D3DFMT_A8R8G8B8;
+
+    ZeroMemory(&d3dpp, sizeof(d3dpp)); // clear out the struct for use
+    d3dpp.Windowed = TRUE; // program windowed, not fullscreen
     int ww = window_get_width(),
         wh = window_get_height();
-		d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
-		d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
-    d3dpp.MultiSampleType = D3DMULTISAMPLE_NONE; // 0 Levels of multi-sampling
-    d3dpp.MultiSampleQuality = 0;                //No multi-sampling
-    d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;  // Throw away previous frames, we don't need them
-    d3dpp.hDeviceWindow = hWnd;  // This is our main (and only) window
-    d3dpp.Flags = NULL;            // No flags to set
-    d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT; //Default Refresh Rate
-    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;   //Present the frame immediately
-    d3dpp.BackBufferCount = 1;  //We only need a single back buffer
-    d3dpp.BackBufferFormat = format;      //Display format
-    d3dpp.EnableAutoDepthStencil = TRUE; // Automatic depth stencil buffer
-    d3dpp.AutoDepthStencilFormat = D3DFMT_D24S8; //32-bit zbuffer 24bits for depth 8 for stencil buffer
+    d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
+    d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
+    d3dpp.MultiSampleType = D3DMULTISAMPLE_NONE;                // 0 Levels of multi-sampling
+    d3dpp.MultiSampleQuality = 0;                               // No multi-sampling
+    d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;                   // Throw away previous frames, we don't need them
+    d3dpp.hDeviceWindow = hWnd;                                 // This is our main (and only) window
+    d3dpp.Flags = 0;                                            // No flags to set
+    d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT; // Default Refresh Rate
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE; // Present the frame immediately
+    d3dpp.BackBufferCount = 1;                                  // We only need a single back buffer
+    d3dpp.BackBufferFormat = format;                            // Display format
+    d3dpp.EnableAutoDepthStencil = TRUE;                        // Automatic depth stencil buffer
+    d3dpp.AutoDepthStencilFormat = D3DFMT_D24S8;                // 32-bit zbuffer 24bits for depth 8 for stencil buffer
     // create a device class using this information and information from the d3dpp stuct
     DWORD behaviors = D3DCREATE_MIXED_VERTEXPROCESSING;
     if (forceSoftwareVertexProcessing) {
       behaviors = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
     }
     hr = d3dobj->CreateDevice(D3DADAPTER_DEFAULT,
-                      D3DDEVTYPE_HAL,
-                      hWnd,
-                      behaviors,
-                      &d3dpp,
-                      &d3dmgr->device);
+                              D3DDEVTYPE_HAL,
+                              hWnd,
+                              behaviors,
+                              &d3dpp,
+                              &d3dmgr->device);
     if (FAILED(hr)) {
       MessageBox(hWnd,
-               "Failed to create Direct3D 9.0 Device",
-         DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
-               MB_ICONERROR | MB_OK);
-         return; // should probably force the game closed
+                 "Failed to create Direct3D 9.0 Device",
+                 DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
+                 MB_ICONERROR | MB_OK);
+      return; // should probably force the game closed
     }
-		
-		d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE); 
-		
-		enigma_user::display_aa = 0;
-		for (int i = 16; i > 1; i--) {
-			if (SUCCEEDED(d3dobj->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, format, TRUE, (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + i), NULL))) {
-				enigma_user::display_aa += i;
-			}
-		}
-		
+
+    d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE);
+
+    enigma_user::display_aa = 0;
+    for (int i = 16; i > 1; i--) {
+      if (SUCCEEDED(d3dobj->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, format, TRUE, (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + i), NULL))) {
+        enigma_user::display_aa += i;
+      }
+    }
   }
 
   void DisableDrawing (HWND hWnd, HDC hDC, HGLRC hRC)
   {
-    d3dmgr->Release();    // close and release the 3D device
-    d3dobj->Release();    // close and release Direct3D
+    d3dmgr->Release(); // close and release the 3D device
+    d3dobj->Release(); // close and release Direct3D
   }
 }
 
 #include "Universal_System/roomsystem.h"
 
-namespace enigma_user 
+namespace enigma_user
 {
 int display_aa = 0;
 
 void display_reset(int samples, bool vsync) {
-	if (d3dmgr == NULL) { return; }
-	IDirect3DSwapChain9 *sc;
-	d3dmgr->GetSwapChain(0, &sc);
-	D3DPRESENT_PARAMETERS d3dpp;
-	sc->GetPresentParameters(&d3dpp);
-	if (vsync) {
-		d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;   //Present the frame immediately
-	} else {
-		d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;   //Present the frame immediately
-	}
-	d3dpp.MultiSampleType = (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + samples); // Levels of multi-sampling
-	d3dpp.MultiSampleQuality = 0;                //No multi-sampling
-	if (samples) {
-		d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, TRUE); 
-	} else {
-		d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE); 
-	}
-	sc->Release();
+  if (d3dmgr == NULL) { return; }
+  IDirect3DSwapChain9 *sc;
+  d3dmgr->GetSwapChain(0, &sc);
+  D3DPRESENT_PARAMETERS d3dpp;
+  sc->GetPresentParameters(&d3dpp);
+  if (vsync) {
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT; // Present the frame immediately
+  } else {
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE; // Present the frame immediately
+  }
+  d3dpp.MultiSampleType = (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + samples); // Levels of multi-sampling
+  d3dpp.MultiSampleQuality = 0; // No multi-sampling
+  if (samples) {
+    d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, TRUE);
+  } else {
+    d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE);
+  }
+  sc->Release();
 
   enigma::OnDeviceLost();
-	d3dmgr->Reset(&d3dpp);
+  d3dmgr->Reset(&d3dpp);
   enigma::OnDeviceReset();
 }
 
@@ -178,21 +177,21 @@ void screen_refresh() {
   d3dmgr->Present(NULL, NULL, NULL, NULL);
 }
 
-void set_synchronization(bool enable) //TODO: Needs to be rewritten
+void set_synchronization(bool enable)
 {
-	if (d3dmgr == NULL) { return; }
-	IDirect3DSwapChain9 *sc;
-	d3dmgr->GetSwapChain(0, &sc);
-	D3DPRESENT_PARAMETERS d3dpp;
-	sc->GetPresentParameters(&d3dpp);
-	if (enable) {
-		d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;   //Present the frame immediately
-	} else {
-		d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;   //Present the frame immediately
-	}
-	sc->Release();
+  if (d3dmgr == NULL) { return; }
+  IDirect3DSwapChain9 *sc;
+  d3dmgr->GetSwapChain(0, &sc);
+  D3DPRESENT_PARAMETERS d3dpp;
+  sc->GetPresentParameters(&d3dpp);
+  if (enable) {
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT; // Present the frame immediately
+  } else {
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE; // Present the frame immediately
+  }
+  sc->Release();
 
-	d3dmgr->Reset(&d3dpp);
-}  
+  d3dmgr->Reset(&d3dpp);
+}
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11model.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11model.cpp
@@ -326,7 +326,7 @@ void d3d_model_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int texId)
     d3d_model_draw(id, x, y, z);
 }
 
-void d3d_model_primitive_begin(int id, int kind)
+void d3d_model_primitive_begin(int id, int kind, int format)
 {
   meshes[id]->Begin(kind);
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
@@ -96,6 +96,16 @@ namespace enigma
 
   }
 
+  void graphics_copy_texture(int source, int destination, int x, int y)
+  {
+
+  }
+
+  void graphics_copy_texture_part(int source, int destination, int xoff, int yoff, int w, int h, int x, int y)
+  {
+
+  }
+
   void graphics_replace_texture_alpha_from_texture(int tex, int copy_tex)
   {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
@@ -24,22 +24,6 @@ using std::map;
 
 namespace enigma {
 
-struct VertexFormat {
-	map<int,int> flags;
-	
-	VertexFormat() {
-	
-	}
-	
-	~VertexFormat() {
-	
-	}
-	
-	void AddAttribute(int type, int usage) {
-		flags.insert(map<int,int>::value_type(type, usage));
-	}
-};
-
 struct VertexBuffer {
 	vector<gs_scalar> vertices;
 	vector<gs_scalar> indices;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9ModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9ModelStruct.h
@@ -51,21 +51,18 @@ namespace enigma {
     string next;
     vector<float> result;
 
-    for (string::const_iterator it = str.begin(); it != str.end(); it++)
-	{
-		if (*it == ch)
-		{
-			if (!next.empty())
-			{
-				result.push_back(atof(next.c_str()));
-				next.clear();
-			}
-        } else {
-            next += *it;
+    for (string::const_iterator it = str.begin(); it != str.end(); it++) {
+      if (*it == ch) {
+        if (!next.empty()) {
+          result.push_back(atof(next.c_str()));
+          next.clear();
         }
+      } else {
+        next += *it;
+      }
     }
     if (!next.empty())
-         result.push_back(atof(next.c_str()));
+      result.push_back(atof(next.c_str()));
     return result;
   }
 
@@ -542,9 +539,6 @@ class Mesh
     if (pointCount > 0) {
       vdata.insert(vdata.end(), pointVertices.begin(), pointVertices.end());
     }
-
-
-    unsigned stride = vertexStride;
 
     if (vertexbuffer != NULL) {
       D3DVERTEXBUFFER_DESC pDesc;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9SurfaceStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9SurfaceStruct.h
@@ -32,7 +32,8 @@ namespace enigma
   {
     LPDIRECT3DSURFACE9 surf;
     int tex, width, height;
-    Surface(): tex(0), width(0), height(0), surf(NULL) {
+
+    Surface(): surf(NULL), tex(0), width(0), height(0) {
 
     };
     

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9model.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9model.cpp
@@ -326,7 +326,7 @@ void d3d_model_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int texId)
     d3d_model_draw(id, x, y, z);
 }
 
-void d3d_model_primitive_begin(int id, int kind)
+void d3d_model_primitive_begin(int id, int kind, int format)
 {
   meshes[id]->Begin(kind);
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -348,4 +348,3 @@ void texture_anisotropy_filter(int sampler, gs_scalar level)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
@@ -24,22 +24,6 @@ using std::map;
 
 namespace enigma {
 
-struct VertexFormat {
-	map<int,int> flags;
-	
-	VertexFormat() {
-	
-	}
-	
-	~VertexFormat() {
-	
-	}
-	
-	void AddAttribute(int type, int usage) {
-		flags.insert(map<int,int>::value_type(type, usage));
-	}
-};
-
 struct VertexBuffer {
 	vector<gs_scalar> vertices;
 	vector<gs_scalar> indices;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
@@ -29,7 +29,7 @@ using std::pair;
 namespace enigma {
   struct VertexFormat {
     vector<pair<int,int> > flags;
-    
+
     void AddAttribute(int type, int attribute) {
       flags.push_back(std::make_pair(type, attribute));
     }
@@ -37,13 +37,28 @@ namespace enigma {
 }
 
 namespace enigma_user {
-	enum {
-		vertex_type_float1,   // D3DDECLTYPE_FLOAT1
-		vertex_type_float2,   // D3DDECLTYPE_FLOAT2
-		vertex_type_float3,   // D3DDECLTYPE_FLOAT3
-		vertex_type_float4,   // D3DDECLTYPE_FLOAT4
-		vertex_type_ubyte4    // D3DDECLTYPE_UBYTE4
-	};
+  enum {
+    vertex_type_float1, // D3DDECLTYPE_FLOAT1
+    vertex_type_float2, // D3DDECLTYPE_FLOAT2
+    vertex_type_float3, // D3DDECLTYPE_FLOAT3
+    vertex_type_float4, // D3DDECLTYPE_FLOAT4
+    vertex_type_colour, // D3DDECLTYPE_D3DCOLOR
+    vertex_type_ubyte4  // D3DDECLTYPE_UBYTE4
+  };
+
+  enum {
+    vertex_usage_position,        // D3DDECLUSAGE_POSITION
+    vertex_usage_colour,          // D3DDECLUSAGE_COLOR
+    vertex_usage_normal,          // D3DDECLUSAGE_NORMAL
+    vertex_usage_textcoord,       // D3DDECLUSAGE_TEXCOORD
+    vertex_usage_blendweight,     // D3DDECLUSAGE_BLENDWEIGHT
+    vertex_usage_blendindices,    // D3DDECLUSAGE_BLENDINDICES
+    vertex_usage_depth,           // D3DDECLUSAGE_DEPTH
+    vertex_usage_tangent,         // D3DDECLUSAGE_TANGENT
+    vertex_usage_binormal,        // D3DDECLUSAGE_BINORMAL
+    vertex_usage_fog,             // D3DDECLUSAGE_FOG
+    vertex_usage_sample           // D3DDECLUSAGE_SAMPLE
+  };
 
   unsigned vertex_format_create();
   void vertex_format_destroy(int id);


### PR DESCRIPTION
Resolves #1034 but these systems need another look. After merging this I want to move all that model code out into the general system and have it make use of the vertex buffer functions. I am sick of looking at all of the duplicated model handling code, it's very ugly.

1) Fixes my warning about the stride of the last primitive batch, can just check if it's 0 since that is an invalid stride.
2) Fixes various formatting and indentation, such as consistent use of 2 spaces, removing blank lines with whitespace characters, etc.
3) Fixes warning about casting NULL to DWORD, convention is to just set d3dpp.flags to 0 since DWORD is unsigned long.
4) Adds the missing format parameter for d3d_model_primitive_begin which was making all the calls have ambiguous overload.
5) Add empty shells for graphics_copy_texture to be implemented.
6) Fixes warning about surface struct parameter initialization order.
7) Readds the semantic vertex format constants removed in 648bb10a9dcfbf636f9ec9298d475faf2d4c8807 because although they don't do anything, they convey meaning and promote self-documenting code.
8) Deletes duplicate VertexFormat struct.

Direct3D9 builds again now and can run the FPS example, and Direct3D11 builds and can successfully clear the background color.
![dx9fps](https://user-images.githubusercontent.com/3212801/31160832-85165b58-a8a1-11e7-8364-8f273398ff0e.png)

