### PR TITLE
Added url_open() and associated functions

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -27,6 +27,9 @@ extern std::string program_directory;
 
 void game_end(int ret=0);
 void action_end_game();
+void url_open(std::string url,std::string target="_self",std::string options="");
+void url_open_ext(std::string url, std::string target);
+void url_open_full(std::string url, std::string target,std::string options);
 void action_webpage(const std::string &url);
 
 // Data type could be unsigned for the paramter since the collection is size_t, however this would make the function not behave as GM.
@@ -46,7 +49,6 @@ void execute_program(std::string fname, std::string args, bool wait);
 void execute_program(std::string operation, std::string fname, std::string args, bool wait);
 
 std::string environment_get_variable(std::string name);
-
 }
 
 #endif //ENIGMA_PLATFORM_MAIN

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -468,10 +468,7 @@ void url_open(std::string url,std::string target,std::string options)
 {
 	if (system(NULL))
 	{
-		if (system(("xdg-open \""+url+"\"").c_str())==-1)
-		{
-
-		}
+		system(("xdg-open \""+url+"\"").c_str());
 	}
 	else
 	{

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -466,13 +466,9 @@ void action_end_game() {
 
 void url_open(std::string url,std::string target,std::string options)
 {
-	if (system(NULL))
-	{
-		system(("xdg-open \""+url+"\"").c_str());
-	}
-	else
-	{
-		printf("url_open cannot be used as there is no command processor!");
+	if (!fork()) {
+		execlp("xdg-open","xdg-open",url.c_str(),NULL);
+		exit(0);
 	}
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -420,8 +420,8 @@ void execute_shell(string fname, string args)
   if (system(NULL)) {
     system((fname + args + " &").c_str());
   } else {
-    printf("execute_shell cannot be used as there is no command processor!"); 
-    return; 
+    printf("execute_shell cannot be used as there is no command processor!");
+    return;
   }
 }
 
@@ -430,8 +430,8 @@ void execute_shell(string operation, string fname, string args)
   if (system(NULL)) {
     system((fname + args + " &").c_str());
   } else {
-    printf("execute_shell cannot be used as there is no command processor!"); 
-    return; 
+    printf("execute_shell cannot be used as there is no command processor!");
+    return;
   }
 }
 
@@ -440,8 +440,8 @@ void execute_program(string operation, string fname, string args, bool wait)
   if (system(NULL)) {
     system((fname + args + (wait?" &":"")).c_str());
   } else {
-    printf("execute_program cannot be used as there is no command processor!"); 
-    return; 
+    printf("execute_program cannot be used as there is no command processor!");
+    return;
   }
 }
 
@@ -450,8 +450,8 @@ void execute_program(string fname, string args, bool wait)
   if (system(NULL)) {
     system((fname + args + (wait?" &":"")).c_str());
   } else {
-    printf("execute_program cannot be used as there is no command processor!"); 
-    return; 
+    printf("execute_program cannot be used as there is no command processor!");
+    return;
   }
 }
 
@@ -462,6 +462,36 @@ void game_end(int ret) {
 
 void action_end_game() {
   game_end();
+}
+
+void url_open(std::string url,std::string target,std::string options)
+{
+	if (system(NULL))
+	{
+		if (system(("xdg-open \""+url+"\"").c_str())==-1)
+		{
+
+		}
+	}
+	else
+	{
+		printf("url_open cannot be used as there is no command processor!");
+	}
+}
+
+void url_open_ext(std::string url,std::string target)
+{
+	url_open(url,target);
+}
+
+void url_open_full(std::string url,std::string target,std::string options)
+{
+	url_open(url,target, options);
+}
+
+void action_webpage(const std::string &url)
+{
+	url_open(url);
 }
 
 int display_get_width() { return XWidthOfScreen(screen); }
@@ -477,4 +507,3 @@ void set_program_priority(int value) {
 }
 
 }
-


### PR DESCRIPTION
Fixes #1039  
I decided to have it so url_open() can optionally take the arguments specified for its associated functions, url_open_ext() and url_open_full(), since they extend each other in case some platform can actually implement them.  
Also implemented action_webpage() for Linux while I was at it.