### PR TITLE
Added Josh's shorten() function

### DIFF
--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -212,6 +212,13 @@ tstring widen(const string &str) {
   return tstring{buf.data(), (size_t)MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, buf.data(), (int)wchar_count)};
 }
 
+// shorten() does the same type conversion as widen(), but in reverse.
+string shorten(tstring str) {
+    int nbytes = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), nullptr, 0, nullptr, nullptr);
+    vector<char> buf((size_t)nbytes);
+    return string{buf.data(), (size_t)WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), buf.data(), nbytes, nullptr, nullptr)};
+}
+
 namespace enigma_user {
 
 extern string window_get_caption();

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -214,9 +214,9 @@ tstring widen(const string &str) {
 
 // shorten() does the same type conversion as widen(), but in reverse.
 string shorten(tstring str) {
-    int nbytes = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), nullptr, 0, nullptr, nullptr);
-    vector<char> buf((size_t)nbytes);
-    return string{buf.data(), (size_t)WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), buf.data(), nbytes, nullptr, nullptr)};
+  int nbytes = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), nullptr, 0, nullptr, nullptr);
+  vector<char> buf((size_t)nbytes);
+  return string{buf.data(), (size_t)WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), buf.data(), nbytes, nullptr, nullptr)};
 }
 
 namespace enigma_user {


### PR DESCRIPTION
shorten() is basically the opposite of widen() and will be useful for functions and built-in constants that return strings and need UTF-8 encoding support on Windows, such as working_directory and program_directory.