### PR TITLE
 This hides the 640x480 black loading window, etc.

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -245,8 +245,12 @@ int WINAPI WinMain (HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine,
     if (wid > screen_width) wid = screen_width;
     if (hgt > screen_height) hgt = screen_height;
     // Create the window initially without the WS_VISIBLE flag until we've loaded all of the resources.
-    // This will be handled by game_start in roomsystem.cpp where window_default(true) sets the initial fullscreen state of the window before showing it.
-    enigma::hWnd = CreateWindow ("EnigmaDevGameMainWindow", "", (enigma::getwindowstyle() & ~(WS_VISIBLE)), (screen_width-wid)/2, (screen_height-hgt)/2, wid, hgt, NULL, NULL, hInstance, NULL);
+    // This will be handled by game_start in roomsystem.cpp where window_default(true) sets the initial
+    // fullscreen state of the window before showing it.
+    enigma::hWnd = CreateWindow("EnigmaDevGameMainWindow", "",
+                                (enigma::getwindowstyle() & ~(WS_VISIBLE)),
+                                (screen_width-wid)/2, (screen_height-hgt)/2, wid, hgt,
+                                NULL, NULL, hInstance, NULL);
 
     if (enigma::touch_extension_register != NULL) {
       enigma::touch_extension_register(enigma::hWnd);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -196,13 +196,13 @@ int WINAPI WinMain (HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine,
     // Set the working_directory
     char buffer[MAX_PATH];
     GetCurrentDirectory( MAX_PATH, buffer );
-    enigma_user::working_directory = string( buffer ) + string( "\\" );
+    enigma_user::working_directory = string( buffer ) + "\\";
 
     // Set the program_directory
     memset(&buffer[0], 0, MAX_PATH);
     GetModuleFileName( NULL, buffer, MAX_PATH );
     enigma_user::program_directory = string( buffer );
-    enigma_user::program_directory = enigma_user::program_directory.substr( 0, enigma_user::program_directory.find_last_of( "\\/" )) + string( "\\" );
+    enigma_user::program_directory = enigma_user::program_directory.substr( 0, enigma_user::program_directory.find_last_of( "\\/" )) + "\\";
 
     LPWSTR *argv;
     if ((argv = CommandLineToArgvW(GetCommandLineW(), &enigma::main_argc)))

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -196,13 +196,13 @@ int WINAPI WinMain (HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine,
     // Set the working_directory
     char buffer[MAX_PATH];
     GetCurrentDirectory( MAX_PATH, buffer );
-    enigma_user::working_directory = string( buffer );
+    enigma_user::working_directory = string( buffer ) + string( "\\" );
 
     // Set the program_directory
     memset(&buffer[0], 0, MAX_PATH);
     GetModuleFileName( NULL, buffer, MAX_PATH );
     enigma_user::program_directory = string( buffer );
-    enigma_user::program_directory = enigma_user::program_directory.substr( 0, enigma_user::program_directory.find_last_of( "\\/" ));
+    enigma_user::program_directory = enigma_user::program_directory.substr( 0, enigma_user::program_directory.find_last_of( "\\/" )) + string( "\\" );
 
     LPWSTR *argv;
     if ((argv = CommandLineToArgvW(GetCommandLineW(), &enigma::main_argc)))
@@ -251,8 +251,8 @@ int WINAPI WinMain (HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine,
     }
     enigma::EnableDrawing (&hRC);
     //Do not set the parent window visible until we have initialized the graphics context.
-    ShowWindow(enigma::hWnd, iCmdShow);
     enigma::initialize_everything();
+    ShowWindow(enigma::hWnd, SW_SHOW);
 
     //Main loop
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -196,13 +196,13 @@ int WINAPI WinMain (HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine,
     // Set the working_directory
     char buffer[MAX_PATH];
     GetCurrentDirectory( MAX_PATH, buffer );
-    enigma_user::working_directory = string( buffer ) + "\\";
+    enigma_user::working_directory = string( buffer );
 
     // Set the program_directory
     memset(&buffer[0], 0, MAX_PATH);
     GetModuleFileName( NULL, buffer, MAX_PATH );
     enigma_user::program_directory = string( buffer );
-    enigma_user::program_directory = enigma_user::program_directory.substr( 0, enigma_user::program_directory.find_last_of( "\\/" )) + "\\";
+    enigma_user::program_directory = enigma_user::program_directory.substr( 0, enigma_user::program_directory.find_last_of( "\\/" ));
 
     LPWSTR *argv;
     if ((argv = CommandLineToArgvW(GetCommandLineW(), &enigma::main_argc)))

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -244,15 +244,15 @@ int WINAPI WinMain (HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine,
     // We won't limit those functions like GM, just the default.
     if (wid > screen_width) wid = screen_width;
     if (hgt > screen_height) hgt = screen_height;
-     enigma::hWnd = CreateWindow ("EnigmaDevGameMainWindow", "", (enigma::getwindowstyle() & ~(WS_VISIBLE)), (screen_width-wid)/2, (screen_height-hgt)/2, wid, hgt, NULL, NULL, hInstance, NULL);
+    // Create the window initially without the WS_VISIBLE flag until we've loaded all of the resources.
+    // This will be handled by game_start in roomsystem.cpp where window_default(true) sets the initial fullscreen state of the window before showing it.
+    enigma::hWnd = CreateWindow ("EnigmaDevGameMainWindow", "", (enigma::getwindowstyle() & ~(WS_VISIBLE)), (screen_width-wid)/2, (screen_height-hgt)/2, wid, hgt, NULL, NULL, hInstance, NULL);
 
     if (enigma::touch_extension_register != NULL) {
       enigma::touch_extension_register(enigma::hWnd);
     }
     enigma::EnableDrawing (&hRC);
-    //Do not set the parent window visible until we have initialized the graphics context.
     enigma::initialize_everything();
-    ShowWindow(enigma::hWnd, SW_SHOW);
 
     //Main loop
 


### PR DESCRIPTION
- Before this change, on Windows, there was a 640x480 window, (with a solid-black client area), that would show at immediately after opening your game executable, and it displays however long it takes for the game to initialize everything. I made it so that window stays hidden until everything is initialized, this way there won't be a nasty random 640x480 window at the start of every game.