### PR TITLE
Continuous integration fixes for "feature" branches/blobs archive

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ environment:
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
   #END WINDOWS
 install:
-  - set "PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;%PATH%"
+  - setx "PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;%PATH%"
   - echo %PATH%
   - set MSYSTEM=MINGW64
   - set MSYSTEM_PREFIX=/mingw64
@@ -82,6 +82,5 @@ install:
         7z x blobs.zip
       }
 build_script:
-  # AppVeyor overrides PLATFORM because it's part of its API
-  # so we can just override AppVeyor
+  # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,8 @@ init:
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
       Start-Process -NoNewWindow 7z -ArgumentList "a blobs.zip foo.txt"
-  - ps: Start-Process bash -il
+      dir
+  - ps: Start-Process bash "-il"
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
         # the blobs artifact while we start building the engine
         $archive = {
           Set-Location $using:PWD
-          7z a -t7z -m0=BCJ -m1=LZMA:d=21 -mx=9 -mmt blobs.zip compileEGMf.dll emake.exe
+          7z a -t7z -mm=lzma -mx=5 -mmt blobs.zip compileEGMf.dll emake.exe
           appveyor PushArtifact blobs.zip -Type Zip
         }
         $daemon = Start-Job -ScriptBlock $archive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,14 +7,15 @@ skip_branch_with_pr: true
       #$daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
       #Start-Job -ScriptBlock $daemon
       # $upload = { () -and (appveyor PushArtifact blobs.zip -Type Zip) }
+      #$archive = Start-Process -PassThru -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
+      #$archive.WaitForExit()
+      #Start-Process -PassThru -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
+      #dir
 init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      $myprocss = Start-Process -PassThru -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
-      $myprocss.WaitForExit()
-      dir
-  - ps: Start-Process -PassThru bash -ArgumentList "-il"
+      (7z a blobs.zip foo.txt > echo) -and (appveyor PushArtifact blobs.zip -Type Zip > echo)
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
   - ps: |
       Start-Process -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
       dir
-  - ps: Start-Process bash "-il"
+  - ps: Start-Process bash -ArgumentList "-il"
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,6 @@ environment:
   #END WINDOWS
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
-  - echo %PATH%
   - set MSYSTEM=MINGW64
   - set MSYSTEM_PREFIX=/mingw64
   - set MSYSTEM_CHOST=x86_64-w64-mingw32
@@ -43,8 +42,8 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - setx TERM ansi
-  - setx GCC_COLORS 'error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+  #- setx TERM ansi
+  #- setx GCC_COLORS 'error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
   - >
     pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis
     mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
@@ -61,9 +60,9 @@ install:
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {
-          Set-Location $using:PWD
-          7z a blobs.zip compileEGMf.dll emake.exe
-          appveyor PushArtifact blobs.zip -Type Zip
+        Set-Location $using:PWD
+        7z a blobs.zip compileEGMf.dll emake.exe
+        appveyor PushArtifact blobs.zip -Type Zip
         }
         $daemon = Start-Job -ScriptBlock $archive
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ environment:
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
   #END WINDOWS
 install:
-  - set PATH=%PATH%;c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;
+  - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - echo %PATH%
   - set MSYSTEM=MINGW64
   - set MSYSTEM_PREFIX=/mingw64
@@ -50,15 +50,12 @@ install:
     mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
     mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet
   - gcc -v
-  - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        Set-Location $env:APPVEYOR_BUILD_FOLDER
-        cd $env:APPVEYOR_BUILD_FOLDER
-        make -j 4 2>&1
-        make -j 4 emake
-        bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
+        bash -lc @"cd $APPVEYOR_BUILD_FOLDER;
+                  make -j 4 2>&1;
+                  make -j 4 emake 2>&1"@
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {
@@ -83,4 +80,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh 2>&1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,8 @@ shallow_clone: true
 # disable automatic tests
 test: off
 # don't build "feature" branches
-branches:
-  only:
-    - master
+skip_branch_with_pr: true
+
 init:
   - echo "%APPVEYOR_JOB_ID%"
   # store the name of the archive job in an environment variable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ skip_branch_with_pr: true
 init:
   - echo 'Hello, world.' >foo.txt
   - ps: |
-      $upload = { 7z a blobs.zip foo.txt && appveyor PushArtifact blobs.zip -Type Zip }
+      $upload = { (7z a blobs.zip foo.txt) -and (appveyor PushArtifact blobs.zip -Type Zip) }
       $daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
       Start-Job -ScriptBlock $daemon
   - ps: Start-Job -ScriptBlock {bash -l} | Wait-Job | Receive-Job | Write-Host

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,14 +6,13 @@ test: off
 skip_branch_with_pr: true
       #$daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
       #Start-Job -ScriptBlock $daemon
+      # $upload = { () -and (appveyor PushArtifact blobs.zip -Type Zip) }
 init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      dir
-      $upload = { (7z a blobs.zip foo.txt) -and (appveyor PushArtifact blobs.zip -Type Zip) }
-      Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job
-  - ps: Start-Job -ScriptBlock {bash -l} | Wait-Job | Receive-Job | Write-Host
+      Start-Process -NoNewWindow 7z a blobs.zip foo.txt
+  - ps: Start-Process bash -il
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # fetch repository as zip archive
 shallow_clone: true
-# disable automatic tests 
+# disable automatic tests
 test: off
 # don't build "feature" branches
 skip_branch_with_pr: true
@@ -52,9 +52,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc "cd $APPVEYOR_BUILD_FOLDER;" +
-                 "make -j 4 2>&1;" +
-                 "make -j 4 emake 2>&1"
+        bash -lc "cd $APPVEYOR_BUILD_FOLDER;make -j 4 2>&1;make -j 4 emake 2>&1"
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,8 @@ environment:
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
   #END WINDOWS
 install:
-  - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;%PATH%
+  - set "PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;%PATH%"
+  - echo %PATH%
   - set MSYSTEM=MINGW64
   - set MSYSTEM_PREFIX=/mingw64
   - set MSYSTEM_CHOST=x86_64-w64-mingw32
@@ -52,27 +53,29 @@ install:
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
-        Set-Location $using:APPVEYOR_BUILD_FOLDER
+        # use our first job to build JDI and the CLI
         Set-Location $env:APPVEYOR_BUILD_FOLDER
-        cd $using:APPVEYOR_BUILD_FOLDER
         cd $env:APPVEYOR_BUILD_FOLDER
         make -j 4 2>&1
         make -j 4 emake
         bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
+
+        # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {
           Set-Location $using:PWD
           7z a blobs.zip compileEGMf.dll emake.exe
           appveyor PushArtifact blobs.zip -Type Zip
         }
         $daemon = Start-Job -ScriptBlock $archive
-        ## test test
-        # test
+
+        # register a callback so we can output the result of the archive when the daemon completes
         $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
           $result = Receive-Job -Job $daemon
           Write-Host ('Archive daemon has completed.') -foregroundcolor "Magenta"
           Write-Host ($result | Out-String) -foregroundcolor "Gray"
         }
       } Else {
+        # simply restore the archive from the first job of this same build using REST API
         $blobsURL = https://ci.appveyor.com/api/buildjobs/$env:CACHE_JOB/artifacts/blobs.zip
         appveyor DownloadFile $blobsURL -FileName blobs.zip
         dir
@@ -80,4 +83,5 @@ install:
       }
 build_script:
   # AppVeyor overrides PLATFORM because it's part of its API
+  # so we can just override AppVeyor
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,9 @@ init:
       $archive = {
         Set-Location $using:PWD;
         7z a blobs.zip foo.txt
-        appveyor PushArtifact blobs.zip -Type Zip > echo
+        appveyor PushArtifact blobs.zip -Type Zip
       }
-      Start-Job -ScriptBlock $archive | Wait-Job | Receive-Job
+      Start-Job -ScriptBlock $archive
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,22 +58,26 @@ install:
         # the blobs artifact while we start building the engine
         $archive = {
           Set-Location $using:PWD
-          7z a -t7z -m0=lzma2:d1024m -mx=9 -aoa -mfb=64 -md=32m -ms=on blobs.zip compileEGMf.dll emake.exe
-          appveyor PushArtifact blobs.zip -Type Zip
+          #7z a -t7z -m0=lzma2:d1024m -mx=9 -aoa -mfb=64 -md=32m -ms=on blobs.zip compileEGMf.dll emake.exe
+          #appveyor PushArtifact blobs.zip -Type Zip
+          appveyor PushArtifact compileEGMf.dll -Type File
+          appveyor PushArtifact emake.exe -Type File
         }
         $daemon = Start-Job -ScriptBlock $archive
 
         # register a callback so we can show the zip and upload output when it completes
         $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
           $result = Receive-Job -Job $daemon
-          Write-Host ('Archive daemon has completed.') -foregroundcolor "Magenta"
+          Write-Host ('Artifact daemon has completed.') -foregroundcolor "Magenta"
           Write-Host ($result | Out-String) -foregroundcolor "Gray"
         }
       } Else {
         # simply restore JDI and the CLI from the archive artifact of this same build using REST API
-        $blobsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/blobs.zip"
-        appveyor DownloadFile $blobsURL -FileName blobs.zip
-        7z x blobs.zip
+        $artifactsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/"
+        appveyor DownloadFile ($artifactsURL + "compileEGMf.dll") -FileName compileEGMf.dll
+        appveyor DownloadFile ($artifactsURL + "emake.exe") -FileName emake.exe
+        #appveyor DownloadFile ($artifactsURL + "blobs.zip") -FileName blobs.zip
+        #7z x blobs.zip
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,9 +53,11 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc @"cd $APPVEYOR_BUILD_FOLDER;
-                  make -j 4 2>&1;
-                  make -j 4 emake 2>&1"@
+        bash -lc @"
+          cd $APPVEYOR_BUILD_FOLDER;
+          make -j 4 2>&1;
+          make -j 4 emake 2>&1
+        "@
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,13 +22,9 @@ init:
       }
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
-        Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta"
-        Write-Host ($daemon | Get-Member | Out-String)
+        Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta" -nonewline
         $result = Receive-Job -Job $daemon
-        Write-Host ($result.Count | Out-String)
         Write-Host ($result | Out-String)
-        Write-Host ($daemon | Out-String)
-        Write-Host ($jobEvent | Unregister-Event)
       }
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
+  - set TERM=ansi
   - setx TERM ansi
   - setx GCC_COLORS 'error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
   - >
@@ -51,7 +52,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc "export TERM=ansi; set TERM=ansi; cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1"
+        bash -lc "export TERM=ansi; SET TERM=ansi; cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1"
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
         # the blobs artifact while we start building the engine
         $archive = {
           Set-Location $using:PWD
-          7z a blobs.zip compileEGMf.dll emake.exe
+          7z a -t7z -m0=lzma2:d1024m -mx=9 -aoa -mfb=64 -md=32m -ms=on blobs.zip compileEGMf.dll emake.exe
           appveyor PushArtifact blobs.zip -Type Zip
         }
         $daemon = Start-Job -ScriptBlock $archive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,10 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc "export TERM=ansi; SET TERM=ansi; cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1"
+        $env:TERM=ansi;
+        $TERM=ansi;
+        [Environment]::SetEnvironmentVariable("TERM", "ansi", "Machine")
+        bash -lc "export TERM=ansi; set TERM=ansi; cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1"
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      Start-Process -NoNewWindow 7z a blobs.zip foo.txt
+      Start-Process -NoNewWindow 7z -ArgumentList "a blobs.zip foo.txt"
   - ps: Start-Process bash -il
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
         # the blobs artifact while we start building the engine
         $archive = {
           Set-Location $using:PWD
-          7z a -t7z -mm=lzma -mx=5 -mmt blobs.zip compileEGMf.dll emake.exe
+          7z a -t7z -mm=lzma2 -mx=4 -mmt blobs.zip compileEGMf.dll emake.exe
           appveyor PushArtifact blobs.zip -Type Zip
         }
         $daemon = Start-Job -ScriptBlock $archive
@@ -75,7 +75,7 @@ install:
         # simply restore JDI and the CLI from the archive artifact of this same build using REST API
         $artifactsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/"
         appveyor DownloadFile ($artifactsURL + "blobs.zip") -FileName blobs.zip
-        7z e -mmt=on blobs.zip
+        7z e -mmt blobs.zip
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,10 @@ init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      Start-Process -PassThru -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
-  - ps: Start-Process bash -ArgumentList "-il"
+      $myprocss = Start-Process -PassThru -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
+      $myprocss.WaitForExit()
+      dir
+  - ps: Start-Process -PassThru bash -ArgumentList "-il"
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      (Start-Process -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt") -and (dir)
+      Start-Process -PassThru -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
   - ps: Start-Process bash -ArgumentList "-il"
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,14 @@ shallow_clone: true
 test: off
 # don't build "feature" branches
 skip_branch_with_pr: true
+      #$daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
+      #Start-Job -ScriptBlock $daemon
 init:
   - echo 'Hello, world.' >foo.txt
   - ps: |
       dir
       $upload = { (7z a blobs.zip foo.txt) -and (appveyor PushArtifact blobs.zip -Type Zip) }
       Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job
-      #$daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
-      #Start-Job -ScriptBlock $daemon
   - ps: Start-Job -ScriptBlock {bash -l} | Wait-Job | Receive-Job | Write-Host
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,11 +23,11 @@ init:
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
         Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta"
-        Write-Host ($daemon | Get-Member)
-        Write-Host ($result = Receive-Job -Job $daemon)
-        Write-Host ($result.Count)
-        Write-Host ($result)
-        Write-Host ($result | Get-Member)
+        Write-Host ($daemon | Get-Member | Out-String)
+        $result = Receive-Job -Job $daemon
+        Write-Host ($result.Count | Out-String)
+        Write-Host ($result | Out-String)
+        Write-Host ($daemon | Out-String)
         Write-Host ($jobEvent | Unregister-Event)
       }
   - echo "%APPVEYOR_JOB_ID%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,8 @@ init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      (7z a blobs.zip foo.txt > echo) -and (appveyor PushArtifact blobs.zip -Type Zip > echo)
+      7z a blobs.zip foo.txt
+      appveyor PushArtifact blobs.zip -Type Zip > echo
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ environment:
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
   #END WINDOWS
 install:
-  - setx "PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;%PATH%"
+  - setx PATH "c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;%PATH%"
   - echo %PATH%
   - set MSYSTEM=MINGW64
   - set MSYSTEM_PREFIX=/mingw64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ skip_branch_with_pr: true
 init:
   - echo 'Hello, world.' >foo.txt
   - ps: |
+      dir
       $upload = { (7z a blobs.zip foo.txt) -and (appveyor PushArtifact blobs.zip -Type Zip) }
       Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job
       $daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,8 @@ install:
     mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet
   - gcc -v
   - ps: |
+      # enable HTTP proxy
+      iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-http-proxy.ps1'))
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
@@ -58,10 +60,8 @@ install:
         # the blobs artifact while we start building the engine
         $archive = {
           Set-Location $using:PWD
-          #7z a -t7z -m0=lzma2:d1024m -mx=9 -aoa -mfb=64 -md=32m -ms=on blobs.zip compileEGMf.dll emake.exe
-          #appveyor PushArtifact blobs.zip -Type Zip
-          appveyor PushArtifact compileEGMf.dll -Type File
-          appveyor PushArtifact emake.exe -Type File
+          7z a -t7z -m0=BCJ -m1=LZMA:d=21 -mx=9 -mmt blobs.zip compileEGMf.dll emake.exe
+          appveyor PushArtifact blobs.zip -Type Zip
         }
         $daemon = Start-Job -ScriptBlock $archive
 
@@ -74,10 +74,8 @@ install:
       } Else {
         # simply restore JDI and the CLI from the archive artifact of this same build using REST API
         $artifactsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/"
-        appveyor DownloadFile ($artifactsURL + "compileEGMf.dll") -FileName compileEGMf.dll
-        appveyor DownloadFile ($artifactsURL + "emake.exe") -FileName emake.exe
-        #appveyor DownloadFile ($artifactsURL + "blobs.zip") -FileName blobs.zip
-        #7z x blobs.zip
+        appveyor DownloadFile ($artifactsURL + "blobs.zip") -FileName blobs.zip
+        7z e -mmt=on blobs.zip
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,9 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc "cd $APPVEYOR_BUILD_FOLDER;make -j 4 2>&1;make -j 4 emake 2>&1"
+        bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER';" +
+                 "make -j 4 2>&1;" +
+                 "make -j 4 emake 2>&1"
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,8 @@ init:
         7z a blobs.zip foo.txt
         appveyor PushArtifact blobs.zip -Type Zip
       }
-      Start-Job -ScriptBlock $archive
+      $daemon = { Start-Job -ScriptBlock $archive | Wait-Job | Receive-Job }
+      Start-Job -ScriptBlock $daemon
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,9 @@ shallow_clone: true
 # disable automatic tests
 test: off
 # don't build "feature" branches
-skip_branch_with_pr: true
+branches:
+  only:
+    - master
 init:
   - echo "%APPVEYOR_JOB_ID%"
   # store the name of the archive job in an environment variable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,12 @@ init:
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
         Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta"
-        $daemon | Get-Member
-        $result = Receive-Job -Job $daemon
-        $result.Count
-        $result
-        $result | Get-Member
-        $jobEvent | Unregister-Event
+        Write-Host ($daemon | Get-Member)
+        Write-Host ($result = Receive-Job -Job $daemon)
+        Write-Host ($result.Count)
+        Write-Host ($result)
+        Write-Host ($result | Get-Member)
+        Write-Host ($jobEvent | Unregister-Event)
       }
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
     mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet
   - gcc -v
   - cd %APPVEYOR_BUILD_FOLDER%
-  ps: |
+  - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         make -j 4 2>&1
         bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,11 +52,9 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc @"
-        cd $APPVEYOR_BUILD_FOLDER;
-        make -j 4 2>&1;
-        make -j 4 emake 2>&1
-        "@
+        bash -lc "cd $APPVEYOR_BUILD_FOLDER;" +
+                 "make -j 4 2>&1;" +
+                 "make -j 4 emake 2>&1"
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,13 @@ init:
       }
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
-          Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta"
-          $job | Get-Member
-          $jobEvent | Unregister-Event
+        Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta"
+        $daemon | Get-Member
+        $result = Receive-Job -Job $job
+        $result.Count
+        $result
+        $result | Get-Member
+        $jobEvent | Unregister-Event
       }
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,12 @@ test: off
 skip_branch_with_pr: true
 init:
   - echo "%APPVEYOR_JOB_ID%"
+  # store the name of the archive job in an environment variable
+  # this designates the first job of every build as the archive job
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
-      $env:CACHE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
-  - echo "%CACHE_JOB%"
+      $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
+  - echo "%ARCHIVE_JOB%"
   - cd %APPVEYOR_BUILD_FOLDER%
 environment:
   OUTPUT: /tmp/test.exe
@@ -41,9 +43,6 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - set TERM=ansi
-  - setx TERM ansi
-  - setx GCC_COLORS 'error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
   - >
     pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis
     mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
@@ -52,12 +51,10 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        $env:TERM=ansi;
-        $TERM=ansi;
-        [Environment]::SetEnvironmentVariable("TERM", "ansi", "Machine")
-        bash -lc "export TERM=ansi; set TERM=ansi; cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1"
+        bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
 
-        # create a daemon job to zip and upload the blobs artifact while we start building the engine
+        # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
+        # the blobs artifact while we start building the engine
         $archive = {
           Set-Location $using:PWD
           7z a blobs.zip compileEGMf.dll emake.exe
@@ -65,19 +62,19 @@ install:
         }
         $daemon = Start-Job -ScriptBlock $archive
 
-        # register a callback so we can output the result of the archive when the daemon completes
+        # register a callback so we can show the zip and upload output when it completes
         $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
           $result = Receive-Job -Job $daemon
           Write-Host ('Archive daemon has completed.') -foregroundcolor "Magenta"
           Write-Host ($result | Out-String) -foregroundcolor "Gray"
         }
       } Else {
-        # simply restore the archive from the first job of this same build using REST API
-        $blobsURL = "https://ci.appveyor.com/api/buildjobs/$env:CACHE_JOB/artifacts/blobs.zip"
+        # simply restore JDI and the CLI from the achive artifact of this same build using REST API
+        $blobsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/blobs.zip"
         appveyor DownloadFile $blobsURL -FileName blobs.zip
         dir
         7z x blobs.zip
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh 2>&1"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ init:
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
         Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta"
         $daemon | Get-Member
-        $result = Receive-Job -Job $job
+        $result = Receive-Job -Job $daemon
         $result.Count
         $result
         $result | Get-Member

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,9 @@ install:
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
+        Set-Location $using:PWD;
         make -j 4 2>&1
+        make -j 4 emake
         bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
         $archive = {
           Set-Location $using:PWD;
@@ -60,6 +62,8 @@ install:
           appveyor PushArtifact blobs.zip -Type Zip
         }
         $daemon = Start-Job -ScriptBlock $archive
+        ## test test
+        # test
         $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
           $result = Receive-Job -Job $daemon
           Write-Host ('Archive daemon has completed.') -foregroundcolor "Magenta"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,7 @@ init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      Start-Process -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
-      dir
+      (Start-Process -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt") -and (dir)
   - ps: Start-Process bash -ArgumentList "-il"
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,11 @@ init:
         7z a blobs.zip foo.txt
         appveyor PushArtifact blobs.zip -Type Zip
       }
-      $daemon = { Start-Job -ScriptBlock $archive | Wait-Job | Receive-Job }
-      Start-Job -ScriptBlock $daemon
+      $daemon = Start-Job -ScriptBlock $archive
+      $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
+          Write-Host ('Job #{0} ({1}) complete.' -f $sender.Id, $sender.Name)
+          $jobEvent | Unregister-Event
+      }
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,9 +51,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER';" +
-                 "make -j 4 2>&1;" +
-                 "make -j 4 emake 2>&1"
+        bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1"
         #bash -ilc "export TERM=ansi; set TERM=ansi; cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,6 @@ install:
         # simply restore JDI and the CLI from the achive artifact of this same build using REST API
         $blobsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/blobs.zip"
         appveyor DownloadFile $blobsURL -FileName blobs.zip
-        dir
         7z x blobs.zip
       }
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ init:
       }
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
-          Write-Host ('Job #{0} ({1}) complete.' -f $sender.Id, $sender.Name)
+          Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta"
           $jobEvent | Unregister-Event
       }
   - echo "%APPVEYOR_JOB_ID%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,16 +53,16 @@ install:
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         bash -lc @"
-          cd $APPVEYOR_BUILD_FOLDER;
-          make -j 4 2>&1;
-          make -j 4 emake 2>&1
+        cd $APPVEYOR_BUILD_FOLDER;
+        make -j 4 2>&1;
+        make -j 4 emake 2>&1
         "@
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {
-        Set-Location $using:PWD
-        7z a blobs.zip compileEGMf.dll emake.exe
-        appveyor PushArtifact blobs.zip -Type Zip
+          Set-Location $using:PWD
+          7z a blobs.zip compileEGMf.dll emake.exe
+          appveyor PushArtifact blobs.zip -Type Zip
         }
         $daemon = Start-Job -ScriptBlock $archive
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ init:
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
           Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta"
+          $job | Get-Member
           $jobEvent | Unregister-Event
       }
   - echo "%APPVEYOR_JOB_ID%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,15 +52,15 @@ install:
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
-        Set-Location $using:APPVEYOR_BUILD_FOLDER;
-        Set-Location $env:APPVEYOR_BUILD_FOLDER;
-        cd $using:APPVEYOR_BUILD_FOLDER;
-        cd $env:APPVEYOR_BUILD_FOLDER;
+        Set-Location $using:APPVEYOR_BUILD_FOLDER
+        Set-Location $env:APPVEYOR_BUILD_FOLDER
+        cd $using:APPVEYOR_BUILD_FOLDER
+        cd $env:APPVEYOR_BUILD_FOLDER
         make -j 4 2>&1
         make -j 4 emake
         bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
         $archive = {
-          Set-Location $using:PWD;
+          Set-Location $using:PWD
           7z a blobs.zip compileEGMf.dll emake.exe
           appveyor PushArtifact blobs.zip -Type Zip
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,8 +41,8 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  #- setx TERM ansi
-  #- setx GCC_COLORS 'error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+  - setx TERM ansi
+  - setx GCC_COLORS 'error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
   - >
     pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis
     mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
@@ -51,8 +51,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1"
-        #bash -ilc "export TERM=ansi; set TERM=ansi; cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
+        bash -lc "export TERM=ansi; set TERM=ansi; cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1"
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ init:
   - echo 'Hello, world.' >foo.txt
   - ps: |
       $upload = { (7z a blobs.zip foo.txt) -and (appveyor PushArtifact blobs.zip -Type Zip) }
+      Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job
       $daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
       Start-Job -ScriptBlock $daemon
   - ps: Start-Job -ScriptBlock {bash -l} | Wait-Job | Receive-Job | Write-Host

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ init:
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
       $archive = {
+        Set-Location $using:PWD;
         7z a blobs.zip foo.txt
         appveyor PushArtifact blobs.zip -Type Zip > echo
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,11 @@ init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      7z a blobs.zip foo.txt
-      appveyor PushArtifact blobs.zip -Type Zip > echo
+      $archive = {
+        7z a blobs.zip foo.txt
+        appveyor PushArtifact blobs.zip -Type Zip > echo
+      }
+      Start-Job -ScriptBlock $archive | Wait-Job | Receive-Job
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,8 @@ init:
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
         $result = Receive-Job -Job $daemon
-        Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta" -nonewline; Write-Host ($result | Out-String)
+        Write-Host ('Archive daemon has completed.') -foregroundcolor "DarkGreen"
+        Write-Host ($result | Out-String) -foregroundcolor "Gray"
       }
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ skip_branch_with_pr: true
       #Start-Job -ScriptBlock $daemon
 init:
   - echo 'Hello, world.' >foo.txt
+  - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
       dir
       $upload = { (7z a blobs.zip foo.txt) -and (appveyor PushArtifact blobs.zip -Type Zip) }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
-      Start-Process -NoNewWindow 7z -ArgumentList "a blobs.zip foo.txt"
+      Start-Process -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
       dir
   - ps: Start-Process bash "-il"
   - echo "%APPVEYOR_JOB_ID%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ skip_branch_with_pr: true
 init:
   - echo 'Hello, world.' >foo.txt
   - ps: |
-      $upload = { 7z a blobs.zip foo.txt | appveyor PushArtifact blobs.zip -Type Zip }
+      $upload = { 7z a blobs.zip foo.txt && appveyor PushArtifact blobs.zip -Type Zip }
       $daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
       Start-Job -ScriptBlock $daemon
   - ps: Start-Job -ScriptBlock {bash -l} | Wait-Job | Receive-Job | Write-Host

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ install:
           Write-Host ($result | Out-String) -foregroundcolor "Gray"
         }
       } Else {
-        # simply restore JDI and the CLI from the achive artifact of this same build using REST API
+        # simply restore JDI and the CLI from the archive artifact of this same build using REST API
         $blobsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/blobs.zip"
         appveyor DownloadFile $blobsURL -FileName blobs.zip
         7z x blobs.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,8 @@ init:
       }
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
-        Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta" -nonewline
         $result = Receive-Job -Job $daemon
-        Write-Host ($result | Out-String)
+        Write-Host ('Archive daemon has completed.') -foregroundcolor "magenta" -nonewline; Write-Host ($result | Out-String)
       }
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ shallow_clone: true
 test: off
 # don't build "feature" branches
 skip_branch_with_pr: true
-#bash -ilc "export TERM=ansi; set TERM=ansi; cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
 init:
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
@@ -55,6 +54,7 @@ install:
         bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER';" +
                  "make -j 4 2>&1;" +
                  "make -j 4 emake 2>&1"
+        #bash -ilc "export TERM=ansi; set TERM=ansi; cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
 
         # create a daemon job to zip and upload the blobs artifact while we start building the engine
         $archive = {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ environment:
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
   #END WINDOWS
 install:
-  - setx PATH "c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;%PATH%"
+  - set PATH=%PATH%;c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\bin;
   - echo %PATH%
   - set MSYSTEM=MINGW64
   - set MSYSTEM_PREFIX=/mingw64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,10 @@ install:
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
-        Set-Location $using:PWD;
+        Set-Location $using:APPVEYOR_BUILD_FOLDER;
+        Set-Location $env:APPVEYOR_BUILD_FOLDER;
+        cd $using:APPVEYOR_BUILD_FOLDER;
+        cd $env:APPVEYOR_BUILD_FOLDER;
         make -j 4 2>&1
         make -j 4 emake
         bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ init:
       dir
       $upload = { (7z a blobs.zip foo.txt) -and (appveyor PushArtifact blobs.zip -Type Zip) }
       Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job
-      $daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
-      Start-Job -ScriptBlock $daemon
+      #$daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
+      #Start-Job -ScriptBlock $daemon
   - ps: Start-Job -ScriptBlock {bash -l} | Wait-Job | Receive-Job | Write-Host
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,6 @@ shallow_clone: true
 test: off
 # don't build "feature" branches
 skip_branch_with_pr: true
-      #$daemon = { Start-Job -ScriptBlock $upload | Wait-Job | Receive-Job }
-      #Start-Job -ScriptBlock $daemon
-      # $upload = { () -and (appveyor PushArtifact blobs.zip -Type Zip) }
-      #$archive = Start-Process -PassThru -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
-      #$archive.WaitForExit()
-      #Start-Process -PassThru -NoNewWindow 7z -ArgumentList "a", "blobs.zip", "foo.txt"
-      #dir
 init:
   - echo 'Hello, world.' >foo.txt
   - cd %APPVEYOR_BUILD_FOLDER%
@@ -23,7 +16,7 @@ init:
       $daemon = Start-Job -ScriptBlock $archive
       $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
         $result = Receive-Job -Job $daemon
-        Write-Host ('Archive daemon has completed.') -foregroundcolor "DarkGreen"
+        Write-Host ('Archive daemon has completed.') -foregroundcolor "Magenta"
         Write-Host ($result | Out-String) -foregroundcolor "Gray"
       }
   - echo "%APPVEYOR_JOB_ID%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,26 +4,14 @@ shallow_clone: true
 test: off
 # don't build "feature" branches
 skip_branch_with_pr: true
+#bash -ilc "export TERM=ansi; set TERM=ansi; cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
 init:
-  - echo 'Hello, world.' >foo.txt
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - ps: |
-      $archive = {
-        Set-Location $using:PWD;
-        7z a blobs.zip foo.txt
-        appveyor PushArtifact blobs.zip -Type Zip
-      }
-      $daemon = Start-Job -ScriptBlock $archive
-      $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
-        $result = Receive-Job -Job $daemon
-        Write-Host ('Archive daemon has completed.') -foregroundcolor "Magenta"
-        Write-Host ($result | Out-String) -foregroundcolor "Gray"
-      }
   - echo "%APPVEYOR_JOB_ID%"
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $env:CACHE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%CACHE_JOB%"
+  - cd %APPVEYOR_BUILD_FOLDER%
 environment:
   OUTPUT: /tmp/test.exe
   matrix:
@@ -62,15 +50,27 @@ install:
     mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet
   - gcc -v
   - cd %APPVEYOR_BUILD_FOLDER%
-  - IF %APPVEYOR_JOB_NUMBER% == 1 (
-      make -j 4 &&
-      bash -ilc "export TERM=ansi; set TERM=ansi; cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake" &&
-      start 7z a blobs.zip compileEGMf.dll emake.exe | start appveyor PushArtifact blobs.zip -Type Zip
-    ) ELSE (
-      appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/%CACHE_JOB%/artifacts/blobs.zip -FileName blobs.zip &&
-      dir &&
-      7z x blobs.zip
-    )
+  ps: |
+      If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
+        make -j 4 2>&1
+        bash -lc "cd $APPVEYOR_BUILD_FOLDER; make -j 4 emake"
+        $archive = {
+          Set-Location $using:PWD;
+          7z a blobs.zip compileEGMf.dll emake.exe
+          appveyor PushArtifact blobs.zip -Type Zip
+        }
+        $daemon = Start-Job -ScriptBlock $archive
+        $jobEvent = Register-ObjectEvent $daemon StateChanged -Action {
+          $result = Receive-Job -Job $daemon
+          Write-Host ('Archive daemon has completed.') -foregroundcolor "Magenta"
+          Write-Host ($result | Out-String) -foregroundcolor "Gray"
+        }
+      } Else {
+        $blobsURL = https://ci.appveyor.com/api/buildjobs/$env:CACHE_JOB/artifacts/blobs.zip
+        appveyor DownloadFile $blobsURL -FileName blobs.zip
+        dir
+        7z x blobs.zip
+      }
 build_script:
   # AppVeyor overrides PLATFORM because it's part of its API
-  - bash -ilc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,6 @@ install:
     mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet
   - gcc -v
   - ps: |
-      # enable HTTP proxy
-      iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-http-proxy.ps1'))
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ install:
         }
       } Else {
         # simply restore the archive from the first job of this same build using REST API
-        $blobsURL = https://ci.appveyor.com/api/buildjobs/$env:CACHE_JOB/artifacts/blobs.zip
+        $blobsURL = "https://ci.appveyor.com/api/buildjobs/$env:CACHE_JOB/artifacts/blobs.zip"
         appveyor DownloadFile $blobsURL -FileName blobs.zip
         dir
         7z x blobs.zip


### PR DESCRIPTION
Ok, lots of great improvements here. I've learned so much about PowerShell, CMD, Bash and general shell scripting the past few days. While my last changes to AppVeyor made it more reliable, this now makes it totally correct.

I wanted to address the issue with feature branches that caused 4 builds to run on Josh's PR he created from a branch the other day. All I had to do was whitelist only "master" for Travis CI. I did the same for AppVeyor as well, but I also noticed that its shorter version of the same option was using my commit "Update AppVeyor.yml" instead of my pull request title in its UI, so I tried the Travis CI way with it too. That's why I opened 3 pull requests in total for this, the other two are closed. Regardless, it didn't work, so I changed it back to the shorter version for AppVeyor and here we are.

**NOTE:** I noticed Travis CI likes to build closed pull requests and had to manually cancel them.

The biggest change here is using the AppVeyor REST API to download the artifacts now. This is more correct because the permalink version may sometimes cause the build to use a stale version of JDI or the CLI, something we do not want. This is actually more efficient because I believe the REST API is also in front of a faster CDN. I tried some other ideas first that did not work, like sharing the `%APPVEYOR_JOB_ID%` of the first job with subsequent jobs using an environment variable. After these changes, if you fork the upstream `enigma-dev/enigma-dev` master branch and set up AppVeyor on your own account, AppVeyor will not fail the first time, which is part of why this method is more "correct" as far as their API is concerned.

Finally, I used PowerShell to zip and upload JDI and the CLI in a separate process. This way the job is able to continue to building a game. I register an event that fires when the daemon completes and writes the output collected from the job to the host console. It first writes out a nice title message in magenta, which I found an appropriate color for our own custom messages in the build log to distinguish them from AppVeyor's. It uses dark gray for the daemon command output though to help distinguish it from the host output that is occurring. I did it this way because the daemon completes in the middle of building the engine and we want its output to stand out.

![Artifact Daemon Completion Message](https://user-images.githubusercontent.com/3212801/31561999-d4796ea0-b027-11e7-8604-bdf3d8dad372.png)
