### PR TITLE
Fixes window fullscreen behavior

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -51,15 +51,19 @@ namespace enigma
     LONG_PTR getwindowstyle()
     {
         LONG_PTR newlong = WS_MINIMIZEBOX;
-        if (showBorder) {
-            newlong |= WS_CAPTION;
-            if (isSizeable)
-              newlong |= WS_SIZEBOX | WS_MAXIMIZEBOX;
-        }
+
         if (showIcons)
             newlong |= WS_SYSMENU;
         if (isVisible)
             newlong |= WS_VISIBLE;
+
+        if (isFullScreen) {
+            newlong |= WS_POPUP | WS_MAXIMIZE;
+        } else if (showBorder) {
+            newlong |= WS_CAPTION;
+            if (isSizeable)
+                newlong |= WS_SIZEBOX | WS_MAXIMIZEBOX;
+        }
 
         // these two flags are necessary for extensions like Ultimate3D and GMOgre to render on top of the window
         return newlong | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
@@ -270,35 +274,17 @@ void window_default(bool center_size)
   if (center)
     enigma::centerwindow();
 
-  if (enigma::isFullScreen)
-  {
-      SetWindowLongPtr(enigma::hWnd,GWL_STYLE,WS_POPUP);
-      ShowWindow(enigma::hWnd,SW_MAXIMIZE);
-  }
-  else
-  {
-      enigma::setwindowstyle();
-      ShowWindow(enigma::hWnd,SW_RESTORE);
-  }
-
+  enigma::setwindowstyle();
   enigma::setwindowsize();
 }
 
 void window_set_fullscreen(bool full)
 {
     if (enigma::isFullScreen == full)
-      return;
+        return;
 
-    if ((enigma::isFullScreen = full))
-    {
-      SetWindowLongPtr(enigma::hWnd,GWL_STYLE,WS_POPUP);
-      ShowWindow(enigma::hWnd,SW_MAXIMIZE);
-    }
-    else
-    {
-      enigma::setwindowstyle();
-      ShowWindow(enigma::hWnd,SW_RESTORE);
-    }
+    enigma::isFullScreen = full;
+    enigma::setwindowstyle();
     enigma::setwindowsize();
 }
 
@@ -1046,4 +1032,3 @@ bool clipboard_has_text()
 }
 
 }
-


### PR DESCRIPTION
I discovered in #1105 that ENIGMA's ``window_default`` was behaving slightly different than GM's. It was not supposed to set the window visible if it wasn't already, which it was, because ShowWindow was called to set the fullscreen state. It was setting it visible regardless of the WS_VISIBLE flag because ShowWindow does not care about that flag. This was inconsistent with how we were handling the other window styles, and also created redundant code.

With these changes, the following will behave exactly as it does in GM8.1, meaning the main window will only be visible for the first message:
```gml
show_message("main window should be visible...");
window_set_visible(false);
show_message("main window should be invisible...");
window_default();
show_message("main window should be visible? in ENIGMA it is");
game_end();
```