### PR TITLE
Change Default Windows Make Directory For Game

### DIFF
--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -78,7 +78,7 @@ OptionsParser::OptionsParser() : _desc("Options")
   std::string def_platform, def_workdir;
   #if CURRENT_PLATFORM_ID == OS_WINDOWS
     def_platform = "Win32";
-    def_workdir = "%APPDATA%/ENIGMA/";
+    def_workdir = "%LOCALAPPDATA%/ENIGMA/";
   #elif CURRENT_PLATFORM_ID ==  OS_MACOSX
     def_platform = "Cocoa";
     def_workdir = "/tmp/ENIGMA/";

--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -78,7 +78,7 @@ OptionsParser::OptionsParser() : _desc("Options")
   std::string def_platform, def_workdir;
   #if CURRENT_PLATFORM_ID == OS_WINDOWS
     def_platform = "Win32";
-    def_workdir = "%PROGRAMDATA%/ENIGMA/";
+    def_workdir = "%APPDATA%/ENIGMA/";
   #elif CURRENT_PLATFORM_ID ==  OS_MACOSX
     def_platform = "Cocoa";
     def_workdir = "/tmp/ENIGMA/";

--- a/CompilerSource/makedir.cpp
+++ b/CompilerSource/makedir.cpp
@@ -48,7 +48,8 @@ string escapeEnv(string str, string env) {
 }
 
 string escapeEnv(string str) {
-	string escaped = escapeEnv(str, "PROGRAMDATA");
+	string escaped = escapeEnv(str, "APPDATA");
+	escaped = escapeEnv(escaped, "PROGRAMDATA");
 	escaped = escapeEnv(escaped, "ALLUSERSPROFILE");
 	escaped = escapeEnv(escaped, "HOME");
 	return escaped;

--- a/CompilerSource/makedir.cpp
+++ b/CompilerSource/makedir.cpp
@@ -48,7 +48,8 @@ string escapeEnv(string str, string env) {
 }
 
 string escapeEnv(string str) {
-	string escaped = escapeEnv(str, "APPDATA");
+	string escaped = escapeEnv(str, "LOCALAPPDATA");
+	escaped = escapeEnv(escaped, "APPDATA");
 	escaped = escapeEnv(escaped, "PROGRAMDATA");
 	escaped = escapeEnv(escaped, "ALLUSERSPROFILE");
 	escaped = escapeEnv(escaped, "HOME");

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -141,7 +141,7 @@ void parse_ide_settings(const char* eyaml)
   // Use a platform-specific make directory.
   std::string make_directory = "./ENIGMA/";
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-  make_directory = "%PROGRAMDATA%/ENIGMA/";
+  make_directory = "%APPDATA%/ENIGMA/";
 #elif CURRENT_PLATFORM_ID == OS_LINUX
   make_directory = "%HOME%/.enigma/";
 #elif CURRENT_PLATFORM_ID == OS_MACOSX

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -141,7 +141,7 @@ void parse_ide_settings(const char* eyaml)
   // Use a platform-specific make directory.
   std::string make_directory = "./ENIGMA/";
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-  make_directory = "%APPDATA%/ENIGMA/";
+  make_directory = "%LOCALAPPDATA%/ENIGMA/";
 #elif CURRENT_PLATFORM_ID == OS_LINUX
   make_directory = "%HOME%/.enigma/";
 #elif CURRENT_PLATFORM_ID == OS_MACOSX

--- a/settings.ey
+++ b/settings.ey
@@ -46,7 +46,7 @@
     -make-directory:
         Type: Textfield
         Label: Make Directory
-        Default-Windows: "%PROGRAMDATA%/ENIGMA/"
+        Default-Windows: "%APPDATA%/ENIGMA/"
         Default-Linux: "%HOME%/.enigma/"
         Default-MacOSX: "./ENIGMA/"
         Default: "./ENIGMA/"

--- a/settings.ey
+++ b/settings.ey
@@ -46,7 +46,7 @@
     -make-directory:
         Type: Textfield
         Label: Make Directory
-        Default-Windows: "%APPDATA%/ENIGMA/"
+        Default-Windows: "%LOCALAPPDATA%/ENIGMA/"
         Default-Linux: "%HOME%/.enigma/"
         Default-MacOSX: "./ENIGMA/"
         Default: "./ENIGMA/"


### PR DESCRIPTION
We were using `%PROGRAMDATA%` before which did not exist on Windows XP and created problems for older users trying to install ENIGMA. It used to be called the **`All Users`** folder or something on Windows, but the environment var wasn't mapped. That folder is where Windows applications should store global settings and files that all users can access. That folder is also what the Education versions of GameMaker use to make a global install on shared school computers:
https://help.yoyogames.com/hc/en-us/articles/216755378-GameMaker-Studio-Education-Version

This pull request changes ENIGMA to use `%LOCALAPPDATA%`, just like GameMaker: Studio, which is specific to each user. This is currently what GameMaker: Studio uses by default to write the game with the YYC. This is also more consistent with the analogous directories ENIGMA was using for this on Linux and Mac. This should fully resolve #994 even though we never actually confirmed what that issue was.

![Save Data Location](https://user-images.githubusercontent.com/3212801/34329528-2d8d373c-e8d2-11e7-9981-924f128650aa.png)

This also means each user account has its own `.eobjs` but this is ok considering different users may want to be on different commits of ENIGMA. The reason this PR uses local AppData and not roaming is because I considered the binaries too large to be roamed and that other computers, in a networked environment, where the user account is roaming may use a different compiler with ENIGMA making the binaries useless.

https://www.makeuseof.com/tag/appdata-roaming-vs-local/

![Temp location](https://user-images.githubusercontent.com/3212801/34329530-2f8b975e-e8d2-11e7-9284-22fd302cad28.png)

Again, I still feel we should add settings for this in the future.

Also, the following guide to get GMS working on Windows XP now applies in the same way to ENIGMA:
https://help.yoyogames.com/hc/en-us/articles/216754048-I-m-running-and-Microsoft-XP-machine-I-can-t-get-GameMaker-Studio-on-Steam-or-any-of-the-WORKSHOP-games-to-run-
