### PR TITLE
Make AppVeyor only build the master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ shallow_clone: true
 test: off
 # don't build "feature" branches
 skip_branch_with_pr: true
+branches:
+  only:
+    - master
 
 init:
   - echo "%APPVEYOR_JOB_ID%"


### PR DESCRIPTION
Our AppVeyor status is now failing from Josh using a feature branch to test/cherrypick fundies PR. This is all we ever use branches for, and building them tends to just waste build cycles. So I have decided we should make a whitelist of branches to build, and, for now, only include master.