### PR TITLE
Skip AppVeyor Font Cache Update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ init:
   - cd %APPVEYOR_BUILD_FOLDER%
 environment:
   OUTPUT: /tmp/test.exe
+  MSYS2_FC_CACHE_SKIP: yes
   matrix:
   #BEGIN WINDOWS
     # Game Modes


### PR DESCRIPTION
It does this because GTK triggers an update to the font cache, and some other libraries may too. We don't actually need it in order to test anything. Since it holds our build up significantly, we can just disable it with `MSYS2_FC_CACHE_SKIP` to skip it.