### PR TITLE
Return a string from file_text_readln instead of void

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -19,7 +19,6 @@
 
 #include <stdio.h> //fstream can get staked
 #include <string> //We will use string, though
-#include <sstream>
 using namespace std;
 
 #include "darray.h" //Simpler vector with logarithmic time

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -118,7 +118,7 @@ void file_text_writeln(int fileid) // Write a newline character to the file.
   fputc('\n',mf.f);
 }
 
-string file_text_read_string(int fileid) { // Reads a string from the file with the given file id and returns this string. A string ends at the end of line.
+string file_text_read_string(int fileid) { // Reads a string from the file, excluding the end of line, with the given file id and returns this string.
   enigma::openFile &mf = enigma::files[fileid];
   string ret = "";
   char buf[BUFSIZ];
@@ -161,7 +161,7 @@ double file_text_read_real(int fileid) { // Reads a real value from the file and
   return ret;
 }
 
-string file_text_readln(int fileid) // Skips the rest of the line in the file and starts at the start of the next line.
+string file_text_readln(int fileid) // Reads a string from the file, including the end of line, with the given file id and returns this string.
 {
   enigma::openFile &mf = enigma::files[fileid];
   mf.eoln = false;

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -36,10 +36,10 @@ namespace enigma
 {
   struct openFile
   {
-    FILE *f;      //FILE we opened, or NULL if it has been closed.
-    string sdata; //Use varies depending on type.
-    unsigned spos;      //position in sdata string
-    size_t dp;
+    FILE *f;       //FILE we opened, or NULL if it has been closed.
+    string sdata;  //Use varies depending on type.
+    unsigned spos; //position in sdata string
+    size_t dp;     //position of the new line or the null-terminator in sdata
 
     openFile(): f(NULL), sdata(), spos(0), dp(0) {};
     openFile(FILE* a,string b): f(a), sdata(b), spos(0), dp(0) {};

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -149,9 +149,8 @@ bool file_text_eoln(int fileid)
 {
   enigma::openFile &mf = enigma::files[fileid];
   int c = fgetc(mf.f);
-  bool eoln = (c == '\n' or c == '\r');
   ungetc(c, mf.f);
-  return eoln;
+  return (c == '\n' or c == '\r');
 }
 
 inline bool is_whitespace(char x) { return x == ' ' or x == '\t' or x == '\r' or x == '\n'; }

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -127,7 +127,7 @@ string file_text_read_string(int fileid) { // Reads a string from the file with 
   size_t dp;
   for (dp = strr.length()-1; dp != size_t(-1) and (strr[dp] == '\n' or strr[dp] == '\r'); dp--);
   strr.erase(dp+1);
-  mf.spos = dp+1;
+  mf.spos += strr.length();
   if (feof(mf.f))
     mf.eof = true;
   return strr;

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -132,7 +132,8 @@ string file_text_read_string(int fileid) { // Reads a string from the file with 
   size_t dp;
   for (dp = ret.length()-1; dp != size_t(-1) and (ret[dp] == '\n' or ret[dp] == '\r'); dp--)
     ungetc(ret[dp], mf.f);
-  return ret.substr(0, dp + 1);
+  ret.erase(dp + 1);
+  return ret;
 }
 
 string file_text_read_all(int fileid) {

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -1,5 +1,5 @@
 /** Copyright (C) 2008-2011 Josh Ventura
-*** Copyright (C) 2014 Robert B. Colton
+*** Copyright (C) 2014, 2017 Robert B. Colton
 *** This file is a part of the ENIGMA Development Environment.
 ***
 *** ENIGMA is free software: you can redistribute it and/or modify it under the

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -94,7 +94,7 @@ void file_text_close(int fileid) // Closes the file with the given file id.
     #endif
     return;
   }
-  
+
   fclose(enigma::files[fileid].f);
   enigma::files[fileid].f = NULL;
 
@@ -124,7 +124,10 @@ string file_text_read_string(int fileid) { // Reads a string from the file with 
   enigma::openFile &mf = enigma::files[fileid];
   if (!mf.sdata[mf.spos]) return "";
   string strr = mf.sdata.substr(mf.spos);
-  mf.spos = mf.sdata.length();
+  size_t dp;
+  for (dp = strr.length()-1; dp != size_t(-1) and (strr[dp] == '\n' or strr[dp] == '\r'); dp--);
+  strr.erase(dp+1);
+  mf.spos = dp+1;
   if (feof(mf.f))
     mf.eof = true;
   return strr;
@@ -164,25 +167,25 @@ double file_text_read_real(int fileid) { // Reads a real value from the file and
   return r1;
 }
 
-void file_text_readln(int fileid) // Skips the rest of the line in the file and starts at the start of the next line.
+string file_text_readln(int fileid) // Skips the rest of the line in the file and starts at the start of the next line.
 {
-  if (feof(enigma::files[fileid].f))
-    enigma::files[fileid].eof = true;
-  string ret;
+  enigma::openFile &mf = enigma::files[fileid];
+  string ret = mf.sdata.substr(mf.spos);
+  if (feof(mf.f))
+    mf.eof = true;
+  string next;
   char buf[BUFSIZ];
-    buf[0] = 0;
-  while (fgets(buf,BUFSIZ,enigma::files[fileid].f))
+  buf[0] = 0;
+  while (fgets(buf,BUFSIZ,mf.f))
   {
-    ret += buf;
-    if (ret[ret.length()-1] == '\n' or ret[ret.length()-1] == '\r')
+    next += buf;
+    if (next[next.length()-1] == '\n' or next[next.length()-1] == '\r')
       break;
     buf[0] = 0;
   }
-  size_t dp;
-  for (dp = ret.length()-1; dp != size_t(-1) and (ret[dp] == '\n' or ret[dp] == '\r'); dp--);
-  ret.erase(dp+1);
-  enigma::files[fileid].sdata = ret;
-  enigma::files[fileid].spos = 0;
+  mf.sdata = next;
+  mf.spos = 0;
+  return ret;
 }
 
 bool file_text_eof(int fileid) { // Returns whether we reached the end of the file.

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -1,5 +1,5 @@
 /** Copyright (C) 2008-2011 Josh Ventura
-*** Copyright (C) 2014, 2017 Robert B. Colton
+*** Copyright (C) 2014, 2018 Robert B. Colton
 *** This file is a part of the ENIGMA Development Environment.
 ***
 *** ENIGMA is free software: you can redistribute it and/or modify it under the

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -38,10 +38,9 @@ namespace enigma
   {
     FILE *f; //FILE we opened, or NULL if it has been closed.
     string name;
-    bool eoln;
 
-    openFile(): f(NULL), name(), eoln(false) {};
-    openFile(FILE* f,string name): f(f), name(name), eoln(false) {};
+    openFile(): f(NULL), name() {};
+    openFile(FILE* f, string name): f(f), name(name) {};
   };
   varray<openFile> files; //Use a dynamic array to store as many files as the user cares to open
   int file_highid = 0; //This isn't what GM does, but it's not a bad idea. GM checks for the smallest unused ID.
@@ -149,7 +148,10 @@ string file_text_read_all(int fileid) {
 bool file_text_eoln(int fileid)
 {
   enigma::openFile &mf = enigma::files[fileid];
-  return mf.eoln;
+  int c = fgetc(mf.f);
+  bool eoln = (c == '\n' or c == '\r');
+  ungetc(c, mf.f);
+  return eoln;
 }
 
 inline bool is_whitespace(char x) { return x == ' ' or x == '\t' or x == '\r' or x == '\n'; }
@@ -163,8 +165,6 @@ double file_text_read_real(int fileid) { // Reads a real value from the file and
 
 string file_text_readln(int fileid) // Reads a string from the file, including the end of line, with the given file id and returns this string.
 {
-  enigma::openFile &mf = enigma::files[fileid];
-  mf.eoln = false;
   string ret;
   char buf[BUFSIZ];
   buf[0] = 0;

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -37,10 +37,11 @@ namespace enigma
   struct openFile
   {
     FILE *f; //FILE we opened, or NULL if it has been closed.
+    string name;
     bool eoln;
 
-    openFile(): f(NULL), eoln(false) {};
-    openFile(FILE* a,string b): f(a), eoln(false) {};
+    openFile(): f(NULL), name(), eoln(false) {};
+    openFile(FILE* f,string name): f(f), name(name), eoln(false) {};
   };
   varray<openFile> files; //Use a dynamic array to store as many files as the user cares to open
   int file_highid = 0; //This isn't what GM does, but it's not a bad idea. GM checks for the smallest unused ID.
@@ -212,8 +213,7 @@ int file_bin_open(string fname,int mode) // Opens the file with the indicated na
 bool file_bin_rewrite(int fileid) // Rewrites the file with the given file id, that is, clears it and starts writing at the start.
 {
   enigma::openFile &mf = enigma::files[fileid];
-  string sdata;
-  mf.f = freopen (sdata.c_str(), "wb", mf.f);
+  mf.f = freopen(mf.name.c_str(), "wb", mf.f);
 
   if (mf.f == NULL) {
     #ifdef DEBUGMODE

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.h
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.h
@@ -1,5 +1,5 @@
 /** Copyright (C) 2008 Josh Ventura
-*** Copyright (C) 2014 Robert B. Colton
+*** Copyright (C) 2014, 2018 Robert B. Colton
 *** This file is a part of the ENIGMA Development Environment.
 ***
 *** ENIGMA is free software: you can redistribute it and/or modify it under the
@@ -23,20 +23,20 @@
 
 namespace enigma_user
 {
-int     file_text_open_read(std::string fname);
-int     file_text_open_write(std::string fname);
-int     file_text_open_append(std::string fname);
-void    file_text_close(int fileid);
-void    file_text_write_string(int fileid, std::string str);
-void    file_text_write_real(int fileid, double x);
-void    file_text_writeln(int fileid);
-std::string file_text_read_string(int fileid);
-std::string file_text_read_all(int fileid);
-double  file_text_read_real(int fileid);
-void    file_text_readln(int fileid);
-bool    file_text_eof(int fileid);
-bool file_text_eoln(int fileid);
-void load_info(std::string fname); // game information function
+int          file_text_open_read(std::string fname);
+int          file_text_open_write(std::string fname);
+int          file_text_open_append(std::string fname);
+void         file_text_close(int fileid);
+void         file_text_write_string(int fileid, std::string str);
+void         file_text_write_real(int fileid, double x);
+void         file_text_writeln(int fileid);
+std::string  file_text_read_string(int fileid);
+std::string  file_text_read_all(int fileid);
+double       file_text_read_real(int fileid);
+std::string  file_text_readln(int fileid);
+bool         file_text_eof(int fileid);
+bool         file_text_eoln(int fileid);
+void         load_info(std::string fname); // game information function
 
 int     file_bin_open(std::string fname,int mode);
 bool    file_bin_rewrite(int fileid);


### PR DESCRIPTION
@time-killer-games pointed out in #1136 that it would be useful to do this. It was possible to change this in a backwards-compatible way. I agreed, because it does make the code shorter and idiomatic with Java and C#, so I decided to just do it.

I fixed the indentation in the header to align the function signatures after their return types using spaces. I know ENIGMA doesn't really have a styleguide, but I've seen this used elsewhere in ENIGMA. Not sure how @JoshDreamland feels about this, but since he wrote this file, it seems to me this may be his style. I think it makes the source easier to read. However, it can make some trivial changesets, i.e. adding a new function, much larger than they need to be if all the function signatures need realigned.

I had to actually fix `file_text_eof` too because it was returning 1 line later than all of the other GameMaker versions. In fact, this function is the only reason we need to actually read ahead, so `feof` reports compatibly.

# Test Case
```gml
var file;
file = file_text_open_read("file_text_readln.txt");

show_message("(" + string(file_text_read_real(file)) + ")");
show_message(string(file_text_eoln(file)));
show_message("(" + string(file_text_read_string(file)) + ")");
show_message(string(file_text_eoln(file)));
show_message("(" + string(file_text_read_string(file)) + ")");
file_text_readln(file);
show_message(string(file_text_eoln(file)));
show_message("(" + string(file_text_read_real(file)) + ")");
show_message("(" + string(file_text_read_real(file)) + ")");
show_message("(" + string(file_text_read_string(file)) + ")");
show_message("(" + string(file_text_read_string(file)) + ")");
show_message("(" + string(file_text_read_real(file)) + ")");
file_text_readln(file);

var line1, line12, line2, line3;
line1 = file_text_read_string(file);
line12 = file_text_read_string(file);
line13 = file_text_readln(file);
show_message(string(file_text_eof(file)));
line2 = file_text_readln(file);
show_message(string(file_text_eof(file)));
line3 = file_text_readln(file);
show_message(string(file_text_eof(file)));

show_message(string(string_length(line1)) + ":" + string(line1));
show_message(string(string_length(line12)) + ":" + string(line12));
show_message(string(string_length(line13)) + ":" + string(line13));
show_message(string(string_length(line2)) + ":" + string(line2));
```

# file_text_readln.txt
```text
1 2 3
4 5 6
line1
line2
line3

```

# Results
| GameMaker: Studio v1.4.1773 | Game Maker 8.0 | Game Maker 5.3 A | ENIGMA  |
|-----------------------------|----------------|------------------|---------|
| (1)                         | (1)            | (1)              | (1)     |
| 0                           | 0              | Unknown function              | 0       |
| ( 2 3)                      | (2 3)          | ( 2 3)           | ( 2 3)  |
| 1                           | 1              | Unknown function              | 1       |
| ()                          | ()             | ()               | ()      |
| 0                           | 0              | Unknown function              | 0       |
| (4)                         | (4)            | (4)              | (4)     |
| (5)                         | (5)            | (5)              | (5)     |
| ( 6)                        | (6)            | ( 6)             | ( 6)    |
| ()                          | ()             | ()               | ()      |
| (0)                          | (0)             | Error reading read. and (0)   | (-1)      |
| 0                           | 0              | 0                | 0       |
| 1                           | 1              | 1                |  0      |
| 1                           | 1              | 1                |  1      |
| 5:line2                     | 5:line1        | 5:line2          | 5:line1 |
| 0:                          | 0:             | 0:               | 0:      |
| 2:                          | 0:0            | 0:0              | 1:      |
| 7:line3                     | 0:0            | 0:0              | 6:line2 |

My changes make ENIGMA behave the same as GMS, however, likely because I am using MSYS2, it has Unix, not Windows, line endings. The result of this is that the above test case shows 5,0,2,7 for GMS and 5,0,1,6 for ENIGMA. `file_text_read_string` should not consume the line feed but leave it in the buffer to be consumed by `file_text_readln`, it simply returns the contents of the buffer up to the line feed. `file_text_readln` consumes the entire buffer up to the first line feed and returns it.
