### PR TITLE
Fix AppVeyor Blobs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,14 +12,15 @@ init:
   - echo "%APPVEYOR_JOB_ID%"
   # store the name of the archive job in an environment variable
   # this designates the first job of every build as the archive job
+  - echo "%APPVEYOR_BUILD_ID%"
+  - echo "%APPVEYOR_BUILD_NUMBER%"
+  - echo "%APPVEYOR_BUILD_VERSION%"
   - ps: |
-      $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
+      $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/build/$env:APPVEYOR_BUILD_VERSION"
       $project = Invoke-RestMethod -Method Get -Uri $apiURL
       Write-Host ($project | ConvertTo-Json)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
-  - echo "%APPVEYOR_BUILD_ID%"
-  - echo "%APPVEYOR_BUILD_NUMBER%"
   - cd %APPVEYOR_BUILD_FOLDER%
 environment:
   OUTPUT: /tmp/test.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,19 +7,15 @@ skip_branch_with_pr: true
 branches:
   only:
     - master
-#test
+
 init:
   - echo "%APPVEYOR_JOB_ID%"
   # store the name of the archive job in an environment variable
   # this designates the first job of every build as the archive job
-  - echo "%APPVEYOR_BUILD_ID%"
-  - echo "%APPVEYOR_BUILD_NUMBER%"
-  - echo "%APPVEYOR_BUILD_VERSION%"
   - ps: |
-      $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/build/$env:APPVEYOR_BUILD_VERSION"
-      $project = Invoke-RestMethod -Method Get -Uri $apiURL
-      Write-Host ($project | ConvertTo-Json)
-      $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
+      $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
+      $project = Invoke-RestMethod -Method Get -Uri $apiURL/build/$env:APPVEYOR_BUILD_VERSION
+      $env:ARCHIVE_JOB = $project.build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - cd %APPVEYOR_BUILD_FOLDER%
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ init:
   # this designates the first job of every build as the archive job
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
-      $mytest = Invoke-RestMethod -Method Get -Uri $apiURL
+      $project = Invoke-RestMethod -Method Get -Uri $apiURL
       Write-Host ($mytest | ConvertTo-Json)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $project = Invoke-RestMethod -Method Get -Uri $apiURL
-      Write-Host ($project | ConvertTo-Json)
+      Write-Host ($project.builds | ConvertTo-Json)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - echo "%APPVEYOR_BUILD_ID%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $mytest = Invoke-RestMethod -Method Get -Uri $apiURL
-      Write-Host ($mytest)
+      Write-Host ($mytest | ConvertFrom-Json | ConvertTo-Json)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - echo "%APPVEYOR_BUILD_ID%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
   # store the name of the archive job in an environment variable
   # this designates the first job of every build as the archive job
   - ps: |
-      $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
+      $apiURL = "http://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - cd %APPVEYOR_BUILD_FOLDER%
@@ -75,7 +75,7 @@ install:
         }
       } Else {
         # simply restore JDI and the CLI from the archive artifact of this same build using REST API
-        $artifactsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/"
+        $artifactsURL = "http://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/"
         appveyor DownloadFile ($artifactsURL + "blobs.zip") -FileName blobs.zip
         7z e -mmt blobs.zip
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $mytest = Invoke-RestMethod -Method Get -Uri $apiURL
-      Write-Host ($mytest | ConvertFrom-Json | ConvertTo-Json)
+      Write-Host ($mytest | ConvertTo-Json)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - echo "%APPVEYOR_BUILD_ID%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ skip_branch_with_pr: true
 branches:
   only:
     - master
-#test
+
 init:
   - echo "%APPVEYOR_JOB_ID%"
   # store the name of the archive job in an environment variable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,9 @@ init:
   # store the name of the archive job in an environment variable
   # this designates the first job of every build as the archive job
   - ps: |
-      $apiURL = "http://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
+      $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
+      $mytest = Invoke-RestMethod -Method Get -Uri $apiURL
+      Write-Host ($mytest | Out-String)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - cd %APPVEYOR_BUILD_FOLDER%
@@ -75,7 +77,7 @@ install:
         }
       } Else {
         # simply restore JDI and the CLI from the archive artifact of this same build using REST API
-        $artifactsURL = "http://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/"
+        $artifactsURL = "https://ci.appveyor.com/api/buildjobs/$env:ARCHIVE_JOB/artifacts/"
         appveyor DownloadFile ($artifactsURL + "blobs.zip") -FileName blobs.zip
         7z e -mmt blobs.zip
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ init:
       Write-Host ($mytest)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
+  - echo "%APPVEYOR_BUILD_ID%"
   - cd %APPVEYOR_BUILD_FOLDER%
 environment:
   OUTPUT: /tmp/test.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,10 @@ init:
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $project = Invoke-RestMethod -Method Get -Uri $apiURL
       Write-Host ($project.builds | ConvertTo-Json)
-      $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
+      $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).builds[$env:APPVEYOR_BUILD_ID].jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - echo "%APPVEYOR_BUILD_ID%"
+  - echo "%APPVEYOR_BUILD_NUMBER%"
   - cd %APPVEYOR_BUILD_FOLDER%
 environment:
   OUTPUT: /tmp/test.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ init:
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $project = Invoke-RestMethod -Method Get -Uri $apiURL
-      Write-Host ($project.builds | ConvertTo-Json)
-      $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).builds[$env:APPVEYOR_BUILD_ID].jobs[0].jobId
+      Write-Host ($project | ConvertTo-Json)
+      $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - echo "%APPVEYOR_BUILD_ID%"
   - echo "%APPVEYOR_BUILD_NUMBER%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ skip_branch_with_pr: true
 branches:
   only:
     - master
-
+#test
 init:
   - echo "%APPVEYOR_JOB_ID%"
   # store the name of the archive job in an environment variable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $mytest = Invoke-RestMethod -Method Get -Uri $apiURL
-      Write-Host ($mytest | Out-String)
+      Write-Host ($mytest)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
   - ps: |
       $apiURL = "https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG"
       $project = Invoke-RestMethod -Method Get -Uri $apiURL
-      Write-Host ($mytest | ConvertTo-Json)
+      Write-Host ($project | ConvertTo-Json)
       $env:ARCHIVE_JOB = (Invoke-RestMethod -Method Get -Uri $apiURL).build.jobs[0].jobId
   - echo "%ARCHIVE_JOB%"
   - echo "%APPVEYOR_BUILD_ID%"


### PR DESCRIPTION
The problem was that the REST API basically returns you the jobs of the current build, which happens to be the latest, not the one it's actually building. So we just look up the specific build using the build version environment variable. This should fix multiple queued builds and stop them from screwing each other up.