### PR TITLE
Fix game global regressions

### DIFF
--- a/ENIGMAsystem/SHELL/Collision_Systems/actions.h
+++ b/ENIGMAsystem/SHELL/Collision_Systems/actions.h
@@ -18,10 +18,9 @@
 #include "Universal_System/scalar.h"
 #include "Universal_System/instance_system_base.h"
 
-extern bool argument_relative;
-
 namespace enigma_user
 {
+extern bool argument_relative;
 
 inline bool action_if_object(const int object, const cs_scalar xx, const cs_scalar yy) {
     if (argument_relative) {
@@ -76,4 +75,3 @@ inline bool action_if_collision(const cs_scalar x, const cs_scalar y, const int 
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Collision_Systems/collision_mandatory.h
+++ b/ENIGMAsystem/SHELL/Collision_Systems/collision_mandatory.h
@@ -35,11 +35,10 @@ namespace enigma
   // It is used to clean up on game termination.
   void free_collision_mask(void* mask);
 
-  #ifdef _COLLISIONS_OBJECT_H
+  #ifdef ENIGMA_COLLISIONS_OBJECT_H
     // This function will be invoked each collision event to obtain a pointer to any
     // instance being collided with. It is expected to return NULL for no collision, or
     // an object_basic* pointing to the first instance found.
     object_basic *place_meeting_inst(cs_scalar x, cs_scalar y, int object);
   #endif
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/actions.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/actions.h
@@ -26,8 +26,6 @@
  **                                                                              **
  \********************************************************************************/
 
-extern bool argument_relative;
-
 #include "libEGMstd.h"
 
 #include "Universal_System/scalar.h"
@@ -37,6 +35,7 @@ extern bool argument_relative;
 
 namespace enigma_user
 {
+extern bool argument_relative;
 
 inline void action_color(const int color) {
 	draw_set_color(color);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/actions.h
@@ -28,10 +28,9 @@
 
 #include "Universal_System/instance_system_base.h"
 
-extern bool argument_relative;
-
 namespace enigma_user
 {
+extern bool argument_relative;
 
 inline void action_linear_step(double x, double y, double stepsize, bool solid_only)
 {
@@ -58,4 +57,3 @@ inline void action_potential_step(double x, double y, double stepsize, bool soli
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/actions.h
@@ -26,10 +26,9 @@
  **                                                                              **
  \********************************************************************************/
 
-extern bool argument_relative;
-
 namespace enigma_user
 {
+extern bool argument_relative;
 
 inline void action_path(unsigned pathid, cs_scalar speed, unsigned endaction, bool absolute)
 {

--- a/ENIGMAsystem/SHELL/Universal_System/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/actions.h
@@ -27,10 +27,6 @@
  **                                                                              **
  \********************************************************************************/
 
-
-
-extern bool argument_relative;
-
 #include "instance_system_base.h"
 #include "lives.h"
 
@@ -38,6 +34,7 @@ extern bool argument_relative;
 
 namespace enigma_user
 {
+extern bool argument_relative;
 
 //TODO: Confirm timeline mechanics (e.g., stopping resets position?)
 inline void action_set_timeline(int timeline, double position, int startImmediately=0, int loop=0)
@@ -48,7 +45,7 @@ inline void action_set_timeline(int timeline, double position, int startImmediat
   ((enigma::object_timelines*)enigma::instance_event_iterator->inst)->timeline_loop = (loop==1);
 }
 
-inline void action_set_timeline_position(double position) 
+inline void action_set_timeline_position(double position)
 {
   ((enigma::object_timelines*)enigma::instance_event_iterator->inst)->timeline_position=position;
 }


### PR DESCRIPTION
Taking a second to address a couple of regressions introduced by #1128 that cause Mark Overmar's FPS example to no longer build.

* argument_relative should have been in namespace enigma_user in Universal_System/actions.h
* argument_relative should have been in namespace enigma_user in MotionPlanning/actions.h
* argument_relative should have been in namespace enigma_user in Paths/actions.h
* argument_relative should have been in namespace enigma_user in Collision_Systems/actions.h
* argument_relative should have been in namespace enigma_user in Graphics_Systems/General/actions.h
* place_meeting_inst was using the old guard, just had to rename it to what @fundies changed it to

After these changes, Mark Overmar's FPS example successfully builds again and the gameplay works fine:
![Mark Overmars FPS working again](https://user-images.githubusercontent.com/3212801/34913897-46889984-f8d6-11e7-9679-b79eedab9719.png)

