### PR TITLE
Fix Travis CI Clone Depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   irc: "chat.freenode.net#enigma"
 language: cpp
 git:
-  depth: 1
+  depth: false
 compiler:
   - gcc
 # don't build "feature" branches


### PR DESCRIPTION
This fixes the issues with Travis erroring about missing references on checkout. The problem was basically that @JoshDreamland merged two prs at the same time and Travis didn't checkout deep enough to have the commit reference. I originally made the depth 1 as an optimization to make the build faster, guess it doesn't work.

> Please note that if you use a depth of 1 and have a queue of jobs, Travis CI won’t build commits that are in the queue when you push a new commit.

https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth

![Travis CI Failed Checkout](https://user-images.githubusercontent.com/3212801/34918689-bdd4fbba-f924-11e7-8ab6-2cca3cb688cc.png)
