### PR TITLE
Dont increment build number for PRs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@
 shallow_clone: true
 # disable automatic tests
 test: off
+# only increment the build number when building master
+pull_requests:
+  do_not_increment_build_number: true
 # don't build "feature" branches
 skip_branch_with_pr: true
 branches:


### PR DESCRIPTION
Ok, so apparently when you have a YAML for AppVeyor, it overrides all settings you put in the UI that are not UI only. This means that just by having a YAML, even if it's empty, you won't be able to configure certain options from the UI. One of these options is one that stops pull requests from incrementing the build number.

I asked AppVeyor: https://github.com/appveyor/ci/issues/2037#issuecomment-358083139

So basically this option just has to go in our YAML and then the build number will only increase when it does a merge build on master.