### PR TITLE
AppVeyor tweaks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
-    - environment: { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,9 +24,7 @@ init:
 environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
-
-matrix:
-  include:
+  matrix:
     - environment: { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,8 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - environment: {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-      before_build:
-        - >
-          pacman --noconfirm -S mingw-w64-x86_64-box2d
+    - {before_build: [pacman --noconfirm -S mingw-w64-x86_64-box2d],COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+          
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,8 @@ environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
-    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-      before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d
+    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
+        PACKAGES: "mingw-w64-x86_64-box2d" }
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64
@@ -37,8 +37,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - >
-    pacman --noconfirm -S mingw-w64-x86_64-boost
+  - pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: "pacman --noconfirm -S mingw-w64-x86_64-box2d",COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {before_build: "pacman --noconfirm -S mingw-w64-x86_64-box2d", COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
           
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - IF DEFINED PACKAGES (pacman --noconfirm -S %PACKAGES%)
+  - pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: ["pacman --noconfirm -S mingw-w64-x86_64-box2d"],COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {before_build: "pacman --noconfirm -S mingw-w64-x86_64-box2d",COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
           
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
+  - pacman --noconfirm -S %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - pacman --noconfirm -S %PACKAGES%
+  - IF DEFINED PACKAGES (pacman --noconfirm -S %PACKAGES%)
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,33 @@ environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
-    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-        PACKAGES: "mingw-w64-x86_64-box2d" }
+    # Game Modes
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Compile, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    # Graphics
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D11, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    # Audio
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: DirectSound, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: OpenAL, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
+       PACKAGES: "mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile" }
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: SFML, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
+       PACKAGES: "mingw-w64-x86_64-sfml" }
+    # Widgets
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: Win32, EXTENSIONS: "None"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: GTK+, EXTENSIONS: "None",
+       PACKAGES: "mingw-w64-x86_64-gtk2"}
+    # Extensions
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "DirectShow"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "WindowsTouch"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "XInput"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "Box2DPhysics",
+       PACKAGES: "mingw-w64-x86_64-box2d"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "StudioPhysics",
+       PACKAGES: "mingw-w64-x86_64-box2d"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "BulletDynamics",
+       PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@
 shallow_clone: true
 # disable automatic tests
 test: off
+# only increment the build number when building master
+pull_requests:
+  do_not_increment_build_number: true
 # don't build "feature" branches
 skip_branch_with_pr: true
 branches:
@@ -22,23 +25,11 @@ environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
-  #BEGIN WINDOWS
     # Game Modes
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Compile, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    # Graphics
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D11, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    # Audio
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: DirectSound, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    # Widgets
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: Win32, EXTENSIONS: "None"}
-    # Extensions
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "DirectShow"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "WindowsTouch"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "XInput"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
-  #END WINDOWS
+      before_build:
+        - >
+          pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64
@@ -52,7 +43,7 @@ install:
   - >
     pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis
     mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
-    mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet
+    mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-bullet
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: [pacman --noconfirm -S mingw-w64-x86_64-box2d],COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {before_build: ["pacman --noconfirm -S mingw-w64-x86_64-box2d"],COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
           
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,13 +34,13 @@ environment:
     # Audio
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: DirectSound, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: OpenAL, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-       PACKAGES: "mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile" }
+       PACKAGES: "mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-alure mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile" }
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: SFML, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
        PACKAGES: "mingw-w64-x86_64-sfml" }
     # Widgets
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: Win32, EXTENSIONS: "None"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: GTK+, EXTENSIONS: "None",
-       PACKAGES: "mingw-w64-x86_64-gtk2"}
+       PACKAGES: "mingw-w64-x86_64-gtk3"}
     # Extensions
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "DirectShow"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "WindowsTouch"}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,12 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d, COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-          
+
+matrix:
+  include:
+    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+      before_build:
+        - pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ environment:
 
 matrix:
   include:
-    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - environment: { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build:
         - pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,6 @@ init:
 environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
-  matrix:
-    # Game Modes
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,7 @@ environment:
 matrix:
   include:
     - environment: { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-      before_build:
-        - pacman --noconfirm -S mingw-w64-x86_64-box2d
+      before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: "pacman --noconfirm -S mingw-w64-x86_64-box2d", COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d, COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
           
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
@@ -39,9 +39,7 @@ install:
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
   - >
-    pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis
-    mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
-    mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-bullet
+    pacman --noconfirm -S mingw-w64-x86_64-boost
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - env: {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build:
         - >
           pacman --noconfirm -S mingw-w64-x86_64-box2d

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - env: {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - environment: {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build:
         - >
           pacman --noconfirm -S mingw-w64-x86_64-box2d


### PR DESCRIPTION
First, this disables pull requests from incrementing the build number. While this build number is not going to be our actual version number, taking the difference of it can be useful in determining our real version number in releases. Since that is the case, then we obviously don't want random PRs that never get merged to increment it. We only want to increment it when we merge or commit directly to master.

Second, I've tweaked the job matrix so that each job only installs its required packages. This allowed me to add a few more tests for Box2D and such. It made no sense that we were downloading the dependencies before but not actually testing it. Even though Travis tests a lot of the same things, we still want to test them at least once in AppVeyor, because even though something builds on Linux doesn't necessarily mean it will also build on Windows, and we know this from experience now. Additionally AppVeyor doesn't need to complete so much quicker than Travis, we should try to always even the two out.
