### PR TITLE
AppVeyor Tweaks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,15 +54,13 @@ environment:
        PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
-  - set TERM="ansi"
   - ps: . C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
   - pwsh: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/usr/bin/bash.exe -lc "export TERM='ansi'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
-        cd '$env:APPVEYOR_BUILD_FOLDER'; make CXXFLAGS='-fdiagnostics-color' -j 4; make -j 4 emake"
+        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make CXXFLAGS='-fdiagnostics-color' -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
-    - environment: { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,9 +24,7 @@ init:
 environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
-
-matrix:
-  include:
+  matrix:
     - environment: { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,10 +57,10 @@ install:
   - ps: . C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
-  - ps: |
+  - pwsh: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake" 2>&1 | out-null
+        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine
@@ -85,4 +85,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh" 2>&1 | out-null
+  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,8 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - environment: {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-      before_build:
-        - >
-          pacman --noconfirm -S mingw-w64-x86_64-box2d
+    - {before_build: [pacman --noconfirm -S mingw-w64-x86_64-box2d],COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+          
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         C:/msys64/usr/bin/bash.exe -lc "export TERM='ansi'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
-        cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 -fdiagnostics-color; make -j 4 emake"
+        cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
   - ps: . C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
-  - ps: |
+  - pwsh: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         C:/msys64/usr/bin/bash.exe -lc "export TERM='ansi'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
   - ps: . C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
-  - pwsh: |
+  - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         C:/msys64/usr/bin/bash.exe -lc "export TERM='ansi'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
+        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake" 2>&1
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine
@@ -85,4 +85,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"
+  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh" 2>&1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,8 @@ environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
-    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-      before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d
+    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
+        PACKAGES: "mingw-w64-x86_64-box2d" }
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64
@@ -37,8 +37,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - >
-    pacman --noconfirm -S mingw-w64-x86_64-boost
+  - pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,8 @@ install:
   - pwsh: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
+        C:/msys64/usr/bin/bash.exe -lc "export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
+        cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine
@@ -85,4 +86,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"
+  - pwsh: C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: "pacman --noconfirm -S mingw-w64-x86_64-box2d",COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {before_build: "pacman --noconfirm -S mingw-w64-x86_64-box2d", COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
           
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - IF DEFINED PACKAGES (pacman --noconfirm -S %PACKAGES%)
+  - pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: ["pacman --noconfirm -S mingw-w64-x86_64-box2d"],COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {before_build: "pacman --noconfirm -S mingw-w64-x86_64-box2d",COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
           
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
+  - pacman --noconfirm -S %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   - set MINGW_PREFIX=/mingw64
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
-  - pacman --noconfirm -S %PACKAGES%
+  - IF DEFINED PACKAGES (pacman --noconfirm -S %PACKAGES%)
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake" 2>&1
+        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1" 2>&1
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine
@@ -85,4 +85,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh" 2>&1
+  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh 2>&1" 2>&1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,33 @@ environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
-    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-        PACKAGES: "mingw-w64-x86_64-box2d" }
+    # Game Modes
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Compile, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    # Graphics
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D11, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    # Audio
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: DirectSound, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: OpenAL, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
+       PACKAGES: "mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile" }
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: SFML, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
+       PACKAGES: "mingw-w64-x86_64-sfml" }
+    # Widgets
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: Win32, EXTENSIONS: "None"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: GTK+, EXTENSIONS: "None",
+       PACKAGES: "mingw-w64-x86_64-gtk2"}
+    # Extensions
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "DirectShow"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "WindowsTouch"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "XInput"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "Box2DPhysics",
+       PACKAGES: "mingw-w64-x86_64-box2d"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "StudioPhysics",
+       PACKAGES: "mingw-w64-x86_64-box2d"}
+    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "BulletDynamics",
+       PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ environment:
        PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
-  - ps:. C:/msys64/mingw64.exe
+  - ps: . C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,13 +54,14 @@ environment:
        PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
+  - set TERM="testheyheyhey"
   - ps: . C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
   - pwsh: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/usr/bin/bash.exe -lc "export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
+        C:/msys64/usr/bin/bash.exe -lc "export TERM='heyheyhey'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
         cd '$env:APPVEYOR_BUILD_FOLDER'; unbuffer make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@
 shallow_clone: true
 # disable automatic tests
 test: off
+# only increment the build number when building master
+pull_requests:
+  do_not_increment_build_number: true
 # don't build "feature" branches
 skip_branch_with_pr: true
 branches:
@@ -22,23 +25,11 @@ environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
-  #BEGIN WINDOWS
     # Game Modes
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Compile, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    # Graphics
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D11, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    # Audio
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: DirectSound, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-    # Widgets
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: Win32, EXTENSIONS: "None"}
-    # Extensions
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "DirectShow"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "WindowsTouch"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "XInput"}
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
-  #END WINDOWS
+      before_build:
+        - >
+          pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64
@@ -52,7 +43,7 @@ install:
   - >
     pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis
     mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
-    mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet
+    mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-bullet
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ environment:
        PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
-  - . C:/msys64/mingw64.exe
+  - ps:. C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: [pacman --noconfirm -S mingw-w64-x86_64-box2d],COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {before_build: ["pacman --noconfirm -S mingw-w64-x86_64-box2d"],COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
           
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,14 +54,7 @@ environment:
        PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
-  - set MSYSTEM=MINGW64
-  - set MSYSTEM_PREFIX=/mingw64
-  - set MSYSTEM_CHOST=x86_64-w64-mingw32
-  - set CONFIG_SITE=/mingw64/etc/config.site
-  - set MINGW_PACKAGE_PREFIX=mingw-w64-x86_64
-  - set MINGW_PREFIX=/mingw64
-  - set MINGW_CHOST=x86_64-w64-mingw32
-  - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
+  - C:/msys64/mingw64.exe
   - pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
   - gcc -v
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
+        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine
@@ -85,4 +85,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - C:/msys64/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"
+  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         C:/msys64/usr/bin/bash.exe -lc "export TERM='ansi'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
-        cd '$env:APPVEYOR_BUILD_FOLDER'; unbuffer make -j 4 -fdiagnostics-color; make -j 4 emake"
+        cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 -fdiagnostics-color; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ environment:
     # Widgets
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: Win32, EXTENSIONS: "None"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: GTK+, EXTENSIONS: "None",
-       PACKAGES: "mingw-w64-x86_64-gtk2"}
+       PACKAGES: "mingw-w64-x86_64-gtk3"}
     # Extensions
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "DirectShow"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "WindowsTouch"}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,12 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d, COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-          
+
+matrix:
+  include:
+    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+      before_build:
+        - pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
+        C:/msys64/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine
@@ -85,4 +85,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - C:/msys64/bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"
+  - C:/msys64/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ environment:
 
 matrix:
   include:
-    - { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - environment: { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build:
         - pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ environment:
     # Audio
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: DirectSound, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: OpenAL, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-       PACKAGES: "mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile" }
+       PACKAGES: "mingw-w64-x86_64-openal mingw-w64-x86_64-alure mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile" }
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: SFML, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
        PACKAGES: "mingw-w64-x86_64-sfml" }
     # Widgets
@@ -55,7 +55,7 @@ environment:
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - ps: . C:/msys64/mingw64.exe
-  - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
+  - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -Sy mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
   - pwsh: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         C:/msys64/usr/bin/bash.exe -lc "export TERM='ansi'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
-        cd '$env:APPVEYOR_BUILD_FOLDER'; unbuffer make -j 4; make -j 4 emake"
+        cd '$env:APPVEYOR_BUILD_FOLDER'; unbuffer make -j 4 -fdiagnostics-color; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,6 @@ init:
 environment:
   OUTPUT: /tmp/test.exe
   MSYS2_FC_CACHE_SKIP: yes
-  matrix:
-    # Game Modes
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ environment:
        PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
-  - C:/msys64/mingw64.exe
+  - . C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ environment:
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - C:/msys64/mingw64.exe
-  - pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
+  - C:/msys64/usr/bin/pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,7 @@ environment:
 matrix:
   include:
     - environment: { COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
-      before_build:
-        - pacman --noconfirm -S mingw-w64-x86_64-box2d
+      before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - set MSYSTEM=MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4 2>&1; make -j 4 emake 2>&1" 2>&1
+        C:/msys64/usr/bin/bash.exe -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake" 2>&1 | out-null
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine
@@ -85,4 +85,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh 2>&1" 2>&1
+  - C:/msys64/usr/bin/bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh" 2>&1 | out-null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {before_build: "pacman --noconfirm -S mingw-w64-x86_64-box2d", COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - {before_build: pacman --noconfirm -S mingw-w64-x86_64-box2d, COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
           
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
@@ -39,9 +39,7 @@ install:
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
   - >
-    pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis
-    mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
-    mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-bullet
+    pacman --noconfirm -S mingw-w64-x86_64-boost
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ install:
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         C:/msys64/usr/bin/bash.exe -lc "export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
-        cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
+        cd '$env:APPVEYOR_BUILD_FOLDER'; unbuffer make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - env: {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build:
         - >
           pacman --noconfirm -S mingw-w64-x86_64-box2d

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,14 +54,14 @@ environment:
        PACKAGES: "mingw-w64-x86_64-bullet"}
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
-  - set TERM="testheyheyhey"
+  - set TERM="ansi"
   - ps: . C:/msys64/mingw64.exe
   - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
   - pwsh: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        C:/msys64/usr/bin/bash.exe -lc "export TERM='heyheyhey'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
+        C:/msys64/usr/bin/bash.exe -lc "export TERM='ansi'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
         cd '$env:APPVEYOR_BUILD_FOLDER'; unbuffer make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
         C:/msys64/usr/bin/bash.exe -lc "export TERM='ansi'; export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
-        cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
+        cd '$env:APPVEYOR_BUILD_FOLDER'; make CXXFLAGS='-fdiagnostics-color' -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ environment:
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - C:/msys64/mingw64.exe
-  - C:/msys64/usr/bin/pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%
+  - C:/msys64/usr/bin/bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-boost %PACKAGES%"
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   MSYS2_FC_CACHE_SKIP: yes
   matrix:
     # Game Modes
-    - env: {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
+    - environment: {COMPILER: gcc, PLATFORM: Win32, MODE: Run, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
       before_build:
         - >
           pacman --noconfirm -S mingw-w64-x86_64-box2d

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {
         # use our first job to build JDI and the CLI
-        bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
+        C:/msys64/bash -lc "cd '$env:APPVEYOR_BUILD_FOLDER'; make -j 4; make -j 4 emake"
 
         # create a daemon PowerShell "job" (not the same as an AppVeyor build job) to zip and upload
         # the blobs artifact while we start building the engine
@@ -85,4 +85,4 @@ install:
       }
 build_script:
   # AppVeyor overrides %PLATFORM% because it's part of its API, so export it
-  - bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"
+  - C:/msys64/bash -lc "cd $APPVEYOR_BUILD_FOLDER; export PLATFORM=%PLATFORM%; ./ci-build.sh"


### PR DESCRIPTION
Continuing from #1168

1) PRs should not increment build number
2) Jobs should only install packages necessary for their specific job
3) Instead of configuring the Windows env for MinGW64, just launch the MSYS2 shell directly

**NOTE TO MYSELF**
I wrote this batch script for a user to double click and launch LateralGM with the MSYS2 setup with the correct MinGW64 env to find make. It could be used in AppVeyor as well to configure our env so that we don't have to explicitly set all those env variables.
```batch
C:\msys64\msys2_shell.cmd -mingw64 --login -c 'cd "C:\Users\Owner\Desktop\enigma-dev" && "C:\Program Files\Java\jre-9.0.4\bin\java.exe" -jar C:\Users\Owner\Desktop\enigma-dev\lateralgm.jar -Xms 1G -Xmx 4G'
```