### PR TITLE
Timeline actions workaround for GM8 and GMS

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Timelines/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Timelines/About.ey
@@ -9,4 +9,3 @@ Icon: timeline.png
 Depends: None
 Dependencies: None
 Implements: extension_timelines
-

--- a/ENIGMAsystem/SHELL/Universal_System/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/actions.h
@@ -55,6 +55,8 @@ inline void action_set_timeline_speed(double speed)
   ((enigma::object_timelines*)enigma::instance_event_iterator->inst)->timeline_speed=speed;
 }
 
+#define action_timeline_set action_set_timeline
+
 inline void action_timeline_pause()
 {
   ((enigma::object_timelines*)enigma::instance_event_iterator->inst)->timeline_running = false;


### PR DESCRIPTION
So somebody at YoYoGames obviously dropped the red ball here big time with GameMaker 8. Using the built-in function lists, I can see that `action_set_timeline` was renamed to `action_timeline_set` starting with GM8 and then `action_set_timeline` was removed in GMS 1.4.

![GM8 Timeline Action Functions](https://user-images.githubusercontent.com/3212801/36799897-347a791e-1c7c-11e8-87ac-6252794bfef8.png)
![GMS 1.4 Timeline Action Functions](https://user-images.githubusercontent.com/3212801/36799907-3b3ef054-1c7c-11e8-9e71-55a3cd472fef.png)

I used ActionMaker to confirm that it was in fact originally `action_set_timeline` in the GameMaker 5 libs:
![GM 5 had action_timeline_set](https://user-images.githubusercontent.com/3212801/36799979-6f872a52-1c7c-11e8-8735-d84f5af55441.png)

Apparently what they did was create a new action (judging by GM8 libs in ActionMaker) so they could add two parameters onto the action, which is fine for us because we just used default parameters which will work in both cases:
![New Timeline Action](https://user-images.githubusercontent.com/3212801/36800705-2913838e-1c7e-11e8-961d-310d0b8367f8.png)
![Old Timeline Action](https://user-images.githubusercontent.com/3212801/36800720-3294faa0-1c7e-11e8-8e95-20c532d64a2d.png)


So, ENIGMA was always correct, but we can work around GMS 1.4 for now with a simple define.
