### PR TITLE
widen() and shorten() can now be used everywhere

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -21,6 +21,8 @@
 #include <sstream>
 #include <algorithm>
 #include <unistd.h>
+#include <windows.h>
+#include <wchar.h>
 #include <vector>
 using std::string;
 using std::vector;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -36,7 +36,6 @@ using std::vector;
 
 #include "Platforms/platforms_mandatory.h"
 
-typedef basic_string<WCHAR> tstring;
 tstring widen(const string &str) {
   // Number of shorts will be <= number of bytes; add one for null terminator
   const size_t wchar_count = str.size() + 1;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -21,8 +21,6 @@
 #include <sstream>
 #include <algorithm>
 #include <unistd.h>
-#include <windows.h>
-#include <wchar.h>
 #include <vector>
 using std::string;
 using std::vector;
@@ -36,18 +34,6 @@ using std::vector;
 
 #include "Platforms/platforms_mandatory.h"
 
-tstring widen(const string &str) {
-  // Number of shorts will be <= number of bytes; add one for null terminator
-  const size_t wchar_count = str.size() + 1;
-  vector<WCHAR> buf(wchar_count);
-  return tstring{buf.data(), (size_t)MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, buf.data(), (int)wchar_count)};
-}
-
-string shorten(tstring str) {
-  int nbytes = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), NULL, 0, NULL, NULL);
-  vector<char> buf((size_t)nbytes);
-  return string{buf.data(), (size_t)WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), buf.data(), nbytes, NULL, NULL)};
-}
 
 namespace enigma_user {
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -34,6 +34,20 @@ using std::vector;
 
 #include "Platforms/platforms_mandatory.h"
 
+typedef basic_string<WCHAR> tstring;
+tstring widen(const string &str) {
+  // Number of shorts will be <= number of bytes; add one for null terminator
+  const size_t wchar_count = str.size() + 1;
+  vector<WCHAR> buf(wchar_count);
+  return tstring{buf.data(), (size_t)MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, buf.data(), (int)wchar_count)};
+}
+
+string shorten(tstring str) {
+  int nbytes = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), NULL, 0, NULL, NULL);
+  vector<char> buf((size_t)nbytes);
+  return string{buf.data(), (size_t)WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), buf.data(), nbytes, NULL, NULL)};
+}
+
 namespace enigma_user {
 
 const int os_type = os_windows;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
@@ -21,6 +21,14 @@
 
 #include "../General/PFmain.h"
 #include <windows.h>
+#include <wchar.h>
+#include <string>
+#include <vector>
+using std::string;
+
+typedef std::basic_string<WCHAR> tstring;
+tstring widen(const string &str);
+string shorten(tstring str);
 
 namespace enigma //TODO: Find where this belongs
 {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 using std::string;
+using std::vector;
 
 typedef std::basic_string<WCHAR> tstring;
 tstring widen(const string &str);

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -28,7 +28,7 @@
 
 using std::string;
 
-#include "CompilerSource/OS_Switchboard.h"
+#include "../../../CompilerSource/OS_Switchboard.h"
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
 

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -28,6 +28,29 @@
 
 using std::string;
 
+#include "CompilerSource/OS_Switchboard.h"
+
+#if CURRENT_PLATFORM_ID == OS_WINDOWS
+
+#include <windows.h>
+#include <wchar.h>
+#include <vector>
+
+tstring widen(const string &str) {
+  // Number of shorts will be <= number of bytes; add one for null terminator
+  const size_t wchar_count = str.size() + 1;
+  vector<WCHAR> buf(wchar_count);
+  return tstring{buf.data(), (size_t)MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, buf.data(), (int)wchar_count)};
+}
+
+string shorten(tstring str) {
+  int nbytes = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), NULL, 0, NULL, NULL);
+  vector<char> buf((size_t)nbytes);
+  return string{buf.data(), (size_t)WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), buf.data(), nbytes, NULL, NULL)};
+}
+
+#endif
+
 static const char ldgrs[256] = {
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -35,6 +35,7 @@ using std::string;
 #include <windows.h>
 #include <wchar.h>
 #include <vector>
+using std::vector;
 
 tstring widen(const string &str) {
   // Number of shorts will be <= number of bytes; add one for null terminator

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -26,9 +26,7 @@
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
 
-#include <windows.h>
 #include <wchar.h>
-#include <vector>
 
 typedef std::basic_string<WCHAR> tstring;
 tstring widen(const std::string &str);

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -26,6 +26,7 @@
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
 
+#include <windows.h>
 #include <wchar.h>
 
 typedef std::basic_string<WCHAR> tstring;

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -22,6 +22,20 @@
 
 #include <string>
 
+#include "CompilerSource/OS_Switchboard.h"
+
+#if CURRENT_PLATFORM_ID == OS_WINDOWS
+
+#include <windows.h>
+#include <wchar.h>
+#include <vector>
+
+typedef std::basic_string<WCHAR> tstring;
+tstring widen(const std::string &str);
+std::string shorten(tstring str);
+
+#endif
+
 namespace enigma_user {
 
 std::string base64_encode(std::string const& str);

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -22,7 +22,7 @@
 
 #include <string>
 
-#include "CompilerSource/OS_Switchboard.h"
+#include "../../../CompilerSource/OS_Switchboard.h"
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -30,6 +30,7 @@
 
 using namespace std;
 #include "Widget_Systems/widgets_mandatory.h"
+#include "Widget_Systems/Win32/win32utf8.h"
 #include "GameSettings.h"
 
 #include "../General/WSdialogs.h"
@@ -208,6 +209,12 @@ tstring widen(const string &str) {
   const size_t wchar_count = str.size() + 1;
   vector<WCHAR> buf(wchar_count);
   return tstring{buf.data(), (size_t)MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, buf.data(), (int)wchar_count)};
+}
+
+string shorten(tstring str) {
+  int nbytes = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), NULL, 0, NULL, NULL);
+  vector<char> buf((size_t)nbytes);
+  return string{buf.data(), (size_t)WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), buf.data(), nbytes, NULL, NULL)};
 }
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -26,11 +26,10 @@
 #include <richedit.h>
 #include <stdio.h>
 #include <string>
-#include <vector>
 
 using namespace std;
 #include "Widget_Systems/widgets_mandatory.h"
-#include "Widget_Systems/Win32/win32utf8.h"
+#include "Platforms/Win32/WINDOWSmain.h"
 #include "GameSettings.h"
 
 #include "../General/WSdialogs.h"
@@ -201,20 +200,6 @@ static INT CALLBACK GetDirectoryAltProc(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM 
     SetWindowText(hwnd, gs_cap.c_str());
 
   return 0;
-}
-
-typedef basic_string<WCHAR> tstring;
-tstring widen(const string &str) {
-  // Number of shorts will be <= number of bytes; add one for null terminator
-  const size_t wchar_count = str.size() + 1;
-  vector<WCHAR> buf(wchar_count);
-  return tstring{buf.data(), (size_t)MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, buf.data(), (int)wchar_count)};
-}
-
-string shorten(tstring str) {
-  int nbytes = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), NULL, 0, NULL, NULL);
-  vector<char> buf((size_t)nbytes);
-  return string{buf.data(), (size_t)WideCharToMultiByte(CP_UTF8, 0, str.c_str(), (int)str.length(), buf.data(), nbytes, NULL, NULL)};
 }
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -29,6 +29,7 @@
 
 using namespace std;
 #include "Widget_Systems/widgets_mandatory.h"
+#include "Universal_System/estring.h"
 #include "GameSettings.h"
 
 #include "../General/WSdialogs.h"

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -29,7 +29,6 @@
 
 using namespace std;
 #include "Widget_Systems/widgets_mandatory.h"
-#include "Platforms/Win32/WINDOWSmain.h"
 #include "GameSettings.h"
 
 #include "../General/WSdialogs.h"

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/win32utf8.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/win32utf8.h
@@ -1,9 +1,0 @@
-#include <windows.h>
-#include <wchar.h>
-#include <string>
-#include <vector>
-using std::string;
-
-typedef std::basic_string<WCHAR> tstring;
-tstring widen(const string &str);
-string shorten(tstring str);

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/win32utf8.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/win32utf8.h
@@ -1,0 +1,9 @@
+#include <windows.h>
+#include <wchar.h>
+#include <string>
+#include <vector>
+using std::string;
+
+typedef std::basic_string<WCHAR> tstring;
+tstring widen(const string &str);
+string shorten(tstring str);


### PR DESCRIPTION
Enables use of these functions so that UTF-8 can potentially be supported on all Windows functions.