### PR TITLE
Fix object_exists

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/object.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/object.cpp
@@ -104,7 +104,7 @@ namespace enigma_user
 
 bool object_exists(int objid)
 {
-  return ((objid >= 0) && (objid < enigma::objectcount) && bool(enigma::objectdata[objid]));
+  return ((objid >= 0) && (unsigned(objid) < enigma::obj_idmax) && bool(enigma::objectdata[objid]));
 }
 
 void object_set_depth(int objid, int val)


### PR DESCRIPTION
Polygonz should have used `object_idmax` in 182e024ecbd8f28a8976545a117fb5fc43d83175 not `object_count` like all of the other `_exists()` functions. I wasn't sure if it's correct to check if the obj id is larger than zero though... none of the other `_exists()` functions do that but it seems as though they should. Either way, we need to later on get rid of all this duplicate code by solving #1125.