### PR TITLE
Optimize ds_list_replace

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/data_structures.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/data_structures.cpp
@@ -1220,8 +1220,7 @@ void ds_list_replace(const unsigned int id, const unsigned int pos, const varian
   //replaces the value at pos with the val in the list
   if (pos < ds_lists[id].size())
   {
-    ds_lists[id].erase(ds_lists[id].begin() + pos);
-    ds_lists[id].insert(ds_lists[id].begin() + pos, val);
+    ds_lists[id][pos] = val;
   }
 }
 


### PR DESCRIPTION
Long story short, user came to the forum and showed us some code that was slower using `ds_list_replace` than arrays with the subscript `[]` operator: https://enigma-dev.org/forums/index.php?topic=2887.

I looked and realized it must be `.erase(...)`'s fault. I sent them this fix and they tested it and confirmed it fixed the issue and Hugar also tested it for me and said the same on Discord.

http://www.cplusplus.com/reference/vector/vector/erase/
> Because vectors use an array as their underlying storage, erasing elements in positions other than the vector end causes the container to relocate all the elements after the segment erased to their new positions. This is generally an inefficient operation compared to the one performed for the same operation by other kinds of sequence containers (such as list or forward_list).