### PR TITLE
Close File Handles for Sound Systems

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -206,6 +206,7 @@ int sound_add(string fname, int kind, bool preload) //At the moment, the latter 
   fseek(afile,0,SEEK_SET);
   if (fread(fdata,1,flen,afile) != flen)
     puts("WARNING: Resource stream cut short while loading sound data");
+  fclose(afile);
 
   // Decode sound
   int rid = enigma::sound_allocate();

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
@@ -341,6 +341,7 @@ int audio_add(string fname)
   fseek(afile,0,SEEK_SET);
   if (fread(fdata,1,flen,afile) != flen)
     puts("WARNING: Resource stream cut short while loading sound data");
+  fclose(afile);
 
   // Decode sound
   int rid = enigma::sound_allocate();

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALbasic.cpp
@@ -296,6 +296,7 @@ int sound_add(string fname, int kind, bool preload) //At the moment, the latter 
   fseek(afile,0,SEEK_SET);
   if (fread(fdata,1,flen,afile) != flen)
     puts("WARNING: Resource stream cut short while loading sound data");
+  fclose(afile);
 
   // Decode sound
   int rid = enigma::sound_allocate();
@@ -333,6 +334,7 @@ bool sound_replace(int sound, string fname, int kind, bool preload)
   fseek(afile,0,SEEK_SET);
   if (fread(fdata,1,flen,afile) != flen)
     puts("WARNING: Resource stream cut short while loading sound data");
+  fclose(afile);
 
   // Decode sound
   bool fail = enigma::sound_add_from_buffer(sound,fdata,flen);


### PR DESCRIPTION
As I reported in #1207, none of the `*_add` or `*_replace` functions in the sound systems are closing the file handle after they finish reading the data.

**It's very important that I make it clear when we shouldn't close the file handle.**
Right now, we should close the file handle, because we always load the sound data immediately and act as if preload is true. If we later change it to actually have preload do what it's supposed to do, then when preload is false we should not close the file handle. That way there is a file lock to prevent the file from being deleted until we actually load the sound data the first time it is played/or gotten/queried.