### PR TITLE
Collision Functions/Bool Cast Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Collision_Systems/BBox/BBOXfuncs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/BBox/BBOXfuncs.cpp
@@ -85,7 +85,7 @@ bool place_meeting(cs_scalar x, cs_scalar y, int object)
   return collide_inst_inst(object,false,true,x,y);
 }
 
-int instance_place(cs_scalar x, cs_scalar y, int object)
+enigma::instance_t instance_place(cs_scalar x, cs_scalar y, int object)
 {
   enigma::object_collisions* const r = collide_inst_inst(object,false,true,x,y);
   return r == NULL ? noone : r->id;
@@ -132,37 +132,37 @@ void position_destroy(cs_scalar x, cs_scalar y)
     destroy_inst_point(all,false,x+.5,y+.5);
 }
 
-int instance_position(cs_scalar x, cs_scalar y, int object)
+enigma::instance_t instance_position(cs_scalar x, cs_scalar y, int object)
 {
   const enigma::object_collisions* r = collide_inst_point(object,false,false,x+.5,y+.5);
   return r == NULL ? noone : r->id;
 }
 
-int collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
+enigma::instance_t collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_rect(obj,false,notme,x1+.5,y1+.5,x2+.5,y2+.5); //false is for solid_only, not prec
   return r == NULL ? noone : r->id;
 }
 
-int collision_line(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
+enigma::instance_t collision_line(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_line(obj,false,notme,x1+.5,y1+.5,x2+.5,y2+.5); //false is for solid_only, not prec
   return r == NULL ? noone : r->id;
 }
 
-int collision_point(cs_scalar x, cs_scalar y, int obj, bool prec /*ignored*/, bool notme)
+enigma::instance_t collision_point(cs_scalar x, cs_scalar y, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_point(obj,false,notme,x+.5,y+.5); //false is for solid_only, not prec
   return r == NULL ? noone : r->id;
 }
 
-int collision_circle(cs_scalar x, cs_scalar y, double radius, int obj, bool prec /*ignored*/, bool notme)
+enigma::instance_t collision_circle(cs_scalar x, cs_scalar y, double radius, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_circle(obj,false,notme,x+.5,y+.5,radius); //false is for solid_only, not prec
   return r == NULL ? noone : r->id;
 }
 
-int collision_ellipse(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
+enigma::instance_t collision_ellipse(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_ellipse(obj,false,notme,((x1+x2)/2)+.5,((y1+y2)/2)+.5,fabs(x2-x1)/2,fabs(y2-y1)/2); //false is for solid_only, not prec
   return r == NULL ? noone : r->id;
@@ -953,4 +953,3 @@ void position_change(cs_scalar x1, cs_scalar y1, int obj, bool perf)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Collision_Systems/BBox/BBOXfuncs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/BBox/BBOXfuncs.cpp
@@ -88,7 +88,7 @@ bool place_meeting(cs_scalar x, cs_scalar y, int object)
 enigma::instance_t instance_place(cs_scalar x, cs_scalar y, int object)
 {
   enigma::object_collisions* const r = collide_inst_inst(object,false,true,x,y);
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 }
@@ -135,37 +135,37 @@ void position_destroy(cs_scalar x, cs_scalar y)
 enigma::instance_t instance_position(cs_scalar x, cs_scalar y, int object)
 {
   const enigma::object_collisions* r = collide_inst_point(object,false,false,x+.5,y+.5);
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_rect(obj,false,notme,x1+.5,y1+.5,x2+.5,y2+.5); //false is for solid_only, not prec
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_line(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_line(obj,false,notme,x1+.5,y1+.5,x2+.5,y2+.5); //false is for solid_only, not prec
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_point(cs_scalar x, cs_scalar y, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_point(obj,false,notme,x+.5,y+.5); //false is for solid_only, not prec
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_circle(cs_scalar x, cs_scalar y, double radius, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_circle(obj,false,notme,x+.5,y+.5,radius); //false is for solid_only, not prec
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_ellipse(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_ellipse(obj,false,notme,((x1+x2)/2)+.5,((y1+y2)/2)+.5,fabs(x2-x1)/2,fabs(y2-y1)/2); //false is for solid_only, not prec
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 double distance_to_object(int object)

--- a/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECfuncs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECfuncs.cpp
@@ -87,7 +87,7 @@ bool place_meeting(cs_scalar x, cs_scalar y, int object)
   return collide_inst_inst(object,false,true,x,y);
 }
 
-int instance_place(cs_scalar x, cs_scalar y, int object)
+enigma::instance_t instance_place(cs_scalar x, cs_scalar y, int object)
 {
   enigma::object_collisions* const r = collide_inst_inst(object,false,true,x,y);
   return r == NULL ? noone : r->id;
@@ -140,37 +140,37 @@ void position_change(cs_scalar x, cs_scalar y, int obj, bool perf)
     change_inst_point(obj, perf, x+.5, y+.5);
 }
 
-int instance_position(cs_scalar x, cs_scalar y, int object)
+enigma::instance_t instance_position(cs_scalar x, cs_scalar y, int object)
 {
   const enigma::object_collisions* r = collide_inst_point(object,false,true,false,x+.5,y+.5);
   return r == NULL ? noone : r->id;
 }
 
-int collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
+enigma::instance_t collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_rect(obj,false,prec,notme,x1+.5,y1+.5,x2+.5,y2+.5); //false is for solid_only
   return r == NULL ? noone : r->id;
 }
 
-int collision_line(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
+enigma::instance_t collision_line(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_line(obj,false,prec,notme,x1+.5,y1+.5,x2+.5,y2+.5);
   return r == NULL ? noone : r->id;
 }
 
-int collision_point(cs_scalar x, cs_scalar y, int obj, bool prec, bool notme)
+enigma::instance_t collision_point(cs_scalar x, cs_scalar y, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_point(obj,false, prec,notme,x+.5,y+.5);
   return r == NULL ? noone : r->id;
 }
 
-int collision_circle(cs_scalar x, cs_scalar y, double radius, int obj, bool prec, bool notme)
+enigma::instance_t collision_circle(cs_scalar x, cs_scalar y, double radius, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_circle(obj,false,prec,notme,x+.5,y+.5,radius);
   return r == NULL ? noone : r->id;
 }
 
-int collision_ellipse(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
+enigma::instance_t collision_ellipse(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_ellipse(obj,false,prec,notme,((x1+x2)/2)+.5,((y1+y2)/2)+.5,fabs(x2-x1)/2,fabs(y2-y1)/2);
   return r == NULL ? noone : r->id;
@@ -689,4 +689,3 @@ void instance_activate_circle(int x, int y, int r, bool inside)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECfuncs.cpp
+++ b/ENIGMAsystem/SHELL/Collision_Systems/Precise/PRECfuncs.cpp
@@ -90,7 +90,7 @@ bool place_meeting(cs_scalar x, cs_scalar y, int object)
 enigma::instance_t instance_place(cs_scalar x, cs_scalar y, int object)
 {
   enigma::object_collisions* const r = collide_inst_inst(object,false,true,x,y);
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 }
@@ -143,37 +143,37 @@ void position_change(cs_scalar x, cs_scalar y, int obj, bool perf)
 enigma::instance_t instance_position(cs_scalar x, cs_scalar y, int object)
 {
   const enigma::object_collisions* r = collide_inst_point(object,false,true,false,x+.5,y+.5);
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_rect(obj,false,prec,notme,x1+.5,y1+.5,x2+.5,y2+.5); //false is for solid_only
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_line(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_line(obj,false,prec,notme,x1+.5,y1+.5,x2+.5,y2+.5);
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_point(cs_scalar x, cs_scalar y, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_point(obj,false, prec,notme,x+.5,y+.5);
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_circle(cs_scalar x, cs_scalar y, double radius, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_circle(obj,false,prec,notme,x+.5,y+.5,radius);
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 enigma::instance_t collision_ellipse(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
 {
   const enigma::object_collisions* r = collide_inst_ellipse(obj,false,prec,notme,((x1+x2)/2)+.5,((y1+y2)/2)+.5,fabs(x2-x1)/2,fabs(y2-y1)/2);
-  return r == NULL ? noone : r->id;
+  return r == NULL ? noone : static_cast<int>(r->id);
 }
 
 double distance_to_object(int object)

--- a/ENIGMAsystem/SHELL/Universal_System/instance.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance.cpp
@@ -117,7 +117,7 @@ bool instance_exists(int obj)
   return enigma::fetch_instance_by_int(obj) != NULL;
 }
 
-int instance_find(int obj, int num)
+enigma::instance_t instance_find(int obj, int num)
 {
   int nth=0;
   for (enigma::iterator it = enigma::fetch_inst_iter_by_int(obj); it; ++it)
@@ -128,6 +128,7 @@ int instance_find(int obj, int num)
   }
   return noone;
 }
+
 enigma::instance_t instance_last(int obj) {
   return (enigma::objects[obj].count > 0)? enigma::objects[obj].prev->inst->id : noone;
 }
@@ -147,4 +148,3 @@ int instance_number(int obj)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/instance.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance.cpp
@@ -130,7 +130,7 @@ enigma::instance_t instance_find(int obj, int num)
 }
 
 enigma::instance_t instance_last(int obj) {
-  return (enigma::objects[obj].count > 0)? enigma::objects[obj].prev->inst->id : noone;
+  return (enigma::objects[obj].count > 0) ? static_cast<int>(enigma::objects[obj].prev->inst->id) : noone;
 }
 
 int instance_number(int obj)

--- a/ENIGMAsystem/SHELL/Universal_System/instance_planar.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_planar.cpp
@@ -33,7 +33,7 @@
 namespace enigma_user
 {
 
-int instance_nearest(int x,int y,int obj,bool notme)
+enigma::instance_t instance_nearest(int x,int y,int obj,bool notme)
 {
   double dist_lowest = DBL_MAX;
   int retid = -4;
@@ -54,7 +54,7 @@ int instance_nearest(int x,int y,int obj,bool notme)
   return retid;
 }
 
-int instance_furthest(int x,int y,int obj,bool notme)
+enigma::instance_t instance_furthest(int x,int y,int obj,bool notme)
 {
   double dist_highest = -1;
   int retid = noone;
@@ -78,4 +78,3 @@ int instance_furthest(int x,int y,int obj,bool notme)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/instance_planar.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_planar.cpp
@@ -36,7 +36,7 @@ namespace enigma_user
 enigma::instance_t instance_nearest(int x,int y,int obj,bool notme)
 {
   double dist_lowest = DBL_MAX;
-  int retid = -4;
+  int retid = noone;
   double xl, yl;
 
   for (enigma::iterator it = enigma::fetch_inst_iter_by_int(obj); it; ++it)

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system_base.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system_base.h
@@ -24,7 +24,7 @@
 
 namespace enigma
 {
-  typedef var instance_t;
+  typedef variant instance_t;
 
   struct inst_iter
   {

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system_base.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system_base.h
@@ -24,7 +24,7 @@
 
 namespace enigma
 {
-  typedef int instance_t;
+  typedef var instance_t;
 
   struct inst_iter
   {
@@ -41,7 +41,7 @@ namespace enigma
     inst_iter *oiter;
     object_basic* prev_other;
     inst_iter niter;
-    
+
     public:
     temp_event_scope(object_basic*);
     ~temp_event_scope();


### PR DESCRIPTION
This is me attempting to fix #1208 to behave similar to GM and GMS.

Basically, a few collision and instance functions return `noone` or the `id` of the instance. Because `noone` is `-4` it is treated as true if you put those functions directly in an if statement. So, we want them to return var so that when the return value is cast to boolean it is false when negative (as it should be in GML). We typedef `instance_t` as an alias of `variant` (lighter weight than `var` according to Josh) instead of `int` now so that it's easy to change and clear which functions support this.

This will now make the following work as expected:
```gml
if (instance_find(...)) {
  // instance was found
}
if (collision_line(...)) {
  // there was a collision
}
```

Without having to add `!= noone` to the condition. Therefore, the FPS example functions correctly and the monsters will in fact chase you now. Testing a variety of other games which use collisions from emake also does not show any signs of regression.
![FPS Example Monsters Chasing](https://user-images.githubusercontent.com/3212801/39731645-d027fde2-5236-11e8-842a-1735951ac526.png)
