### PR TITLE
Audio System Clang Tool Reformat

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -15,55 +15,50 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <string>
-#include <stdio.h>
-#include <stddef.h>
 #include <math.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string>
 using std::string;
 #include "../General/ASbasic.h"
 #include "Audio_Systems/audio_mandatory.h"
 #include "DSsystem.h"
 
 #ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
 #include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
 #endif
 
 #include "Universal_System/estring.h"
 
-namespace enigma_user
-{
+namespace enigma_user {
 
-bool sound_exists(int sound)
+bool sound_exists(int sound) { return unsigned(sound) < sound_resources.size() && bool(sound_resources[sound]); }
+
+bool sound_play(int sound)  // Returns whether sound is playing
 {
-    return unsigned(sound) < sound_resources.size() && bool(sound_resources[sound]);
+  get_sound(snd, sound, false);
+  snd->soundBuffer->SetCurrentPosition(0);
+  snd->soundBuffer->Play(0, 0, 0);
+  return true;
 }
 
-bool sound_play(int sound) // Returns whether sound is playing
+bool sound_loop(int sound)  // Returns whether sound is playing
 {
-	get_sound(snd, sound, false);
-	snd->soundBuffer->SetCurrentPosition(0);
-	snd->soundBuffer->Play(0, 0, 0);
-	return true;
+  get_sound(snd, sound, false);
+  snd->soundBuffer->SetCurrentPosition(0);
+  snd->soundBuffer->Play(0, 0, DSBPLAY_LOOPING);
+  return true;
 }
 
-bool sound_loop(int sound) // Returns whether sound is playing
+bool sound_pause(int sound)  // Returns whether the sound was successfully paused
 {
-	get_sound(snd, sound, false);
-	snd->soundBuffer->SetCurrentPosition(0);
-	snd->soundBuffer->Play(0, 0, DSBPLAY_LOOPING);
-	return true;
+  get_sound(snd, sound, false);
+  snd->soundBuffer->Stop();
+  return true;
 }
 
-bool sound_pause(int sound) // Returns whether the sound was successfully paused
-{
-	get_sound(snd, sound, false);
-	snd->soundBuffer->Stop();
-	return true;
-}
-
-void sound_pause_all()
-{
+void sound_pause_all() {
   for (size_t i = 0; i < sound_resources.size(); i++) {
     get_soundv(snd, i);
     snd->soundBuffer->Stop();
@@ -71,12 +66,11 @@ void sound_pause_all()
 }
 
 void sound_stop(int sound) {
-	get_soundv(snd, sound);
-	snd->soundBuffer->Stop();
+  get_soundv(snd, sound);
+  snd->soundBuffer->Stop();
 }
 
-void sound_stop_all()
-{
+void sound_stop_all() {
   for (size_t i = 0; i < sound_resources.size(); i++) {
     get_soundv(snd, i);
     snd->soundBuffer->Stop();
@@ -90,23 +84,20 @@ void sound_delete(int sound) {
 }
 
 void sound_volume(int sound, float volume) {
-	get_soundv(snd, sound);
-	snd->soundBuffer->SetVolume((1-volume) * DSBVOLUME_MIN);
+  get_soundv(snd, sound);
+  snd->soundBuffer->SetVolume((1 - volume) * DSBVOLUME_MIN);
 }
 
-void sound_global_volume(float volume) {
-	primaryBuffer->SetVolume(volume);
-}
+void sound_global_volume(float volume) { primaryBuffer->SetVolume(volume); }
 
-bool sound_resume(int sound) // Returns whether the sound is playing
+bool sound_resume(int sound)  // Returns whether the sound is playing
 {
-	get_sound(snd, sound, false);
-	snd->soundBuffer->Play(0, 0, 0);
-	return true;
+  get_sound(snd, sound, false);
+  snd->soundBuffer->Play(0, 0, 0);
+  return true;
 }
 
-void sound_resume_all()
-{
+void sound_resume_all() {
   for (size_t i = 0; i < sound_resources.size(); i++) {
     get_soundv(snd, i);
     snd->soundBuffer->Play(0, 0, 0);
@@ -114,10 +105,10 @@ void sound_resume_all()
 }
 
 bool sound_isplaying(int sound) {
-	get_sound(snd, sound, false);
-	DWORD ret = 0;
-	snd->soundBuffer->GetStatus(&ret);
-	return (ret & DSBSTATUS_PLAYING);
+  get_sound(snd, sound, false);
+  DWORD ret = 0;
+  snd->soundBuffer->GetStatus(&ret);
+  return (ret & DSBSTATUS_PLAYING);
 }
 
 bool sound_ispaused(int sound) {
@@ -125,42 +116,41 @@ bool sound_ispaused(int sound) {
   return !snd->idle and !snd->playing;
 }
 
-void sound_pan(int sound, float value)
-{
-	get_soundv(snd, sound);
-	snd->soundBuffer->SetPan(value * 10000);
+void sound_pan(int sound, float value) {
+  get_soundv(snd, sound);
+  snd->soundBuffer->SetPan(value * 10000);
 }
 
 float sound_get_pan(int sound) {
-	get_sound(snd, sound, -1);
-	LONG ret = 0;
-	snd->soundBuffer->GetPan(&ret);
-	return ret;
+  get_sound(snd, sound, -1);
+  LONG ret = 0;
+  snd->soundBuffer->GetPan(&ret);
+  return ret;
 }
 
 float sound_get_volume(int sound) {
-	get_sound(snd, sound, -1);
-	LONG ret = 0;
-	snd->soundBuffer->GetVolume(&ret);
-	return ret;
+  get_sound(snd, sound, -1);
+  LONG ret = 0;
+  snd->soundBuffer->GetVolume(&ret);
+  return ret;
 }
 
-float sound_get_length(int sound) { // Not for Streams
-	get_sound(snd, sound, -1);
-	//snd->soundBuffer->GetLength();
-	return 0;
+float sound_get_length(int sound) {  // Not for Streams
+  get_sound(snd, sound, -1);
+  //snd->soundBuffer->GetLength();
+  return 0;
 }
 
-float sound_get_position(int sound) { // Not for Streams
-	get_sound(snd, sound, -1);
-	DWORD ret = 0;
-	snd->soundBuffer->GetCurrentPosition(&ret, NULL);
-	return ret;
+float sound_get_position(int sound) {  // Not for Streams
+  get_sound(snd, sound, -1);
+  DWORD ret = 0;
+  snd->soundBuffer->GetCurrentPosition(&ret, NULL);
+  return ret;
 }
 
 void sound_seek(int sound, float position) {
-	get_soundv(snd, sound);
-	snd->soundBuffer->SetCurrentPosition(position);
+  get_soundv(snd, sound);
+  snd->soundBuffer->SetCurrentPosition(position);
 }
 
 void sound_seek_all(float position) {
@@ -170,57 +160,49 @@ void sound_seek_all(float position) {
   }
 }
 
-void action_sound(int snd, bool loop)
-{
-  (loop ? sound_loop:sound_play)(snd);
-}
+void action_sound(int snd, bool loop) { (loop ? sound_loop : sound_play)(snd); }
 
-const char* sound_get_audio_error() {
-	return "";
-}
+const char* sound_get_audio_error() { return ""; }
 
-}
+}  // namespace enigma_user
 
-#include "../General/ASutil.h"
 #include <string>
+#include "../General/ASutil.h"
 using namespace std;
 extern void show_message(string);
 
-namespace enigma_user
-{
+namespace enigma_user {
 
-int sound_add(string fname, int kind, bool preload) //At the moment, the latter two arguments do nothing! =D
+int sound_add(string fname, int kind, bool preload)  //At the moment, the latter two arguments do nothing! =D
 {
   // Open sound
   size_t flen = 0;
-  char *fdata = enigma::read_all_bytes(fname, flen);
+  char* fdata = enigma::read_all_bytes(fname, flen);
   if (!fdata) return -1;
 
   // Decode sound
   int rid = enigma::sound_allocate();
-  bool fail = enigma::sound_add_from_buffer(rid,fdata,flen);
-  delete [] fdata;
+  bool fail = enigma::sound_add_from_buffer(rid, fdata, flen);
+  delete[] fdata;
 
-  if (fail)
-    return -1;
+  if (fail) return -1;
   return rid;
 }
 
-bool sound_replace(int sound, string fname, int kind, bool preload)
-{
+bool sound_replace(int sound, string fname, int kind, bool preload) {
   if (sound >= 0 && sound < sound_resources.size() && sound_resources[sound]) {
-    get_sound(snd,sound,false);
+    get_sound(snd, sound, false);
     delete snd;
   }
 
   // Open sound
   size_t flen = 0;
-  char *fdata = enigma::read_all_bytes(fname, flen);
+  char* fdata = enigma::read_all_bytes(fname, flen);
   if (!fdata) return -1;
 
   // Decode sound
-  bool fail = enigma::sound_add_from_buffer(sound,fdata,flen);
-  delete [] fdata;
+  bool fail = enigma::sound_add_from_buffer(sound, fdata, flen);
+  delete[] fdata;
   return fail;
 }
 
@@ -229,7 +211,7 @@ void sound_3d_set_sound_cone(int sound, float x, float y, float z, double anglei
 
   // query for the 3d buffer interface
   IDirectSound3DBuffer8* sound3DBuffer8 = 0;
-  snd->soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**) &sound3DBuffer8);
+  snd->soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**)&sound3DBuffer8);
 
   sound3DBuffer8->SetConeOrientation(x, y, z, DS3D_IMMEDIATE);
   sound3DBuffer8->SetConeAngles(anglein, angleout, DS3D_IMMEDIATE);
@@ -241,7 +223,7 @@ void sound_3d_set_sound_distance(int sound, float mindist, float maxdist) {
 
   // query for the 3d buffer interface
   IDirectSound3DBuffer8* sound3DBuffer8 = 0;
-  snd->soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**) &sound3DBuffer8);
+  snd->soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**)&sound3DBuffer8);
 
   sound3DBuffer8->SetMinDistance(mindist, DS3D_IMMEDIATE);
   sound3DBuffer8->SetMaxDistance(maxdist, DS3D_IMMEDIATE);
@@ -252,7 +234,7 @@ void sound_3d_set_sound_position(int sound, float x, float y, float z) {
 
   // query for the 3d buffer interface
   IDirectSound3DBuffer8* sound3DBuffer8 = 0;
-  snd->soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**) &sound3DBuffer8);
+  snd->soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**)&sound3DBuffer8);
 
   sound3DBuffer8->SetPosition(x, y, z, DS3D_IMMEDIATE);
 }
@@ -262,12 +244,13 @@ void sound_3d_set_sound_velocity(int sound, float x, float y, float z) {
 
   // query for the 3d buffer interface
   IDirectSound3DBuffer8* sound3DBuffer8 = 0;
-  snd->soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**) &sound3DBuffer8);
+  snd->soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**)&sound3DBuffer8);
 
   sound3DBuffer8->SetVelocity(x, y, z, DS3D_IMMEDIATE);
 }
 
-void sound_effect_chorus(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay, long phase) {
+void sound_effect_chorus(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay,
+                         long phase) {
   /*
 	DSFXChorus effectParams = { };
   effectParams.fWetDryMix = wetdry;
@@ -291,7 +274,8 @@ void sound_effect_echo(int sound, float wetdry, float feedback, float leftdelay,
   */
 }
 
-void sound_effect_flanger(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay, long phase) {
+void sound_effect_flanger(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay,
+                          long phase) {
   /*
   DSFXFlanger effectParams = { };
   effectParams.fWetDryMix = wetdry;
@@ -322,7 +306,8 @@ void sound_effect_reverb(int sound, float gain, float mix, float time, float rat
   */
 }
 
-void sound_effect_compressor(int sound, float gain, float attack, float release, float threshold, float ratio, float delay) {
+void sound_effect_compressor(int sound, float gain, float attack, float release, float threshold, float ratio,
+                             float delay) {
   /*
   DSFXCompressor effectParams = { };
   effectParams.fGain = gain;
@@ -343,8 +328,9 @@ void sound_effect_equalizer(int sound, float center, float bandwidth, float gain
   */
 }
 
-static const GUID sound_effect_guids[7] = { GUID_DSFX_STANDARD_CHORUS, GUID_DSFX_STANDARD_ECHO, GUID_DSFX_STANDARD_FLANGER, GUID_DSFX_STANDARD_GARGLE,
-	GUID_DSFX_WAVES_REVERB, GUID_DSFX_STANDARD_COMPRESSOR, GUID_DSFX_STANDARD_PARAMEQ };
+static const GUID sound_effect_guids[7] = {
+    GUID_DSFX_STANDARD_CHORUS, GUID_DSFX_STANDARD_ECHO,       GUID_DSFX_STANDARD_FLANGER, GUID_DSFX_STANDARD_GARGLE,
+    GUID_DSFX_WAVES_REVERB,    GUID_DSFX_STANDARD_COMPRESSOR, GUID_DSFX_STANDARD_PARAMEQ};
 
 void sound_effect_set(int sound, int effect) {
   size_t numOfEffects = 0;
@@ -386,17 +372,17 @@ void sound_effect_set(int sound, int effect) {
   // "Additionally, the buffer must not be playing or locked."
   // https://msdn.microsoft.com/en-us/library/windows/desktop/microsoft.directx_sdk.idirectsoundbuffer8.idirectsoundbuffer8.setfx%28v=vs.85%29.aspx
   DWORD status = 0;
-	snd->soundBuffer->GetStatus(&status);
+  snd->soundBuffer->GetStatus(&status);
   bool wasPlaying = (status & DSBSTATUS_PLAYING);
   bool wasLooping = (status & DSBSTATUS_LOOPING);
-  if (wasPlaying) snd->soundBuffer->Stop(); // pause
+  if (wasPlaying) snd->soundBuffer->Stop();  // pause
 
   // query for the effect interface and set the effects on the sound buffer
   IDirectSoundBuffer8* soundBuffer8 = 0;
-  snd->soundBuffer->QueryInterface(IID_IDirectSoundBuffer8, (void**) &soundBuffer8);
+  snd->soundBuffer->QueryInterface(IID_IDirectSoundBuffer8, (void**)&soundBuffer8);
   soundBuffer8->SetFX(numOfEffects, dsEffects, dwResults);
 
-  if (wasPlaying) snd->soundBuffer->Play(0, 0, wasLooping ? DSBPLAY_LOOPING : 0); // resume
+  if (wasPlaying) snd->soundBuffer->Play(0, 0, wasLooping ? DSBPLAY_LOOPING : 0);  // resume
 }
 
-}
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -18,39 +18,38 @@
 #include <stdio.h>
 
 #include "DSsystem.h"
-struct WaveHeaderType
-{
-	char chunkId[4];
-	unsigned long chunkSize;
-	char format[4];
-	char subChunkId[4];
-	unsigned long subChunkSize;
-	unsigned short audioFormat;
-	unsigned short numChannels;
-	unsigned long sampleRate;
-	unsigned long bytesPerSecond;
-	unsigned short blockAlign;
-	unsigned short bitsPerSample;
-	unsigned short parSize;
-	unsigned short headerSize;
-	unsigned long dataOffset;
-	char dataChunkId[4];
-	unsigned long dataSize;
+struct WaveHeaderType {
+  char chunkId[4];
+  unsigned long chunkSize;
+  char format[4];
+  char subChunkId[4];
+  unsigned long subChunkSize;
+  unsigned short audioFormat;
+  unsigned short numChannels;
+  unsigned long sampleRate;
+  unsigned long bytesPerSecond;
+  unsigned short blockAlign;
+  unsigned short bitsPerSample;
+  unsigned short parSize;
+  unsigned short headerSize;
+  unsigned long dataOffset;
+  char dataChunkId[4];
+  unsigned long dataSize;
 };
 
 IDirectSound8* dsound;
 
-const GUID GUID_NULL = { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } };
+const GUID GUID_NULL = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
 
 #include <time.h>
 clock_t starttime;
 clock_t elapsedtime;
 clock_t lasttime;
 
-#include <string>
 #include <sstream>
-using std::stringstream;
+#include <string>
 using std::string;
+using std::stringstream;
 
 #include "Platforms/Win32/WINDOWSmain.h"
 IDirectSoundBuffer* primaryBuffer;
@@ -59,194 +58,181 @@ vector<SoundResource*> sound_resources(0);
 
 namespace enigma {
 
-  void eos_callback(void *soundID, unsigned src)
-  {
-    get_sound(snd, (ptrdiff_t)soundID, );
-    snd->playing = false;
-    snd->idle = true;
+void eos_callback(void* soundID, unsigned src) {
+  get_sound(snd, (ptrdiff_t)soundID, );
+  snd->playing = false;
+  snd->idle = true;
+}
+
+int audiosystem_initialize() {
+  starttime = clock();
+  elapsedtime = starttime;
+  lasttime = elapsedtime;
+  printf("Initializing audio system...\n");
+
+  HRESULT result;
+  DSBUFFERDESC bufferDesc;
+
+  // Initialize the direct sound interface pointer for the default sound device.
+  result = DirectSoundCreate8(NULL, &dsound, NULL);
+  if (FAILED(result)) {
+    MessageBox(NULL, "Failed to create DirectSound8 object.", "Error", MB_OK);
+    return false;
   }
 
-  int audiosystem_initialize()
-  {
-  	starttime = clock();
-    elapsedtime = starttime;
-    lasttime = elapsedtime;
-    printf("Initializing audio system...\n");
-
-	HRESULT result;
-	DSBUFFERDESC bufferDesc;
-
-	// Initialize the direct sound interface pointer for the default sound device.
-	result = DirectSoundCreate8(NULL, &dsound, NULL);
-	if (FAILED(result))
-	{
-		MessageBox(NULL, "Failed to create DirectSound8 object.", "Error", MB_OK);
-		return false;
-	}
-
-	// Set the cooperative level to priority so the format of the primary sound buffer can be modified.
-	result = dsound->SetCooperativeLevel(hWnd, DSSCL_PRIORITY);
-	if (FAILED(result))
-	{
-		MessageBox(NULL, "Failed to set the cooperative level of the Window handle.", "Error", MB_OK);
-		return false;
-	}
-
-	// Setup the primary buffer description.
-	bufferDesc.dwSize = sizeof(DSBUFFERDESC);
-	bufferDesc.dwFlags = DSBCAPS_PRIMARYBUFFER | DSBCAPS_CTRLVOLUME;
-	bufferDesc.dwBufferBytes = 0;
-	bufferDesc.dwReserved = 0;
-	bufferDesc.lpwfxFormat = NULL;
-	bufferDesc.guid3DAlgorithm = GUID_NULL;
-	dsound->CreateSoundBuffer(&bufferDesc, &primaryBuffer, NULL);
-
-	// Setup the format of the primary sound bufffer.
-	// In this case it is a .WAV file recorded at 44,100 samples per second in 16-bit stereo (cd audio format).
-	WAVEFORMATEX primaryFormat;
-	primaryFormat.wFormatTag = WAVE_FORMAT_PCM;
-	primaryFormat.nSamplesPerSec = 44100;
-	primaryFormat.wBitsPerSample = 16;
-	primaryFormat.nChannels = 2;
-	primaryFormat.nBlockAlign = (primaryFormat.wBitsPerSample / 8) * primaryFormat.nChannels;
-	primaryFormat.nAvgBytesPerSec = primaryFormat.nSamplesPerSec * primaryFormat.nBlockAlign;
-	primaryFormat.cbSize = 0;
-
-	primaryBuffer->SetFormat(&primaryFormat);
-
-	return true;
+  // Set the cooperative level to priority so the format of the primary sound buffer can be modified.
+  result = dsound->SetCooperativeLevel(hWnd, DSSCL_PRIORITY);
+  if (FAILED(result)) {
+    MessageBox(NULL, "Failed to set the cooperative level of the Window handle.", "Error", MB_OK);
+    return false;
   }
+
+  // Setup the primary buffer description.
+  bufferDesc.dwSize = sizeof(DSBUFFERDESC);
+  bufferDesc.dwFlags = DSBCAPS_PRIMARYBUFFER | DSBCAPS_CTRLVOLUME;
+  bufferDesc.dwBufferBytes = 0;
+  bufferDesc.dwReserved = 0;
+  bufferDesc.lpwfxFormat = NULL;
+  bufferDesc.guid3DAlgorithm = GUID_NULL;
+  dsound->CreateSoundBuffer(&bufferDesc, &primaryBuffer, NULL);
+
+  // Setup the format of the primary sound bufffer.
+  // In this case it is a .WAV file recorded at 44,100 samples per second in 16-bit stereo (cd audio format).
+  WAVEFORMATEX primaryFormat;
+  primaryFormat.wFormatTag = WAVE_FORMAT_PCM;
+  primaryFormat.nSamplesPerSec = 44100;
+  primaryFormat.wBitsPerSample = 16;
+  primaryFormat.nChannels = 2;
+  primaryFormat.nBlockAlign = (primaryFormat.wBitsPerSample / 8) * primaryFormat.nChannels;
+  primaryFormat.nAvgBytesPerSec = primaryFormat.nSamplesPerSec * primaryFormat.nBlockAlign;
+  primaryFormat.cbSize = 0;
+
+  primaryBuffer->SetFormat(&primaryFormat);
+
+  return true;
+}
 
 WaveHeaderType* buffer_get_wave_header(char* buffer, size_t bufsize) {
-	WaveHeaderType* waveHeader = new WaveHeaderType();
+  WaveHeaderType* waveHeader = new WaveHeaderType();
 
-	memcpy(waveHeader,buffer,36);
+  memcpy(waveHeader, buffer, 36);
 
-	unsigned long remaining = waveHeader->subChunkSize - 16;
-	if (remaining) {
-		memcpy(&waveHeader->parSize,buffer+36,2);
-	}
+  unsigned long remaining = waveHeader->subChunkSize - 16;
+  if (remaining) {
+    memcpy(&waveHeader->parSize, buffer + 36, 2);
+  }
 
-	if (strncmp(waveHeader->chunkId, "RIFF",4) != 0 || strncmp(waveHeader->format, "WAVE",4) != 0) {
-		return NULL; // Not a WAVE file or the format is just messed up
-	}
+  if (strncmp(waveHeader->chunkId, "RIFF", 4) != 0 || strncmp(waveHeader->format, "WAVE", 4) != 0) {
+    return NULL;  // Not a WAVE file or the format is just messed up
+  }
 
-	// Read Subchunks
-	char chunkId[5] = { 'H', 'U', 'N', 'G' };
-	unsigned long chunkSize = 0;
-	for (unsigned i = 36 + remaining; i < bufsize; i += 8 + chunkSize) {
-
-		memcpy(&chunkId, buffer + i, 4);
-		memcpy(&chunkSize, buffer + i + 4, 4);
-		if (strncmp(chunkId, "data", 4) == 0) {
-			waveHeader->dataSize = chunkSize;
-			waveHeader->dataOffset = i + 8;
-			break;
-		} else {
-			continue;
-		}
-	}
-
-	return waveHeader;
-}
-
-  int sound_add_from_buffer(int id, void* buffer, size_t bufsize)
-  {
-    SoundResource *snd = new SoundResource();
-    if (id >= sound_resources.size()) {
-      sound_resources.resize(id + 1);
+  // Read Subchunks
+  char chunkId[5] = {'H', 'U', 'N', 'G'};
+  unsigned long chunkSize = 0;
+  for (unsigned i = 36 + remaining; i < bufsize; i += 8 + chunkSize) {
+    memcpy(&chunkId, buffer + i, 4);
+    memcpy(&chunkSize, buffer + i + 4, 4);
+    if (strncmp(chunkId, "data", 4) == 0) {
+      waveHeader->dataSize = chunkSize;
+      waveHeader->dataOffset = i + 8;
+      break;
+    } else {
+      continue;
     }
-    sound_resources[id] = snd;
-
-	WaveHeaderType* waveHeader = buffer_get_wave_header((char*)buffer, bufsize);
-	WAVEFORMATEX waveFormat = { };
-	waveFormat.wFormatTag = waveHeader->audioFormat;
-	waveFormat.nSamplesPerSec = waveHeader->sampleRate;
-	waveFormat.wBitsPerSample = waveHeader->bitsPerSample;
-	waveFormat.nChannels = waveHeader->numChannels;
-	waveFormat.nBlockAlign = waveHeader->blockAlign;
-	waveFormat.nAvgBytesPerSec = waveHeader->bytesPerSecond;
-	waveFormat.cbSize = waveHeader->parSize;
-
-	DSBUFFERDESC bufferDesc = { };
-	bufferDesc.dwSize = sizeof(DSBUFFERDESC);
-	bufferDesc.dwFlags = DSBCAPS_CTRLDEFAULT | DSBCAPS_CTRLFX;
-	bufferDesc.dwBufferBytes = waveHeader->dataSize;
-	bufferDesc.dwReserved = 0;
-	bufferDesc.lpwfxFormat = &waveFormat;
-	bufferDesc.guid3DAlgorithm = GUID_NULL;
-	dsound->CreateSoundBuffer(&bufferDesc, &snd->soundBuffer, NULL);
-
-	LPVOID lpvWrite;
-	DWORD  dwLength;
-
-	IDirectSoundBuffer* sndBuf = snd->soundBuffer;
-
-	if (DS_OK == sndBuf->Lock(
-      0,          // Offset at which to start lock.
-      waveHeader->dataSize,          // Size of lock; ignored because of flag.
-      &lpvWrite,  // Gets address of first part of lock.
-      &dwLength,  // Gets size of first part of lock.
-      NULL,       // Address of wraparound not needed.
-      NULL,       // Size of wraparound not needed.
-      0))  // Flag.
-	{
-		memcpy(lpvWrite, (char*)buffer + waveHeader->dataOffset, waveHeader->dataSize);
-		sndBuf->Unlock(
-		lpvWrite,   // Address of lock start.
-		dwLength,   // Size of lock.
-		NULL,       // No wraparound portion.
-		0);         // No wraparound size.
-	} else {
-		//ErrorHandler();  // Add error-handling here.
-	}
-
-	delete waveHeader;
-
-	snd->soundBuffer->SetCurrentPosition(0);
-	// Set volume of the buffer to 100%.
-	snd->soundBuffer->SetVolume(0);
-    snd->loaded = LOADSTATE_COMPLETE;
-
-    return 0;
   }
 
-  int sound_add_from_stream(int id, size_t (*callback)(void *userdata, void *buffer, size_t size), void (*seek)(void *userdata, float position), void (*cleanup)(void *userdata), void *userdata)
-  {
-	return -1;
-  }
-
-  int sound_allocate()
-  {
-	int id = -1;
-	for (unsigned i = 0; i < sound_resources.size(); i++) {
-		if (sound_resources[id] == NULL) {
-			id = i;
-		}
-	}
-	if (id < 0) {
-	  id = sound_resources.size();
-	  sound_resources.push_back(NULL);
-	}
-
-	return id;
-  }
-
-  void audiosystem_update(void)
-  {
-
-  }
-
-  void audiosystem_cleanup()
-  {
-	// Release the direct sound interface pointer.
-	if(dsound)
-	{
-		dsound->Release();
-		dsound = 0;
-	}
-
-	return;
-  }
-
+  return waveHeader;
 }
+
+int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
+  SoundResource* snd = new SoundResource();
+  if (id >= sound_resources.size()) {
+    sound_resources.resize(id + 1);
+  }
+  sound_resources[id] = snd;
+
+  WaveHeaderType* waveHeader = buffer_get_wave_header((char*)buffer, bufsize);
+  WAVEFORMATEX waveFormat = {};
+  waveFormat.wFormatTag = waveHeader->audioFormat;
+  waveFormat.nSamplesPerSec = waveHeader->sampleRate;
+  waveFormat.wBitsPerSample = waveHeader->bitsPerSample;
+  waveFormat.nChannels = waveHeader->numChannels;
+  waveFormat.nBlockAlign = waveHeader->blockAlign;
+  waveFormat.nAvgBytesPerSec = waveHeader->bytesPerSecond;
+  waveFormat.cbSize = waveHeader->parSize;
+
+  DSBUFFERDESC bufferDesc = {};
+  bufferDesc.dwSize = sizeof(DSBUFFERDESC);
+  bufferDesc.dwFlags = DSBCAPS_CTRLDEFAULT | DSBCAPS_CTRLFX;
+  bufferDesc.dwBufferBytes = waveHeader->dataSize;
+  bufferDesc.dwReserved = 0;
+  bufferDesc.lpwfxFormat = &waveFormat;
+  bufferDesc.guid3DAlgorithm = GUID_NULL;
+  dsound->CreateSoundBuffer(&bufferDesc, &snd->soundBuffer, NULL);
+
+  LPVOID lpvWrite;
+  DWORD dwLength;
+
+  IDirectSoundBuffer* sndBuf = snd->soundBuffer;
+
+  if (DS_OK == sndBuf->Lock(0,                     // Offset at which to start lock.
+                            waveHeader->dataSize,  // Size of lock; ignored because of flag.
+                            &lpvWrite,             // Gets address of first part of lock.
+                            &dwLength,             // Gets size of first part of lock.
+                            NULL,                  // Address of wraparound not needed.
+                            NULL,                  // Size of wraparound not needed.
+                            0))                    // Flag.
+  {
+    memcpy(lpvWrite, (char*)buffer + waveHeader->dataOffset, waveHeader->dataSize);
+    sndBuf->Unlock(lpvWrite,  // Address of lock start.
+                   dwLength,  // Size of lock.
+                   NULL,      // No wraparound portion.
+                   0);        // No wraparound size.
+  } else {
+    //ErrorHandler();  // Add error-handling here.
+  }
+
+  delete waveHeader;
+
+  snd->soundBuffer->SetCurrentPosition(0);
+  // Set volume of the buffer to 100%.
+  snd->soundBuffer->SetVolume(0);
+  snd->loaded = LOADSTATE_COMPLETE;
+
+  return 0;
+}
+
+int sound_add_from_stream(int id, size_t (*callback)(void* userdata, void* buffer, size_t size),
+                          void (*seek)(void* userdata, float position), void (*cleanup)(void* userdata),
+                          void* userdata) {
+  return -1;
+}
+
+int sound_allocate() {
+  int id = -1;
+  for (unsigned i = 0; i < sound_resources.size(); i++) {
+    if (sound_resources[id] == NULL) {
+      id = i;
+    }
+  }
+  if (id < 0) {
+    id = sound_resources.size();
+    sound_resources.push_back(NULL);
+  }
+
+  return id;
+}
+
+void audiosystem_update(void) {}
+
+void audiosystem_cleanup() {
+  // Release the direct sound interface pointer.
+  if (dsound) {
+    dsound->Release();
+    dsound = 0;
+  }
+
+  return;
+}
+
+}  // namespace enigma

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.h
@@ -18,45 +18,48 @@
 #ifndef ENIGMA_DS_SYSTEM_H
 #define ENIGMA_DS_SYSTEM_H
 
+#include <dsound.h>
+#include <mmsystem.h>
 #include <stddef.h>
 #include <windows.h>
-#include <mmsystem.h>
-#include <dsound.h>
 
-extern IDirectSoundBuffer* primaryBuffer;
+extern IDirectSoundBuffer *primaryBuffer;
 
 #include "SoundResource.h"
 
 namespace enigma {
 
-  int get_free_channel(double priority);
+int get_free_channel(double priority);
 
-  #ifdef DEBUG_MODE
-    #define get_sound(snd,id,failure)\
-      if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {\
-        show_error("Sound " + enigma_user::toString(id) + " does not exist", false);\
-        return failure;\
-      } SoundResource *const snd = sound_resources[id];
-  #define get_soundv(snd,id)\
-      if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {\
-        show_error("Sound " + enigma_user::toString(id) + " does not exist", false);\
-        return;\
-      } SoundResource *const snd = sound_resources[id];
-  #else
-    #define get_sound(snd,id,failure)\
-      SoundResource *const snd = sound_resources[id];
-  #define get_soundv(snd,id)\
-      SoundResource *const snd = sound_resources[id];
-  #endif
+#ifdef DEBUG_MODE
+#define get_sound(snd, id, failure)                                              \
+  if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {  \
+    show_error("Sound " + enigma_user::toString(id) + " does not exist", false); \
+    return failure;                                                              \
+  }                                                                              \
+  SoundResource *const snd = sound_resources[id];
+#define get_soundv(snd, id)                                                      \
+  if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {  \
+    show_error("Sound " + enigma_user::toString(id) + " does not exist", false); \
+    return;                                                                      \
+  }                                                                              \
+  SoundResource *const snd = sound_resources[id];
+#else
+#define get_sound(snd, id, failure) SoundResource *const snd = sound_resources[id];
+#define get_soundv(snd, id) SoundResource *const snd = sound_resources[id];
+#endif
 
-  void eos_callback(void *soundID, unsigned src);
-  int audiosystem_initialize();
-  SoundResource* sound_new_with_source();
-  int sound_add_from_buffer(int id, void* buffer, size_t bufsize);
-  int sound_add_from_stream(int id, size_t (*callback)(void *userdata, void *buffer, size_t size), void (*seek)(void *userdata, float position), void (*cleanup)(void *userdata), void *userdata);
-  int sound_allocate();
-  void audiosystem_update(void);
-  void audiosystem_cleanup();
-}
+void eos_callback(void *soundID, unsigned src);
+int audiosystem_initialize();
+SoundResource *sound_new_with_source();
+int sound_add_from_buffer(int id, void *buffer, size_t bufsize);
+int sound_add_from_stream(int id, size_t (*callback)(void *userdata, void *buffer, size_t size),
+                          void (*seek)(void *userdata, float position), void (*cleanup)(void *userdata),
+                          void *userdata);
+int sound_allocate();
+void audiosystem_update(void);
+void audiosystem_cleanup();
+
+}  // namespace enigma
 
 #endif

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/Info/About.ey
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/Info/About.ey
@@ -3,7 +3,7 @@
 
 Name: DirectSound
 Identifier: DirectSound
-Description: Basic audio playback using DirectSound for regular WAVE format audio and 3D positional sounds with other effects and  DirectMusic for MIDI and MP3 formats. Fully compatible with older Game Maker versions and for simple and easy audio playback. Requires the DirectX 9.0 End User Runtime or later which is included with our MinGW in the Windows Portable ZIP, DirectX, being Microsoft technology is also exceptionally proprietary.
+Description: Basic audio playback using DirectSound for regular WAVE format audio and 3D positional sounds with other effects and DirectMusic for MIDI and MP3 formats. Fully compatible with older Game Maker versions and for simple and easy audio playback. Requires the DirectX 9.0 End User Runtime or later.
 Author: Robert B. Colton
 
 Depends:

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
@@ -19,40 +19,36 @@
 #define ENIGMA_SOUND_RESOURCE_H
 
 #ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
 #include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
 #endif
 
 #include <vector>
 using std::vector;
 
-enum load_state {
-    LOADSTATE_NONE,
-    LOADSTATE_INDICATED,
-    LOADSTATE_COMPLETE
+enum load_state { LOADSTATE_NONE, LOADSTATE_INDICATED, LOADSTATE_COMPLETE };
+
+struct SoundResource {
+  IDirectSoundBuffer *soundBuffer;
+  void (*cleanup)(void *userdata);               // optional cleanup callback for streams
+  void *userdata;                                // optional userdata for streams
+  void (*seek)(void *userdata, float position);  // optional seeking
+  int type;                                      //0 for sound, 1 for music, -1 for error
+  int kind;                                      //
+
+  load_state loaded;  // Degree to which this sound has been loaded successfully
+  bool idle;          // True if this sound is not being used, false if playing or paused.
+  bool playing;       // True if this sound is playing; not paused or idle.
+
+  SoundResource() : soundBuffer(0), cleanup(0), userdata(0), seek(0), type(0), kind(0),
+    loaded(LOADSTATE_NONE), idle(1), playing(0) {}
+
+  ~SoundResource() {
+    soundBuffer->Release();
+    soundBuffer = 0;
+  }
 };
 
-struct SoundResource
-{
-    IDirectSoundBuffer* soundBuffer;
-    void (*cleanup)(void *userdata); // optional cleanup callback for streams
-    void *userdata; // optional userdata for streams
-    void (*seek)(void *userdata, float position); // optional seeking
-    int type; //0 for sound, 1 for music, -1 for error
-    int kind; //
-
-    load_state loaded;   // Degree to which this sound has been loaded successfully
-    bool idle;    // True if this sound is not being used, false if playing or paused.
-    bool playing; // True if this sound is playing; not paused or idle.
-
-    SoundResource(): soundBuffer(0), cleanup(0), userdata(0), seek(0), type(0), kind(0), loaded(LOADSTATE_NONE), idle(1), playing(0) {}
-
-    ~SoundResource() {
-        soundBuffer->Release();
-        soundBuffer = 0;
-    }
-};
-
-extern vector<SoundResource*> sound_resources;
+extern vector<SoundResource *> sound_resources;
 
 #endif

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/include.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/include.h
@@ -1,2 +1,1 @@
 #include "../General/ASbasic.h"
-

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
@@ -16,17 +16,17 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <string>
-#include <stdio.h>
-#include <stddef.h>
 #include <math.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string>
 using std::string;
 #include "../General/ASadvanced.h"
+#include "ALsystem.h"
 #include "Audio_Systems/audio_mandatory.h"
 #include "SoundChannel.h"
-#include "SoundResource.h"
 #include "SoundEmitter.h"
-#include "ALsystem.h"
+#include "SoundResource.h"
 
 #ifdef __APPLE__
 #include "../../../additional/alure/include/AL/alure.h"
@@ -35,8 +35,8 @@ using std::string;
 #endif
 
 #ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
 #include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
 #endif
 
 #include "Universal_System/estring.h"
@@ -45,38 +45,34 @@ using std::string;
 using std::vector;
 #include <time.h>
 
-ALenum falloff_models[7] = {
-  AL_NONE, AL_INVERSE_DISTANCE, AL_INVERSE_DISTANCE_CLAMPED, AL_LINEAR_DISTANCE,
-  AL_LINEAR_DISTANCE_CLAMPED, AL_EXPONENT_DISTANCE, AL_EXPONENT_DISTANCE_CLAMPED
-};
+ALenum falloff_models[7] = {AL_NONE,
+                            AL_INVERSE_DISTANCE,
+                            AL_INVERSE_DISTANCE_CLAMPED,
+                            AL_LINEAR_DISTANCE,
+                            AL_LINEAR_DISTANCE_CLAMPED,
+                            AL_EXPONENT_DISTANCE,
+                            AL_EXPONENT_DISTANCE_CLAMPED};
 
-namespace enigma_user
-{
+namespace enigma_user {
 
-bool audio_exists(int sound)
-{
-  return sound_resources.find(sound)!=sound_resources.end() && sound_resources[sound];
-}
+bool audio_exists(int sound) { return sound_resources.find(sound) != sound_resources.end() && sound_resources[sound]; }
 
 bool audio_is_playing(int index) {
   if (index >= 200000) {
     if (sound_channels[index - 200000]->soundIndex == index) {
-        ALint state;
-        alGetSourcei(sound_channels[index - 200000]->source, AL_SOURCE_STATE, &state);
-        if (state == AL_PLAYING)
-        {
-          return true;
-        }
+      ALint state;
+      alGetSourcei(sound_channels[index - 200000]->source, AL_SOURCE_STATE, &state);
+      if (state == AL_PLAYING) {
+        return true;
+      }
     }
   }
   // test for channels playing the sound
-  for (size_t i = 0; i < sound_channels.size(); i++)
-  {
+  for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == index) {
       ALint state;
       alGetSourcei(sound_channels[i]->source, AL_SOURCE_STATE, &state);
-      if (state == AL_PLAYING)
-      {
+      if (state == AL_PLAYING) {
         return true;
       }
     }
@@ -87,22 +83,19 @@ bool audio_is_playing(int index) {
 bool audio_is_paused(int index) {
   if (index >= 200000) {
     if (sound_channels[index - 200000]->soundIndex == index) {
-        ALint state;
-        alGetSourcei(sound_channels[index - 200000]->source, AL_SOURCE_STATE, &state);
-        if (state == AL_PAUSED)
-        {
-          return true;
-        }
+      ALint state;
+      alGetSourcei(sound_channels[index - 200000]->source, AL_SOURCE_STATE, &state);
+      if (state == AL_PAUSED) {
+        return true;
+      }
     }
   }
   // test for channels with the sound paused
-  for (size_t i = 0; i < sound_channels.size(); i++)
-  {
+  for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == index) {
       ALint state;
       alGetSourcei(sound_channels[i]->source, AL_SOURCE_STATE, &state);
-      if (state == AL_PAUSED)
-      {
+      if (state == AL_PAUSED) {
         return true;
       }
     }
@@ -110,36 +103,36 @@ bool audio_is_paused(int index) {
   return false;
 }
 
-int audio_play_sound(int sound, double priority, bool loop)
-{
+int audio_play_sound(int sound, double priority, bool loop) {
   int src = enigma::get_free_channel(priority);
   if (src != -1) {
-    get_sound(snd,sound,0);
+    get_sound(snd, sound, 0);
     alSourcei(sound_channels[src]->source, AL_BUFFER, snd->buf[0]);
     alSourcei(sound_channels[src]->source, AL_SOURCE_RELATIVE, AL_TRUE);
     alSourcei(sound_channels[src]->source, AL_REFERENCE_DISTANCE, 1);
-    alSourcei(sound_channels[src]->source, AL_LOOPING, loop?AL_TRUE:AL_FALSE);
+    alSourcei(sound_channels[src]->source, AL_LOOPING, loop ? AL_TRUE : AL_FALSE);
     alSourcef(sound_channels[src]->source, AL_PITCH, snd->pitch);
     alSourcef(sound_channels[src]->source, AL_GAIN, snd->volume);
     sound_channels[src]->priority = priority;
     sound_channels[src]->soundIndex = sound;
-    snd->idle = !(snd->playing = !snd->stream ?
-      alurePlaySource(sound_channels[src]->source, enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE :
-      alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1, enigma::eos_callback,
-        (void*)(ptrdiff_t)sound) != AL_FALSE);
+    snd->idle = !(snd->playing =
+                      !snd->stream ? alurePlaySource(sound_channels[src]->source, enigma::eos_callback,
+                                                     (void *)(ptrdiff_t)sound) != AL_FALSE
+                                   : alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1,
+                                                           enigma::eos_callback, (void *)(ptrdiff_t)sound) != AL_FALSE);
     return src + 200000;
   } else {
     return -1;
   }
 }
 
-int audio_play_sound_at(int sound, as_scalar x, as_scalar y, as_scalar z, as_scalar falloff_ref, as_scalar falloff_max, as_scalar falloff_factor, bool loop, double priority)
-{
+int audio_play_sound_at(int sound, as_scalar x, as_scalar y, as_scalar z, as_scalar falloff_ref, as_scalar falloff_max,
+                        as_scalar falloff_factor, bool loop, double priority) {
   int src = enigma::get_free_channel(priority);
   if (src != -1) {
-    get_sound(snd,sound,0);
-    alSourcei(sound_channels[src]->source, AL_LOOPING, loop?AL_TRUE:AL_FALSE);
-    ALfloat soundPos[3] = { x, y, z };
+    get_sound(snd, sound, 0);
+    alSourcei(sound_channels[src]->source, AL_LOOPING, loop ? AL_TRUE : AL_FALSE);
+    ALfloat soundPos[3] = {x, y, z};
     alSourcefv(sound_channels[src]->source, AL_POSITION, soundPos);
     alSourcef(sound_channels[src]->source, AL_REFERENCE_DISTANCE, falloff_ref);
     alSourcef(sound_channels[src]->source, AL_MAX_DISTANCE, falloff_max);
@@ -148,29 +141,29 @@ int audio_play_sound_at(int sound, as_scalar x, as_scalar y, as_scalar z, as_sca
     alSourcef(sound_channels[src]->source, AL_GAIN, snd->volume);
     sound_channels[src]->priority = priority;
     sound_channels[src]->soundIndex = sound;
-    snd->idle = !(snd->playing = !snd->stream ?
-      alurePlaySource(sound_channels[src]->source, enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE :
-      alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1, enigma::eos_callback,
-        (void*)(ptrdiff_t)sound) != AL_FALSE);
+    snd->idle = !(snd->playing =
+                      !snd->stream ? alurePlaySource(sound_channels[src]->source, enigma::eos_callback,
+                                                     (void *)(ptrdiff_t)sound) != AL_FALSE
+                                   : alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1,
+                                                           enigma::eos_callback, (void *)(ptrdiff_t)sound) != AL_FALSE);
     return src + 200000;
   } else {
     return -1;
   }
 }
 
-int audio_play_sound_on(int emitter, int sound, bool loop, double priority)
-{
-  get_sound(snd,sound,0);
+int audio_play_sound_on(int emitter, int sound, bool loop, double priority) {
+  get_sound(snd, sound, 0);
   SoundEmitter *emit = sound_emitters[emitter];
-  int src = audio_play_sound_at(sound, emit->emitPos[0], emit->emitPos[1], emit->emitPos[2],
-  emit->falloff[0], emit->falloff[1], emit->falloff[2], loop, priority) - 200000;
+  int src = audio_play_sound_at(sound, emit->emitPos[0], emit->emitPos[1], emit->emitPos[2], emit->falloff[0],
+                                emit->falloff[1], emit->falloff[2], loop, priority) -
+            200000;
   alSourcefv(sound_channels[src]->source, AL_VELOCITY, emit->emitVel);
   alSourcei(sound_channels[src]->source, AL_PITCH, emit->pitch);
   return src + 200000;
 }
 
-void audio_stop_sound(int index)
-{
+void audio_stop_sound(int index) {
   if (index >= 200000) {
     alureStopSource(sound_channels[index - 200000]->source, AL_TRUE);
   } else {
@@ -182,8 +175,7 @@ void audio_stop_sound(int index)
   }
 }
 
-void audio_pause_sound(int index)
-{
+void audio_pause_sound(int index) {
   if (index >= 200000) {
     alurePauseSource(sound_channels[index - 200000]->source);
   } else {
@@ -195,8 +187,7 @@ void audio_pause_sound(int index)
   }
 }
 
-void audio_resume_sound(int index)
-{
+void audio_resume_sound(int index) {
   if (index >= 200000) {
     alureResumeSource(sound_channels[index - 200000]->source);
   } else {
@@ -208,46 +199,38 @@ void audio_resume_sound(int index)
   }
 }
 
-void audio_stop_all()
-{
+void audio_stop_all() {
   for (size_t i = 0; i < sound_channels.size(); i++) {
     alureStopSource(sound_channels[i]->source, AL_TRUE);
   }
 }
 
-void audio_pause_all()
-{
+void audio_pause_all() {
   for (size_t i = 0; i < sound_channels.size(); i++) {
     alurePauseSource(sound_channels[i]->source);
   }
 }
 
-void audio_resume_all()
-{
+void audio_resume_all() {
   for (size_t i = 0; i < sound_channels.size(); i++) {
     alureResumeSource(sound_channels[i]->source);
   }
 }
 
-void audio_sound_seek(int index, double offset)
-{
-  alSourcef(sound_channels[index]->source, AL_SEC_OFFSET, offset);
-}
+void audio_sound_seek(int index, double offset) { alSourcef(sound_channels[index]->source, AL_SEC_OFFSET, offset); }
 
-double audio_sound_offset(int index)
-{
+double audio_sound_offset(int index) {
   float offset;
   alGetSourcef(sound_channels[index]->source, AL_SEC_OFFSET, &offset);
   return offset;
 }
 
-int audio_sound_length(int index)
-{
+int audio_sound_length(int index) {
   ALint buffer;
   if (index >= 200000) {
     alGetSourcei(sound_channels[index - 200000]->source, AL_BUFFER, &buffer);
   } else {
-    get_sound(snd,index,0);
+    get_sound(snd, index, 0);
     buffer = snd->buf[0];
   }
   ALint size, bits, channels, freq;
@@ -257,11 +240,10 @@ int audio_sound_length(int index)
   alGetBufferi(buffer, AL_CHANNELS, &channels);
   alGetBufferi(buffer, AL_FREQUENCY, &freq);
 
-  return size / channels / (bits/8) / (float)freq;
+  return size / channels / (bits / 8) / (float)freq;
 }
 
-void audio_sound_gain(int index, float volume, double time)
-{
+void audio_sound_gain(int index, float volume, double time) {
   if (index >= 200000) {
     alSourcef(sound_channels[index - 200000]->source, AL_GAIN, volume);
   } else {
@@ -273,8 +255,7 @@ void audio_sound_gain(int index, float volume, double time)
   }
 }
 
-void audio_sound_pitch(int index, float pitch)
-{
+void audio_sound_pitch(int index, float pitch) {
   if (index >= 200000) {
     alSourcef(sound_channels[index - 200000]->source, AL_PITCH, pitch);
   } else {
@@ -286,8 +267,8 @@ void audio_sound_pitch(int index, float pitch)
   }
 }
 
-void audio_listener_orientation(as_scalar lookat_x, as_scalar lookat_y, as_scalar lookat_z, as_scalar up_x, as_scalar up_y, as_scalar up_z)
-{
+void audio_listener_orientation(as_scalar lookat_x, as_scalar lookat_y, as_scalar lookat_z, as_scalar up_x,
+                                as_scalar up_y, as_scalar up_z) {
   listenerOri[0] = up_x;
   listenerOri[1] = up_y;
   listenerOri[2] = up_z;
@@ -297,50 +278,38 @@ void audio_listener_orientation(as_scalar lookat_x, as_scalar lookat_y, as_scala
   alListenerfv(AL_ORIENTATION, listenerOri);
 }
 
-void audio_listener_position(as_scalar x, as_scalar y, as_scalar z)
-{
+void audio_listener_position(as_scalar x, as_scalar y, as_scalar z) {
   listenerPos[0] = x;
   listenerPos[1] = y;
   listenerPos[2] = z;
   alListenerfv(AL_POSITION, listenerPos);
 }
 
-void audio_listener_velocity(as_scalar vx, as_scalar vy, as_scalar vz)
-{
+void audio_listener_velocity(as_scalar vx, as_scalar vy, as_scalar vz) {
   listenerVel[0] = vx;
   listenerVel[1] = vy;
   listenerVel[2] = vz;
   alListenerfv(AL_VELOCITY, listenerVel);
 }
 
-void audio_master_gain(float volume)
-{
-  alListenerf(AL_GAIN, volume);
-}
+void audio_master_gain(float volume) { alListenerf(AL_GAIN, volume); }
 
-void audio_channel_num(int num) {
-  channel_num = num;
-}
+void audio_channel_num(int num) { channel_num = num; }
 
-int audio_system()
-{
-  return audio_new_system;
-}
+int audio_system() { return audio_new_system; }
 
-int audio_add(string fname)
-{
+int audio_add(string fname) {
   // Decode sound
   int rid = enigma::sound_allocate();
-  bool fail = enigma::sound_add_from_file(rid,fname);
+  bool fail = enigma::sound_add_from_file(rid, fname);
 
   return (fail ? -1 : rid);
 }
 
-void audio_delete(int sound)
-{
-  if (sound_resources.find(sound)!=sound_resources.end()) {
+void audio_delete(int sound) {
+  if (sound_resources.find(sound) != sound_resources.end()) {
     if (sound_resources[sound]) {
-      get_soundv(snd,sound);
+      get_soundv(snd, sound);
       alureDestroyStream(snd->stream, 0, 0);
       delete sound_resources[sound];
       sound_resources[sound] = 0;
@@ -348,63 +317,50 @@ void audio_delete(int sound)
   }
 }
 
-void audio_falloff_set_model(int model)
-{
-  alDistanceModel(falloff_models[model]);
-}
+void audio_falloff_set_model(int model) { alDistanceModel(falloff_models[model]); }
 
-int audio_emitter_create()
-{
+int audio_emitter_create() {
   int i = sound_emitters.size();
   sound_emitters.push_back(new SoundEmitter());
   return i;
 }
 
-bool audio_emitter_exists(int index)
-{
-  return (((unsigned)index < sound_emitters.size()) && (sound_emitters[index]));
-}
+bool audio_emitter_exists(int index) { return (((unsigned)index < sound_emitters.size()) && (sound_emitters[index])); }
 
-void audio_emitter_falloff(int emitter, as_scalar falloff_ref, as_scalar falloff_max, as_scalar falloff_factor)
-{
+void audio_emitter_falloff(int emitter, as_scalar falloff_ref, as_scalar falloff_max, as_scalar falloff_factor) {
   SoundEmitter *emit = sound_emitters[emitter];
   emit->falloff[0] = falloff_ref;
   emit->falloff[1] = falloff_max;
   emit->falloff[2] = falloff_factor;
 }
 
-void audio_emitter_free(int emitter)
-{
+void audio_emitter_free(int emitter) {
   delete sound_emitters[emitter];
   sound_emitters[emitter] = NULL;
 }
 
-void audio_emitter_gain(int emitter, double volume)
-{
+void audio_emitter_gain(int emitter, double volume) {
   SoundEmitter *emit = sound_emitters[emitter];
   emit->volume = volume;
 }
 
-void audio_emitter_pitch(int emitter, double pitch)
-{
+void audio_emitter_pitch(int emitter, double pitch) {
   SoundEmitter *emit = sound_emitters[emitter];
   emit->pitch = pitch;
 }
 
-void audio_emitter_position(int emitter, as_scalar x, as_scalar y, as_scalar z)
-{
+void audio_emitter_position(int emitter, as_scalar x, as_scalar y, as_scalar z) {
   SoundEmitter *emit = sound_emitters[emitter];
   emit->emitPos[0] = x;
   emit->emitPos[1] = y;
   emit->emitPos[2] = z;
 }
 
-void audio_emitter_velocity(int emitter, as_scalar vx, as_scalar vy, as_scalar vz)
-{
+void audio_emitter_velocity(int emitter, as_scalar vx, as_scalar vy, as_scalar vz) {
   SoundEmitter *emit = sound_emitters[emitter];
   emit->emitVel[0] = vx;
   emit->emitVel[1] = vy;
   emit->emitVel[2] = vz;
 }
 
-}
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALbasic.cpp
@@ -19,21 +19,21 @@
 // We don't want to load ALURE from a DLL. Would be kind of a waste.
 #define ALURE_STATIC_LIBRARY 1
 
-#include <string>
-#include <stdio.h>
-#include <stddef.h>
 #include <math.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string>
 using std::string;
 #include "../General/ASbasic.h"
+#include "ALsystem.h"
 #include "Audio_Systems/audio_mandatory.h"
 #include "SoundChannel.h"
-#include "SoundResource.h"
 #include "SoundEmitter.h"
-#include "ALsystem.h"
+#include "SoundResource.h"
 
 #ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
 #include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
 #endif
 
 #include "Universal_System/estring.h"
@@ -41,51 +41,57 @@ using std::string;
 #include <vector>
 using std::vector;
 
-namespace enigma_user
-{
+namespace enigma_user {
 
-bool sound_exists(int sound)
-{
-  return sound_resources.find(sound)!=sound_resources.end() && sound_resources[sound];
-}
+bool sound_exists(int sound) { return sound_resources.find(sound) != sound_resources.end() && sound_resources[sound]; }
 
-bool sound_play(int sound) { // Returns whether sound is playing
+bool sound_play(int sound) {  // Returns whether sound is playing
   int src = enigma::get_free_channel(1);
-  if (src == -1) { return false; }
-  get_sound(snd,sound,false);
+  if (src == -1) {
+    return false;
+  }
+  get_sound(snd, sound, false);
   alSourcei(sound_channels[src]->source, AL_BUFFER, snd->buf[0]);
   alSourcei(sound_channels[src]->source, AL_SOURCE_RELATIVE, AL_TRUE);
   alSourcei(sound_channels[src]->source, AL_REFERENCE_DISTANCE, 1);
   alSourcei(sound_channels[src]->source, AL_LOOPING, AL_FALSE);
   alSourcef(sound_channels[src]->source, AL_GAIN, snd->volume);
   alSourcef(sound_channels[src]->source, AL_PITCH, snd->pitch);
-  float sourcePosAL[] = { snd->pan, 0.0f, 0.0f};
+  float sourcePosAL[] = {snd->pan, 0.0f, 0.0f};
   alSourcefv(sound_channels[src]->source, AL_POSITION, sourcePosAL);
   sound_channels[src]->soundIndex = sound;
-  return !(snd->idle = !(snd->playing = !snd->stream ?
-	alurePlaySource(sound_channels[src]->source, enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE :
-	alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1, enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE));
+  return !(snd->idle =
+               !(snd->playing =
+                     !snd->stream ? alurePlaySource(sound_channels[src]->source, enigma::eos_callback,
+                                                    (void*)(ptrdiff_t)sound) != AL_FALSE
+                                  : alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1,
+                                                          enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE));
 }
 
-bool sound_loop(int sound) { // Returns whether sound is playing
+bool sound_loop(int sound) {  // Returns whether sound is playing
   int src = enigma::get_free_channel(1);
-  if (src == -1) { return false; }
-  get_sound(snd,sound,false);
+  if (src == -1) {
+    return false;
+  }
+  get_sound(snd, sound, false);
   alSourcei(sound_channels[src]->source, AL_BUFFER, snd->buf[0]);
   alSourcei(sound_channels[src]->source, AL_SOURCE_RELATIVE, AL_TRUE);
   alSourcei(sound_channels[src]->source, AL_REFERENCE_DISTANCE, 1);
-  alSourcei(sound_channels[src]->source, AL_LOOPING, AL_TRUE); //Just playing
+  alSourcei(sound_channels[src]->source, AL_LOOPING, AL_TRUE);  //Just playing
   alSourcef(sound_channels[src]->source, AL_GAIN, snd->volume);
   alSourcef(sound_channels[src]->source, AL_PITCH, snd->pitch);
-  float sourcePosAL[] = { snd->pan, 0.0f, 0.0f};
+  float sourcePosAL[] = {snd->pan, 0.0f, 0.0f};
   alSourcefv(sound_channels[src]->source, AL_POSITION, sourcePosAL);
   sound_channels[src]->soundIndex = sound;
-  return !(snd->idle = !(snd->playing = !snd->stream ?
-	alurePlaySource(sound_channels[src]->source, enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE :
-	alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1, enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE));
+  return !(snd->idle =
+               !(snd->playing =
+                     !snd->stream ? alurePlaySource(sound_channels[src]->source, enigma::eos_callback,
+                                                    (void*)(ptrdiff_t)sound) != AL_FALSE
+                                  : alurePlaySourceStream(sound_channels[src]->source, snd->stream, 3, -1,
+                                                          enigma::eos_callback, (void*)(ptrdiff_t)sound) != AL_FALSE));
 }
 
-bool sound_pause(int sound) { // Returns whether the sound was successfully paused
+bool sound_pause(int sound) {  // Returns whether the sound was successfully paused
   for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == sound) {
       return alurePauseSource(sound_channels[i]->source);
@@ -115,9 +121,9 @@ void sound_stop_all() {
 }
 
 void sound_delete(int sound) {
-  if (sound_resources.find(sound)!=sound_resources.end()) {
+  if (sound_resources.find(sound) != sound_resources.end()) {
     if (sound_resources[sound]) {
-      get_soundv(snd,sound);
+      get_soundv(snd, sound);
       alureDestroyStream(snd->stream, 0, 0);
       delete sound_resources[sound];
       sound_resources[sound] = 0;
@@ -126,18 +132,18 @@ void sound_delete(int sound) {
 }
 
 void sound_pan(int sound, float value) {
-  get_soundv(snd,sound);
+  get_soundv(snd, sound);
   snd->pan = value;
   for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == sound) {
-      float sourcePosAL[] = { value, 0.0f, 0.0f};
+      float sourcePosAL[] = {value, 0.0f, 0.0f};
       alSourcefv(sound_channels[i]->source, AL_POSITION, sourcePosAL);
     }
   }
 }
 
 void sound_volume(int sound, float value) {
-  get_soundv(snd,sound);
+  get_soundv(snd, sound);
   snd->volume = value;
   for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == sound) {
@@ -147,7 +153,7 @@ void sound_volume(int sound, float value) {
 }
 
 void sound_pitch(int sound, float value) {
-  get_soundv(snd,sound);
+  get_soundv(snd, sound);
   snd->pitch = value;
   for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == sound) {
@@ -156,11 +162,9 @@ void sound_pitch(int sound, float value) {
   }
 }
 
-void sound_global_volume(float mastervolume) {
-    alListenerf(AL_GAIN, mastervolume);
-}
+void sound_global_volume(float mastervolume) { alListenerf(AL_GAIN, mastervolume); }
 
-bool sound_resume(int sound) // Returns whether the sound is playing
+bool sound_resume(int sound)  // Returns whether the sound is playing
 {
   for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == sound) {
@@ -170,8 +174,7 @@ bool sound_resume(int sound) // Returns whether the sound is playing
   return false;
 }
 
-void sound_resume_all()
-{
+void sound_resume_all() {
   for (size_t i = 0; i < sound_channels.size(); i++) {
     alureResumeSource(sound_channels[i]->source);
   }
@@ -179,13 +182,11 @@ void sound_resume_all()
 
 bool sound_isplaying(int sound) {
   // test for channels playing the sound
-  for (size_t i = 0; i < sound_channels.size(); i++)
-  {
+  for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == sound) {
       ALint state;
       alGetSourcei(sound_channels[i]->source, AL_SOURCE_STATE, &state);
-      if (state == AL_PLAYING)
-      {
+      if (state == AL_PLAYING) {
         return true;
       }
     }
@@ -193,12 +194,10 @@ bool sound_isplaying(int sound) {
   return false;
 }
 
-bool sound_ispaused(int sound) {
-  return !sound_resources[sound]->idle and !sound_resources[sound]->playing;
-}
+bool sound_ispaused(int sound) { return !sound_resources[sound]->idle and !sound_resources[sound]->playing; }
 
-float sound_get_length(int sound) { // Not for Streams
-  get_sound(snd,sound,0.0);
+float sound_get_length(int sound) {  // Not for Streams
+  get_sound(snd, sound, 0.0);
   ALint size, bits, channels, freq;
 
   alGetBufferi(snd->buf[0], AL_SIZE, &size);
@@ -206,124 +205,105 @@ float sound_get_length(int sound) { // Not for Streams
   alGetBufferi(snd->buf[0], AL_CHANNELS, &channels);
   alGetBufferi(snd->buf[0], AL_FREQUENCY, &freq);
 
-  return size / channels / (bits/8) / (float)freq;
+  return size / channels / (bits / 8) / (float)freq;
 }
 
-float sound_get_pan(int sound){  // Not for Streams
-  get_sound(snd,sound,0.0);
+float sound_get_pan(int sound) {  // Not for Streams
+  get_sound(snd, sound, 0.0);
   return snd->pan;
 }
 
-float sound_get_volume(int sound){
-  get_sound(snd,sound,0.0);
+float sound_get_volume(int sound) {
+  get_sound(snd, sound, 0.0);
   return snd->volume;
 }
 
-float sound_get_position(int sound) { // Not for Streams
+float sound_get_position(int sound) {  // Not for Streams
   float offset = -1;
   for (size_t i = 0; i < sound_channels.size(); i++) {
-    if (sound_channels[i]->soundIndex == sound)
-      alGetSourcef(sound_channels[i]->source, AL_SEC_OFFSET, &offset);
+    if (sound_channels[i]->soundIndex == sound) alGetSourcef(sound_channels[i]->source, AL_SEC_OFFSET, &offset);
   }
   return offset;
 }
 
 void sound_seek(int sound, float position) {
-  get_soundv(snd,sound);
-  if (snd->seek) snd->seek(snd->userdata, position); // Streams
+  get_soundv(snd, sound);
+  if (snd->seek) snd->seek(snd->userdata, position);  // Streams
   for (size_t i = 0; i < sound_channels.size(); i++) {
     if (sound_channels[i]->soundIndex == sound) {
-      alSourcef(sound_channels[i]->source, AL_SEC_OFFSET, position); // Non Streams
+      alSourcef(sound_channels[i]->source, AL_SEC_OFFSET, position);  // Non Streams
     }
   }
 }
 
 void sound_seek_all(float position) {
-  for (std::map<int, SoundResource*>::iterator it=sound_resources.begin(); it!=sound_resources.end(); it++) {
+  for (std::map<int, SoundResource*>::iterator it = sound_resources.begin(); it != sound_resources.end(); it++) {
     SoundResource* sr = it->second;
-    if(sr) {
-      if (sr->seek) sr->seek(sr->userdata, position); // Streams
+    if (sr) {
+      if (sr->seek) sr->seek(sr->userdata, position);  // Streams
     }
   }
 
-  for(size_t i = 0; i < sound_channels.size(); i++) {
-    alSourcef(sound_channels[i]->source, AL_SEC_OFFSET, position); // Non Streams
+  for (size_t i = 0; i < sound_channels.size(); i++) {
+    alSourcef(sound_channels[i]->source, AL_SEC_OFFSET, position);  // Non Streams
   }
 }
 
-void action_sound(int snd, bool loop)
-{
-  (loop ? sound_loop:sound_play)(snd);
-}
+void action_sound(int snd, bool loop) { (loop ? sound_loop : sound_play)(snd); }
 
-const char* sound_get_audio_error() {
-  return alureGetErrorString();
-}
+const char* sound_get_audio_error() { return alureGetErrorString(); }
 
-}
+}  // namespace enigma_user
 
 #include <string>
 using namespace std;
 extern void show_message(string);
 
-namespace enigma_user
-{
+namespace enigma_user {
 
-int sound_add(string fname, int kind, bool preload) //At the moment, the latter two arguments do nothing! =D
+int sound_add(string fname, int kind, bool preload)  //At the moment, the latter two arguments do nothing! =D
 {
   // Decode sound
   int rid = enigma::sound_allocate();
-  bool fail = enigma::sound_add_from_file(rid,fname);
+  bool fail = enigma::sound_add_from_file(rid, fname);
 
   return (fail ? -1 : rid);
 }
 
-bool sound_replace(int sound, string fname, int kind, bool preload)
-{
-  if (sound_resources.find(sound)!=sound_resources.end() && sound_resources[sound]) {
-    get_sound(snd,sound,false);
+bool sound_replace(int sound, string fname, int kind, bool preload) {
+  if (sound_resources.find(sound) != sound_resources.end() && sound_resources[sound]) {
+    get_sound(snd, sound, false);
     alureDestroyStream(snd->stream, 0, 0);
   }
 
-  return enigma::sound_replace_from_file(sound,fname);
+  return enigma::sound_replace_from_file(sound, fname);
 }
 
-void sound_3d_set_sound_cone(int sound, float x, float y, float z, double anglein, double angleout, long voloutside) {
-}
+void sound_3d_set_sound_cone(int sound, float x, float y, float z, double anglein, double angleout, long voloutside) {}
 
-void sound_3d_set_sound_distance(int sound, float mindist, float maxdist) {
-}
+void sound_3d_set_sound_distance(int sound, float mindist, float maxdist) {}
 
-void sound_3d_set_sound_position(int sound, float x, float y, float z) {
-}
+void sound_3d_set_sound_position(int sound, float x, float y, float z) {}
 
-void sound_3d_set_sound_velocity(int sound, float x, float y, float z) {
-}
+void sound_3d_set_sound_velocity(int sound, float x, float y, float z) {}
 
-void sound_effect_chorus(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay, long phase) {
+void sound_effect_chorus(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay,
+                         long phase) {}
 
-}
+void sound_effect_compressor(int sound, float gain, float attack, float release, float threshold, float ratio,
+                             float delay) {}
 
-void sound_effect_compressor(int sound, float gain, float attack, float release, float threshold, float ratio, float delay) {
-}
+void sound_effect_echo(int sound, float wetdry, float feedback, float leftdelay, float rightdelay, long pandelay) {}
 
-void sound_effect_echo(int sound, float wetdry, float feedback, float leftdelay, float rightdelay, long pandelay) {
-}
+void sound_effect_equalizer(int sound, float center, float bandwidth, float gain) {}
 
-void sound_effect_equalizer(int sound, float center, float bandwidth, float gain) {
-}
+void sound_effect_flanger(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay,
+                          long phase) {}
 
-void sound_effect_flanger(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay, long phase) {
-}
+void sound_effect_gargle(int sound, unsigned rate, unsigned wave) {}
 
-void sound_effect_gargle(int sound, unsigned rate, unsigned wave) {
-}
+void sound_effect_reverb(int sound, float gain, float mix, float time, float ratio) {}
 
-void sound_effect_reverb(int sound, float gain, float mix, float time, float ratio) {
-}
+void sound_effect_set(int sound, int effect) {}
 
-void sound_effect_set(int sound, int effect) {
-
-}
-
-}
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALsystem.cpp
@@ -19,10 +19,10 @@
 
 #include "ALsystem.h"
 #include "SoundChannel.h"
-#include "SoundResource.h"
 #include "SoundEmitter.h"
+#include "SoundResource.h"
 
-#include "Widget_Systems/widgets_mandatory.h" // show_error
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
 
 #include <time.h>
 clock_t starttime;
@@ -30,221 +30,220 @@ clock_t elapsedtime;
 clock_t lasttime;
 
 #include <stdio.h>
-#include <vector>
 #include <map>
-using std::vector;
+#include <vector>
 using std::map;
+using std::vector;
 
 bool load_al_dll();
 size_t channel_num = 128;
 
-ALfloat listenerPos[] = {0.0f,0.0f,0.0f};
-ALfloat listenerVel[] = {0.0f,0.0f,0.0f};
-ALfloat listenerOri[] = {0.0f,0.0f,1.0f, 0.0f,1.0f,0.0f};
+ALfloat listenerPos[] = {0.0f, 0.0f, 0.0f};
+ALfloat listenerVel[] = {0.0f, 0.0f, 0.0f};
+ALfloat listenerOri[] = {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f};
 
-vector<SoundChannel*> sound_channels(0);
-map<int, SoundResource*> sound_resources;
-vector<SoundEmitter*> sound_emitters(0);
+vector<SoundChannel *> sound_channels(0);
+map<int, SoundResource *> sound_resources;
+vector<SoundEmitter *> sound_emitters(0);
 
-list<ALuint> garbageBuffers; // OpenAL buffers queued for deletion
+list<ALuint> garbageBuffers;  // OpenAL buffers queued for deletion
 
 namespace {
-int next_sound_id = 0; //ID of the next sound to allocate (GM does not actually re-use sound IDs).
+int next_sound_id = 0;  //ID of the next sound to allocate (GM does not actually re-use sound IDs).
 }
 
 namespace enigma {
-  int get_free_channel(double priority)
-  {
-    // test for channels not playing anything
-    for (size_t i = 0; i < sound_channels.size(); i++) {
-      ALint state;
-      alGetSourcei(sound_channels[i]->source, AL_SOURCE_STATE, &state);
-      if (state != AL_PLAYING) {
-        return i;
-      }
-    }
-    // finally if you still couldnt find an empty channel, and we have a few more we can generate
-    // go ahead and generate a new one
-    if (sound_channels.size() < channel_num) {
-      int i = sound_channels.size();
-      ALuint src;
-      alGenSources(1, &src);
-      SoundChannel* sndsrc = new SoundChannel(src,-1);
-      sound_channels.push_back(sndsrc);
+int get_free_channel(double priority) {
+  // test for channels not playing anything
+  for (size_t i = 0; i < sound_channels.size(); i++) {
+    ALint state;
+    alGetSourcei(sound_channels[i]->source, AL_SOURCE_STATE, &state);
+    if (state != AL_PLAYING) {
       return i;
     }
-    // test for channels playing a lower priority sound, and take their spot if they are
-    for (size_t i = 0; i < sound_channels.size(); i++) {
-      if (sound_channels[i]->priority < priority) {
-        return i;
-      }
+  }
+  // finally if you still couldnt find an empty channel, and we have a few more we can generate
+  // go ahead and generate a new one
+  if (sound_channels.size() < channel_num) {
+    int i = sound_channels.size();
+    ALuint src;
+    alGenSources(1, &src);
+    SoundChannel *sndsrc = new SoundChannel(src, -1);
+    sound_channels.push_back(sndsrc);
+    return i;
+  }
+  // test for channels playing a lower priority sound, and take their spot if they are
+  for (size_t i = 0; i < sound_channels.size(); i++) {
+    if (sound_channels[i]->priority < priority) {
+      return i;
     }
-
-    return -1;
   }
 
-  void eos_callback(void *soundID, ALuint src)
-  {
-    get_sound(snd, (ptrdiff_t)soundID, );
-    snd->playing = false;
-    snd->idle = true;
-  }
+  return -1;
+}
 
-  int audiosystem_initialize()
-  {
-    starttime = clock();
-    elapsedtime = starttime;
-    lasttime = elapsedtime;
-    printf("Initializing audio system...\n");
+void eos_callback(void *soundID, ALuint src) {
+  get_sound(snd, (ptrdiff_t)soundID, );
+  snd->playing = false;
+  snd->idle = true;
+}
 
-    /*#ifdef _WIN32
+int audiosystem_initialize() {
+  starttime = clock();
+  elapsedtime = starttime;
+  lasttime = elapsedtime;
+  printf("Initializing audio system...\n");
+
+  /*#ifdef _WIN32
     if (!load_al_dll())
       return 1;
 	printf("Starting ALURE (Windows thing).\n");
 	init_alure();
     #endif*/
 
-    printf("Opening ALURE devices.\n");
-    if(!alureInitDevice(NULL, NULL)) {
-      fprintf(stderr, "Failed to open OpenAL device: %s\n", alureGetErrorString());
-      return 1;
-    }
-
-    return 0;
+  printf("Opening ALURE devices.\n");
+  if (!alureInitDevice(NULL, NULL)) {
+    fprintf(stderr, "Failed to open OpenAL device: %s\n", alureGetErrorString());
+    return 1;
   }
 
-  int sound_add_from_buffer(int id, void* buffer, size_t bufsize)
-  {
-    SoundResource *snd = new SoundResource();
-    sound_resources[id] = snd;
-    if (id>=next_sound_id) { next_sound_id=id+1; }
-
-    ALuint& buf = snd->buf[0];
-    buf = alureCreateBufferFromMemory((ALubyte*)buffer, bufsize);
-
-    if(!buf) {
-      fprintf(stderr, "Could not load sound %d from memory buffer: %s\n", id, alureGetErrorString());
-      return 1;
-    }
-
-    snd->loaded = LOADSTATE_COMPLETE;
-    return 0;
-  }
-
-  int sound_add_from_file(int id, string fname)
-  {
-    SoundResource *snd = new SoundResource();
-    sound_resources[id] = snd;
-    if (id>=next_sound_id) { next_sound_id=id+1; }
-
-    ALuint& buf = snd->buf[0];
-    buf = alureCreateBufferFromFile(fname.c_str());
-
-    if(!buf) {
-      fprintf(stderr, "Could not add sound %d from file %s: %s\n", id, fname.c_str(), alureGetErrorString());
-      return 1;
-    }
-
-    snd->loaded = LOADSTATE_COMPLETE;
-    return 0;
-  }
-
-  int sound_replace_from_file(int id, string fname)
-  {
-    get_sound(snd, id, -1);
-
-    ALuint& buf = snd->buf[0];
-    garbageBuffers.push_back(buf);
-    buf = alureCreateBufferFromFile(fname.c_str());
-
-    if (!buf) {
-      fprintf(stderr, "Could not replace sound %d from file %s: %s\n", id, fname.c_str(), alureGetErrorString());
-      return 1;
-    }
-
-    snd->loaded = LOADSTATE_COMPLETE;
-    return 0;
-  }
-
-  int sound_add_from_stream(int id, size_t (*callback)(void *userdata, void *buffer, size_t size), void (*seek)(void *userdata, float position), void (*cleanup)(void *userdata), void *userdata)
-  {
-    SoundResource *snd = new SoundResource();
-    sound_resources[id] = snd;
-    if (id>=next_sound_id) { next_sound_id=id+1; }
-
-    snd->stream = alureCreateStreamFromCallback((ALuint (*)(void*, ALubyte*, ALuint))callback, userdata, AL_FORMAT_STEREO16, 44100, 4096, 0, NULL);
-    if (!snd->stream) {
-      fprintf(stderr, "Could not create stream %d: %s\n", id, alureGetErrorString());
-      return 1;
-    }
-    snd->cleanup = cleanup;
-    snd->userdata = userdata;
-    snd->seek = seek;
-
-    snd->loaded = LOADSTATE_COMPLETE;
-    return 0;
-  }
-
-  int sound_allocate()
-  {
-    int id = next_sound_id++;
-    sound_resources[id] = NULL;
-    return id;
-  }
-
-  void audiosystem_update(void)
-  {
-    map<ALuint, int> bufferReferences;
-    // count how many sources are still referencing each buffer
-    for (SoundChannel* channel : sound_channels) {
-      ALint buffer, state;
-      alGetSourcei(channel->source, AL_BUFFER, &buffer);
-      alGetSourcei(channel->source, AL_SOURCE_STATE, &state);
-
-      bufferReferences[buffer] += (state == AL_PLAYING);
-    }
-    // remove garbage buffers that are no longer referenced by sources
-    for (auto it = garbageBuffers.begin(); it != garbageBuffers.end();) {
-      ALuint buffer = *it;
-      if (bufferReferences.find(buffer) == bufferReferences.end()) {
-        alDeleteBuffers(1, &buffer);
-        it = garbageBuffers.erase(it);
-      } else {
-        ++it;
-      }
-    }
-    alureUpdate();
-  }
-
-  void audiosystem_cleanup()
-  {
-    // cleanup sound resources
-    for (std::map<int, SoundResource*>::iterator it=sound_resources.begin(); it!=sound_resources.end(); it++)
-    {
-      SoundResource* sr = it->second;
-      if (!sr) { continue; }
-      switch (sr->loaded)
-      {
-        case LOADSTATE_COMPLETE:
-          alDeleteBuffers(sr->stream ? 3 : 1, sr->buf);
-          if (sr->stream) {
-            alureDestroyStream(sr->stream, 0, 0);
-            if (sr->cleanup) sr->cleanup(sr->userdata);
-          }
-        // fallthrough
-        case LOADSTATE_INDICATED:
-        case LOADSTATE_NONE:
-        default: ;
-      }
-    }
-
-    // cleanup sound channels
-    for (size_t j = 0; j < sound_channels.size(); j++) {
-      alureStopSource(sound_channels[j]->source, true);
-      alDeleteSources(1, &sound_channels[j]->source);
-    }
-
-    alureShutdownDevice();
-  }
-
+  return 0;
 }
+
+int sound_add_from_buffer(int id, void *buffer, size_t bufsize) {
+  SoundResource *snd = new SoundResource();
+  sound_resources[id] = snd;
+  if (id >= next_sound_id) {
+    next_sound_id = id + 1;
+  }
+
+  ALuint &buf = snd->buf[0];
+  buf = alureCreateBufferFromMemory((ALubyte *)buffer, bufsize);
+
+  if (!buf) {
+    fprintf(stderr, "Could not load sound %d from memory buffer: %s\n", id, alureGetErrorString());
+    return 1;
+  }
+
+  snd->loaded = LOADSTATE_COMPLETE;
+  return 0;
+}
+
+int sound_add_from_file(int id, string fname) {
+  SoundResource *snd = new SoundResource();
+  sound_resources[id] = snd;
+  if (id >= next_sound_id) {
+    next_sound_id = id + 1;
+  }
+
+  ALuint &buf = snd->buf[0];
+  buf = alureCreateBufferFromFile(fname.c_str());
+
+  if (!buf) {
+    fprintf(stderr, "Could not add sound %d from file %s: %s\n", id, fname.c_str(), alureGetErrorString());
+    return 1;
+  }
+
+  snd->loaded = LOADSTATE_COMPLETE;
+  return 0;
+}
+
+int sound_replace_from_file(int id, string fname) {
+  get_sound(snd, id, -1);
+
+  ALuint &buf = snd->buf[0];
+  garbageBuffers.push_back(buf);
+  buf = alureCreateBufferFromFile(fname.c_str());
+
+  if (!buf) {
+    fprintf(stderr, "Could not replace sound %d from file %s: %s\n", id, fname.c_str(), alureGetErrorString());
+    return 1;
+  }
+
+  snd->loaded = LOADSTATE_COMPLETE;
+  return 0;
+}
+
+int sound_add_from_stream(int id, size_t (*callback)(void *userdata, void *buffer, size_t size),
+                          void (*seek)(void *userdata, float position), void (*cleanup)(void *userdata),
+                          void *userdata) {
+  SoundResource *snd = new SoundResource();
+  sound_resources[id] = snd;
+  if (id >= next_sound_id) {
+    next_sound_id = id + 1;
+  }
+
+  snd->stream = alureCreateStreamFromCallback((ALuint(*)(void *, ALubyte *, ALuint))callback, userdata,
+                                              AL_FORMAT_STEREO16, 44100, 4096, 0, NULL);
+  if (!snd->stream) {
+    fprintf(stderr, "Could not create stream %d: %s\n", id, alureGetErrorString());
+    return 1;
+  }
+  snd->cleanup = cleanup;
+  snd->userdata = userdata;
+  snd->seek = seek;
+
+  snd->loaded = LOADSTATE_COMPLETE;
+  return 0;
+}
+
+int sound_allocate() {
+  int id = next_sound_id++;
+  sound_resources[id] = NULL;
+  return id;
+}
+
+void audiosystem_update(void) {
+  map<ALuint, int> bufferReferences;
+  // count how many sources are still referencing each buffer
+  for (SoundChannel *channel : sound_channels) {
+    ALint buffer, state;
+    alGetSourcei(channel->source, AL_BUFFER, &buffer);
+    alGetSourcei(channel->source, AL_SOURCE_STATE, &state);
+
+    bufferReferences[buffer] += (state == AL_PLAYING);
+  }
+  // remove garbage buffers that are no longer referenced by sources
+  for (auto it = garbageBuffers.begin(); it != garbageBuffers.end();) {
+    ALuint buffer = *it;
+    if (bufferReferences.find(buffer) == bufferReferences.end()) {
+      alDeleteBuffers(1, &buffer);
+      it = garbageBuffers.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  alureUpdate();
+}
+
+void audiosystem_cleanup() {
+  // cleanup sound resources
+  for (std::map<int, SoundResource *>::iterator it = sound_resources.begin(); it != sound_resources.end(); it++) {
+    SoundResource *sr = it->second;
+    if (!sr) {
+      continue;
+    }
+    switch (sr->loaded) {
+      case LOADSTATE_COMPLETE:
+        alDeleteBuffers(sr->stream ? 3 : 1, sr->buf);
+        if (sr->stream) {
+          alureDestroyStream(sr->stream, 0, 0);
+          if (sr->cleanup) sr->cleanup(sr->userdata);
+        }
+      // fallthrough
+      case LOADSTATE_INDICATED:
+      case LOADSTATE_NONE:
+      default:;
+    }
+  }
+
+  // cleanup sound channels
+  for (size_t j = 0; j < sound_channels.size(); j++) {
+    alureStopSource(sound_channels[j]->source, true);
+    alDeleteSources(1, &sound_channels[j]->source);
+  }
+
+  alureShutdownDevice();
+}
+
+}  // namespace enigma

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALsystem.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALsystem.h
@@ -43,40 +43,44 @@ extern list<ALuint> garbageBuffers;
 #include "SoundResource.h"
 
 namespace enigma {
-  extern size_t sound_idmax;
+extern size_t sound_idmax;
 
-  int get_free_channel(double priority);
+int get_free_channel(double priority);
 
-  #ifdef DEBUG_MODE
-    #define get_sound(snd,id,failure)\
-      if (id < 0 or sound_resources.find(id)==sound_resources.end() or !sound_resources[id]) {\
-        show_error("Sound " + enigma_user::toString(id) + " does not exist", false);\
-        return failure;\
-      } SoundResource *const snd = sound_resources[id];
-    #define get_soundv(snd,id)\
-      if (id < 0 or sound_resources.find(id)==sound_resources.end() or !sound_resources[id]) {\
-        show_error("Sound " + enigma_user::toString(id) + " does not exist", false);\
-        return;\
-      } SoundResource *const snd = sound_resources[id];
-  #else
-    #define get_sound(snd,id,failure)\
-      if (id < 0) return failure;\
-      SoundResource *const snd = sound_resources[id];
-    #define get_soundv(snd,id)\
-      if (id < 0) return;\
-      SoundResource *const snd = sound_resources[id];
-  #endif
+#ifdef DEBUG_MODE
+#define get_sound(snd, id, failure)                                                          \
+  if (id < 0 or sound_resources.find(id) == sound_resources.end() or !sound_resources[id]) { \
+    show_error("Sound " + enigma_user::toString(id) + " does not exist", false);             \
+    return failure;                                                                          \
+  }                                                                                          \
+  SoundResource *const snd = sound_resources[id];
+#define get_soundv(snd, id)                                                                  \
+  if (id < 0 or sound_resources.find(id) == sound_resources.end() or !sound_resources[id]) { \
+    show_error("Sound " + enigma_user::toString(id) + " does not exist", false);             \
+    return;                                                                                  \
+  }                                                                                          \
+  SoundResource *const snd = sound_resources[id];
+#else
+#define get_sound(snd, id, failure) \
+  if (id < 0) return failure;       \
+  SoundResource *const snd = sound_resources[id];
+#define get_soundv(snd, id) \
+  if (id < 0) return;       \
+  SoundResource *const snd = sound_resources[id];
+#endif
 
-  void eos_callback(void *soundID, ALuint src);
-  int audiosystem_initialize();
-  SoundResource* sound_new_with_source();
-  int sound_add_from_buffer(int id, void* buffer, size_t bufsize);
-  int sound_add_from_file(int id, string fname);
-  int sound_replace_from_file(int id, string fname);
-  int sound_add_from_stream(int id, size_t (*callback)(void *userdata, void *buffer, size_t size), void (*seek)(void *userdata, float position), void (*cleanup)(void *userdata), void *userdata);
-  int sound_allocate();
-  void audiosystem_update(void);
-  void audiosystem_cleanup();
-}
+void eos_callback(void *soundID, ALuint src);
+int audiosystem_initialize();
+SoundResource *sound_new_with_source();
+int sound_add_from_buffer(int id, void *buffer, size_t bufsize);
+int sound_add_from_file(int id, string fname);
+int sound_replace_from_file(int id, string fname);
+int sound_add_from_stream(int id, size_t (*callback)(void *userdata, void *buffer, size_t size),
+                          void (*seek)(void *userdata, float position), void (*cleanup)(void *userdata),
+                          void *userdata);
+int sound_allocate();
+void audiosystem_update(void);
+void audiosystem_cleanup();
+}  // namespace enigma
 
 #endif

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundChannel.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundChannel.h
@@ -21,20 +21,19 @@
 #include "ALsystem.h"
 
 #ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
 #include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
 #endif
 
 #include <vector>
 using std::vector;
 
 struct SoundChannel {
-ALuint source;
-int soundIndex;
-double priority;
-SoundChannel(ALuint alsource, int sound_id): source(alsource), soundIndex(sound_id), priority(0) {}
-~SoundChannel() {}
-
+  ALuint source;
+  int soundIndex;
+  double priority;
+  SoundChannel(ALuint alsource, int sound_id) : source(alsource), soundIndex(sound_id), priority(0) {}
+  ~SoundChannel() {}
 };
 
 extern vector<SoundChannel*> sound_channels;

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundEmitter.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundEmitter.h
@@ -21,29 +21,24 @@
 #include "ALsystem.h"
 
 #ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
 #include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
 #endif
 
 #include <vector>
 using std::vector;
 
-struct SoundEmitter
-{
+struct SoundEmitter {
   ALfloat emitPos[3];
   ALfloat emitVel[3];
   ALfloat falloff[3];
   ALfloat pitch;
   ALfloat volume;
   vector<int> sound_tracks;
-  SoundEmitter()
-  {
-	  emitPos[0] = emitPos[1] = emitPos[2] = 0.0f,
-	  emitVel[0] = emitVel[1] = emitVel[2] = 0.0f,
-	  falloff[0] = 100.0f, falloff[1] = 300.0f, falloff[2] = 1.0f,
-	  volume = 1.0f;
-   }
-
+  SoundEmitter() {
+    emitPos[0] = emitPos[1] = emitPos[2] = 0.0f, emitVel[0] = emitVel[1] = emitVel[2] = 0.0f, falloff[0] = 100.0f,
+    falloff[1] = 300.0f, falloff[2] = 1.0f, volume = 1.0f;
+  }
 };
 
 extern vector<SoundEmitter*> sound_emitters;

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundResource.h
@@ -22,43 +22,41 @@
 #include "ALsystem.h"
 
 #ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
 #include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
 #endif
 
 #include <map>
 
-enum load_state {
-    LOADSTATE_NONE,
-    LOADSTATE_INDICATED,
-    LOADSTATE_COMPLETE
+enum load_state { LOADSTATE_NONE, LOADSTATE_INDICATED, LOADSTATE_COMPLETE };
+
+struct SoundResource {
+  ALuint buf[3];                                 // The buffer-id of the sound data
+  alureStream *stream;                           // optional stream
+  void (*cleanup)(void *userdata);               // optional cleanup callback for streams
+  void *userdata;                                // optional userdata for streams
+  void (*seek)(void *userdata, float position);  // optional seeking
+  int kind;                                      //
+  float volume;
+  float pan;
+  float pitch;
+
+  load_state loaded;  // Degree to which this sound has been loaded successfully
+  bool idle;          // True if this sound is not being used, false if playing or paused.
+  bool playing;       // True if this sound is playing; not paused or idle.
+
+  SoundResource() : stream(0), cleanup(0), userdata(0), seek(0), kind(0), loaded(LOADSTATE_NONE), idle(1), playing(0) {
+    buf[0] = 0;
+    buf[1] = 0;
+    buf[2] = 0;
+    volume = 1.0f;
+    pan = 0.0f;
+    pitch = 1.0f;
+  }
+
+  ~SoundResource() { garbageBuffers.push_back(buf[0]); }
 };
 
-struct SoundResource
-{
-    ALuint buf[3]; // The buffer-id of the sound data
-    alureStream *stream; // optional stream
-    void (*cleanup)(void *userdata); // optional cleanup callback for streams
-    void *userdata; // optional userdata for streams
-    void (*seek)(void *userdata, float position); // optional seeking
-	int kind; //
-	float volume;
-	float pan;
-	float pitch;
-
-    load_state loaded;   // Degree to which this sound has been loaded successfully
-    bool idle;    // True if this sound is not being used, false if playing or paused.
-    bool playing; // True if this sound is playing; not paused or idle.
-
-	SoundResource(): stream(0), cleanup(0), userdata(0), seek(0), kind(0), loaded(LOADSTATE_NONE), idle(1), playing(0) {
-		buf[0] = 0; buf[1] = 0; buf[2] = 0; volume = 1.0f; pan = 0.0f; pitch = 1.0f;
-	}
-
-	~SoundResource() {
-        garbageBuffers.push_back(buf[0]);
-	}
-};
-
-extern std::map<int, SoundResource*> sound_resources;
+extern std::map<int, SoundResource *> sound_resources;
 
 #endif

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/include.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/include.h
@@ -1,2 +1,2 @@
-#include "../General/ASbasic.h"
 #include "../General/ASadvanced.h"
+#include "../General/ASbasic.h"


### PR DESCRIPTION
I am continuing this from #1219 to pave the way for future work on these two systems (OpenAL and DirectSound). All I did was run the clang formatting tool using the `.clang-format` settings on the two directories for `*.h` and `*.cpp` files and then open each file to check it looked good.
```bash
clang-format -i -style=file *.cpp
clang-format -i -style=file *.h
```

This formatting was an utter mess as far as tabs and spaces mixture (I know Graphics systems are really bad too). The messed up formatting made it really hard for me to even do #1219. Maybe, after we do all this, we'll configure a stylecheck for the repo too to prevent this stuff from happening again.

I know formatting changes shouldn't break anything, but I just don't trust the CI enough, so I ran the `sound_replace` tests as well as the FPS example again in both OpenAL and DirectSound to ensure the #1219 issues are still fixed. Long story short, they are. 👍 