### PR TITLE
System Bridges Clang Tool Reformat

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
@@ -16,58 +16,53 @@
 **/
 
 #include "../General/glxew.h"
-#include "Platforms/Cocoa/CocoaMain.h"
-#include "Graphics_Systems/graphics_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/graphics_mandatory.h"
+#include "Platforms/Cocoa/CocoaMain.h"
+#include "Platforms/General/PFwindow.h"
 
-#include <iostream>
 #include <cstring>
+#include <iostream>
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL3 version.
 
 extern "C" {
-  void cocoa_screen_refresh();
-  void cocoa_flush_opengl();
+void cocoa_screen_refresh();
+void cocoa_flush_opengl();
 }
 
 namespace enigma {
-  GLuint msaa_fbo = 0;
-  
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
-    // clear the window color, viewport does not need set because backbuffer was just recreated
-    glViewport(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
-    glScissor(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
-    enigma_user::draw_clear(enigma_user::window_get_color());
-  }
+GLuint msaa_fbo = 0;
 
-  void SetResizeFptr() {
-    WindowResizedCallback = &WindowResized;
-  }
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  // clear the window color, viewport does not need set because backbuffer was just recreated
+  glViewport(0, 0, enigma_user::window_get_width(), enigma_user::window_get_height());
+  glScissor(0, 0, enigma_user::window_get_width(), enigma_user::window_get_height());
+  enigma_user::draw_clear(enigma_user::window_get_color());
 }
 
-#include "Platforms/General/PFwindow.h" // window_set_caption
-#include "Universal_System/roomsystem.h" // room_caption, update_mouse_variables
+void SetResizeFptr() { WindowResizedCallback = &WindowResized; }
+}  // namespace enigma
+
+#include "Platforms/General/PFwindow.h"   // window_set_caption
+#include "Universal_System/roomsystem.h"  // room_caption, update_mouse_variables
 
 namespace enigma_user {
-  // Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
-  int display_aa = 14;
+// Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
+int display_aa = 14;
 
-  void set_synchronization(bool enable) {
+void set_synchronization(bool enable) {}
 
-  }
-    
-  void display_reset(int samples, bool vsync) {
-    set_synchronization(vsync);
-    //TODO: Copy over from the Win32 bridge
-  }
-    
-  void screen_refresh() {
-    cocoa_screen_refresh();
-    enigma::update_mouse_variables();
-    cocoa_flush_opengl();
-  }
-
+void display_reset(int samples, bool vsync) {
+  set_synchronization(vsync);
+  //TODO: Copy over from the Win32 bridge
 }
 
+void screen_refresh() {
+  cocoa_screen_refresh();
+  enigma::update_mouse_variables();
+  cocoa_flush_opengl();
+}
+
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
@@ -16,58 +16,53 @@
 **/
 
 #include "../General/glxew.h"
-#include "Platforms/Cocoa/CocoaMain.h"
-#include "Graphics_Systems/graphics_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/graphics_mandatory.h"
+#include "Platforms/Cocoa/CocoaMain.h"
+#include "Platforms/General/PFwindow.h"
 
-#include <iostream>
 #include <cstring>
+#include <iostream>
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL3 version.
 
 extern "C" {
-  void cocoa_screen_refresh();
-  void cocoa_flush_opengl();
+void cocoa_screen_refresh();
+void cocoa_flush_opengl();
 }
 
 namespace enigma {
-  GLuint msaa_fbo = 0;
-  
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
-    // clear the window color, viewport does not need set because backbuffer was just recreated
-    glViewport(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
-    glScissor(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
-    enigma_user::draw_clear(enigma_user::window_get_color());
-  }
+GLuint msaa_fbo = 0;
 
-  void SetResizeFptr() {
-    WindowResizedCallback = &WindowResized;
-  }
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  // clear the window color, viewport does not need set because backbuffer was just recreated
+  glViewport(0, 0, enigma_user::window_get_width(), enigma_user::window_get_height());
+  glScissor(0, 0, enigma_user::window_get_width(), enigma_user::window_get_height());
+  enigma_user::draw_clear(enigma_user::window_get_color());
 }
 
-#include "Platforms/General/PFwindow.h" // window_set_caption
-#include "Universal_System/roomsystem.h" // room_caption, update_mouse_variables
+void SetResizeFptr() { WindowResizedCallback = &WindowResized; }
+}  // namespace enigma
+
+#include "Platforms/General/PFwindow.h"   // window_set_caption
+#include "Universal_System/roomsystem.h"  // room_caption, update_mouse_variables
 
 namespace enigma_user {
-  // Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
-  int display_aa = 14;
+// Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
+int display_aa = 14;
 
-  void set_synchronization(bool enable) {
+void set_synchronization(bool enable) {}
 
-  }
-    
-  void display_reset(int samples, bool vsync) {
-    set_synchronization(vsync);
-    //TODO: Copy over from the Win32 bridge
-  }
-    
-  void screen_refresh() {
-    cocoa_screen_refresh();
-    enigma::update_mouse_variables();
-    cocoa_flush_opengl();
-  }
-
+void display_reset(int samples, bool vsync) {
+  set_synchronization(vsync);
+  //TODO: Copy over from the Win32 bridge
 }
 
+void screen_refresh() {
+  cocoa_screen_refresh();
+  enigma::update_mouse_variables();
+  cocoa_flush_opengl();
+}
+
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
+++ b/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
@@ -18,137 +18,126 @@
 #ifndef DIRECTX9CONTEXTMANAGER
 #define DIRECTX9CONTEXTMANAGER
 
-#include <windows.h>
-#include <windowsx.h>
 #include <d3d9.h>
 #include <dxerr9.h>
+#include <windows.h>
+#include <windowsx.h>
 #include "Graphics_Systems/Direct3D9/Direct3D9Headers.h"
 #include "Graphics_Systems/General/GSmodel.h"
 #include "Platforms/Win32/WINDOWSmain.h"
 using namespace enigma_user;
 
-#include <vector>
 #include <map>
-using std::vector;
+#include <vector>
 using std::map;
+using std::vector;
 
-#include "Widget_Systems/widgets_mandatory.h"
-#include <sstream>
 #include <string.h>
+#include <sstream>
+#include "Widget_Systems/widgets_mandatory.h"
 using std::string;
 using std::stringstream;
 
-extern LPDIRECT3D9 d3dobj;    // the pointer to our Direct3D interface
+extern LPDIRECT3D9 d3dobj;  // the pointer to our Direct3D interface
 
 //TODO: Replace the fixed function pipeline with shaders
 
 class ContextManager {
-private:
+ private:
+  //Keep track of current shaders.
+  LPDIRECT3DPIXELSHADER9 pixelShader;
+  LPDIRECT3DVERTEXSHADER9 vertexShader;
 
-//Keep track of current shaders.
-LPDIRECT3DPIXELSHADER9	pixelShader;
-LPDIRECT3DVERTEXSHADER9	vertexShader;
+  // This is used for resetting the render target if it is changed
+  LPDIRECT3DSURFACE9 pBackBuffer;
+  LPDIRECT3DSURFACE9 pRenderTarget;
 
-// This is used for resetting the render target if it is changed
-LPDIRECT3DSURFACE9 pBackBuffer;
-LPDIRECT3DSURFACE9 pRenderTarget;
+  float last_depth;
+  unsigned last_stride;
+  bool hasdrawn;
+  int shapes_d3d_model;
+  int shapes_d3d_texture;
 
-float last_depth;
-unsigned last_stride;
-bool hasdrawn;
-int shapes_d3d_model;
-int shapes_d3d_texture;
+  bool renderingScene;
 
-bool renderingScene;
+ protected:
+  map<D3DRENDERSTATETYPE, DWORD> cacheRenderStates;                 /// cached RenderStates
+  map<DWORD, LPDIRECT3DTEXTURE9> cacheTextureStates;                /// cached Texture States
+  map<DWORD, map<D3DSAMPLERSTATETYPE, DWORD> > cacheSamplerStates;  /// cached Sampler States
+  map<DWORD, D3DLIGHT9> cacheLightStates;                           /// cached Light States
+  map<DWORD, BOOL> cacheLightEnable;                                /// cached Light States
 
-protected:
-   map< D3DRENDERSTATETYPE, DWORD > cacheRenderStates;                  /// cached RenderStates
-   map< DWORD, LPDIRECT3DTEXTURE9 > cacheTextureStates;                 /// cached Texture States
-   map< DWORD, map< D3DSAMPLERSTATETYPE, DWORD > > cacheSamplerStates;  /// cached Sampler States
-   map< DWORD, D3DLIGHT9 > cacheLightStates;                            /// cached Light States
-   map< DWORD, BOOL > cacheLightEnable;                                 /// cached Light States
+ public:
+  LPDIRECT3DDEVICE9 device;  // the pointer to the device class
 
-public:
-LPDIRECT3DDEVICE9 device;    // the pointer to the device class
+  ContextManager() {
+    hasdrawn = false;
+    shapes_d3d_model = -1;
+    shapes_d3d_texture = -1;
+    last_stride = 0;
+    vertexShader = NULL;
+    pixelShader = NULL;
+    last_depth = 0.0f;
+  }
 
-ContextManager() {
-	hasdrawn = false;
-	shapes_d3d_model = -1;
-	shapes_d3d_texture = -1;
-	last_stride = 0;
-	vertexShader = NULL;
-	pixelShader = NULL;
-	last_depth = 0.0f;
-}
+  ~ContextManager() {}
 
-~ContextManager() {
+  float GetDepth() { return last_depth; }
 
-}
+  //TODO: Write this method so that for debugging purposes we can dump the entire render state to a text file.
+  void DumpState() {}
 
-float GetDepth() {
-	return last_depth;
-}
+  //TODO: Write this method so that we can serialize and save the entire render state to be reloaded
+  void SaveState() {}
 
-//TODO: Write this method so that for debugging purposes we can dump the entire render state to a text file.
-void DumpState() {
+  //TODO: Write this method so that we can read and restore a previously saved render state
+  void LoadState() {}
 
-}
-
-//TODO: Write this method so that we can serialize and save the entire render state to be reloaded
-void SaveState() {
-
-}
-
-//TODO: Write this method so that we can read and restore a previously saved render state
-void LoadState() {
-
-}
-
-// Reapply the render states and other stuff to the device.
-void RestoreState() {
-	// Cached Texture Stage States
-	map< DWORD, LPDIRECT3DTEXTURE9 >::iterator tit = cacheTextureStates.begin();
+  // Reapply the render states and other stuff to the device.
+  void RestoreState() {
+    // Cached Texture Stage States
+    map<DWORD, LPDIRECT3DTEXTURE9>::iterator tit = cacheTextureStates.begin();
     while (tit != cacheTextureStates.end()) {
-		device->SetTexture(tit->first, tit->second);
-		tit++;
-	}
+      device->SetTexture(tit->first, tit->second);
+      tit++;
+    }
 
-	device->SetVertexShader(vertexShader);
-	device->SetPixelShader(pixelShader);
+    device->SetVertexShader(vertexShader);
+    device->SetPixelShader(pixelShader);
 
-	// Cached Render States
-	map< D3DRENDERSTATETYPE, DWORD >::iterator it = cacheRenderStates.begin();
+    // Cached Render States
+    map<D3DRENDERSTATETYPE, DWORD>::iterator it = cacheRenderStates.begin();
     while (it != cacheRenderStates.end()) {
-		device->SetRenderState(it->first, it->second);
-		it++;
-	}
+      device->SetRenderState(it->first, it->second);
+      it++;
+    }
 
-	// Cached Sampler States
-	map< DWORD, map< D3DSAMPLERSTATETYPE, DWORD > >::iterator sit = cacheSamplerStates.begin();
+    // Cached Sampler States
+    map<DWORD, map<D3DSAMPLERSTATETYPE, DWORD> >::iterator sit = cacheSamplerStates.begin();
     while (sit != cacheSamplerStates.end()) {
-		map< D3DSAMPLERSTATETYPE, DWORD >::iterator secit = sit->second.begin();
-		while (secit != sit->second.end()) {
-			device->SetSamplerState(sit->first, secit->first, secit->second);
-			secit++;
-		}
-		sit++;
-	}
+      map<D3DSAMPLERSTATETYPE, DWORD>::iterator secit = sit->second.begin();
+      while (secit != sit->second.end()) {
+        device->SetSamplerState(sit->first, secit->first, secit->second);
+        secit++;
+      }
+      sit++;
+    }
 
-	// Cached Lights
-	map< DWORD, BOOL >::iterator lite = cacheLightEnable.begin();
+    // Cached Lights
+    map<DWORD, BOOL>::iterator lite = cacheLightEnable.begin();
     while (lite != cacheLightEnable.end()) {
-		device->LightEnable(lite->first, lite->second);
-		lite++;
-	}
-	return;
-	map< DWORD, D3DLIGHT9 >::iterator lit = cacheLightStates.begin();
+      device->LightEnable(lite->first, lite->second);
+      lite++;
+    }
+    return;
+    map<DWORD, D3DLIGHT9>::iterator lit = cacheLightStates.begin();
     while (lit != cacheLightStates.end()) {
-		device->SetLight(lit->first, &lit->second);
-		lit++;
-	}
-}
+      device->SetLight(lit->first, &lit->second);
+      lit++;
+    }
+  }
 
-/*
+  /*
 void EndSpriteBatch() {
 	// Textures should be clamped when rendering 2D sprites and stuff, so memorize it.
 	DWORD wrapu, wrapv, wrapw;
@@ -176,338 +165,326 @@ void EndSpriteBatch() {
 }
 */
 
-int GetShapesModel() {
-	return shapes_d3d_model;
-}
+  int GetShapesModel() { return shapes_d3d_model; }
 
-void BeginShapesBatching(int texId) {
-	if (shapes_d3d_model == -1) {
-		shapes_d3d_model = d3d_model_create(model_dynamic);
-		last_stride = 0;
-	} else if (texId != shapes_d3d_texture || (d3d_model_get_stride(shapes_d3d_model) != last_stride)) {
-		last_stride = 0;
-		if (!hasdrawn) {
-			d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
-			d3d_model_clear(shapes_d3d_model);
-		}
-	} else {
-		last_stride = d3d_model_get_stride(shapes_d3d_model);
-	}
-	hasdrawn = false;
-	shapes_d3d_texture = texId;
-}
-
-void EndShapesBatching() {
-	last_depth -= 1;
-	if (hasdrawn || shapes_d3d_model == -1) { return; }
-	hasdrawn = true;
-	d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
-	d3d_model_clear(shapes_d3d_model);
-	shapes_d3d_texture = -1;
-	last_stride = 0;
-}
-
-void Clear(DWORD Count, const D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil) {
-	device->Clear(Count, pRects, Flags, Color, Z, Stencil);
-}
-
-void LightEnable(DWORD Index, BOOL bEnable) {
-	// Update the light state cache
-    // If the return value is 'true', the command must be forwarded to the D3D Runtime.
-	map< DWORD, BOOL >::iterator it = cacheLightEnable.find( Index );
-    if( cacheLightEnable.end() == it )
-    {
-        cacheLightEnable.insert( map< DWORD, BOOL >::value_type(Index, bEnable) );
-		EndShapesBatching();
-        device->LightEnable( Index, bEnable );
-		return;
+  void BeginShapesBatching(int texId) {
+    if (shapes_d3d_model == -1) {
+      shapes_d3d_model = d3d_model_create(model_dynamic);
+      last_stride = 0;
+    } else if (texId != shapes_d3d_texture || (d3d_model_get_stride(shapes_d3d_model) != last_stride)) {
+      last_stride = 0;
+      if (!hasdrawn) {
+        d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
+        d3d_model_clear(shapes_d3d_model);
+      }
+    } else {
+      last_stride = d3d_model_get_stride(shapes_d3d_model);
     }
-    if( it->second == bEnable )
-        return;
-    it->second = bEnable;
-	EndShapesBatching();
-    device->LightEnable( Index, bEnable );
-}
+    hasdrawn = false;
+    shapes_d3d_texture = texId;
+  }
 
-void BeginScene() {
-	last_depth = 0;
-	device->BeginScene();
-	// Reapply the stored render states and what not
-	RestoreState();
-}
-
-void EndScene() {
-	EndShapesBatching();
-	device->EndScene();
-}
-
-void Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion) {
-	device->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
-}
-
-void Release() {
-	device->Release();
-}
-
-void Reset(D3DPRESENT_PARAMETERS *pPresentationParameters) {
-	HRESULT hr = device->Reset(pPresentationParameters);
-		if(FAILED(hr)){
-			MessageBox(enigma::hWnd,
-               "Failed to reset Direct3D 9.0 Device",
-			   DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
-               MB_ICONERROR | MB_OK);
-			return;  // should probably force the game closed
-		}
-}
-
-void DrawIndexedPrimitive(D3DPRIMITIVETYPE Type, INT BaseVertexIndex, UINT MinIndex, UINT NumVertices, UINT StartIndex, UINT PrimitiveCount) {
-	//EndShapesBatching();
-	device->DrawIndexedPrimitive(Type, BaseVertexIndex, MinIndex, NumVertices, StartIndex, PrimitiveCount);
-}
-
-void DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount) {
-	//EndShapesBatching();
-	device->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount);
-}
-
-void DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void *pVertexStreamZeroData, UINT VertexStreamZeroStride) {
-	//EndShapesBatching();
-	device->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
-}
-
-void CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer9 **ppVertexBuffer, HANDLE *pSharedHandle) {
-	device->CreateVertexBuffer(Length, Usage, FVF, Pool, ppVertexBuffer, pSharedHandle);
-}
-
-void CreateIndexBuffer(UINT Length, DWORD Usage,  D3DFORMAT Format,  D3DPOOL Pool, IDirect3DIndexBuffer9 **ppIndexBuffer, HANDLE *pSharedHandle) {
-	device->CreateIndexBuffer(Length, Usage, Format, Pool, ppIndexBuffer, pSharedHandle);
-}
-
-void CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture9 **ppTexture, HANDLE *pSharedHandle) {
-	HRESULT hr = device->CreateTexture(Width, Height, Levels, Usage, Format, Pool, ppTexture, pSharedHandle);
-  	if (FAILED(hr)) {
-      MessageBox(NULL, DXGetErrorDescription9(hr), DXGetErrorString9(hr), MB_OK|MB_ICONEXCLAMATION);
-	  return;
-    }
-}
-
-void CreateRenderTarget(UINT Width,  UINT Height,  D3DFORMAT Format,  D3DMULTISAMPLE_TYPE MultiSample,
-DWORD MultisampleQuality,  BOOL Lockable, IDirect3DSurface9 **ppSurface, HANDLE *pSharedHandle) {
-	device->CreateRenderTarget(Width, Height, Format, MultiSample, MultisampleQuality, Lockable, ppSurface, pSharedHandle);
-}
-
-void CreateVertexDeclaration(const D3DVERTEXELEMENT9 *pVertexElements, IDirect3DVertexDeclaration9 **ppDecl) {
-	device->CreateVertexDeclaration(pVertexElements, ppDecl);
-}
-
-void CreatePixelShader(const DWORD *pFunction, IDirect3DPixelShader9 **ppShader) {
-	HRESULT hr = device->CreatePixelShader(pFunction, ppShader);
-	if (FAILED(hr)) {
-      MessageBox(NULL, "CreatePixelShader failed", "CRendererDX9::Create", MB_OK|MB_ICONEXCLAMATION);
+  void EndShapesBatching() {
+    last_depth -= 1;
+    if (hasdrawn || shapes_d3d_model == -1) {
       return;
     }
-}
+    hasdrawn = true;
+    d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
+    d3d_model_clear(shapes_d3d_model);
+    shapes_d3d_texture = -1;
+    last_stride = 0;
+  }
 
-void CreateVertexShader(const DWORD *pFunction, IDirect3DVertexShader9 **ppShader) {
-	HRESULT hr = device->CreateVertexShader(pFunction, ppShader);
-	if (FAILED(hr)) {
-      MessageBox(NULL, "CreateVertexShader failed", "CRendererDX9::Create", MB_OK|MB_ICONEXCLAMATION);
-	  return;
-    }
-}
+  void Clear(DWORD Count, const D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil) {
+    device->Clear(Count, pRects, Flags, Color, Z, Stencil);
+  }
 
-void GetSwapChain(UINT  iSwapChain, IDirect3DSwapChain9 **ppSwapChain) {
-	HRESULT hr = device->GetSwapChain(iSwapChain, ppSwapChain);
-		if(FAILED(hr)){
-			MessageBox(enigma::hWnd,
-               "Failed to retrieve the Direct3D 9.0 Swap Chain",
-			   DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
-               MB_ICONERROR | MB_OK);
-			return;  // should probably force the game closed
-		}
-}
-
-void GetRenderTarget(DWORD RenderTargetIndex, IDirect3DSurface9 **ppRenderTarget) {
-	device->GetRenderTarget(RenderTargetIndex, ppRenderTarget);
-}
-
-void GetRenderState(D3DRENDERSTATETYPE State, DWORD *pValue) {
-	device->GetRenderState(State, pValue);
-}
-
-void GetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD *pValue) {
-	device->GetSamplerState(Sampler, Type, pValue);
-}
-
-void GetDeviceCaps(D3DCAPS9 *pCaps) {
-	device->GetDeviceCaps(pCaps);
-}
-
-void SetSoftwareVertexProcessing(bool bSoftware) {
-	device->SetSoftwareVertexProcessing(bSoftware);
-}
-
-void SetMaterial(const D3DMATERIAL9 *pMaterial) {
-	device->SetMaterial(pMaterial);
-}
-
-void SetFVF(DWORD FVF) {
-	//EndShapesBatching();
-	device->SetFVF(FVF);
-}
-
-void SetViewport(const D3DVIEWPORT9 *pViewport) {
-	EndShapesBatching();
-	device->SetViewport(pViewport);
-}
-
-void SetLight(DWORD Index, const D3DLIGHT9 *pLight) {
-device->SetLight( Index, pLight );
-	return;
-	// Update the light state cache
+  void LightEnable(DWORD Index, BOOL bEnable) {
+    // Update the light state cache
     // If the return value is 'true', the command must be forwarded to the D3D Runtime.
-	map< DWORD, D3DLIGHT9 >::iterator it = cacheLightStates.find( Index );
-    if ( cacheLightStates.end() == it ) {
-        cacheLightStates.insert( map< DWORD, D3DLIGHT9 >::value_type(Index, *pLight) );
-		EndShapesBatching();
-        device->SetLight( Index, pLight );
-		return;
+    map<DWORD, BOOL>::iterator it = cacheLightEnable.find(Index);
+    if (cacheLightEnable.end() == it) {
+      cacheLightEnable.insert(map<DWORD, BOOL>::value_type(Index, bEnable));
+      EndShapesBatching();
+      device->LightEnable(Index, bEnable);
+      return;
+    }
+    if (it->second == bEnable) return;
+    it->second = bEnable;
+    EndShapesBatching();
+    device->LightEnable(Index, bEnable);
+  }
+
+  void BeginScene() {
+    last_depth = 0;
+    device->BeginScene();
+    // Reapply the stored render states and what not
+    RestoreState();
+  }
+
+  void EndScene() {
+    EndShapesBatching();
+    device->EndScene();
+  }
+
+  void Present(const RECT *pSourceRect, const RECT *pDestRect, HWND hDestWindowOverride, const RGNDATA *pDirtyRegion) {
+    device->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
+  }
+
+  void Release() { device->Release(); }
+
+  void Reset(D3DPRESENT_PARAMETERS *pPresentationParameters) {
+    HRESULT hr = device->Reset(pPresentationParameters);
+    if (FAILED(hr)) {
+      MessageBox(enigma::hWnd, "Failed to reset Direct3D 9.0 Device",
+                 DXGetErrorDescription9(hr),  //DXGetErrorString9(hr)
+                 MB_ICONERROR | MB_OK);
+      return;  // should probably force the game closed
+    }
+  }
+
+  void DrawIndexedPrimitive(D3DPRIMITIVETYPE Type, INT BaseVertexIndex, UINT MinIndex, UINT NumVertices,
+                            UINT StartIndex, UINT PrimitiveCount) {
+    //EndShapesBatching();
+    device->DrawIndexedPrimitive(Type, BaseVertexIndex, MinIndex, NumVertices, StartIndex, PrimitiveCount);
+  }
+
+  void DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount) {
+    //EndShapesBatching();
+    device->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount);
+  }
+
+  void DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, const void *pVertexStreamZeroData,
+                       UINT VertexStreamZeroStride) {
+    //EndShapesBatching();
+    device->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
+  }
+
+  void CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer9 **ppVertexBuffer,
+                          HANDLE *pSharedHandle) {
+    device->CreateVertexBuffer(Length, Usage, FVF, Pool, ppVertexBuffer, pSharedHandle);
+  }
+
+  void CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool,
+                         IDirect3DIndexBuffer9 **ppIndexBuffer, HANDLE *pSharedHandle) {
+    device->CreateIndexBuffer(Length, Usage, Format, Pool, ppIndexBuffer, pSharedHandle);
+  }
+
+  void CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool,
+                     IDirect3DTexture9 **ppTexture, HANDLE *pSharedHandle) {
+    HRESULT hr = device->CreateTexture(Width, Height, Levels, Usage, Format, Pool, ppTexture, pSharedHandle);
+    if (FAILED(hr)) {
+      MessageBox(NULL, DXGetErrorDescription9(hr), DXGetErrorString9(hr), MB_OK | MB_ICONEXCLAMATION);
+      return;
+    }
+  }
+
+  void CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample,
+                          DWORD MultisampleQuality, BOOL Lockable, IDirect3DSurface9 **ppSurface,
+                          HANDLE *pSharedHandle) {
+    device->CreateRenderTarget(Width, Height, Format, MultiSample, MultisampleQuality, Lockable, ppSurface,
+                               pSharedHandle);
+  }
+
+  void CreateVertexDeclaration(const D3DVERTEXELEMENT9 *pVertexElements, IDirect3DVertexDeclaration9 **ppDecl) {
+    device->CreateVertexDeclaration(pVertexElements, ppDecl);
+  }
+
+  void CreatePixelShader(const DWORD *pFunction, IDirect3DPixelShader9 **ppShader) {
+    HRESULT hr = device->CreatePixelShader(pFunction, ppShader);
+    if (FAILED(hr)) {
+      MessageBox(NULL, "CreatePixelShader failed", "CRendererDX9::Create", MB_OK | MB_ICONEXCLAMATION);
+      return;
+    }
+  }
+
+  void CreateVertexShader(const DWORD *pFunction, IDirect3DVertexShader9 **ppShader) {
+    HRESULT hr = device->CreateVertexShader(pFunction, ppShader);
+    if (FAILED(hr)) {
+      MessageBox(NULL, "CreateVertexShader failed", "CRendererDX9::Create", MB_OK | MB_ICONEXCLAMATION);
+      return;
+    }
+  }
+
+  void GetSwapChain(UINT iSwapChain, IDirect3DSwapChain9 **ppSwapChain) {
+    HRESULT hr = device->GetSwapChain(iSwapChain, ppSwapChain);
+    if (FAILED(hr)) {
+      MessageBox(enigma::hWnd, "Failed to retrieve the Direct3D 9.0 Swap Chain",
+                 DXGetErrorDescription9(hr),  //DXGetErrorString9(hr)
+                 MB_ICONERROR | MB_OK);
+      return;  // should probably force the game closed
+    }
+  }
+
+  void GetRenderTarget(DWORD RenderTargetIndex, IDirect3DSurface9 **ppRenderTarget) {
+    device->GetRenderTarget(RenderTargetIndex, ppRenderTarget);
+  }
+
+  void GetRenderState(D3DRENDERSTATETYPE State, DWORD *pValue) { device->GetRenderState(State, pValue); }
+
+  void GetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD *pValue) {
+    device->GetSamplerState(Sampler, Type, pValue);
+  }
+
+  void GetDeviceCaps(D3DCAPS9 *pCaps) { device->GetDeviceCaps(pCaps); }
+
+  void SetSoftwareVertexProcessing(bool bSoftware) { device->SetSoftwareVertexProcessing(bSoftware); }
+
+  void SetMaterial(const D3DMATERIAL9 *pMaterial) { device->SetMaterial(pMaterial); }
+
+  void SetFVF(DWORD FVF) {
+    //EndShapesBatching();
+    device->SetFVF(FVF);
+  }
+
+  void SetViewport(const D3DVIEWPORT9 *pViewport) {
+    EndShapesBatching();
+    device->SetViewport(pViewport);
+  }
+
+  void SetLight(DWORD Index, const D3DLIGHT9 *pLight) {
+    device->SetLight(Index, pLight);
+    return;
+    // Update the light state cache
+    // If the return value is 'true', the command must be forwarded to the D3D Runtime.
+    map<DWORD, D3DLIGHT9>::iterator it = cacheLightStates.find(Index);
+    if (cacheLightStates.end() == it) {
+      cacheLightStates.insert(map<DWORD, D3DLIGHT9>::value_type(Index, *pLight));
+      EndShapesBatching();
+      device->SetLight(Index, pLight);
+      return;
     }
     //if( it->second == *pLight )
-        //return;
+    //return;
     it->second = *pLight;
-	EndShapesBatching();
-    device->SetLight( Index, pLight );
-}
+    EndShapesBatching();
+    device->SetLight(Index, pLight);
+  }
 
-void SetTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix) {
-	// if projection EndShapesBatching();
-	EndShapesBatching();
-	device->SetTransform(State, pMatrix);
-}
+  void SetTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatrix) {
+    // if projection EndShapesBatching();
+    EndShapesBatching();
+    device->SetTransform(State, pMatrix);
+  }
 
-void SetRenderState(D3DRENDERSTATETYPE State, DWORD Value) {
-	// Update the render state cache
+  void SetRenderState(D3DRENDERSTATETYPE State, DWORD Value) {
+    // Update the render state cache
     // If the return value is 'true', the command must be forwarded to the D3D Runtime.
-	map< D3DRENDERSTATETYPE, DWORD >::iterator it = cacheRenderStates.find( State );
-    if ( cacheRenderStates.end() == it ) {
-        cacheRenderStates.insert( map< D3DRENDERSTATETYPE, DWORD >::value_type(State, Value) );
-		EndShapesBatching();
-        device->SetRenderState( State, Value );
+    map<D3DRENDERSTATETYPE, DWORD>::iterator it = cacheRenderStates.find(State);
+    if (cacheRenderStates.end() == it) {
+      cacheRenderStates.insert(map<D3DRENDERSTATETYPE, DWORD>::value_type(State, Value));
+      EndShapesBatching();
+      device->SetRenderState(State, Value);
     }
-    if( it->second == Value )
-        return;
+    if (it->second == Value) return;
     it->second = Value;
-	EndShapesBatching();
-    device->SetRenderState( State, Value );
-}
+    EndShapesBatching();
+    device->SetRenderState(State, Value);
+  }
 
-void GetBackBuffer(UINT  iSwapChain, UINT BackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface9 **ppBackBuffer) {
-	device->GetBackBuffer(iSwapChain, BackBuffer, Type, ppBackBuffer);
-}
+  void GetBackBuffer(UINT iSwapChain, UINT BackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface9 **ppBackBuffer) {
+    device->GetBackBuffer(iSwapChain, BackBuffer, Type, ppBackBuffer);
+  }
 
-void SetRenderTarget(DWORD RenderTargetIndex, IDirect3DSurface9 *pTarget) {
-	device->GetRenderTarget(0, &pBackBuffer);
-	if (pBackBuffer == pTarget) { return; }
-	EndShapesBatching();
-	device->SetRenderTarget(RenderTargetIndex, pTarget);
-	pRenderTarget = pTarget;
-}
-
-void ResetRenderTarget() {
-	device->GetRenderTarget(0, &pBackBuffer);
-	if (pBackBuffer == pRenderTarget) { return; }
-	EndShapesBatching();
-	device->SetRenderTarget(0, pBackBuffer);
-}
-
-void SetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD Value) {
-	// Update the render state cache
-    // If the return value is 'true', the command must be forwarded to the D3D Runtime.
-	typedef map<D3DSAMPLERSTATETYPE, DWORD> innerType;
-	map< DWORD, map< D3DSAMPLERSTATETYPE, DWORD >  >::iterator it = cacheSamplerStates.find( Sampler );
-    if ( it == cacheSamplerStates.end() ) {
-		map<DWORD, innerType> outer;
-		innerType inner;
-		inner.insert(pair<D3DSAMPLERSTATETYPE, DWORD>(Type, Value));
-        cacheSamplerStates.insert( pair<DWORD, innerType>(Sampler, inner) );
-		//EndShapesBatching();
-        device->SetSamplerState( Sampler, Type, Value );
+  void SetRenderTarget(DWORD RenderTargetIndex, IDirect3DSurface9 *pTarget) {
+    device->GetRenderTarget(0, &pBackBuffer);
+    if (pBackBuffer == pTarget) {
+      return;
     }
-	map< D3DSAMPLERSTATETYPE, DWORD >::iterator sit = it->second.find( Type );
-    if ( sit != it->second.end() ) {
-		if (sit->second == Value) {
-			return;
-		}
-		sit->second = Value;
-		//EndShapesBatching();
-		device->SetSamplerState( Sampler, Type, Value );
-	} else {
-		it->second.insert(map< D3DSAMPLERSTATETYPE, DWORD >::value_type(Type, Value));
-		device->SetSamplerState( Sampler, Type, Value );
-	}
-}
+    EndShapesBatching();
+    device->SetRenderTarget(RenderTargetIndex, pTarget);
+    pRenderTarget = pTarget;
+  }
 
-void SetTexture(DWORD Sampler, LPDIRECT3DTEXTURE9 pTexture) {
-	// Update the render state cache
-    // If the return value is 'true', the command must be forwarded to the D3D Runtime.
-	map< DWORD, LPDIRECT3DTEXTURE9 >::iterator it = cacheTextureStates.find( Sampler );
-    if ( cacheTextureStates.end() == it ) {
-        cacheTextureStates.insert( map< DWORD, LPDIRECT3DTEXTURE9 >::value_type(Sampler, pTexture) );
-		//EndShapesBatching();
-        device->SetTexture( Sampler, pTexture );
+  void ResetRenderTarget() {
+    device->GetRenderTarget(0, &pBackBuffer);
+    if (pBackBuffer == pRenderTarget) {
+      return;
     }
-    if( it->second == pTexture )
+    EndShapesBatching();
+    device->SetRenderTarget(0, pBackBuffer);
+  }
+
+  void SetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD Value) {
+    // Update the render state cache
+    // If the return value is 'true', the command must be forwarded to the D3D Runtime.
+    typedef map<D3DSAMPLERSTATETYPE, DWORD> innerType;
+    map<DWORD, map<D3DSAMPLERSTATETYPE, DWORD> >::iterator it = cacheSamplerStates.find(Sampler);
+    if (it == cacheSamplerStates.end()) {
+      map<DWORD, innerType> outer;
+      innerType inner;
+      inner.insert(pair<D3DSAMPLERSTATETYPE, DWORD>(Type, Value));
+      cacheSamplerStates.insert(pair<DWORD, innerType>(Sampler, inner));
+      //EndShapesBatching();
+      device->SetSamplerState(Sampler, Type, Value);
+    }
+    map<D3DSAMPLERSTATETYPE, DWORD>::iterator sit = it->second.find(Type);
+    if (sit != it->second.end()) {
+      if (sit->second == Value) {
         return;
+      }
+      sit->second = Value;
+      //EndShapesBatching();
+      device->SetSamplerState(Sampler, Type, Value);
+    } else {
+      it->second.insert(map<D3DSAMPLERSTATETYPE, DWORD>::value_type(Type, Value));
+      device->SetSamplerState(Sampler, Type, Value);
+    }
+  }
+
+  void SetTexture(DWORD Sampler, LPDIRECT3DTEXTURE9 pTexture) {
+    // Update the render state cache
+    // If the return value is 'true', the command must be forwarded to the D3D Runtime.
+    map<DWORD, LPDIRECT3DTEXTURE9>::iterator it = cacheTextureStates.find(Sampler);
+    if (cacheTextureStates.end() == it) {
+      cacheTextureStates.insert(map<DWORD, LPDIRECT3DTEXTURE9>::value_type(Sampler, pTexture));
+      //EndShapesBatching();
+      device->SetTexture(Sampler, pTexture);
+    }
+    if (it->second == pTexture) return;
     it->second = pTexture;
-	//EndShapesBatching();
-    device->SetTexture( Sampler, pTexture );
-}
+    //EndShapesBatching();
+    device->SetTexture(Sampler, pTexture);
+  }
 
-void SetTextureStageState(DWORD Sampler, D3DTEXTURESTAGESTATETYPE Type, DWORD Value) {
-	device->SetTextureStageState(Sampler, Type, Value);
-}
+  void SetTextureStageState(DWORD Sampler, D3DTEXTURESTAGESTATETYPE Type, DWORD Value) {
+    device->SetTextureStageState(Sampler, Type, Value);
+  }
 
-void SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer9 *pStreamData, UINT OffsetInBytes, UINT Stride) {
-	device->SetStreamSource(StreamNumber, pStreamData, OffsetInBytes, Stride);
-}
+  void SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer9 *pStreamData, UINT OffsetInBytes, UINT Stride) {
+    device->SetStreamSource(StreamNumber, pStreamData, OffsetInBytes, Stride);
+  }
 
-void SetVertexDeclaration(IDirect3DVertexDeclaration9 *pDecl) {
-	device->SetVertexDeclaration(pDecl);
-}
+  void SetVertexDeclaration(IDirect3DVertexDeclaration9 *pDecl) { device->SetVertexDeclaration(pDecl); }
 
-void SetIndices(IDirect3DIndexBuffer9 *pIndexData) {
-	device->SetIndices(pIndexData);
-}
+  void SetIndices(IDirect3DIndexBuffer9 *pIndexData) { device->SetIndices(pIndexData); }
 
-void SetPixelShader(LPDIRECT3DPIXELSHADER9 shader)
-{
-	//Nothing to do, return
-	if (shader == pixelShader) return;
-	EndShapesBatching();
-	pixelShader = shader;
-	device->SetPixelShader(shader);
-}
+  void SetPixelShader(LPDIRECT3DPIXELSHADER9 shader) {
+    //Nothing to do, return
+    if (shader == pixelShader) return;
+    EndShapesBatching();
+    pixelShader = shader;
+    device->SetPixelShader(shader);
+  }
 
-void SetVertexShader(LPDIRECT3DVERTEXSHADER9 shader)
-{
-	//Nothing to do, return
-	if (shader == vertexShader) return;
-	EndShapesBatching();
-	vertexShader = shader;
-	device->SetVertexShader(shader);
-}
+  void SetVertexShader(LPDIRECT3DVERTEXSHADER9 shader) {
+    //Nothing to do, return
+    if (shader == vertexShader) return;
+    EndShapesBatching();
+    vertexShader = shader;
+    device->SetVertexShader(shader);
+  }
 
-void SetVertexShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4fCount) {
-	device->SetVertexShaderConstantF(StartRegister, pConstantData, Vector4fCount);
-}
+  void SetVertexShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4fCount) {
+    device->SetVertexShaderConstantF(StartRegister, pConstantData, Vector4fCount);
+  }
 
-void SetPixelShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4fCount) {
-	device->SetPixelShaderConstantF(StartRegister, pConstantData, Vector4fCount);
-}
-
+  void SetPixelShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4fCount) {
+    device->SetPixelShaderConstantF(StartRegister, pConstantData, Vector4fCount);
+  }
 };
 
-extern ContextManager* d3dmgr; // point to our device manager
+extern ContextManager *d3dmgr;  // point to our device manager
 
 #endif

--- a/ENIGMAsystem/SHELL/Bridges/General/GL3Context.h
+++ b/ENIGMAsystem/SHELL/Bridges/General/GL3Context.h
@@ -18,188 +18,167 @@
 #ifndef OPENGL3CONTEXTMANAGER
 #define OPENGL3CONTEXTMANAGER
 
-#include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSmodel.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/OpenGL3/GL3profiler.h"
 
-#include <vector>
 #include <map>
-using std::vector;
+#include <vector>
 using std::map;
+using std::vector;
 
 class ContextManager {
-private:
-GLuint bound_tex;
+ private:
+  GLuint bound_tex;
 
-protected:
-  map< GLenum, GLuint > cacheTextureStates;    /// cached texture stages
+ protected:
+  map<GLenum, GLuint> cacheTextureStates;  /// cached texture stages
 
-public:
+ public:
+  float last_depth;
+  int last_stride;
+  bool hasdrawn;
+  int shapes_d3d_model;
+  int shapes_d3d_texture;
+  enigma::GPUProfiler gpuprof;
 
-float last_depth;
-int last_stride;
-bool hasdrawn;
-int shapes_d3d_model;
-int shapes_d3d_texture;
-enigma::GPUProfiler gpuprof;
+  ContextManager() {
+    hasdrawn = false;
+    shapes_d3d_model = -1;
+    shapes_d3d_texture = -1;
+    last_stride = -1;
+    last_depth = 0.0f;
+    bound_tex = 0;
+  }
 
-ContextManager() {
-	hasdrawn = false;
-	shapes_d3d_model = -1;
-	shapes_d3d_texture = -1;
-	last_stride = -1;
-	last_depth = 0.0f;
-	bound_tex = 0;
-}
+  ~ContextManager() {}
 
-~ContextManager() {
+  float GetDepth() { return last_depth; }
 
-}
+  int GetShapesModel() { return shapes_d3d_model; }
 
-float GetDepth() {
-	return last_depth;
-}
+  //TODO: Write this method so that for debugging purposes we can dump the entire render state to a text file.
+  void DumpState() {}
 
-int GetShapesModel() {
-	return shapes_d3d_model;
-}
+  //TODO: Write this method so that we can serialize and save the entire render state to be reloaded
+  void SaveState() {}
 
-//TODO: Write this method so that for debugging purposes we can dump the entire render state to a text file.
-void DumpState() {
+  //TODO: Write this method so that we can read and restore a previously saved render state
+  void LoadState() {}
 
-}
+  //TODO: Write this method so that it applies its cached render states to the graphics handle
+  void RestoreState() {}
 
-//TODO: Write this method so that we can serialize and save the entire render state to be reloaded
-void SaveState() {
+  void BeginShapesBatching(int texId) {
+    if (shapes_d3d_model == -1) {
+      shapes_d3d_model = enigma_user::d3d_model_create(enigma_user::model_stream);
+      last_stride = -1;
+    } else if (texId != shapes_d3d_texture ||
+               (enigma_user::d3d_model_get_stride(shapes_d3d_model) != last_stride && last_stride != -1)) {
+      last_stride = -1;
+      if (!hasdrawn) {
+        enigma_user::d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
+        enigma_user::d3d_model_clear(shapes_d3d_model);
+      }
+    } else {
+      last_stride = enigma_user::d3d_model_get_stride(shapes_d3d_model);
+    }
+    hasdrawn = false;
+    shapes_d3d_texture = texId;
+  }
 
-}
+  void EndShapesBatching() {
+    if (hasdrawn || shapes_d3d_model == -1) {
+      return;
+    }
+    hasdrawn = true;
+    enigma_user::d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
+    enigma_user::d3d_model_clear(shapes_d3d_model);
 
-//TODO: Write this method so that we can read and restore a previously saved render state
-void LoadState() {
+    shapes_d3d_texture = -1;
+    last_stride = -1;
+    last_depth -= 1;
+  }
 
-}
+  void BeginScene() {
+    last_depth = 0;
+    // Reapply the stored render states and what not
+    RestoreState();
+  }
 
-//TODO: Write this method so that it applies its cached render states to the graphics handle
-void RestoreState() {
+  void EndScene() {
+    gpuprof.end_frame();
+    EndShapesBatching();
+  }
 
-}
+  void SetEnabled(GLenum cap, bool enabled) {
+    EndShapesBatching();
+    (enabled ? glEnable : glDisable)(cap);
+  }
 
-void BeginShapesBatching(int texId) {
-	if (shapes_d3d_model == -1) {
-		shapes_d3d_model = enigma_user::d3d_model_create(enigma_user::model_stream);
-		last_stride = -1;
-	} else if (texId != shapes_d3d_texture || (enigma_user::d3d_model_get_stride(shapes_d3d_model) != last_stride && last_stride != -1)) {
-		last_stride = -1;
-		if (!hasdrawn) {
-			enigma_user::d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
-			enigma_user::d3d_model_clear(shapes_d3d_model);
-		}
-	} else {
-		last_stride = enigma_user::d3d_model_get_stride(shapes_d3d_model);
-	}
-	hasdrawn = false;
-	shapes_d3d_texture = texId;
-}
+  void Bind() { EndShapesBatching(); }
 
-void EndShapesBatching() {
-	if (hasdrawn || shapes_d3d_model == -1) { return; }
-	hasdrawn = true;
-	enigma_user::d3d_model_draw(shapes_d3d_model, shapes_d3d_texture);
-	enigma_user::d3d_model_clear(shapes_d3d_model);
+  void ActiveTexture() { EndShapesBatching(); }
 
-	shapes_d3d_texture = -1;
-	last_stride = -1;
-  last_depth -= 1;
-}
+  void ReadPixels() { EndShapesBatching(); }
 
-void BeginScene() {
-	last_depth = 0;
-	// Reapply the stored render states and what not
-	RestoreState();
-}
-
-void EndScene() {
-  gpuprof.end_frame();
-  EndShapesBatching();
-}
-
-void SetEnabled(GLenum cap, bool enabled) {
-	EndShapesBatching();
-	(enabled?glEnable:glDisable)(cap);
-}
-
-void Bind() {
-	EndShapesBatching();
-}
-
-void ActiveTexture() {
-	EndShapesBatching();
-}
-
-void ReadPixels() {
-	EndShapesBatching();
-}
-
-// Function no longer used since introduction of sampler states for compatibility with Studio.
-void BindTexture(GLenum target,  GLuint texture) {
-  if (bound_tex != texture) {
+  // Function no longer used since introduction of sampler states for compatibility with Studio.
+  void BindTexture(GLenum target, GLuint texture) {
+    if (bound_tex != texture) {
       //EndShapesBatching();
       glBindTexture(target, bound_tex = texture);
-  }
-  return;
-  // Update the texture state cache
-  // If the return value is 'true', the command must be forwarded to OpenGL
-  map< GLenum, GLuint >::iterator it = cacheTextureStates.find( target );
-  if ( cacheTextureStates.end() == it ) {
-    cacheTextureStates.insert( map< GLenum, GLuint >::value_type(target, texture) );
+    }
+    return;
+    // Update the texture state cache
+    // If the return value is 'true', the command must be forwarded to OpenGL
+    map<GLenum, GLuint>::iterator it = cacheTextureStates.find(target);
+    if (cacheTextureStates.end() == it) {
+      cacheTextureStates.insert(map<GLenum, GLuint>::value_type(target, texture));
+      EndShapesBatching();
+      glBindTexture(target, texture);
+    }
+    if (it->second == texture) return;
+    it->second = texture;
     EndShapesBatching();
     glBindTexture(target, texture);
   }
-  if( it->second == texture )
-      return;
-  it->second = texture;
-  EndShapesBatching();
-  glBindTexture(target, texture);
-}
 
-void ResetTextureStates() {
-	// loop through and check if any of the texture states opengl has set do not match the ones we've cached
-}
+  void ResetTextureStates() {
+    // loop through and check if any of the texture states opengl has set do not match the ones we've cached
+  }
 
-void Viewport() {
-	EndShapesBatching();
-}
+  void Viewport() { EndShapesBatching(); }
 
-void Transformation() { //Used when calling 3d transformations (translation, scaling etc.)
-	EndShapesBatching();
-}
+  void Transformation() {  //Used when calling 3d transformations (translation, scaling etc.)
+    EndShapesBatching();
+  }
 
-void BlendFunc() { //Used when calling blend functions
-	EndShapesBatching();
-}
+  void BlendFunc() {  //Used when calling blend functions
+    EndShapesBatching();
+  }
 
-void ColorFunc() { //Used when calling color functions
-	if (shapes_d3d_model != -1){
-		if (enigma_user::d3d_model_has_color(shapes_d3d_model) == false){
-			EndShapesBatching();
-		}
-	}
-}
+  void ColorFunc() {  //Used when calling color functions
+    if (shapes_d3d_model != -1) {
+      if (enigma_user::d3d_model_has_color(shapes_d3d_model) == false) {
+        EndShapesBatching();
+      }
+    }
+  }
 
-void Lighting() { //Used when lighting is enabled/disabled
-	EndShapesBatching();
-}
+  void Lighting() {  //Used when lighting is enabled/disabled
+    EndShapesBatching();
+  }
 
-void ShaderFunc() { //Used when calling shader functions, like uniform changes
-  EndShapesBatching();
-}
+  void ShaderFunc() {  //Used when calling shader functions, like uniform changes
+    EndShapesBatching();
+  }
 
-GLuint GetBoundTexture() { //This is used for cases when there are texture coordinates provided, but texture is 0 (like d3d_model_block)
-	return bound_tex;
-}
-
+  GLuint
+  GetBoundTexture() {  //This is used for cases when there are texture coordinates provided, but texture is 0 (like d3d_model_block)
+    return bound_tex;
+  }
 };
 
-extern ContextManager* oglmgr; // point to our device manager
+extern ContextManager* oglmgr;  // point to our device manager
 
 #endif

--- a/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
@@ -14,22 +14,21 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
+#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Platforms/General/PFwindow.h"
-#include "Graphics_Systems/General/GScolors.h"
 
-#include <iostream>
-#include <cstring>
+#include <Universal_System/roomsystem.h>  // room_caption, update_mouse_variables
 #include <stdio.h>
-#include <Universal_System/roomsystem.h> // room_caption, update_mouse_variables
+#include <cstring>
+#include <iostream>
 
 namespace enigma_user {
-  int display_aa = 14;
+int display_aa = 14;
 
-  void set_synchronization(bool enable){}
-    
-  void display_reset(int samples, bool vsync){}
-    
-  void screen_refresh(){}
-}
+void set_synchronization(bool enable) {}
 
+void display_reset(int samples, bool vsync) {}
+
+void screen_refresh() {}
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D11/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D11/graphics_bridge.cpp
@@ -15,392 +15,358 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <string>
+#include <d3d11.h>
 #include <windows.h>
 #include <windowsx.h>
-#include <d3d11.h>
+#include <string>
 using namespace std;
 
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h"
-#include "Platforms/Win32/WINDOWSmain.h"
-#include "Platforms/General/PFwindow.h"
-#include "Platforms/platforms_mandatory.h"
-#include "Universal_System/roomsystem.h"
-#include "Graphics_Systems/graphics_mandatory.h"
 #include "Bridges/General/DX11Context.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/graphics_mandatory.h"
+#include "Platforms/General/PFwindow.h"
+#include "Platforms/Win32/WINDOWSmain.h"
+#include "Platforms/platforms_mandatory.h"
+#include "Universal_System/roomsystem.h"
+#include "Widget_Systems/widgets_mandatory.h"
+#include "libEGMstd.h"
 
-	bool m_vsync_enabled;
-	int m_videoCardMemory;
-	char m_videoCardDescription[128];
-	IDXGISwapChain* m_swapChain;
-	ID3D11Device* m_device;
-	ID3D11DeviceContext* m_deviceContext;
-	ID3D11RenderTargetView* m_renderTargetView;
-	ID3D11Texture2D* m_depthStencilBuffer;
-	ID3D11DepthStencilState* m_depthStencilState;
-	ID3D11DepthStencilView* m_depthStencilView;
-	ID3D11RasterizerState* m_rasterState;
+bool m_vsync_enabled;
+int m_videoCardMemory;
+char m_videoCardDescription[128];
+IDXGISwapChain* m_swapChain;
+ID3D11Device* m_device;
+ID3D11DeviceContext* m_deviceContext;
+ID3D11RenderTargetView* m_renderTargetView;
+ID3D11Texture2D* m_depthStencilBuffer;
+ID3D11DepthStencilState* m_depthStencilState;
+ID3D11DepthStencilView* m_depthStencilView;
+ID3D11RasterizerState* m_rasterState;
 
 // global declarations
-ContextManager* d3dmgr;    // the pointer to the device class
+ContextManager* d3dmgr;  // the pointer to the device class
 
 // the WindowProc function prototype
 LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
-	
-namespace enigma
-{
-	
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
-    // clear the window color, viewport does not need set because backbuffer was just recreated
-    enigma_user::draw_clear(enigma_user::window_get_color());
+
+namespace enigma {
+
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  // clear the window color, viewport does not need set because backbuffer was just recreated
+  enigma_user::draw_clear(enigma_user::window_get_color());
+}
+
+void EnableDrawing(HGLRC* hRC) {
+  WindowResizedCallback = &WindowResized;
+
+  d3dmgr = new ContextManager();
+  int screenWidth = window_get_width(), screenHeight = window_get_height();
+  screenWidth = screenWidth <= 0 ? 1 : screenWidth;
+  screenHeight = screenHeight <= 0 ? 1 : screenHeight;
+  bool vsync = false;
+  HWND hwnd = enigma::hWnd;
+  bool fullscreen = false;
+
+  HRESULT result;
+  IDXGIFactory* factory;
+  IDXGIAdapter* adapter;
+  IDXGIOutput* adapterOutput;
+  unsigned int numModes, i, numerator, denominator, stringLength;
+  DXGI_MODE_DESC* displayModeList;
+  DXGI_ADAPTER_DESC adapterDesc;
+  int error;
+  DXGI_SWAP_CHAIN_DESC swapChainDesc;
+  D3D_FEATURE_LEVEL featureLevel;
+  ID3D11Texture2D* backBufferPtr;
+  D3D11_TEXTURE2D_DESC depthBufferDesc;
+  D3D11_DEPTH_STENCIL_DESC depthStencilDesc;
+  D3D11_DEPTH_STENCIL_VIEW_DESC depthStencilViewDesc;
+  D3D11_RASTERIZER_DESC rasterDesc;
+  D3D11_VIEWPORT viewport;
+  float fieldOfView, screenAspect;
+
+  // Store the vsync setting.
+  m_vsync_enabled = vsync;
+
+  // Create a DirectX graphics interface factory.
+  result = CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory);
+  if (FAILED(result)) {
+    //return false;
   }
-  
-  void EnableDrawing (HGLRC *hRC) {
-    WindowResizedCallback = &WindowResized;
-  
-    d3dmgr = new ContextManager();
-      int screenWidth = window_get_width(),
-          screenHeight = window_get_height();
-      screenWidth = screenWidth <= 0 ? 1 : screenWidth;
-      screenHeight = screenHeight <= 0 ? 1 : screenHeight;
-    bool vsync = false;
-    HWND hwnd = enigma::hWnd;
-    bool fullscreen = false;
-    
-    HRESULT result;
-    IDXGIFactory* factory;
-    IDXGIAdapter* adapter;
-    IDXGIOutput* adapterOutput;
-    unsigned int numModes, i, numerator, denominator, stringLength;
-    DXGI_MODE_DESC* displayModeList;
-    DXGI_ADAPTER_DESC adapterDesc;
-    int error;
-    DXGI_SWAP_CHAIN_DESC swapChainDesc;
-    D3D_FEATURE_LEVEL featureLevel;
-    ID3D11Texture2D* backBufferPtr;
-    D3D11_TEXTURE2D_DESC depthBufferDesc;
-    D3D11_DEPTH_STENCIL_DESC depthStencilDesc;
-    D3D11_DEPTH_STENCIL_VIEW_DESC depthStencilViewDesc;
-    D3D11_RASTERIZER_DESC rasterDesc;
-    D3D11_VIEWPORT viewport;
-    float fieldOfView, screenAspect;
 
+  // Use the factory to create an adapter for the primary graphics interface (video card).
+  result = factory->EnumAdapters(0, &adapter);
+  if (FAILED(result)) {
+    //return false;
+  }
 
-    // Store the vsync setting.
-    m_vsync_enabled = vsync;
+  // Enumerate the primary adapter output (monitor).
+  result = adapter->EnumOutputs(0, &adapterOutput);
+  if (FAILED(result)) {
+    //return false;
+  }
 
-    // Create a DirectX graphics interface factory.
-    result = CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory);
-    if(FAILED(result))
-    {
-      //return false;
-    }
+  // Get the number of modes that fit the DXGI_FORMAT_R8G8B8A8_UNORM display format for the adapter output (monitor).
+  result = adapterOutput->GetDisplayModeList(DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_ENUM_MODES_INTERLACED, &numModes, NULL);
+  if (FAILED(result)) {
+    //return false;
+  }
 
-    // Use the factory to create an adapter for the primary graphics interface (video card).
-    result = factory->EnumAdapters(0, &adapter);
-    if(FAILED(result))
-    {
-      //return false;
-    }
+  // Create a list to hold all the possible display modes for this monitor/video card combination.
+  displayModeList = new DXGI_MODE_DESC[numModes];
+  if (!displayModeList) {
+    //return false;
+  }
 
-    // Enumerate the primary adapter output (monitor).
-    result = adapter->EnumOutputs(0, &adapterOutput);
-    if(FAILED(result))
-    {
-      //return false;
-    }
+  // Now fill the display mode list structures.
+  result = adapterOutput->GetDisplayModeList(DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_ENUM_MODES_INTERLACED, &numModes,
+                                             displayModeList);
+  if (FAILED(result)) {
+    //return false;
+  }
 
-    // Get the number of modes that fit the DXGI_FORMAT_R8G8B8A8_UNORM display format for the adapter output (monitor).
-    result = adapterOutput->GetDisplayModeList(DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_ENUM_MODES_INTERLACED, &numModes, NULL);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Create a list to hold all the possible display modes for this monitor/video card combination.
-    displayModeList = new DXGI_MODE_DESC[numModes];
-    if(!displayModeList)
-    {
-      //return false;
-    }
-
-    // Now fill the display mode list structures.
-    result = adapterOutput->GetDisplayModeList(DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_ENUM_MODES_INTERLACED, &numModes, displayModeList);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Now go through all the display modes and find the one that matches the screen width and height.
-    // When a match is found store the numerator and denominator of the refresh rate for that monitor.
-    for(i=0; i<numModes; i++)
-    {
-      if(displayModeList[i].Width == (unsigned int)screenWidth)
-      {
-        if(displayModeList[i].Height == (unsigned int)screenHeight)
-        {
-          numerator = displayModeList[i].RefreshRate.Numerator;
-          denominator = displayModeList[i].RefreshRate.Denominator;
-        }
+  // Now go through all the display modes and find the one that matches the screen width and height.
+  // When a match is found store the numerator and denominator of the refresh rate for that monitor.
+  for (i = 0; i < numModes; i++) {
+    if (displayModeList[i].Width == (unsigned int)screenWidth) {
+      if (displayModeList[i].Height == (unsigned int)screenHeight) {
+        numerator = displayModeList[i].RefreshRate.Numerator;
+        denominator = displayModeList[i].RefreshRate.Denominator;
       }
     }
-
-    // Get the adapter (video card) description.
-    result = adapter->GetDesc(&adapterDesc);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Store the dedicated video card memory in megabytes.
-    m_videoCardMemory = (int)(adapterDesc.DedicatedVideoMemory / 1024 / 1024);
-
-    // Convert the name of the video card to a character array and store it.
-    //error = wcstombs_s(&stringLength, m_videoCardDescription, 128, adapterDesc.Description, 128);
-    if(error != 0)
-    {
-      //return false;
-    }
-
-    // Release the display mode list.
-    delete [] displayModeList;
-    displayModeList = 0;
-
-    // Release the adapter output.
-    adapterOutput->Release();
-    adapterOutput = 0;
-
-    // Release the adapter.
-    adapter->Release();
-    adapter = 0;
-
-    // Release the factory.
-    factory->Release();
-    factory = 0;
-
-    // Initialize the swap chain description.
-    ZeroMemory(&swapChainDesc, sizeof(swapChainDesc));
-
-    // Set to a single back buffer.
-    swapChainDesc.BufferCount = 1;
-
-    // Set the width and height of the back buffer.
-    swapChainDesc.BufferDesc.Width = screenWidth;
-    swapChainDesc.BufferDesc.Height = screenHeight;
-
-    // Set regular 32-bit surface for the back buffer.
-    swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-
-    // Set the refresh rate of the back buffer.
-    if(m_vsync_enabled)
-    {
-      swapChainDesc.BufferDesc.RefreshRate.Numerator = numerator;
-      swapChainDesc.BufferDesc.RefreshRate.Denominator = denominator;
-    }
-    else
-    {
-      swapChainDesc.BufferDesc.RefreshRate.Numerator = 0;
-      swapChainDesc.BufferDesc.RefreshRate.Denominator = 1;
-    }
-
-    // Set the usage of the back buffer.
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-
-    // Set the handle for the window to render to.
-    swapChainDesc.OutputWindow = hwnd;
-
-    // Turn multisampling off.
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.SampleDesc.Quality = 0;
-
-    // Set to full screen or windowed mode.
-    if(fullscreen)
-    {
-      swapChainDesc.Windowed = false;
-    }
-    else
-    {
-      swapChainDesc.Windowed = true;
-    }
-
-    // Set the scan line ordering and scaling to unspecified.
-    swapChainDesc.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
-    swapChainDesc.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
-
-    // Discard the back buffer contents after presenting.
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
-
-    // Don't set the advanced flags.
-    swapChainDesc.Flags = 0;
-
-    // Set the feature level to DirectX 11.
-    featureLevel = D3D_FEATURE_LEVEL_11_0;
-
-    // Create the swap chain, Direct3D device, and Direct3D device context.
-    result = D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, 0, &featureLevel, 1, 
-                   D3D11_SDK_VERSION, &swapChainDesc, &m_swapChain, &m_device, NULL, &m_deviceContext);
-
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Get the pointer to the back buffer.
-    result = m_swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&backBufferPtr);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Create the render target view with the back buffer pointer.
-    result = m_device->CreateRenderTargetView(backBufferPtr, NULL, &m_renderTargetView);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Release pointer to the back buffer as we no longer need it.
-    backBufferPtr->Release();
-    backBufferPtr = 0;
-
-    // Initialize the description of the depth buffer.
-    ZeroMemory(&depthBufferDesc, sizeof(depthBufferDesc));
-
-    // Set up the description of the depth buffer.
-    depthBufferDesc.Width = screenWidth;
-    depthBufferDesc.Height = screenHeight;
-    depthBufferDesc.MipLevels = 1;
-    depthBufferDesc.ArraySize = 1;
-    depthBufferDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
-    depthBufferDesc.SampleDesc.Count = 1;
-    depthBufferDesc.SampleDesc.Quality = 0;
-    depthBufferDesc.Usage = D3D11_USAGE_DEFAULT;
-    depthBufferDesc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
-    depthBufferDesc.CPUAccessFlags = 0;
-    depthBufferDesc.MiscFlags = 0;
-
-    // Create the texture for the depth buffer using the filled out description.
-    result = m_device->CreateTexture2D(&depthBufferDesc, NULL, &m_depthStencilBuffer);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Initialize the description of the stencil state.
-    ZeroMemory(&depthStencilDesc, sizeof(depthStencilDesc));
-
-    // Set up the description of the stencil state.
-    depthStencilDesc.DepthEnable = true;
-    depthStencilDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
-    depthStencilDesc.DepthFunc = D3D11_COMPARISON_LESS;
-
-    depthStencilDesc.StencilEnable = true;
-    depthStencilDesc.StencilReadMask = 0xFF;
-    depthStencilDesc.StencilWriteMask = 0xFF;
-
-    // Stencil operations if pixel is front-facing.
-    depthStencilDesc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
-    depthStencilDesc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_INCR;
-    depthStencilDesc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
-    depthStencilDesc.FrontFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
-
-    // Stencil operations if pixel is back-facing.
-    depthStencilDesc.BackFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
-    depthStencilDesc.BackFace.StencilDepthFailOp = D3D11_STENCIL_OP_DECR;
-    depthStencilDesc.BackFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
-    depthStencilDesc.BackFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
-
-    // Create the depth stencil state.
-    result = m_device->CreateDepthStencilState(&depthStencilDesc, &m_depthStencilState);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Set the depth stencil state.
-    m_deviceContext->OMSetDepthStencilState(m_depthStencilState, 1);
-
-    // Initailze the depth stencil view.
-    ZeroMemory(&depthStencilViewDesc, sizeof(depthStencilViewDesc));
-
-    // Set up the depth stencil view description.
-    depthStencilViewDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
-    depthStencilViewDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
-    depthStencilViewDesc.Texture2D.MipSlice = 0;
-
-    // Create the depth stencil view.
-    result = m_device->CreateDepthStencilView(m_depthStencilBuffer, &depthStencilViewDesc, &m_depthStencilView);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Bind the render target view and depth stencil buffer to the output render pipeline.
-    m_deviceContext->OMSetRenderTargets(1, &m_renderTargetView, m_depthStencilView);
-
-    // Setup the raster description which will determine how and what polygons will be drawn.
-    rasterDesc.AntialiasedLineEnable = false;
-    rasterDesc.CullMode = D3D11_CULL_BACK;
-    rasterDesc.DepthBias = 0;
-    rasterDesc.DepthBiasClamp = 0.0f;
-    rasterDesc.DepthClipEnable = true;
-    rasterDesc.FillMode = D3D11_FILL_SOLID;
-    rasterDesc.FrontCounterClockwise = false;
-    rasterDesc.MultisampleEnable = false;
-    rasterDesc.ScissorEnable = false;
-    rasterDesc.SlopeScaledDepthBias = 0.0f;
-
-    // Create the rasterizer state from the description we just filled out.
-    result = m_device->CreateRasterizerState(&rasterDesc, &m_rasterState);
-    if(FAILED(result))
-    {
-      //return false;
-    }
-
-    // Now set the rasterizer state.
-    m_deviceContext->RSSetState(m_rasterState);
-      
-    // Setup the viewport for rendering.
-    viewport.Width = (float)screenWidth;
-    viewport.Height = (float)screenHeight;
-    viewport.MinDepth = 0.0f;
-    viewport.MaxDepth = 1.0f;
-    viewport.TopLeftX = 0.0f;
-    viewport.TopLeftY = 0.0f;
-
-    // Create the viewport.
-    m_deviceContext->RSSetViewports(1, &viewport);
   }
 
-  void DisableDrawing (HWND hWnd, HDC hDC, HGLRC hRC)
-  {
-
+  // Get the adapter (video card) description.
+  result = adapter->GetDesc(&adapterDesc);
+  if (FAILED(result)) {
+    //return false;
   }
 
+  // Store the dedicated video card memory in megabytes.
+  m_videoCardMemory = (int)(adapterDesc.DedicatedVideoMemory / 1024 / 1024);
+
+  // Convert the name of the video card to a character array and store it.
+  //error = wcstombs_s(&stringLength, m_videoCardDescription, 128, adapterDesc.Description, 128);
+  if (error != 0) {
+    //return false;
+  }
+
+  // Release the display mode list.
+  delete[] displayModeList;
+  displayModeList = 0;
+
+  // Release the adapter output.
+  adapterOutput->Release();
+  adapterOutput = 0;
+
+  // Release the adapter.
+  adapter->Release();
+  adapter = 0;
+
+  // Release the factory.
+  factory->Release();
+  factory = 0;
+
+  // Initialize the swap chain description.
+  ZeroMemory(&swapChainDesc, sizeof(swapChainDesc));
+
+  // Set to a single back buffer.
+  swapChainDesc.BufferCount = 1;
+
+  // Set the width and height of the back buffer.
+  swapChainDesc.BufferDesc.Width = screenWidth;
+  swapChainDesc.BufferDesc.Height = screenHeight;
+
+  // Set regular 32-bit surface for the back buffer.
+  swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+  // Set the refresh rate of the back buffer.
+  if (m_vsync_enabled) {
+    swapChainDesc.BufferDesc.RefreshRate.Numerator = numerator;
+    swapChainDesc.BufferDesc.RefreshRate.Denominator = denominator;
+  } else {
+    swapChainDesc.BufferDesc.RefreshRate.Numerator = 0;
+    swapChainDesc.BufferDesc.RefreshRate.Denominator = 1;
+  }
+
+  // Set the usage of the back buffer.
+  swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+
+  // Set the handle for the window to render to.
+  swapChainDesc.OutputWindow = hwnd;
+
+  // Turn multisampling off.
+  swapChainDesc.SampleDesc.Count = 1;
+  swapChainDesc.SampleDesc.Quality = 0;
+
+  // Set to full screen or windowed mode.
+  if (fullscreen) {
+    swapChainDesc.Windowed = false;
+  } else {
+    swapChainDesc.Windowed = true;
+  }
+
+  // Set the scan line ordering and scaling to unspecified.
+  swapChainDesc.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
+  swapChainDesc.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
+
+  // Discard the back buffer contents after presenting.
+  swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+
+  // Don't set the advanced flags.
+  swapChainDesc.Flags = 0;
+
+  // Set the feature level to DirectX 11.
+  featureLevel = D3D_FEATURE_LEVEL_11_0;
+
+  // Create the swap chain, Direct3D device, and Direct3D device context.
+  result = D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, 0, &featureLevel, 1, D3D11_SDK_VERSION,
+                                         &swapChainDesc, &m_swapChain, &m_device, NULL, &m_deviceContext);
+
+  if (FAILED(result)) {
+    //return false;
+  }
+
+  // Get the pointer to the back buffer.
+  result = m_swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&backBufferPtr);
+  if (FAILED(result)) {
+    //return false;
+  }
+
+  // Create the render target view with the back buffer pointer.
+  result = m_device->CreateRenderTargetView(backBufferPtr, NULL, &m_renderTargetView);
+  if (FAILED(result)) {
+    //return false;
+  }
+
+  // Release pointer to the back buffer as we no longer need it.
+  backBufferPtr->Release();
+  backBufferPtr = 0;
+
+  // Initialize the description of the depth buffer.
+  ZeroMemory(&depthBufferDesc, sizeof(depthBufferDesc));
+
+  // Set up the description of the depth buffer.
+  depthBufferDesc.Width = screenWidth;
+  depthBufferDesc.Height = screenHeight;
+  depthBufferDesc.MipLevels = 1;
+  depthBufferDesc.ArraySize = 1;
+  depthBufferDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+  depthBufferDesc.SampleDesc.Count = 1;
+  depthBufferDesc.SampleDesc.Quality = 0;
+  depthBufferDesc.Usage = D3D11_USAGE_DEFAULT;
+  depthBufferDesc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
+  depthBufferDesc.CPUAccessFlags = 0;
+  depthBufferDesc.MiscFlags = 0;
+
+  // Create the texture for the depth buffer using the filled out description.
+  result = m_device->CreateTexture2D(&depthBufferDesc, NULL, &m_depthStencilBuffer);
+  if (FAILED(result)) {
+    //return false;
+  }
+
+  // Initialize the description of the stencil state.
+  ZeroMemory(&depthStencilDesc, sizeof(depthStencilDesc));
+
+  // Set up the description of the stencil state.
+  depthStencilDesc.DepthEnable = true;
+  depthStencilDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
+  depthStencilDesc.DepthFunc = D3D11_COMPARISON_LESS;
+
+  depthStencilDesc.StencilEnable = true;
+  depthStencilDesc.StencilReadMask = 0xFF;
+  depthStencilDesc.StencilWriteMask = 0xFF;
+
+  // Stencil operations if pixel is front-facing.
+  depthStencilDesc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+  depthStencilDesc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_INCR;
+  depthStencilDesc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
+  depthStencilDesc.FrontFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
+
+  // Stencil operations if pixel is back-facing.
+  depthStencilDesc.BackFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+  depthStencilDesc.BackFace.StencilDepthFailOp = D3D11_STENCIL_OP_DECR;
+  depthStencilDesc.BackFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
+  depthStencilDesc.BackFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
+
+  // Create the depth stencil state.
+  result = m_device->CreateDepthStencilState(&depthStencilDesc, &m_depthStencilState);
+  if (FAILED(result)) {
+    //return false;
+  }
+
+  // Set the depth stencil state.
+  m_deviceContext->OMSetDepthStencilState(m_depthStencilState, 1);
+
+  // Initailze the depth stencil view.
+  ZeroMemory(&depthStencilViewDesc, sizeof(depthStencilViewDesc));
+
+  // Set up the depth stencil view description.
+  depthStencilViewDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+  depthStencilViewDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
+  depthStencilViewDesc.Texture2D.MipSlice = 0;
+
+  // Create the depth stencil view.
+  result = m_device->CreateDepthStencilView(m_depthStencilBuffer, &depthStencilViewDesc, &m_depthStencilView);
+  if (FAILED(result)) {
+    //return false;
+  }
+
+  // Bind the render target view and depth stencil buffer to the output render pipeline.
+  m_deviceContext->OMSetRenderTargets(1, &m_renderTargetView, m_depthStencilView);
+
+  // Setup the raster description which will determine how and what polygons will be drawn.
+  rasterDesc.AntialiasedLineEnable = false;
+  rasterDesc.CullMode = D3D11_CULL_BACK;
+  rasterDesc.DepthBias = 0;
+  rasterDesc.DepthBiasClamp = 0.0f;
+  rasterDesc.DepthClipEnable = true;
+  rasterDesc.FillMode = D3D11_FILL_SOLID;
+  rasterDesc.FrontCounterClockwise = false;
+  rasterDesc.MultisampleEnable = false;
+  rasterDesc.ScissorEnable = false;
+  rasterDesc.SlopeScaledDepthBias = 0.0f;
+
+  // Create the rasterizer state from the description we just filled out.
+  result = m_device->CreateRasterizerState(&rasterDesc, &m_rasterState);
+  if (FAILED(result)) {
+    //return false;
+  }
+
+  // Now set the rasterizer state.
+  m_deviceContext->RSSetState(m_rasterState);
+
+  // Setup the viewport for rendering.
+  viewport.Width = (float)screenWidth;
+  viewport.Height = (float)screenHeight;
+  viewport.MinDepth = 0.0f;
+  viewport.MaxDepth = 1.0f;
+  viewport.TopLeftX = 0.0f;
+  viewport.TopLeftY = 0.0f;
+
+  // Create the viewport.
+  m_deviceContext->RSSetViewports(1, &viewport);
 }
+
+void DisableDrawing(HWND hWnd, HDC hDC, HGLRC hRC) {}
+
+}  // namespace enigma
 
 #include "Universal_System/roomsystem.h"
 
-namespace enigma_user 
-{
-  int display_aa = 0;
+namespace enigma_user {
+int display_aa = 0;
 
-  void display_reset(int samples, bool vsync) {
+void display_reset(int samples, bool vsync) {}
 
-  }
-
-  void screen_refresh() {
-      window_set_caption(room_caption);
-      enigma::update_mouse_variables();
-    m_swapChain->Present(0, 0);
-  }
-
-  void set_synchronization(bool enable) //TODO: Needs to be rewritten
-  {
-
-  }  
-
+void screen_refresh() {
+  window_set_caption(room_caption);
+  enigma::update_mouse_variables();
+  m_swapChain->Present(0, 0);
 }
+
+void set_synchronization(bool enable)  //TODO: Needs to be rewritten
+{}
+
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
@@ -15,150 +15,143 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <string>
-#include <windows.h>
-#include <windowsx.h>
 #include <d3d9.h>
 #include <dxerr9.h>
+#include <windows.h>
+#include <windowsx.h>
+#include <string>
 using namespace std;
 
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h"
-#include "Platforms/Win32/WINDOWSmain.h"
+#include "Bridges/General/DX9Context.h"
+#include "Graphics_Systems/Direct3D9/DX9SurfaceStruct.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/graphics_mandatory.h"
 #include "Platforms/General/PFwindow.h"
+#include "Platforms/Win32/WINDOWSmain.h"
 #include "Platforms/platforms_mandatory.h"
 #include "Universal_System/roomsystem.h"
-#include "Graphics_Systems/graphics_mandatory.h"
-#include "Graphics_Systems/Direct3D9/DX9SurfaceStruct.h"
-#include "Bridges/General/DX9Context.h"
-#include "Graphics_Systems/General/GScolors.h"
+#include "Widget_Systems/widgets_mandatory.h"
+#include "libEGMstd.h"
 
 // global declarations
-LPDIRECT3D9 d3dobj; // the pointer to our Direct3D interface
-ContextManager* d3dmgr; // the pointer to the device class
+LPDIRECT3D9 d3dobj;      // the pointer to our Direct3D interface
+ContextManager *d3dmgr;  // the pointer to the device class
 
 // the WindowProc function prototype
 LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
-namespace enigma
-{
-  extern bool forceSoftwareVertexProcessing;
+namespace enigma {
+extern bool forceSoftwareVertexProcessing;
 
-  void OnDeviceLost() {
-    for (vector<Surface*>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
-      (*it)->OnDeviceLost();
-    }
-  }
-
-  void OnDeviceReset() {
-    for (vector<Surface*>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
-      (*it)->OnDeviceReset();
-    }
-  }
-
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
-    if (d3dmgr == NULL) { return; }
-    IDirect3DSwapChain9 *sc;
-    d3dmgr->GetSwapChain(0, &sc);
-    D3DPRESENT_PARAMETERS d3dpp;
-    sc->GetPresentParameters(&d3dpp);
-    int ww = window_get_width(),
-        wh = window_get_height();
-    d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
-    d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
-    sc->Release();
-    OnDeviceLost();
-    d3dmgr->Reset(&d3dpp);
-    OnDeviceReset();
-
-    // clear the window color, viewport does not need set because backbuffer was just recreated
-    enigma_user::draw_clear(enigma_user::window_get_color());
-  }
-
-  void EnableDrawing (HGLRC *hRC)
-  {
-    WindowResizedCallback = &WindowResized;
-
-    d3dmgr = new ContextManager();
-    HRESULT hr;
-
-    D3DPRESENT_PARAMETERS d3dpp; // create a struct to hold various device information
-    d3dobj = Direct3DCreate9(D3D_SDK_VERSION); // create the Direct3D interface
-    D3DFORMAT format = D3DFMT_A8R8G8B8;
-
-    ZeroMemory(&d3dpp, sizeof(d3dpp)); // clear out the struct for use
-    d3dpp.Windowed = TRUE; // program windowed, not fullscreen
-    int ww = window_get_width(),
-        wh = window_get_height();
-    d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
-    d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
-    d3dpp.MultiSampleType = D3DMULTISAMPLE_NONE;                // 0 Levels of multi-sampling
-    d3dpp.MultiSampleQuality = 0;                               // No multi-sampling
-    d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;                   // Throw away previous frames, we don't need them
-    d3dpp.hDeviceWindow = hWnd;                                 // This is our main (and only) window
-    d3dpp.Flags = 0;                                            // No flags to set
-    d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT; // Default Refresh Rate
-    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE; // Present the frame immediately
-    d3dpp.BackBufferCount = 1;                                  // We only need a single back buffer
-    d3dpp.BackBufferFormat = format;                            // Display format
-    d3dpp.EnableAutoDepthStencil = TRUE;                        // Automatic depth stencil buffer
-    d3dpp.AutoDepthStencilFormat = D3DFMT_D24S8;                // 32-bit zbuffer 24bits for depth 8 for stencil buffer
-    // create a device class using this information and information from the d3dpp stuct
-    DWORD behaviors = D3DCREATE_MIXED_VERTEXPROCESSING;
-    if (forceSoftwareVertexProcessing) {
-      behaviors = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
-    }
-    hr = d3dobj->CreateDevice(D3DADAPTER_DEFAULT,
-                              D3DDEVTYPE_HAL,
-                              hWnd,
-                              behaviors,
-                              &d3dpp,
-                              &d3dmgr->device);
-    if (FAILED(hr)) {
-      MessageBox(hWnd,
-                 "Failed to create Direct3D 9.0 Device",
-                 DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
-                 MB_ICONERROR | MB_OK);
-      return; // should probably force the game closed
-    }
-
-    d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE);
-
-    enigma_user::display_aa = 0;
-    for (int i = 16; i > 1; i--) {
-      if (SUCCEEDED(d3dobj->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, format, TRUE, (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + i), NULL))) {
-        enigma_user::display_aa += i;
-      }
-    }
-  }
-
-  void DisableDrawing (HWND hWnd, HDC hDC, HGLRC hRC)
-  {
-    d3dmgr->Release(); // close and release the 3D device
-    d3dobj->Release(); // close and release Direct3D
+void OnDeviceLost() {
+  for (vector<Surface *>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
+    (*it)->OnDeviceLost();
   }
 }
 
+void OnDeviceReset() {
+  for (vector<Surface *>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
+    (*it)->OnDeviceReset();
+  }
+}
+
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  if (d3dmgr == NULL) {
+    return;
+  }
+  IDirect3DSwapChain9 *sc;
+  d3dmgr->GetSwapChain(0, &sc);
+  D3DPRESENT_PARAMETERS d3dpp;
+  sc->GetPresentParameters(&d3dpp);
+  int ww = window_get_width(), wh = window_get_height();
+  d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
+  d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
+  sc->Release();
+  OnDeviceLost();
+  d3dmgr->Reset(&d3dpp);
+  OnDeviceReset();
+
+  // clear the window color, viewport does not need set because backbuffer was just recreated
+  enigma_user::draw_clear(enigma_user::window_get_color());
+}
+
+void EnableDrawing(HGLRC *hRC) {
+  WindowResizedCallback = &WindowResized;
+
+  d3dmgr = new ContextManager();
+  HRESULT hr;
+
+  D3DPRESENT_PARAMETERS d3dpp;                // create a struct to hold various device information
+  d3dobj = Direct3DCreate9(D3D_SDK_VERSION);  // create the Direct3D interface
+  D3DFORMAT format = D3DFMT_A8R8G8B8;
+
+  ZeroMemory(&d3dpp, sizeof(d3dpp));  // clear out the struct for use
+  d3dpp.Windowed = TRUE;              // program windowed, not fullscreen
+  int ww = window_get_width(), wh = window_get_height();
+  d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
+  d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
+  d3dpp.MultiSampleType = D3DMULTISAMPLE_NONE;                 // 0 Levels of multi-sampling
+  d3dpp.MultiSampleQuality = 0;                                // No multi-sampling
+  d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;                    // Throw away previous frames, we don't need them
+  d3dpp.hDeviceWindow = hWnd;                                  // This is our main (and only) window
+  d3dpp.Flags = 0;                                             // No flags to set
+  d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;  // Default Refresh Rate
+  d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;  // Present the frame immediately
+  d3dpp.BackBufferCount = 1;                                   // We only need a single back buffer
+  d3dpp.BackBufferFormat = format;                             // Display format
+  d3dpp.EnableAutoDepthStencil = TRUE;                         // Automatic depth stencil buffer
+  d3dpp.AutoDepthStencilFormat = D3DFMT_D24S8;                 // 32-bit zbuffer 24bits for depth 8 for stencil buffer
+  // create a device class using this information and information from the d3dpp stuct
+  DWORD behaviors = D3DCREATE_MIXED_VERTEXPROCESSING;
+  if (forceSoftwareVertexProcessing) {
+    behaviors = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
+  }
+  hr = d3dobj->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, hWnd, behaviors, &d3dpp, &d3dmgr->device);
+  if (FAILED(hr)) {
+    MessageBox(hWnd, "Failed to create Direct3D 9.0 Device",
+               DXGetErrorDescription9(hr),  //DXGetErrorString9(hr)
+               MB_ICONERROR | MB_OK);
+    return;  // should probably force the game closed
+  }
+
+  d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE);
+
+  enigma_user::display_aa = 0;
+  for (int i = 16; i > 1; i--) {
+    if (SUCCEEDED(d3dobj->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, format, TRUE,
+                                                     (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + i), NULL))) {
+      enigma_user::display_aa += i;
+    }
+  }
+}
+
+void DisableDrawing(HWND hWnd, HDC hDC, HGLRC hRC) {
+  d3dmgr->Release();  // close and release the 3D device
+  d3dobj->Release();  // close and release Direct3D
+}
+}  // namespace enigma
+
 #include "Universal_System/roomsystem.h"
 
-namespace enigma_user
-{
+namespace enigma_user {
 int display_aa = 0;
 
 void display_reset(int samples, bool vsync) {
-  if (d3dmgr == NULL) { return; }
+  if (d3dmgr == NULL) {
+    return;
+  }
   IDirect3DSwapChain9 *sc;
   d3dmgr->GetSwapChain(0, &sc);
   D3DPRESENT_PARAMETERS d3dpp;
   sc->GetPresentParameters(&d3dpp);
   if (vsync) {
-    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT; // Present the frame immediately
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;  // Present the frame immediately
   } else {
-    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE; // Present the frame immediately
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;  // Present the frame immediately
   }
-  d3dpp.MultiSampleType = (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + samples); // Levels of multi-sampling
-  d3dpp.MultiSampleQuality = 0; // No multi-sampling
+  d3dpp.MultiSampleType = (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + samples);  // Levels of multi-sampling
+  d3dpp.MultiSampleQuality = 0;                                                       // No multi-sampling
   if (samples) {
     d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, TRUE);
   } else {
@@ -177,21 +170,22 @@ void screen_refresh() {
   d3dmgr->Present(NULL, NULL, NULL, NULL);
 }
 
-void set_synchronization(bool enable)
-{
-  if (d3dmgr == NULL) { return; }
+void set_synchronization(bool enable) {
+  if (d3dmgr == NULL) {
+    return;
+  }
   IDirect3DSwapChain9 *sc;
   d3dmgr->GetSwapChain(0, &sc);
   D3DPRESENT_PARAMETERS d3dpp;
   sc->GetPresentParameters(&d3dpp);
   if (enable) {
-    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT; // Present the frame immediately
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;  // Present the frame immediately
   } else {
-    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE; // Present the frame immediately
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;  // Present the frame immediately
   }
   sc->Release();
 
   d3dmgr->Reset(&d3dpp);
 }
 
-}
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL1/graphics_bridge.cpp
@@ -25,159 +25,157 @@
 **                                                                              **
 \********************************************************************************/
 
-#include <string>
 #include <windows.h>
+#include <string>
 using namespace std;
 
 #include "../General/wglew.h"
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h"
-#include "Platforms/Win32/WINDOWSmain.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Platforms/General/PFwindow.h"
+#include "Platforms/Win32/WINDOWSmain.h"
+#include "Widget_Systems/widgets_mandatory.h"
+#include "libEGMstd.h"
 
-namespace enigma
-{
-    GLuint msaa_fbo = 0;
+namespace enigma {
+GLuint msaa_fbo = 0;
 
-    extern void (*WindowResizedCallback)();
-    void WindowResized() {
-      // clear the window color, viewport does not need set because backbuffer was just recreated
-      enigma_user::draw_clear(enigma_user::window_get_color());
-    }
-
-    void EnableDrawing (HGLRC *hRC)
-    {
-      WindowResizedCallback = &WindowResized;
-
-      PIXELFORMATDESCRIPTOR pfd;
-      int iFormat;
-
-      enigma::window_hDC = GetDC (hWnd);
-      ZeroMemory (&pfd, sizeof (pfd));
-      pfd.nSize = sizeof (pfd);
-      pfd.nVersion = 1;
-      pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
-      pfd.iPixelType = PFD_TYPE_RGBA;
-      pfd.cColorBits = 24;
-      pfd.cDepthBits = 24;
-      pfd.cStencilBits = 8;
-      pfd.iLayerType = PFD_MAIN_PLANE;
-      iFormat = ChoosePixelFormat (enigma::window_hDC, &pfd);
-
-      if (iFormat==0) { show_error("Failed to set the format of the OpenGL graphics device.",1); }
-
-      SetPixelFormat (enigma::window_hDC, iFormat, &pfd);
-      *hRC = wglCreateContext( enigma::window_hDC );
-      wglMakeCurrent( enigma::window_hDC, *hRC );
-
-      //TODO: This never reports higher than 8, but display_aa should be 14 if 2,4,and 8 are supported and 8 only when only 8 is supported
-      glGetIntegerv(GL_MAX_SAMPLES_EXT, &enigma_user::display_aa);
-    }
-
-    void DisableDrawing (HWND hWnd, HDC hDC, HGLRC hRC)
-    {
-      wglMakeCurrent (NULL, NULL);
-      wglDeleteContext (hRC);
-      ReleaseDC (hWnd, hDC);
-    }
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  // clear the window color, viewport does not need set because backbuffer was just recreated
+  enigma_user::draw_clear(enigma_user::window_get_color());
 }
+
+void EnableDrawing(HGLRC *hRC) {
+  WindowResizedCallback = &WindowResized;
+
+  PIXELFORMATDESCRIPTOR pfd;
+  int iFormat;
+
+  enigma::window_hDC = GetDC(hWnd);
+  ZeroMemory(&pfd, sizeof(pfd));
+  pfd.nSize = sizeof(pfd);
+  pfd.nVersion = 1;
+  pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+  pfd.iPixelType = PFD_TYPE_RGBA;
+  pfd.cColorBits = 24;
+  pfd.cDepthBits = 24;
+  pfd.cStencilBits = 8;
+  pfd.iLayerType = PFD_MAIN_PLANE;
+  iFormat = ChoosePixelFormat(enigma::window_hDC, &pfd);
+
+  if (iFormat == 0) {
+    show_error("Failed to set the format of the OpenGL graphics device.", 1);
+  }
+
+  SetPixelFormat(enigma::window_hDC, iFormat, &pfd);
+  *hRC = wglCreateContext(enigma::window_hDC);
+  wglMakeCurrent(enigma::window_hDC, *hRC);
+
+  //TODO: This never reports higher than 8, but display_aa should be 14 if 2,4,and 8 are supported and 8 only when only 8 is supported
+  glGetIntegerv(GL_MAX_SAMPLES_EXT, &enigma_user::display_aa);
+}
+
+void DisableDrawing(HWND hWnd, HDC hDC, HGLRC hRC) {
+  wglMakeCurrent(NULL, NULL);
+  wglDeleteContext(hRC);
+  ReleaseDC(hWnd, hDC);
+}
+}  // namespace enigma
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL1 version.
 
 namespace enigma {
-  namespace swaphandling {
-    bool has_checked_extensions = false;
-    bool ext_swapcontrol_supported;
+namespace swaphandling {
+bool has_checked_extensions = false;
+bool ext_swapcontrol_supported;
 
-    void investigate_swapcontrol_support() {
+void investigate_swapcontrol_support() {
+  if (has_checked_extensions) return;  // Already calculated, no need to calculate it more.
 
-      if (has_checked_extensions) return; // Already calculated, no need to calculate it more.
+  const char *wgl_extensions = wglGetExtensionsStringARB(window_hDC);
 
-      const char *wgl_extensions = wglGetExtensionsStringARB(window_hDC);
+  ext_swapcontrol_supported = strstr(wgl_extensions, "WGL_EXT_swap_control");
 
-      ext_swapcontrol_supported = strstr(wgl_extensions, "WGL_EXT_swap_control");
-
-      has_checked_extensions = true;
-    }
-  }
-
-  bool is_ext_swapcontrol_supported() {
-    swaphandling::investigate_swapcontrol_support();
-    return swaphandling::ext_swapcontrol_supported;
-  }
+  has_checked_extensions = true;
 }
+}  // namespace swaphandling
+
+bool is_ext_swapcontrol_supported() {
+  swaphandling::investigate_swapcontrol_support();
+  return swaphandling::ext_swapcontrol_supported;
+}
+}  // namespace enigma
 
 #include "Universal_System/roomsystem.h"
 
 namespace enigma_user {
 
-	int display_aa = 0;
+int display_aa = 0;
 
-	void display_reset(int samples, bool vsync) {
-		int interval = vsync ? 1 : 0;
+void display_reset(int samples, bool vsync) {
+  int interval = vsync ? 1 : 0;
 
-		if (enigma::is_ext_swapcontrol_supported()) {
-		  wglSwapIntervalEXT(interval);
-		}
-
-		GLint fbo;
-		glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &fbo);
-
-		GLuint ColorBufferID, DepthBufferID;
-
-		// Cleanup the multi-sampler fbo if turning off multi-sampling
-		if (samples == 0) {
-			if (enigma::msaa_fbo != 0) {
-				glDeleteFramebuffers(1, &enigma::msaa_fbo);
-				enigma::msaa_fbo = 0;
-			}
-			return;
-		}
-
-		//TODO: Change the code below to fix this to size properly to views
-		// If we don't already have a multi-sample fbo then create one
-		if (enigma::msaa_fbo == 0) {
-			glGenFramebuffersEXT(1, &enigma::msaa_fbo);
-		}
-		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, enigma::msaa_fbo);
-		// Now make a multi-sample color buffer
-		glGenRenderbuffersEXT(1, &ColorBufferID);
-		glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, ColorBufferID);
-		glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER_EXT, samples, GL_RGBA8, window_get_region_width(), window_get_region_height());
-		// We also need a depth buffer
-		glGenRenderbuffersEXT(1, &DepthBufferID);
-		glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, DepthBufferID);
-		glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER_EXT, samples, GL_DEPTH_COMPONENT24, window_get_region_width(), window_get_region_height());
-		// Attach the render buffers to the multi-sampler fbo
-		glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, ColorBufferID);
-		glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, DepthBufferID);
-
-	}
-
-  void screen_refresh() {
-    window_set_caption(room_caption);
-    enigma::update_mouse_variables();
-    SwapBuffers(enigma::window_hDC);
+  if (enigma::is_ext_swapcontrol_supported()) {
+    wglSwapIntervalEXT(interval);
   }
 
-  void set_synchronization(bool enable) {
+  GLint fbo;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &fbo);
 
-    // General notes:
-    // Setting swapping on and off is platform-dependent and requires platform-specific extensions.
-    // Platform-specific extensions are even more bothersome than regular extensions.
-    // What functions and features to use depends on which version of OpenGL is used.
-    // For more information, see the following pages:
-    // http://www.opengl.org/wiki/Load_OpenGL_Functions
-    // http://www.opengl.org/wiki/OpenGL_Loading_Library
-    // http://www.opengl.org/wiki/Swap_Interval
-    // http://en.wikipedia.org/wiki/WGL_%28software%29
-    // Also note that OpenGL version >= 3.0 does not use glGetString for getting extensions.
+  GLuint ColorBufferID, DepthBufferID;
 
-      int interval = enable ? 1 : 0;
-
-    if (enigma::is_ext_swapcontrol_supported()) {
-      wglSwapIntervalEXT(interval);
+  // Cleanup the multi-sampler fbo if turning off multi-sampling
+  if (samples == 0) {
+    if (enigma::msaa_fbo != 0) {
+      glDeleteFramebuffers(1, &enigma::msaa_fbo);
+      enigma::msaa_fbo = 0;
     }
+    return;
+  }
+
+  //TODO: Change the code below to fix this to size properly to views
+  // If we don't already have a multi-sample fbo then create one
+  if (enigma::msaa_fbo == 0) {
+    glGenFramebuffersEXT(1, &enigma::msaa_fbo);
+  }
+  glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, enigma::msaa_fbo);
+  // Now make a multi-sample color buffer
+  glGenRenderbuffersEXT(1, &ColorBufferID);
+  glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, ColorBufferID);
+  glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER_EXT, samples, GL_RGBA8, window_get_region_width(),
+                                      window_get_region_height());
+  // We also need a depth buffer
+  glGenRenderbuffersEXT(1, &DepthBufferID);
+  glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, DepthBufferID);
+  glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER_EXT, samples, GL_DEPTH_COMPONENT24, window_get_region_width(),
+                                      window_get_region_height());
+  // Attach the render buffers to the multi-sampler fbo
+  glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, ColorBufferID);
+  glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, DepthBufferID);
+}
+
+void screen_refresh() {
+  window_set_caption(room_caption);
+  enigma::update_mouse_variables();
+  SwapBuffers(enigma::window_hDC);
+}
+
+void set_synchronization(bool enable) {
+  // General notes:
+  // Setting swapping on and off is platform-dependent and requires platform-specific extensions.
+  // Platform-specific extensions are even more bothersome than regular extensions.
+  // What functions and features to use depends on which version of OpenGL is used.
+  // For more information, see the following pages:
+  // http://www.opengl.org/wiki/Load_OpenGL_Functions
+  // http://www.opengl.org/wiki/OpenGL_Loading_Library
+  // http://www.opengl.org/wiki/Swap_Interval
+  // http://en.wikipedia.org/wiki/WGL_%28software%29
+  // Also note that OpenGL version >= 3.0 does not use glGetString for getting extensions.
+
+  int interval = enable ? 1 : 0;
+
+  if (enigma::is_ext_swapcontrol_supported()) {
+    wglSwapIntervalEXT(interval);
   }
 }
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL3/graphics_bridge.cpp
@@ -16,253 +16,285 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <string>
 #include <windows.h>
+#include <string>
 using namespace std;
 
 #include "../General/wglew.h"
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h"
-#include "Platforms/Win32/WINDOWSmain.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Platforms/General/PFwindow.h"
+#include "Platforms/Win32/WINDOWSmain.h"
+#include "Widget_Systems/widgets_mandatory.h"
+#include "libEGMstd.h"
 
-namespace enigma
-{
-	#ifdef DEBUG_MODE
-	#include "Widget_Systems/widgets_mandatory.h"
-	//Based on code from Cort Stratton (http://www.altdev.co/2011/06/23/improving-opengl-error-messages/)
-	void FormatDebugOutputARB(char outStr[], size_t outStrSize, GLenum source, GLenum type, GLuint id, GLenum severity, const char *msg) {
-		char sourceStr[32]; const char *sourceFmt = "UNDEFINED(0x%04X)";
-		switch(source) {
-			case GL_DEBUG_SOURCE_API_ARB: sourceFmt = "API"; break;
-			case GL_DEBUG_SOURCE_WINDOW_SYSTEM_ARB: sourceFmt = "WINDOW_SYSTEM"; break;
-			case GL_DEBUG_SOURCE_SHADER_COMPILER_ARB: sourceFmt = "SHADER_COMPILER"; break;
-			case GL_DEBUG_SOURCE_THIRD_PARTY_ARB: sourceFmt = "THIRD_PARTY"; break;
-			case GL_DEBUG_SOURCE_APPLICATION_ARB: sourceFmt = "APPLICATION"; break;
-			case GL_DEBUG_SOURCE_OTHER_ARB: sourceFmt = "OTHER"; break;
-		}
-		snprintf(sourceStr, 32, sourceFmt, source);
-		char typeStr[32];
-		const char *typeFmt = "UNDEFINED(0x%04X)";
-		switch(type) {
-			case GL_DEBUG_TYPE_ERROR_ARB: typeFmt = "ERROR"; break;
-			case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR_ARB: typeFmt = "DEPRECATED_BEHAVIOR"; break;
-			case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB: typeFmt = "UNDEFINED_BEHAVIOR"; break;
-			case GL_DEBUG_TYPE_PORTABILITY_ARB: typeFmt = "PORTABILITY"; break;
-			case GL_DEBUG_TYPE_PERFORMANCE_ARB: typeFmt = "PERFORMANCE"; break;
-			case GL_DEBUG_TYPE_OTHER_ARB: typeFmt = "OTHER"; break;
-		}
-		snprintf(typeStr, 32, typeFmt, type);
-		char severityStr[32];
-		const char *severityFmt = "UNDEFINED(%i)";
-		switch(severity) {
-			case GL_DEBUG_SEVERITY_HIGH_ARB: severityFmt = "HIGH"; break;
-			case GL_DEBUG_SEVERITY_MEDIUM_ARB: severityFmt = "MEDIUM"; break;
-			case GL_DEBUG_SEVERITY_LOW_ARB: severityFmt = "LOW"; break;
-		}
-		snprintf(severityStr, 32, severityFmt, severity);
-		snprintf(outStr, outStrSize, "OpenGL: %s [source=%s type=%s severity=%s id=%d]", msg, sourceStr, typeStr, severityStr, id);
-	}
-
-	void DebugCallbackARB(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, GLvoid* userParam) {
-		char finalMessage[256];
-		FormatDebugOutputARB(finalMessage, 256, source, type, id, severity, message);
-		printf("%s\n", finalMessage);
-    show_error(toString(finalMessage), false);
-	}
-	#endif
-
-	GLuint msaa_fbo = 0;
-
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
-    // clear the window color, viewport does not need set because backbuffer was just recreated
-    enigma_user::draw_clear(enigma_user::window_get_color());
+namespace enigma {
+#ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"
+//Based on code from Cort Stratton (http://www.altdev.co/2011/06/23/improving-opengl-error-messages/)
+void FormatDebugOutputARB(char outStr[], size_t outStrSize, GLenum source, GLenum type, GLuint id, GLenum severity,
+                          const char *msg) {
+  char sourceStr[32];
+  const char *sourceFmt = "UNDEFINED(0x%04X)";
+  switch (source) {
+    case GL_DEBUG_SOURCE_API_ARB:
+      sourceFmt = "API";
+      break;
+    case GL_DEBUG_SOURCE_WINDOW_SYSTEM_ARB:
+      sourceFmt = "WINDOW_SYSTEM";
+      break;
+    case GL_DEBUG_SOURCE_SHADER_COMPILER_ARB:
+      sourceFmt = "SHADER_COMPILER";
+      break;
+    case GL_DEBUG_SOURCE_THIRD_PARTY_ARB:
+      sourceFmt = "THIRD_PARTY";
+      break;
+    case GL_DEBUG_SOURCE_APPLICATION_ARB:
+      sourceFmt = "APPLICATION";
+      break;
+    case GL_DEBUG_SOURCE_OTHER_ARB:
+      sourceFmt = "OTHER";
+      break;
   }
+  snprintf(sourceStr, 32, sourceFmt, source);
+  char typeStr[32];
+  const char *typeFmt = "UNDEFINED(0x%04X)";
+  switch (type) {
+    case GL_DEBUG_TYPE_ERROR_ARB:
+      typeFmt = "ERROR";
+      break;
+    case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR_ARB:
+      typeFmt = "DEPRECATED_BEHAVIOR";
+      break;
+    case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB:
+      typeFmt = "UNDEFINED_BEHAVIOR";
+      break;
+    case GL_DEBUG_TYPE_PORTABILITY_ARB:
+      typeFmt = "PORTABILITY";
+      break;
+    case GL_DEBUG_TYPE_PERFORMANCE_ARB:
+      typeFmt = "PERFORMANCE";
+      break;
+    case GL_DEBUG_TYPE_OTHER_ARB:
+      typeFmt = "OTHER";
+      break;
+  }
+  snprintf(typeStr, 32, typeFmt, type);
+  char severityStr[32];
+  const char *severityFmt = "UNDEFINED(%i)";
+  switch (severity) {
+    case GL_DEBUG_SEVERITY_HIGH_ARB:
+      severityFmt = "HIGH";
+      break;
+    case GL_DEBUG_SEVERITY_MEDIUM_ARB:
+      severityFmt = "MEDIUM";
+      break;
+    case GL_DEBUG_SEVERITY_LOW_ARB:
+      severityFmt = "LOW";
+      break;
+  }
+  snprintf(severityStr, 32, severityFmt, severity);
+  snprintf(outStr, outStrSize, "OpenGL: %s [source=%s type=%s severity=%s id=%d]", msg, sourceStr, typeStr, severityStr,
+           id);
+}
 
-  void EnableDrawing (HGLRC *hRC)
-  {
-    WindowResizedCallback = &WindowResized;
-    /**
+void DebugCallbackARB(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message,
+                      GLvoid *userParam) {
+  char finalMessage[256];
+  FormatDebugOutputARB(finalMessage, 256, source, type, id, severity, message);
+  printf("%s\n", finalMessage);
+  show_error(toString(finalMessage), false);
+}
+#endif
+
+GLuint msaa_fbo = 0;
+
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  // clear the window color, viewport does not need set because backbuffer was just recreated
+  enigma_user::draw_clear(enigma_user::window_get_color());
+}
+
+void EnableDrawing(HGLRC *hRC) {
+  WindowResizedCallback = &WindowResized;
+  /**
      * Edited by Cool Breeze on 16th October 2013
      * + Updated the Pixel Format to support 24-bitdepth buffers
      * + Correctly create a GL 3.x compliant context
      */
-    HGLRC LegacyRC;
-    PIXELFORMATDESCRIPTOR pfd;
-    int iFormat;
+  HGLRC LegacyRC;
+  PIXELFORMATDESCRIPTOR pfd;
+  int iFormat;
 
-    enigma::window_hDC = GetDC (hWnd);
-    ZeroMemory (&pfd, sizeof (pfd));
-    pfd.nSize = sizeof (pfd);
-    pfd.nVersion = 1;
-    pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
-    pfd.iPixelType = PFD_TYPE_RGBA;
-    pfd.cColorBits = 24;
-    pfd.cDepthBits = 24;
-    pfd.cStencilBits = 8;
-    pfd.iLayerType = PFD_MAIN_PLANE;
-    iFormat = ChoosePixelFormat (enigma::window_hDC, &pfd);
+  enigma::window_hDC = GetDC(hWnd);
+  ZeroMemory(&pfd, sizeof(pfd));
+  pfd.nSize = sizeof(pfd);
+  pfd.nVersion = 1;
+  pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+  pfd.iPixelType = PFD_TYPE_RGBA;
+  pfd.cColorBits = 24;
+  pfd.cDepthBits = 24;
+  pfd.cStencilBits = 8;
+  pfd.iLayerType = PFD_MAIN_PLANE;
+  iFormat = ChoosePixelFormat(enigma::window_hDC, &pfd);
 
-    if (iFormat==0) { show_error("Failed to set the format of the OpenGL graphics device.",1); }
-
-    SetPixelFormat ( enigma::window_hDC, iFormat, &pfd );
-    LegacyRC = wglCreateContext( enigma::window_hDC );
-    wglMakeCurrent( enigma::window_hDC, LegacyRC );
-
-    // -- Initialise GLEW
-    GLenum err = glewInit();
-    if (GLEW_OK != err)
-    {
-      return;
-    }
-
-    // -- Define an array of Context Attributes
-    int attribs[] =
-    {
-      WGL_CONTEXT_MAJOR_VERSION_ARB, 3,
-      WGL_CONTEXT_MINOR_VERSION_ARB, 3,
-      //WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
-      #ifdef DEBUG_MODE
-        WGL_CONTEXT_FLAGS_ARB, WGL_CONTEXT_DEBUG_BIT_ARB,
-      #else
-        WGL_CONTEXT_FLAGS_ARB, 0,
-      #endif
-      0
-    };
-
-    if ( wglewIsSupported("WGL_ARB_create_context") )
-    {
-      *hRC = wglCreateContextAttribsARB( enigma::window_hDC,0, attribs );
-      wglMakeCurrent( NULL,NULL );
-      wglDeleteContext( LegacyRC );
-      wglMakeCurrent(enigma::window_hDC, *hRC );
-    }
-    else // Unable to get a 3.3 Core Context, use the Legacy 1.x context
-    {
-      *hRC = LegacyRC;
-    }
-
-    #ifdef DEBUG_MODE
-    glDebugMessageCallbackARB((GLDEBUGPROCARB)&DebugCallbackARB, 0);
-    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
-    printf("OpenGL version supported by this platform (%s): \n", glGetString(GL_VERSION));
-
-    GLuint other_ids[] = { 131185 };
-    glDebugMessageControlARB(GL_DEBUG_SOURCE_API_ARB, GL_DEBUG_TYPE_OTHER_ARB, GL_DONT_CARE, 1, other_ids, GL_FALSE); //Disable some notifications shown below:
-    //OpenGL: Buffer detailed info: Buffer object 1 (bound to GL_ELEMENT_ARRAY_BUFFER_ARB, usage hint is GL_STATIC_DRAW) will use VIDEO memory as the source for buffer object operations. [source=API type=OTHER severity=UNDEFINED (33387) id=131185]
-    GLuint performance_ids[] = { 131218, 2 };
-    glDebugMessageControlARB(GL_DEBUG_SOURCE_API_ARB, GL_DEBUG_TYPE_PERFORMANCE_ARB, GL_DONT_CARE, 2, performance_ids, GL_FALSE); //Disable some notifications shown below:
-    //OpenGL: Program/shader state performance warning: Vertex shader in program 9 is being recompiled based on GL state. [source=API type=PERFORMANCE severity=MEDIUM id=131218] - This is NVidia only and doesn't tell much
-    #endif
-
-    //TODO: This never reports higher than 8, but display_aa should be 14 if 2,4,and 8 are supported and 8 only when only 8 is supported
-    glGetIntegerv(GL_MAX_SAMPLES_EXT, &enigma_user::display_aa);
+  if (iFormat == 0) {
+    show_error("Failed to set the format of the OpenGL graphics device.", 1);
   }
 
-  void DisableDrawing (HWND hWnd, HDC hDC, HGLRC hRC)
+  SetPixelFormat(enigma::window_hDC, iFormat, &pfd);
+  LegacyRC = wglCreateContext(enigma::window_hDC);
+  wglMakeCurrent(enigma::window_hDC, LegacyRC);
+
+  // -- Initialise GLEW
+  GLenum err = glewInit();
+  if (GLEW_OK != err) {
+    return;
+  }
+
+  // -- Define an array of Context Attributes
+  int attribs[] = {WGL_CONTEXT_MAJOR_VERSION_ARB,
+                   3,
+                   WGL_CONTEXT_MINOR_VERSION_ARB,
+                   3,
+//WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+#ifdef DEBUG_MODE
+                   WGL_CONTEXT_FLAGS_ARB,
+                   WGL_CONTEXT_DEBUG_BIT_ARB,
+#else
+                   WGL_CONTEXT_FLAGS_ARB,
+                   0,
+#endif
+                   0};
+
+  if (wglewIsSupported("WGL_ARB_create_context")) {
+    *hRC = wglCreateContextAttribsARB(enigma::window_hDC, 0, attribs);
+    wglMakeCurrent(NULL, NULL);
+    wglDeleteContext(LegacyRC);
+    wglMakeCurrent(enigma::window_hDC, *hRC);
+  } else  // Unable to get a 3.3 Core Context, use the Legacy 1.x context
   {
-      wglMakeCurrent (NULL, NULL);
-      wglDeleteContext (hRC);
-      ReleaseDC (hWnd, hDC);
+    *hRC = LegacyRC;
   }
+
+#ifdef DEBUG_MODE
+  glDebugMessageCallbackARB((GLDEBUGPROCARB)&DebugCallbackARB, 0);
+  glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+  printf("OpenGL version supported by this platform (%s): \n", glGetString(GL_VERSION));
+
+  GLuint other_ids[] = {131185};
+  glDebugMessageControlARB(GL_DEBUG_SOURCE_API_ARB, GL_DEBUG_TYPE_OTHER_ARB, GL_DONT_CARE, 1, other_ids,
+                           GL_FALSE);  //Disable some notifications shown below:
+  //OpenGL: Buffer detailed info: Buffer object 1 (bound to GL_ELEMENT_ARRAY_BUFFER_ARB, usage hint is GL_STATIC_DRAW) will use VIDEO memory as the source for buffer object operations. [source=API type=OTHER severity=UNDEFINED (33387) id=131185]
+  GLuint performance_ids[] = {131218, 2};
+  glDebugMessageControlARB(GL_DEBUG_SOURCE_API_ARB, GL_DEBUG_TYPE_PERFORMANCE_ARB, GL_DONT_CARE, 2, performance_ids,
+                           GL_FALSE);  //Disable some notifications shown below:
+//OpenGL: Program/shader state performance warning: Vertex shader in program 9 is being recompiled based on GL state. [source=API type=PERFORMANCE severity=MEDIUM id=131218] - This is NVidia only and doesn't tell much
+#endif
+
+  //TODO: This never reports higher than 8, but display_aa should be 14 if 2,4,and 8 are supported and 8 only when only 8 is supported
+  glGetIntegerv(GL_MAX_SAMPLES_EXT, &enigma_user::display_aa);
+}
+
+void DisableDrawing(HWND hWnd, HDC hDC, HGLRC hRC) {
+  wglMakeCurrent(NULL, NULL);
+  wglDeleteContext(hRC);
+  ReleaseDC(hWnd, hDC);
+}
 }
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL1 version.
 
 namespace enigma {
-  namespace swaphandling {
-    bool has_checked_extensions = false;
-    bool ext_swapcontrol_supported;
+namespace swaphandling {
+bool has_checked_extensions = false;
+bool ext_swapcontrol_supported;
 
-    void investigate_swapcontrol_support() {
+void investigate_swapcontrol_support() {
+  if (has_checked_extensions) return;  // Already calculated, no need to calculate it more.
 
-      if (has_checked_extensions) return; // Already calculated, no need to calculate it more.
+  const char *wgl_extensions = wglGetExtensionsStringARB(window_hDC);
 
-      const char *wgl_extensions = wglGetExtensionsStringARB(window_hDC);
+  ext_swapcontrol_supported = strstr(wgl_extensions, "WGL_EXT_swap_control");
 
-      ext_swapcontrol_supported = strstr(wgl_extensions, "WGL_EXT_swap_control");
-
-      has_checked_extensions = true;
-    }
-  }
-
-  bool is_ext_swapcontrol_supported() {
-    swaphandling::investigate_swapcontrol_support();
-    return swaphandling::ext_swapcontrol_supported;
-  }
+  has_checked_extensions = true;
 }
+}  // namespace swaphandling
+
+bool is_ext_swapcontrol_supported() {
+  swaphandling::investigate_swapcontrol_support();
+  return swaphandling::ext_swapcontrol_supported;
+}
+}  // namespace enigma
 
 #include "Universal_System/roomsystem.h"
 
 namespace enigma_user {
-	int display_aa = 0;
+int display_aa = 0;
 
-	void display_reset(int samples, bool vsync) {
-		int interval = vsync ? 1 : 0;
+void display_reset(int samples, bool vsync) {
+  int interval = vsync ? 1 : 0;
 
-		if (enigma::is_ext_swapcontrol_supported()) {
-		  wglSwapIntervalEXT(interval);
-		}
-
-		GLint fbo;
-		glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
-
-		GLuint ColorBufferID, DepthBufferID;
-
-		// Cleanup the multi-sampler fbo if turning off multi-sampling
-		if (samples == 0) {
-			if (enigma::msaa_fbo != 0) {
-				glDeleteFramebuffers(1, &enigma::msaa_fbo);
-				enigma::msaa_fbo = 0;
-			}
-			return;
-		}
-
-		//TODO: Change the code below to fix this to size properly to views
-		// If we don't already have a multi-sample fbo then create one
-		if (enigma::msaa_fbo == 0) {
-			glGenFramebuffers(1, &enigma::msaa_fbo);
-		}
-		glBindFramebuffer(GL_FRAMEBUFFER, enigma::msaa_fbo);
-		// Now make a multi-sample color buffer
-		glGenRenderbuffers(1, &ColorBufferID);
-		glBindRenderbuffer(GL_RENDERBUFFER, ColorBufferID);
-		glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, samples, GL_RGBA8, window_get_region_width(), window_get_region_height());
-		// We also need a depth buffer
-		glGenRenderbuffersEXT(1, &DepthBufferID);
-		glBindRenderbufferEXT(GL_RENDERBUFFER, DepthBufferID);
-		glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, GL_DEPTH_COMPONENT24, window_get_region_width(), window_get_region_height());
-		// Attach the render buffers to the multi-sampler fbo
-		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, ColorBufferID);
-		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, DepthBufferID);
-	}
-
-
-  void screen_refresh() {
-    window_set_caption(room_caption);
-    enigma::update_mouse_variables();
-    SwapBuffers(enigma::window_hDC);
+  if (enigma::is_ext_swapcontrol_supported()) {
+    wglSwapIntervalEXT(interval);
   }
 
-  void set_synchronization(bool enable) {
+  GLint fbo;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
 
-    // General notes:
-    // Setting swapping on and off is platform-dependent and requires platform-specific extensions.
-    // Platform-specific extensions are even more bothersome than regular extensions.
-    // What functions and features to use depends on which version of OpenGL is used.
-    // For more information, see the following pages:
-    // http://www.opengl.org/wiki/Load_OpenGL_Functions
-    // http://www.opengl.org/wiki/OpenGL_Loading_Library
-    // http://www.opengl.org/wiki/Swap_Interval
-    // http://en.wikipedia.org/wiki/WGL_%28software%29
-    // Also note that OpenGL version >= 3.0 does not use glGetString for getting extensions.
+  GLuint ColorBufferID, DepthBufferID;
 
-    int interval = enable ? 1 : 0;
-
-    if (enigma::is_ext_swapcontrol_supported()) {
-      wglSwapIntervalEXT(interval);
+  // Cleanup the multi-sampler fbo if turning off multi-sampling
+  if (samples == 0) {
+    if (enigma::msaa_fbo != 0) {
+      glDeleteFramebuffers(1, &enigma::msaa_fbo);
+      enigma::msaa_fbo = 0;
     }
+    return;
+  }
+
+  //TODO: Change the code below to fix this to size properly to views
+  // If we don't already have a multi-sample fbo then create one
+  if (enigma::msaa_fbo == 0) {
+    glGenFramebuffers(1, &enigma::msaa_fbo);
+  }
+  glBindFramebuffer(GL_FRAMEBUFFER, enigma::msaa_fbo);
+  // Now make a multi-sample color buffer
+  glGenRenderbuffers(1, &ColorBufferID);
+  glBindRenderbuffer(GL_RENDERBUFFER, ColorBufferID);
+  glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, samples, GL_RGBA8, window_get_region_width(),
+                                      window_get_region_height());
+  // We also need a depth buffer
+  glGenRenderbuffersEXT(1, &DepthBufferID);
+  glBindRenderbufferEXT(GL_RENDERBUFFER, DepthBufferID);
+  glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, GL_DEPTH_COMPONENT24, window_get_region_width(),
+                                   window_get_region_height());
+  // Attach the render buffers to the multi-sampler fbo
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, ColorBufferID);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, DepthBufferID);
+}
+
+void screen_refresh() {
+  window_set_caption(room_caption);
+  enigma::update_mouse_variables();
+  SwapBuffers(enigma::window_hDC);
+}
+
+void set_synchronization(bool enable) {
+  // General notes:
+  // Setting swapping on and off is platform-dependent and requires platform-specific extensions.
+  // Platform-specific extensions are even more bothersome than regular extensions.
+  // What functions and features to use depends on which version of OpenGL is used.
+  // For more information, see the following pages:
+  // http://www.opengl.org/wiki/Load_OpenGL_Functions
+  // http://www.opengl.org/wiki/OpenGL_Loading_Library
+  // http://www.opengl.org/wiki/Swap_Interval
+  // http://en.wikipedia.org/wiki/WGL_%28software%29
+  // Also note that OpenGL version >= 3.0 does not use glGetString for getting extensions.
+
+  int interval = enable ? 1 : 0;
+
+  if (enigma::is_ext_swapcontrol_supported()) {
+    wglSwapIntervalEXT(interval);
   }
 }
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL1/graphics_bridge.cpp
@@ -17,58 +17,58 @@
 //#include <GL/glx.h>
 #include <X11/Xlib.h>
 #include "../General/glxew.h"
-#include "Platforms/xlib/XLIBmain.h"
+#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Platforms/General/PFwindow.h"
-#include "Graphics_Systems/General/GScolors.h"
+#include "Platforms/xlib/XLIBmain.h"
 
-#include <iostream>
-#include <cstring>
 #include <stdio.h>
+#include <cstring>
+#include <iostream>
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL3 version.
 
 namespace enigma {
-  GLuint msaa_fbo = 0;
-  GLXContext glxc;
-  XVisualInfo *vi;
-  
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
-    glViewport(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
-    glScissor(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
-    enigma_user::draw_clear(enigma_user::window_get_color());
+GLuint msaa_fbo = 0;
+GLXContext glxc;
+XVisualInfo *vi;
+
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  glViewport(0, 0, enigma_user::window_get_width(), enigma_user::window_get_height());
+  glScissor(0, 0, enigma_user::window_get_width(), enigma_user::window_get_height());
+  enigma_user::draw_clear(enigma_user::window_get_color());
+}
+
+XVisualInfo *CreateVisualInfo() {
+  // Prepare openGL
+  GLint att[] = {GLX_RGBA, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, None};
+  vi = glXChooseVisual(enigma::x11::disp, 0, att);
+  if (!vi) {
+    printf("Failed to Obtain GL Visual Info\n");
+    return NULL;
   }
-  
-  XVisualInfo* CreateVisualInfo() {
-    // Prepare openGL
-    GLint att[] = { GLX_RGBA, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, None };
-    vi = glXChooseVisual(enigma::x11::disp,0,att);
-    if(!vi){
-        printf("Failed to Obtain GL Visual Info\n");
-        return NULL;
-    }
-    return vi;
+  return vi;
+}
+
+void EnableDrawing() {
+  WindowResizedCallback = &WindowResized;
+
+  //give us a GL context
+  glxc = glXCreateContext(enigma::x11::disp, vi, NULL, True);
+  if (!glxc) {
+    printf("Failed to Create Graphics Context\n");
+    return;
   }
 
-  void EnableDrawing() {
-    WindowResizedCallback = &WindowResized;
-    
-    //give us a GL context
-    glxc = glXCreateContext(enigma::x11::disp, vi, NULL, True);
-    if (!glxc){
-        printf("Failed to Create Graphics Context\n");
-        return;
-    }
-    
-    //apply context
-    glXMakeCurrent(enigma::x11::disp,enigma::x11::win,glxc); //flushes
-    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_ACCUM_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
-  }
-  
-  void DisableDrawing() {
-   glXDestroyContext(enigma::x11::disp,glxc);
-      /*
+  //apply context
+  glXMakeCurrent(enigma::x11::disp, enigma::x11::win, glxc);  //flushes
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_ACCUM_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+}
+
+void DisableDrawing() {
+  glXDestroyContext(enigma::x11::disp, glxc);
+  /*
     for(char q=1;q;ENIGMA_events())
         while(XQLength(disp))
             if(handleEvents()>0) q=0;
@@ -76,86 +76,84 @@ namespace enigma {
     glXDestroyContext(disp,glxc);
     XCloseDisplay(disp);
     return 0;*/
-  }
-  
-  namespace swaphandling {
-    static bool has_checked_extensions = false;
-    static bool ext_swapcontrol_supported;
-    static bool mesa_swapcontrol_supported;
-
-    static void investigate_swapcontrol_support() {
-      if (has_checked_extensions) return; // Already calculated, no need to calculate it more.
-
-      // TODO: The second argument to glXQueryExtensionsString is screen number,
-      // and it is unknown if the value 0 is generally correct for calling that function.
-      // For more information, see the following pages:
-      // http://pic.dhe.ibm.com/infocenter/aix/v6r1/index.jsp?topic=%2Fcom.ibm.aix.opengl%2Fdoc%2Fopenglrf%2FglXQueryExtensionsString.htm
-      const char *glx_extensions = glXQueryExtensionsString(enigma::x11::disp, 0);
-
-      ext_swapcontrol_supported = strstr(glx_extensions, "GLX_EXT_swap_control");
-      mesa_swapcontrol_supported = strstr(glx_extensions, "GLX_MESA_swap_control");
-
-      has_checked_extensions = true;
-    }
-  }
-
-  static bool is_ext_swapcontrol_supported() {
-    swaphandling::investigate_swapcontrol_support();
-    return swaphandling::ext_swapcontrol_supported;
-  }
-  static bool is_mesa_swapcontrol_supported() {
-    swaphandling::investigate_swapcontrol_support();
-    return swaphandling::mesa_swapcontrol_supported;
-  }
 }
 
-#include <Platforms/xlib/XLIBwindow.h> // window_set_caption
-#include <Universal_System/roomsystem.h> // room_caption, update_mouse_variables
+namespace swaphandling {
+static bool has_checked_extensions = false;
+static bool ext_swapcontrol_supported;
+static bool mesa_swapcontrol_supported;
+
+static void investigate_swapcontrol_support() {
+  if (has_checked_extensions) return;  // Already calculated, no need to calculate it more.
+
+  // TODO: The second argument to glXQueryExtensionsString is screen number,
+  // and it is unknown if the value 0 is generally correct for calling that function.
+  // For more information, see the following pages:
+  // http://pic.dhe.ibm.com/infocenter/aix/v6r1/index.jsp?topic=%2Fcom.ibm.aix.opengl%2Fdoc%2Fopenglrf%2FglXQueryExtensionsString.htm
+  const char *glx_extensions = glXQueryExtensionsString(enigma::x11::disp, 0);
+
+  ext_swapcontrol_supported = strstr(glx_extensions, "GLX_EXT_swap_control");
+  mesa_swapcontrol_supported = strstr(glx_extensions, "GLX_MESA_swap_control");
+
+  has_checked_extensions = true;
+}
+}  // namespace swaphandling
+
+static bool is_ext_swapcontrol_supported() {
+  swaphandling::investigate_swapcontrol_support();
+  return swaphandling::ext_swapcontrol_supported;
+}
+static bool is_mesa_swapcontrol_supported() {
+  swaphandling::investigate_swapcontrol_support();
+  return swaphandling::mesa_swapcontrol_supported;
+}
+}  // namespace enigma
+
+#include <Platforms/xlib/XLIBwindow.h>    // window_set_caption
+#include <Universal_System/roomsystem.h>  // room_caption, update_mouse_variables
 
 namespace enigma_user {
-  // Don't know where to query this on XLIB, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
-  int display_aa = 14;
+// Don't know where to query this on XLIB, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
+int display_aa = 14;
 
-  void set_synchronization(bool enable) {
-    // General notes:
-    // Setting swapping on and off is platform-dependent and requires platform-specific extensions.
-    // Platform-specific extensions are even more bothersome than regular extensions.
-    // What functions and features to use depends on which version of OpenGL is used.
-    // For more information, see the following pages:
-    // http://www.opengl.org/wiki/Load_OpenGL_Functions
-    // http://www.opengl.org/wiki/OpenGL_Loading_Library
-    // http://www.opengl.org/wiki/Swap_Interval
-    // http://en.wikipedia.org/wiki/GLX
-    // Also note that OpenGL version >= 3.0 does not use glGetString for getting extensions.
+void set_synchronization(bool enable) {
+  // General notes:
+  // Setting swapping on and off is platform-dependent and requires platform-specific extensions.
+  // Platform-specific extensions are even more bothersome than regular extensions.
+  // What functions and features to use depends on which version of OpenGL is used.
+  // For more information, see the following pages:
+  // http://www.opengl.org/wiki/Load_OpenGL_Functions
+  // http://www.opengl.org/wiki/OpenGL_Loading_Library
+  // http://www.opengl.org/wiki/Swap_Interval
+  // http://en.wikipedia.org/wiki/GLX
+  // Also note that OpenGL version >= 3.0 does not use glGetString for getting extensions.
 
-    if (enigma::x11::disp != 0) {
-      GLXDrawable drawable = glXGetCurrentDrawable();
+  if (enigma::x11::disp != 0) {
+    GLXDrawable drawable = glXGetCurrentDrawable();
 
-      int interval = enable ? 1 : 0;
+    int interval = enable ? 1 : 0;
 
-      if (enigma::is_ext_swapcontrol_supported()) {
+    if (enigma::is_ext_swapcontrol_supported()) {
       glXSwapIntervalEXT(enigma::x11::disp, drawable, interval);
-      }
-      else if (enigma::is_mesa_swapcontrol_supported()) {
+    } else if (enigma::is_mesa_swapcontrol_supported()) {
       glXSwapIntervalMESA(interval);
-      }
-      // NOTE: GLX_SGI_swap_control, which is not used here, does not seem
-      // to support disabling of synchronization, since its argument may not
-      // be zero or less, so therefore it is not used here.
-      // See http://www.opengl.org/registry/specs/SGI/swap_control.txt for more information.
     }
+    // NOTE: GLX_SGI_swap_control, which is not used here, does not seem
+    // to support disabling of synchronization, since its argument may not
+    // be zero or less, so therefore it is not used here.
+    // See http://www.opengl.org/registry/specs/SGI/swap_control.txt for more information.
   }
-    
-  void display_reset(int samples, bool vsync) {
-    set_synchronization(vsync);
-    //TODO: Copy over from the Win32 bridge
-  }
-    
-  void screen_refresh() {
-    glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
-    enigma::update_mouse_variables();
-    window_set_caption(room_caption);
-  }
-
 }
 
+void display_reset(int samples, bool vsync) {
+  set_synchronization(vsync);
+  //TODO: Copy over from the Win32 bridge
+}
+
+void screen_refresh() {
+  glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
+  enigma::update_mouse_variables();
+  window_set_caption(room_caption);
+}
+
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL3/graphics_bridge.cpp
@@ -17,57 +17,57 @@
 //#include <GL/glx.h>
 #include <X11/Xlib.h>
 #include "../General/glxew.h"
-#include "Platforms/xlib/XLIBmain.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Platforms/General/PFwindow.h"
+#include "Platforms/xlib/XLIBmain.h"
 
-#include <iostream>
-#include <cstring>
 #include <stdio.h>
+#include <cstring>
+#include <iostream>
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL1 version.
 
 namespace enigma {
-  GLuint msaa_fbo = 0;
-  GLXContext glxc;
-  XVisualInfo *vi;
-  
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
-    glViewport(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
-    glScissor(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
-    enigma_user::draw_clear(enigma_user::window_get_color());
+GLuint msaa_fbo = 0;
+GLXContext glxc;
+XVisualInfo *vi;
+
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  glViewport(0, 0, enigma_user::window_get_width(), enigma_user::window_get_height());
+  glScissor(0, 0, enigma_user::window_get_width(), enigma_user::window_get_height());
+  enigma_user::draw_clear(enigma_user::window_get_color());
+}
+
+XVisualInfo *CreateVisualInfo() {
+  // Prepare openGL
+  GLint att[] = {GLX_RGBA, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, None};
+  vi = glXChooseVisual(enigma::x11::disp, 0, att);
+  if (!vi) {
+    printf("Failed to Obtain GL Visual Info\n");
+    return NULL;
   }
-  
-  XVisualInfo* CreateVisualInfo() {
-    // Prepare openGL
-    GLint att[] = { GLX_RGBA, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, None };
-    vi = glXChooseVisual(enigma::x11::disp,0,att);
-    if(!vi){
-        printf("Failed to Obtain GL Visual Info\n");
-        return NULL;
-    }
-    return vi;
+  return vi;
+}
+
+void EnableDrawing() {
+  WindowResizedCallback = &WindowResized;
+
+  //give us a GL context
+  glxc = glXCreateContext(enigma::x11::disp, vi, NULL, True);
+  if (!glxc) {
+    printf("Failed to Create Graphics Context\n");
+    return;
   }
 
-  void EnableDrawing() {
-    WindowResizedCallback = &WindowResized;
-    
-    //give us a GL context
-    glxc = glXCreateContext(enigma::x11::disp, vi, NULL, True);
-    if (!glxc){
-        printf("Failed to Create Graphics Context\n");
-        return;
-    }
-    
-    //apply context
-    glXMakeCurrent(enigma::x11::disp,enigma::x11::win,glxc); //flushes
-    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_ACCUM_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
-  }
-  
-  void DisableDrawing() {
-   glXDestroyContext(enigma::x11::disp,glxc);
-      /*
+  //apply context
+  glXMakeCurrent(enigma::x11::disp, enigma::x11::win, glxc);  //flushes
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_ACCUM_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+}
+
+void DisableDrawing() {
+  glXDestroyContext(enigma::x11::disp, glxc);
+  /*
     for(char q=1;q;ENIGMA_events())
         while(XQLength(disp))
             if(handleEvents()>0) q=0;
@@ -75,88 +75,84 @@ namespace enigma {
     glXDestroyContext(disp,glxc);
     XCloseDisplay(disp);
     return 0;*/
-  }
-  
-  namespace swaphandling {
-    bool has_checked_extensions = false;
-    bool ext_swapcontrol_supported;
-    bool mesa_swapcontrol_supported;
-
-    void investigate_swapcontrol_support() {
-
-      if (has_checked_extensions) return; // Already calculated, no need to calculate it more.
-
-      // TODO: The second argument to glXQueryExtensionsString is screen number,
-      // and it is unknown if the value 0 is generally correct for calling that function.
-      // For more information, see the following pages:
-      // http://pic.dhe.ibm.com/infocenter/aix/v6r1/index.jsp?topic=%2Fcom.ibm.aix.opengl%2Fdoc%2Fopenglrf%2FglXQueryExtensionsString.htm
-      const char *glx_extensions = glXQueryExtensionsString(enigma::x11::disp, 0);
-
-      ext_swapcontrol_supported = strstr(glx_extensions, "GLX_EXT_swap_control");
-      mesa_swapcontrol_supported = strstr(glx_extensions, "GLX_MESA_swap_control");
-
-      has_checked_extensions = true;
-    }
-  }
-
-  bool is_ext_swapcontrol_supported() {
-    swaphandling::investigate_swapcontrol_support();
-    return swaphandling::ext_swapcontrol_supported;
-  }
-  bool is_mesa_swapcontrol_supported() {
-    swaphandling::investigate_swapcontrol_support();
-    return swaphandling::mesa_swapcontrol_supported;
-  }
 }
 
-#include <Platforms/xlib/XLIBwindow.h> // window_set_caption
-#include <Universal_System/roomsystem.h> // room_caption, update_mouse_variables
+namespace swaphandling {
+bool has_checked_extensions = false;
+bool ext_swapcontrol_supported;
+bool mesa_swapcontrol_supported;
+
+void investigate_swapcontrol_support() {
+  if (has_checked_extensions) return;  // Already calculated, no need to calculate it more.
+
+  // TODO: The second argument to glXQueryExtensionsString is screen number,
+  // and it is unknown if the value 0 is generally correct for calling that function.
+  // For more information, see the following pages:
+  // http://pic.dhe.ibm.com/infocenter/aix/v6r1/index.jsp?topic=%2Fcom.ibm.aix.opengl%2Fdoc%2Fopenglrf%2FglXQueryExtensionsString.htm
+  const char *glx_extensions = glXQueryExtensionsString(enigma::x11::disp, 0);
+
+  ext_swapcontrol_supported = strstr(glx_extensions, "GLX_EXT_swap_control");
+  mesa_swapcontrol_supported = strstr(glx_extensions, "GLX_MESA_swap_control");
+
+  has_checked_extensions = true;
+}
+}  // namespace swaphandling
+
+bool is_ext_swapcontrol_supported() {
+  swaphandling::investigate_swapcontrol_support();
+  return swaphandling::ext_swapcontrol_supported;
+}
+bool is_mesa_swapcontrol_supported() {
+  swaphandling::investigate_swapcontrol_support();
+  return swaphandling::mesa_swapcontrol_supported;
+}
+}  // namespace enigma
+
+#include <Platforms/xlib/XLIBwindow.h>    // window_set_caption
+#include <Universal_System/roomsystem.h>  // room_caption, update_mouse_variables
 
 namespace enigma_user {
 // Don't know where to query this on XLIB, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
 int display_aa = 14;
 
 void set_synchronization(bool enable) {
-	// General notes:
-	// Setting swapping on and off is platform-dependent and requires platform-specific extensions.
-	// Platform-specific extensions are even more bothersome than regular extensions.
-	// What functions and features to use depends on which version of OpenGL is used.
-	// For more information, see the following pages:
-	// http://www.opengl.org/wiki/Load_OpenGL_Functions
-	// http://www.opengl.org/wiki/OpenGL_Loading_Library
-	// http://www.opengl.org/wiki/Swap_Interval
-	// http://en.wikipedia.org/wiki/GLX
-	// Also note that OpenGL version >= 3.0 does not use glGetString for getting extensions.
+  // General notes:
+  // Setting swapping on and off is platform-dependent and requires platform-specific extensions.
+  // Platform-specific extensions are even more bothersome than regular extensions.
+  // What functions and features to use depends on which version of OpenGL is used.
+  // For more information, see the following pages:
+  // http://www.opengl.org/wiki/Load_OpenGL_Functions
+  // http://www.opengl.org/wiki/OpenGL_Loading_Library
+  // http://www.opengl.org/wiki/Swap_Interval
+  // http://en.wikipedia.org/wiki/GLX
+  // Also note that OpenGL version >= 3.0 does not use glGetString for getting extensions.
 
-	if (enigma::x11::disp != 0) {
-	  GLXDrawable drawable = glXGetCurrentDrawable();
+  if (enigma::x11::disp != 0) {
+    GLXDrawable drawable = glXGetCurrentDrawable();
 
-	  int interval = enable ? 1 : 0;
+    int interval = enable ? 1 : 0;
 
-	  if (enigma::is_ext_swapcontrol_supported()) {
-		glXSwapIntervalEXT(enigma::x11::disp, drawable, interval);
-	  }
-	  else if (enigma::is_mesa_swapcontrol_supported()) {
-		glXSwapIntervalMESA(interval);
-	  }
-	  // NOTE: GLX_SGI_swap_control, which is not used here, does not seem
-	  // to support disabling of synchronization, since its argument may not
-	  // be zero or less, so therefore it is not used here.
-	  // See http://www.opengl.org/registry/specs/SGI/swap_control.txt for more information.
-	}
+    if (enigma::is_ext_swapcontrol_supported()) {
+      glXSwapIntervalEXT(enigma::x11::disp, drawable, interval);
+    } else if (enigma::is_mesa_swapcontrol_supported()) {
+      glXSwapIntervalMESA(interval);
+    }
+    // NOTE: GLX_SGI_swap_control, which is not used here, does not seem
+    // to support disabling of synchronization, since its argument may not
+    // be zero or less, so therefore it is not used here.
+    // See http://www.opengl.org/registry/specs/SGI/swap_control.txt for more information.
+  }
 }
-	
+
 void display_reset(int samples, bool vsync) {
-	set_synchronization(vsync);
-	//TODO: Copy over from the Win32 bridge
+  set_synchronization(vsync);
+  //TODO: Copy over from the Win32 bridge
 }
-  
+
 void screen_refresh() {
-	glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
-	enigma::update_mouse_variables();
-	window_set_caption(room_caption);
+  glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
+  enigma::update_mouse_variables();
+  window_set_caption(room_caption);
 }
 
-}
-
-
+}  // namespace enigma_user


### PR DESCRIPTION
This follows #1221 making the `Bridges` sources now more legible.

```bash
$ find -iname *.h -o -iname *.cpp | xargs clang-format -i
```

This is a recreation of #995 which has been closed since the clang-format tool is probably more comprehensive than me doing it manually. I will address all cases of where I called `ZeroMemory` in a followup PR to this one.

Tested on the FPS example with `Direct3D9`, `OpenGL1`, and `OpenGL3` on `Win32`.