### PR TITLE
Fix OpenGL3 for newer glew

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3ModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3ModelStruct.h
@@ -826,7 +826,7 @@ namespace enigma {
       }
       enigma::glsl_uniformi_internal(enigma::shaderprograms[enigma::bound_shader]->uni_colorEnable,useColors);
 
-      #define OFFSETE( P )  ( ( const GLvoid * ) ( sizeof( GLuint ) * ( P         ) ) )
+      #define OFFSETE( P )  ( ( GLvoid * ) ( sizeof( GLuint ) * ( P         ) ) )
       offset = ringBufferIDrawOffset+vertex_start;
 
       // Draw the indexed primitives


### PR DESCRIPTION
I don't know how this one slipped through the cracks because I swear I tested to make sure OpenGL3 was still building on #1226. For that matter, Travis also told us it was still building. Anyways, after this change I can run the FPS example again with GL3 (there is still the problem of no fog though, but that has been that way).

```bash
In file included from Graphics_Systems/OpenGL3/GL3model.cpp:18:0:
Graphics_Systems/OpenGL3/GL3ModelStruct.h: In member function 'void enigma::Mesh::Draw(int, int)':
Graphics_Systems/OpenGL3/GL3ModelStruct.h:829:31: error: invalid conversion from 'const GLvoid* {aka const void*}' to 'void*' [-fpermissive]
       #define OFFSETE( P )  ( ( const GLvoid * ) ( sizeof( GLuint ) * ( P         ) ) )
                             ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Graphics_Systems/OpenGL3/GL3ModelStruct.h:839:120: note: in expansion of macro  OFFSETE'
         glDrawElementsBaseVertex (GL_TRIANGLES, (vertex_count==-1?triangleIndexedCount:vertex_count), GL_UNSIGNED_INT, OFFSETE(offset), ringBufferVDrawOffset);
                                                                                                                        ^

```