### PR TITLE
Install glew for Mac in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ before_install:
       fi
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
       brew upgrade gcc || brew install gcc || brew link --overwrite gcc;
+      brew install glew;
     fi
 
 # build JDI and the CLI


### PR DESCRIPTION
I didn't realize the Mac test stopped passing in #1226 because we allow it to fail. We just need to install glew through brew.

I added this to the announcement too:
https://enigma-dev.org/forums/index.php?topic=2894

The second Mac job fails because of #1230 and is unrelated to this.