### PR TITLE
Fix tile_layer_find by using rectangle intersection check

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtiles.cpp
@@ -28,6 +28,11 @@
 #include "../General/OpenGLHeaders.h"
 #include "GLTextureStruct.h"
 
+// not allowed to include mathnc.h outside of SHELLmain
+namespace enigma_user {
+    bool point_in_rectangle(ma_scalar px, ma_scalar py, ma_scalar x1, ma_scalar y1, ma_scalar x2, ma_scalar y2);
+}
+
 namespace enigma
 {
     static void draw_tile(int back, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, double alpha)
@@ -475,7 +480,7 @@ int tile_layer_find(int layer_depth, int x, int y)
             for(std::vector<enigma::tile>::size_type i = 0; i !=  dit->second.tiles.size(); i++)
             {
                 enigma::tile t = dit->second.tiles[i];
-                if (t.roomX == x && t.roomY == y)
+                if (point_in_rectangle(x, y, t.roomX, t.roomY, t.roomX + t.width, t.roomY + t.height))
                     return t.id;
             }
         }
@@ -535,4 +540,3 @@ bool tile_layer_shift(int layer_depth, int x, int y)
 }
 
 }
-


### PR DESCRIPTION
The function `tile_layer_find` uses a rectangle intersection test in GM8 and GMS. I simply reused our helper method `point_in_rectangle` to fix this one, but I had a problem because as @JoshDreamland knows we shouldn't include `Universal_System/mathnc.h` outside of SHELLmain. I didn't know where else to go with the function, but I can change this before merging it. Regardless, this fixes #1199 and the following test project then behaves the same in GM8 and ENIGMA:
[tile_layer_find_test.zip](https://github.com/enigma-dev/enigma-dev/files/2000230/tile_layer_find_test.zip)

It should show you the id of the tile you are hovering over with the mouse in the room caption.