### PR TITLE
emake Improvements

### DIFF
--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -30,14 +30,13 @@ int main(int argc, char* argv[])
 
     GameMode mode;
     std::string _mode = options.GetOption("mode").as<std::string>();
-    
-    std::string output_file; 
-    
+
+    std::string output_file;
+
     if (!options.GetOption("output").empty())
       output_file = options.GetOption("output").as<std::string>();
-    
-    bool list = options.GetOption("list").as<bool>();
-    if (list) {
+
+    if (options.HasOption("list")) {
       plugin.PrintBuiltins(output_file);
       return result;
     }
@@ -54,7 +53,7 @@ int main(int argc, char* argv[])
       mode = emode_rebuild;
     else
       mode = emode_invalid;
-      
+
     if (mode == emode_invalid) {
       std::cerr << "Invalid game mode: " << _mode << " aborting!" << std::endl;
       return OPTIONS_ERROR;
@@ -65,11 +64,11 @@ int main(int argc, char* argv[])
 
     Game game;
     std::string input_file = options.GetOption("input").as<std::string>();
-    
+
     // Working directory hacks
     if (mode != emode_compile)
       game.SetOutputFile(input_file);
-    
+
     if (input_file.size()) {
       std::string ext;
       size_t dot = input_file.find_last_of('.');

--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -7,7 +7,7 @@
 #include <boost/foreach.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/exception/diagnostic_information.hpp> 
+#include <boost/exception/diagnostic_information.hpp>
 
 #include <iostream>
 
@@ -92,17 +92,17 @@ OptionsParser::OptionsParser() : _desc("Options")
 
   _desc.add_options()
     ("help,h", "Print help messages")
-    ("list,l", opt::bool_switch()->default_value(false), "List available types, globals & functions")
+    ("list,l", "List available types, globals & functions")
     ("info,i", opt::value<std::string>(), "Provides a listing of Platforms, APIs and Extensions")
     ("input",   opt::value<std::string>()->default_value(""), "Input game file; currently, only test harness single-object games (*.sog) are supported. The --input string is optional.")
     ("output,o", opt::value<std::string>()->required(), "Output executable file")
     ("platform,p", opt::value<std::string>()->default_value(def_platform), "Target Platform (XLib, Win32, Cocoa)")
-    ("workdir,w", opt::value<std::string>()->default_value(def_workdir), "Working Directory")
+    ("workdir,d", opt::value<std::string>()->default_value(def_workdir), "Working Directory")
     ("codegen,k", opt::value<std::string>()->default_value(def_workdir), "Codegen Directory")
     ("mode,m", opt::value<std::string>()->default_value("Debug"), "Game Mode (Run, Release, Debug, Design)")
     ("graphics,g", opt::value<std::string>()->default_value("OpenGL1"), "Graphics System (OpenGL1, OpenGL3, DirectX)")
     ("audio,a", opt::value<std::string>()->default_value("None"), "Audio System (OpenAL, DirectSound, SFML, None)")
-    ("widgets,W", opt::value<std::string>()->default_value("None"), "Widget System (GTK, None)")
+    ("widgets,w", opt::value<std::string>()->default_value("None"), "Widget System (Win32, GTK, None)")
     ("network,n", opt::value<std::string>()->default_value("None"), "Networking System (Async, Berkeley, DirectPlay)")
     ("collision,c", opt::value<std::string>()->default_value("None"), "Collision System")
     ("extensions,e", opt::value<std::string>()->default_value("None"), "Extensions (Paths, Timelines, Particles)")
@@ -129,6 +129,11 @@ opt::variable_value OptionsParser::GetOption(std::string option)
   return _rawArgs[option];
 }
 
+bool OptionsParser::HasOption(std::string option)
+{
+  return _rawArgs.count(option) > 0;
+}
+
 int OptionsParser::ReadArgs(int argc, char* argv[])
 {
   _readArgsFail = false;
@@ -151,7 +156,7 @@ int OptionsParser::ReadArgs(int argc, char* argv[])
 
     return OPTIONS_ERROR;
   }
-  
+
   find_ey("ENIGMAsystem/SHELL/");
 
   // Platform Compilers
@@ -171,7 +176,7 @@ int OptionsParser::HandleArgs()
   // Exit early on list
   if (_rawArgs.count("list"))
     return OPTIONS_SUCCESS;
-  
+
   // Exit early on help
   if (_readArgsFail || _rawArgs.count("help"))
   {

--- a/CommandLine/emake/OptionsParser.hpp
+++ b/CommandLine/emake/OptionsParser.hpp
@@ -24,6 +24,7 @@ public:
   int HandleArgs();
   std::string APIyaml();
   opt::variable_value GetOption(std::string option);
+  bool HasOption(std::string option);
 
 private:
   int find_ey(const char* dir);


### PR DESCRIPTION
Trying to fix some of the issues with #1190 

I fixed `--help` by making `--list` not a bool switch and creating `OptionsParser::HasOption` so that `main()` can check if it is actually present. `--list` should not be a bool switch, in the same way `--help` isn't, because it does not need toggled.

I also remapped `--widgets` to lowercase `-w` for its short option and `--workdir` to lowercase `-d` for its short option. I feel like `--widgets` should take precedence over `--workdir` so it has more right to the lowercase `-w` in my opinion and I'm also sick of confusing when to use lower and uppercase. This is better than having a random system use an uppercase switch option imho.

