### PR TITLE
Fix draw_getpixel crash in DX9 caused by double-delete

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -128,7 +128,7 @@ int draw_getpixel(int x, int y)
 	unsigned offset = y * rect.Pitch + x * 4;
 	int ret = bitmap[offset + 2] | (bitmap[offset + 1] << 8) | (bitmap[offset + 0] << 16);
 	pDestBuffer->UnlockRect();
-	delete[] bitmap;
+
 	pBackBuffer->Release();
 	pDestBuffer->Release();
 
@@ -165,7 +165,7 @@ int draw_getpixel_ext(int x, int y)
 	unsigned offset = y * rect.Pitch + x * 4;
 	int ret = bitmap[offset + 2] | (bitmap[offset + 1] << 8) | (bitmap[offset + 0] << 16) | (bitmap[offset + 3] << 24);
 	pDestBuffer->UnlockRect();
-	delete[] bitmap;
+
 	pBackBuffer->Release();
 	pDestBuffer->Release();
 	return ret;
@@ -183,4 +183,3 @@ bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColo
 }
 
 }
-


### PR DESCRIPTION
This is a simple one, there was no need to delete the bitmap data because we don't allocate it, it's just a cast into the buffer Direct3D9 allocated. By releasing the destination and back buffers, we are able to clean up the bitmap data we read.

This stops the Wild Racing game from crashing upon start when using the Direct3D9 graphics system. It at least launches, but does not draw anything except the skybox after starting - yet. Regardless the crash is fixed fully though.
![Wild Racing in Direct3D9](https://user-images.githubusercontent.com/3212801/40362062-73e1ea70-5d99-11e8-89b6-8489742cf7ed.png)

