### PR TITLE
Fix Collision Function Return Type Mismatch in Motion Planning Extension

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/motion_planning.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/motion_planning.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************\
 **                                                                              **
-**  Copyright (C) 2011 Harijs Grînbergs                                         **
+**  Copyright (C) 2011 Harijs GrÃ®nbergs                                         **
 **  Modified 2013 by Josh Ventura                                               **
 **                                                                              **
 **  This file is a part of the ENIGMA Development Environment.                  **
@@ -36,11 +36,8 @@ using namespace std;
 #include "libEGMstd.h"
 #include "motion_planning_struct.h"
 #include "motion_planning.h"
+#include "Collision_Systems/General/CSfuncs.h"
 #include "Universal_System/scalar.h"
-
-namespace enigma_user {
-int collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme);
-}
 
 namespace enigma {
 	extern size_t grid_idmax;


### PR DESCRIPTION
Hugar showed me one of his build logs with the motion planning extension enabled where I noticed the following warning:
```
Universal_System/Extensions/MotionPlanning/motion_planning.cpp:42:5: warning: type of ‘collision_rectangle’ does not match original declaration [-Wlto-type-mismatch]
 int collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec /*ignored*/, bool notme);
     ^
Collision_Systems/Precise/PRECfuncs.cpp:149:20: note: return value type mismatch
 enigma::instance_t collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
                    ^
./Universal_System/instance_system_base.h:27:19: note: type ‘struct instance_t’ should match type ‘int’
   typedef variant instance_t;
                   ^
Collision_Systems/Precise/PRECfuncs.cpp:149:20: note: ‘collision_rectangle’ was previously declared here
 enigma::instance_t collision_rectangle(cs_scalar x1, cs_scalar y1, cs_scalar x2, cs_scalar y2, int obj, bool prec, bool notme)
                    ^
```

This is the correct fix, to not redeclare the function but to just include the general header that declares the user function to prevent any future return type mismatches. This is also continuing from #1218 where I changed the collision function definitions to return `instance_t` in the sources, which they were already declared to return in the headers.