### PR TITLE
Fix warnings in highscore functions

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/highscore_functions.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/highscore_functions.cpp
@@ -166,17 +166,15 @@ std::string highscore_name(int place) {
 
 }
 
+#include "Graphics_Systems/General/GSfont.h"
+
 #include "var4.h"
 #include "Universal_System/scalar.h"
 
 namespace enigma_user
 {
 
-void draw_text(gs_scalar x, gs_scalar y,variant str); // TODO: Holy shit.
-int string_width(variant str);
-
 void draw_highscore(int x1, int y1, int x2, int y2) {
-
     for (size_t i=0; i<enigma::highscore_list.size(); i++) {
         draw_text(x1, (i*((y2-y1)/10))+y1+10, enigma::highscore_list[i].player_name.c_str());
         draw_text(x2-string_width(toString((var)enigma::highscore_list[i].player_score)), (i*((y2-y1)/10))+y1+10 , toString((var)enigma::highscore_list[i].player_score));


### PR DESCRIPTION
This is to fix the other warning in the log Hugar shared with me. This is a continuation of #1256 and I am fixing it the same way, by including the general header that already declares the functions and removing the redundant declaration from the source.

Just worth mentioning I see @JoshDreamland was the one responsible for the "holy shit" comment: https://github.com/enigma-dev/enigma-dev/commit/5200d9f7fc018bcf556bfe89bd0a2f22201e583f#diff-765c74df0d2f6fac085f83fb959e38ceR176
So I assume he wanted this moved before we had a general header setup and it wasn't easy at the time for him to do that.

```bash
Universal_System/highscore_functions.cpp:176:5: warning: ‘string_width’ violates the C++ One Definition Rule  [-Wodr]
 int string_width(variant str);
     ^
Graphics_Systems/General/GSfont.cpp:152:14: note: return value type mismatch
 unsigned int string_width(variant vstr)
              ^
Graphics_Systems/General/GSfont.cpp:152:14: note: type ‘unsigned int’ should match type ‘int’
Graphics_Systems/General/GSfont.cpp:152:14: note: ‘string_width’ was previously declared here
```