### PR TITLE
Cleanup Color Macro Duplication

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11ModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11ModelStruct.h
@@ -330,7 +330,7 @@ class Mesh
 
   void AddColor(int col, double alpha)
   {
-    //DWORD final = D3DCOLOR_ARGB( (unsigned char)(alpha*255), __GETR(col), __GETG(col), __GETB(col) );
+    //DWORD final = D3DCOLOR_ARGB( (unsigned char)(alpha*255), COL_GET_R(col), COL_GET_G(col), COL_GET_B(col) );
     //vertices.push_back(final);
     useColors = true;
   }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11background.cpp
@@ -22,6 +22,7 @@
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GSbackground.h"
 #include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/background_internal.h"
 #include "Universal_System/sprites_internal.h"
@@ -49,10 +50,6 @@
     const enigma::background *const bck2d = enigma::backgroundstructarray[back];
 #endif
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
-
 namespace enigma_user {
   extern int room_width, room_height;
 }
@@ -75,4 +72,3 @@ int background_create_from_screen(int x, int y, int w, int h, bool removeback, b
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11colors.cpp
@@ -33,9 +33,9 @@ void draw_clear_alpha(int col, float alpha)
 	float color[4];
 
 	// Setup the color to clear the buffer to.
-	color[0] = __GETR(col)/255.0;
-	color[1] = __GETG(col)/255.0;
-	color[2] = __GETB(col)/255.0;
+	color[0] = COL_GET_R(col)/255.0;
+	color[1] = COL_GET_G(col)/255.0;
+	color[2] = COL_GET_B(col)/255.0;
 	color[3] = alpha;
 
 	// Clear the back buffer.
@@ -47,9 +47,9 @@ void draw_clear(int col)
 	float color[4];
 
 	// Setup the color to clear the buffer to.
-	color[0] = __GETR(col)/255.0;
-	color[1] = __GETG(col)/255.0;
-	color[2] = __GETB(col)/255.0;
+	color[0] = COL_GET_R(col)/255.0;
+	color[1] = COL_GET_G(col)/255.0;
+	color[2] = COL_GET_B(col)/255.0;
 	color[3] = 1;
 
 	// Clear the back buffer.
@@ -58,9 +58,9 @@ void draw_clear(int col)
 
 void draw_set_color(int col)
 {
-	enigma::currentcolor[0] = __GETR(col);
-	enigma::currentcolor[1] = __GETG(col);
-	enigma::currentcolor[2] = __GETB(col);
+	enigma::currentcolor[0] = COL_GET_R(col);
+	enigma::currentcolor[1] = COL_GET_G(col);
+	enigma::currentcolor[2] = COL_GET_B(col);
 }
 
 void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue)
@@ -72,7 +72,7 @@ void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue
 
 void draw_set_alpha(float alpha)
 {
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 }
 
 void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blue,float alpha)
@@ -80,7 +80,7 @@ void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blu
 	enigma::currentcolor[0] = red;
 	enigma::currentcolor[1] = green;
 	enigma::currentcolor[2] = blue;
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 }
 
 void draw_set_color_write_enable(bool red, bool green, bool blue, bool alpha)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -15,17 +15,14 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 #include "Bridges/General/DX11Context.h"
-#include "Graphics_Systems/General/GSd3d.h"
 #include "Direct3D11Headers.h"
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GSmodel.h"
 #include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
-#include "../General/GSmodel.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
-
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
 
 namespace enigma {
   bool d3dMode = false;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
@@ -17,19 +17,16 @@
 **/
 
 #include <math.h>
-#include "../General/GSprimitives.h"
 #include "Direct3D11Headers.h"
 #include "Bridges/General/DX11Context.h"
 #include "Graphics_Systems/General/GSstdraw.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
-#include <stdio.h>
 #include "Universal_System/roomsystem.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
-
+#include <stdio.h>
 #include <vector>
 using std::vector;
 
@@ -114,4 +111,3 @@ bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColo
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -15,27 +15,22 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <string>
-#include <cstdio>
 #include "Bridges/General/DX11Context.h"
 #include "Direct3D11Headers.h"
-#include "../General/GSbackground.h"
-#include "../General/GSscreen.h"
-#include "../General/GSd3d.h"
-#include "../General/GSmatrix.h"
-#include "../General/GStextures.h"
-#include "../General/GScolors.h"
-
-using namespace std;
+#include "Graphics_Systems/General/GSbackground.h"
+#include "Graphics_Systems/General/GSscreen.h"
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GSmodel.h"
+#include "Graphics_Systems/General/GSmatrix.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/graphics_mandatory.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #include "Universal_System/var4.h"
 #include "Universal_System/estring.h"
 #include "Universal_System/background.h"
 #include "Universal_System/background_internal.h"
-
-#define __GETR(x) (((unsigned int)x & 0x0000FF))/255.0
-#define __GETG(x) (((unsigned int)x & 0x00FF00) >> 8)/255.0
-#define __GETB(x) (((unsigned int)x & 0xFF0000) >> 16)/255.0
 
 #include "Universal_System/roomsystem.h"
 #include "Universal_System/instance_system.h"
@@ -44,8 +39,12 @@ using namespace std;
 #include "Platforms/platforms_mandatory.h"
 #include "Platforms/General/PFwindow.h"
 #include "Platforms/General/PFmain.h"
-#include "Graphics_Systems/graphics_mandatory.h"
+
 #include <limits>
+#include <string>
+#include <cstdio>
+
+using namespace std;
 
 //Fuck whoever did this to the spec
 #ifndef GL_BGR
@@ -53,8 +52,6 @@ using namespace std;
 #endif
 
 using namespace enigma;
-
-#include "../General/GSmodel.h"
 
 namespace enigma_user {
   extern int window_get_width();
@@ -89,7 +86,7 @@ static inline void draw_back()
 				background_x[back_current] += background_hspeed[back_current];
 				background_y[back_current] += background_vspeed[back_current];
 	            if (background_htiled[back_current] || background_vtiled[back_current]) {
-	                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], 
+	                draw_background_tiled_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current],
 						background_xscale[back_current], background_coloring[back_current], background_alpha[back_current], background_htiled[back_current], background_vtiled[back_current]);
 	            } else {
 	                draw_background_ext(background_index[back_current], background_x[back_current], background_y[back_current], background_xscale[back_current], background_xscale[back_current], 0, background_coloring[back_current], background_alpha[back_current]);
@@ -126,7 +123,7 @@ void screen_redraw()
     {
 		screen_set_viewport(0, 0, window_get_region_width(), window_get_region_height());
 		d3d_set_projection_ortho(0, 0, window_get_region_width(), window_get_region_height(), 0);
-	
+
 		if (background_showcolor)
 		{
 			draw_clear(background_color);
@@ -278,7 +275,7 @@ void screen_redraw()
 			screen_set_viewport(view_xport[vc], view_yport[vc],
 				(window_get_region_width_scaled() - view_xport[vc]), (window_get_region_height_scaled() - view_yport[vc]));
 			d3d_set_projection_ortho(view_xview[vc], view_wview[vc] + view_xview[vc], view_yview[vc], view_hview[vc] + view_yview[vc], 0);
-				
+
 			if (background_showcolor && view_first)
 			{
 				draw_clear(background_color);
@@ -392,10 +389,10 @@ void screen_init()
 {
 	enigma::gui_width = window_get_region_width();
 	enigma::gui_height = window_get_region_height();
-	
+
 	//d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
 	//d3dmgr->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
-	
+
     if (!view_enabled)
     {
 		//d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11sprite.cpp
@@ -15,28 +15,25 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <cmath>
-#include <cstdlib>
-#include <string>
-using std::string;
-
 #include "Direct3D11Headers.h"
 #include "Bridges/General/DX11Context.h"
 #include "DX11TextureStruct.h"
-#include "../General/GScolors.h"
-#include "../General/GSsprite.h"
-#include "../General/GStextures.h"
-#include "../General/GSprimitives.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
+#include "Graphics_Systems/General/GSsprite.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
 #include "Universal_System/instance_system.h"
 #include "Universal_System/graphics_object.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include <cmath>
+#include <cstdlib>
+#include <string>
 
+using std::string;
 
 #ifdef DEBUG_MODE
   #include "libEGMstd.h"
@@ -81,4 +78,3 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11surface.cpp
@@ -17,35 +17,32 @@
 
 #include "Bridges/General/DX11Context.h"
 #include "Direct3D11Headers.h"
-using namespace std;
-#include <cstddef>
-#include <iostream>
-#include <math.h>
 
+#include "DX11SurfaceStruct.h"
+#include "DX11TextureStruct.h"
 
-#include <stdio.h> //for file writing (surface_save)
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
 #include "Universal_System/background_internal.h"
 #include "Collision_Systems/collision_types.h"
+#include "Graphics_Systems/General/GSprimitives.h"
+#include "Graphics_Systems/General/GSsurface.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include <stdio.h> //for file writing (surface_save)
+#include <cstddef>
+#include <iostream>
+#include <math.h>
+
+using namespace std;
 
 namespace enigma_user {
 extern int room_width, room_height/*, sprite_idmax*/;
 }
 
-#include "../General/GSprimitives.h"
-#include "../General/GSsurface.h"
-#include "DX11SurfaceStruct.h"
-#include "DX11TextureStruct.h"
-
 namespace enigma
 {
   vector<Surface*> Surfaces(0);
-
 }
 
 
@@ -246,4 +243,3 @@ void surface_copy(int destination, gs_scalar x, gs_scalar y, int source)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11tiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11tiles.cpp
@@ -30,20 +30,18 @@
     const enigma::background *const bck2d = enigma::backgroundstructarray[back];
 #endif
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 // Tile system
 #include "Universal_System/depth_draw.h"
 #include <algorithm>
-#include "../General/GSbackground.h"
+#include "Graphics_Systems/General/GSbackground.h"
 #include "Universal_System/background_internal.h"
-#include "../General/GStextures.h"
+#include "Graphics_Systems/General/GStextures.h"
 
 #include "Direct3D11Headers.h"
-#include "../General/GStiles.h"
-#include "../General/DXtilestruct.h"
+#include "Graphics_Systems/General/GStiles.h"
+#include "Graphics_Systems/General/DXtilestruct.h"
 namespace enigma
 {
     void draw_tile(int back, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, double alpha)
@@ -484,4 +482,3 @@ bool tile_layer_shift(int layer_depth, int x, int y)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9ModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9ModelStruct.h
@@ -334,7 +334,7 @@ class Mesh
 
   void AddColor(int col, double alpha)
   {
-    DWORD final = D3DCOLOR_ARGB( (unsigned char)(alpha*255), __GETR(col), __GETG(col), __GETB(col) );
+    DWORD final = D3DCOLOR_ARGB( (unsigned char)(alpha*255), COL_GET_R(col), COL_GET_G(col), COL_GET_B(col) );
     vertices.push_back(final);
     useColors = true;
   }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
@@ -49,9 +49,7 @@
     const enigma::background *const bck2d = enigma::backgroundstructarray[back];
 #endif
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 namespace enigma_user {
   extern int room_width, room_height;
@@ -76,4 +74,3 @@ int background_create_from_screen(int x, int y, int w, int h, bool removeback, b
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
@@ -33,19 +33,19 @@ namespace enigma_user
 
 void draw_clear_alpha(int col, float alpha)
 {
-	d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_COLORVALUE(__GETR(col), __GETG(col), __GETB(col), alpha), 1.0f, 0);
+	d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_COLORVALUE(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col), alpha), 1.0f, 0);
 }
 
 void draw_clear(int col)
 {
-	d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(__GETR(col), __GETG(col), __GETB(col)), 1.0f, 0);
+	d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col)), 1.0f, 0);
 }
 
 void draw_set_color(int col)
 {
-	enigma::currentcolor[0] = __GETR(col);
-	enigma::currentcolor[1] = __GETG(col);
-	enigma::currentcolor[2] = __GETB(col);
+	enigma::currentcolor[0] = COL_GET_R(col);
+	enigma::currentcolor[1] = COL_GET_G(col);
+	enigma::currentcolor[2] = COL_GET_B(col);
 }
 
 void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue)
@@ -57,7 +57,7 @@ void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue
 
 void draw_set_alpha(float alpha)
 {
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 }
 
 void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blue,float alpha)
@@ -65,7 +65,7 @@ void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blu
 	enigma::currentcolor[0] = red;
 	enigma::currentcolor[1] = green;
 	enigma::currentcolor[2] = blue;
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 }
 
 void draw_set_color_write_enable(bool red, bool green, bool blue, bool alpha)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -24,9 +24,7 @@
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
 
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 namespace enigma {
   bool d3dMode = false;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -133,7 +133,7 @@ void d3d_set_fog_hint(int mode) {
 void d3d_set_fog_color(int color)
 {
 	d3dmgr->SetRenderState(D3DRS_FOGCOLOR,
-                    D3DCOLOR_COLORVALUE(__GETR(color), __GETG(color), __GETB(color), 1.0f)); // Highest 8 bits are not used.
+                    D3DCOLOR_COLORVALUE(COL_GET_R(color), COL_GET_G(color), COL_GET_B(color), 1.0f)); // Highest 8 bits are not used.
 }
 
 void d3d_set_fog_start(double start)
@@ -270,7 +270,7 @@ class d3d_lights
 
 		ZeroMemory(&light, sizeof(light));    // clear out the light struct for use
 		light.Type = D3DLIGHT_DIRECTIONAL;    // make the light type 'directional light'
-		light.Diffuse = D3DXCOLOR(__GETR(col), __GETR(col), __GETB(col), 1.0f);    // set the light's color
+		light.Diffuse = D3DXCOLOR(COL_GET_R(col), COL_GET_R(col), COL_GET_B(col), 1.0f);    // set the light's color
 		light.Direction = D3DXVECTOR3(dx, dy, dz);
 
 		d3dmgr->SetLight(ms, &light);    // send the light struct properties to nth light
@@ -315,7 +315,7 @@ class d3d_lights
 
 		ZeroMemory(&light, sizeof(light));    // clear out the light struct for use
 		light.Type = D3DLIGHT_POINT;    // make the light type 'directional light'
-		light.Diffuse = D3DXCOLOR(__GETR(col), __GETG(col), __GETB(col), 1.0f);    // set the light's color
+		light.Diffuse = D3DXCOLOR(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col), 1.0f);    // set the light's color
 		light.Position = D3DXVECTOR3(x, y, z);
 		light.Range = range;
 		light.Attenuation0 = 1.0f;    // no constant inverse attenuation
@@ -417,7 +417,7 @@ void d3d_light_shininess(int facemode, int shine)
 
 void d3d_light_define_ambient(int col)
 {
-	d3dmgr->SetRenderState(D3DRS_AMBIENT, D3DCOLOR_COLORVALUE(__GETR(col), __GETG(col), __GETB(col), 1));
+	d3dmgr->SetRenderState(D3DRS_AMBIENT, D3DCOLOR_COLORVALUE(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col), 1));
 }
 
 bool d3d_light_enable(int id, bool enable)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -26,9 +26,7 @@
 #include <stdio.h>
 #include "Universal_System/roomsystem.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #include <vector>
 using std::vector;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9matrix.cpp
@@ -24,9 +24,7 @@
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
 
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 namespace enigma_user
 {
@@ -57,8 +55,8 @@ void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs_sca
 	D3DXMatrixLookAtLH( &matView, &vEyePt, &vLookatPt, &vUpVec );
 
 	// Set our view matrix
-	d3dmgr->SetTransform( D3DTS_VIEW, &matView ); 
-	
+	d3dmgr->SetTransform( D3DTS_VIEW, &matView );
+
 	D3DXMATRIX matProj;
 
 	D3DXMatrixPerspectiveFovLH( &matProj, D3DXToRadian(45), view_wview[view_current] / (double)view_hview[view_current], 1.0f, 32000.0f );
@@ -74,10 +72,10 @@ void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs
 	// Get D3DX to fill in the matrix values
 	D3DXMATRIX matView;
 	D3DXMatrixLookAtLH( &matView, &vEyePt, &vLookatPt, &vUpVec );
-		
+
 	// Set our view matrix
-	d3dmgr->SetTransform( D3DTS_VIEW, &matView ); 
-	
+	d3dmgr->SetTransform( D3DTS_VIEW, &matView );
+
 	D3DXMATRIX matProj;
 
 	D3DXMatrixPerspectiveFovLH( &matProj, gs_angle_to_radians(angle), aspect, znear, zfar );
@@ -89,13 +87,13 @@ void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scal
   // This fixes font glyph edge artifacting and vertical scroll gaps
   // seen by mostly NVIDIA GPU users.  Rounds x and y and adds +0.01 offset.
   // This will prevent the fix from being negated through moving projections
-  // and fractional coordinates. 
+  // and fractional coordinates.
   x = round(x) + 0.01f; y = round(y) + 0.01f;
   D3DXMATRIX matRotZ, mat1Trans, mat2Trans, matScale;
 
   // Translate so the center is at 0,0
-  D3DXMatrixTranslation(&mat1Trans, -x-width/2.0, -y-height/2.0, 0); 
-  
+  D3DXMatrixTranslation(&mat1Trans, -x-width/2.0, -y-height/2.0, 0);
+
 	// Rotate around the center
 	D3DXMatrixRotationZ( &matRotZ, gs_angle_to_radians(angle) );        // Roll
 
@@ -106,7 +104,7 @@ void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scal
 	D3DXMatrixTranslation(&mat2Trans, width/2.0, height/2.0-height, 0);
   // I don't get why the view moving is done here though. It should be possible in D3DXMatrixOrthoOffCenterLH instead,
   // like we do in GL - H.G.
-  
+
  	D3DXMatrixScaling(&matScale, 1, -1, 1);
 
 	// Calculate our world matrix by multiplying the above (in the correct order)
@@ -114,16 +112,16 @@ void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scal
 
 	// Set the matrix to be applied to anything we render from now on
 	d3dmgr->SetTransform( D3DTS_VIEW, &matView);
-	
+
 	D3DXMATRIX matProjection;    // the projection transform matrix
 	D3DXMatrixOrthoOffCenterLH(&matProjection,
 							0,
-							(FLOAT)width,   
-							0, 
-							(FLOAT)height,   
+							(FLOAT)width,
+							0,
+							(FLOAT)height,
 							32000.0f,    // the near view-plane
 							-32000.0f);    // the far view-plane
-						   
+
 	d3dmgr->SetTransform(D3DTS_PROJECTION, &matProjection);    // set the projection transform
 }
 
@@ -133,12 +131,12 @@ void d3d_set_projection_perspective(gs_scalar x, gs_scalar y, gs_scalar width, g
 
   D3DXMatrixOrthoOffCenterLH(&matView,
     (FLOAT)x,
-    (FLOAT)x+width,   
+    (FLOAT)x+width,
     (FLOAT)y,
-    (FLOAT)y+height,   
+    (FLOAT)y+height,
     -32000.0f,    // the near view-plane
     32000.0f);    // the far view-plane
-    
+
   // Initialize rotation matrix
   D3DXMatrixRotationZ( &matRotZ, gs_angle_to_radians(angle) );
   matView *= matRotZ;
@@ -153,7 +151,7 @@ void d3d_set_projection_perspective(gs_scalar x, gs_scalar y, gs_scalar width, g
   d3dmgr->SetTransform(D3DTS_PROJECTION, &matProj);    // set the projection transform
 }
 
-D3DXMATRIX matWorld; 
+D3DXMATRIX matWorld;
 D3DXMATRIX matNull;
 
 // ***** TRANSFORMATIONS BEGIN *****
@@ -171,12 +169,12 @@ void d3d_transform_add_translation(gs_scalar xt, gs_scalar yt, gs_scalar zt)
 	// build a matrix to move the model
 	// store it to matTranslate
 	D3DXMatrixTranslation(&matTranslate, xt, yt, zt);
-	
+
 	matWorld *= matTranslate;
 
 	// tell Direct3D about our matrix
 	d3dmgr->SetTransform(D3DTS_WORLD, &matWorld);
-	
+
 }
 
 void d3d_transform_add_scaling(gs_scalar xs, gs_scalar ys, gs_scalar zs)
@@ -186,7 +184,7 @@ void d3d_transform_add_scaling(gs_scalar xs, gs_scalar ys, gs_scalar zs)
 	// build a matrix to double the size of the model
 	// store it to matScale
 	D3DXMatrixScaling(&matScale, xs, ys, zs);
-	
+
 	matWorld *= matScale;
 
 	// tell Direct3D about our matrix
@@ -199,7 +197,7 @@ void d3d_transform_add_rotation_x(gs_scalar angle)
 
 	// build a matrix to rotate the model by so many radians
 	D3DXMatrixRotationX(&matRot, gs_angle_to_radians(-angle));
-	
+
 	matWorld *= matRot;
 
 	// tell Direct3D about our matrix
@@ -210,10 +208,10 @@ void d3d_transform_add_rotation_y(gs_scalar angle)
 {
 //D3DXMatrixIdentity( &matWorld );
 	D3DXMATRIX matRot;
-	
+
 	// build a matrix to rotate the model by so many radians
 	D3DXMatrixRotationY(&matRot, gs_angle_to_radians(-angle));
-	
+
 	matWorld *= matRot;
 
 	// tell Direct3D about our matrix
@@ -223,10 +221,10 @@ void d3d_transform_add_rotation_y(gs_scalar angle)
 void d3d_transform_add_rotation_z(gs_scalar angle)
 {
 	D3DXMATRIX matRot;
-	
+
 	// build a matrix to rotate the model by so many radians
 	D3DXMatrixRotationZ(&matRot, gs_angle_to_radians(-angle));
-	
+
 	matWorld *= matRot;
 
 	// tell Direct3D about our matrix
@@ -236,13 +234,13 @@ void d3d_transform_add_rotation_z(gs_scalar angle)
 void d3d_transform_add_rotation_axis(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar angle)
 {
 	D3DXMATRIX matRot;
-	
+
 	// build a matrix to rotate the model by so many radians
 	angle = D3DXToRadian(-angle);
 	D3DXMatrixRotationYawPitchRoll(&matRot, y * angle, x * angle, z * angle);
-	
+
 	matWorld *= matRot;
-	
+
 	// tell Direct3D about our matrix
 	d3dmgr->SetTransform(D3DTS_WORLD, &matWorld);
 }
@@ -271,7 +269,7 @@ void d3d_transform_set_rotation_x(double angle)
 {
 	// build a matrix to rotate the model by so many radians
 	D3DXMatrixRotationX(&matWorld, gs_angle_to_radians(-angle));
-	
+
 	// tell Direct3D about our matrix
 	d3dmgr->SetTransform(D3DTS_WORLD, &matWorld);
 }
@@ -280,7 +278,7 @@ void d3d_transform_set_rotation_y(gs_scalar angle)
 {
 	// build a matrix to rotate the model by so many radians
 	D3DXMatrixRotationY(&matWorld, gs_angle_to_radians(-angle));
-		
+
 	// tell Direct3D about our matrix
 	d3dmgr->SetTransform(D3DTS_WORLD, &matWorld);
 }
@@ -290,7 +288,7 @@ void d3d_transform_set_rotation_z(gs_scalar angle)
 	D3DXMatrixIdentity( &matWorld );
 	// build a matrix to rotate the model by so many radians
 	D3DXMatrixRotationZ(&matWorld, gs_angle_to_radians(-angle));
-		
+
 	// tell Direct3D about our matrix
 	d3dmgr->SetTransform(D3DTS_WORLD, &matWorld);
 }
@@ -300,7 +298,7 @@ void d3d_transform_set_rotation_axis(gs_scalar x, gs_scalar y, gs_scalar z, gs_s
 	// build a matrix to rotate the model by so many radians
 	angle = gs_angle_to_radians(-angle);
 	D3DXMatrixRotationYawPitchRoll(&matWorld, y * angle, x * angle, z * angle);
-		
+
 	// tell Direct3D about our matrix
 	d3dmgr->SetTransform(D3DTS_WORLD, &matWorld);
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -35,9 +35,7 @@ using namespace std;
 #include "Universal_System/var4.h"
 #include "Universal_System/estring.h"
 
-#define __GETR(x) (((unsigned int)x & 0x0000FF))
-#define __GETG(x) (((unsigned int)x & 0x00FF00) >> 8)
-#define __GETB(x) (((unsigned int)x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #include "Universal_System/roomsystem.h"
 #include "Universal_System/instance_system.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -194,7 +194,7 @@ void clear_view(float x, float y, float w, float h, float angle, bool showcolor)
 	if (enigma::d3dMode)
 		clearflags |= D3DCLEAR_ZBUFFER;
 
-  d3dmgr->Clear(0, NULL, clearflags, D3DCOLOR_XRGB(__GETR(clearcolor), __GETG(clearcolor), __GETB(clearcolor)), 1.0f, 0);
+  d3dmgr->Clear(0, NULL, clearflags, D3DCOLOR_XRGB(COL_GET_R(clearcolor), COL_GET_G(clearcolor), COL_GET_B(clearcolor)), 1.0f, 0);
 }
 
 static inline void draw_gui()

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
@@ -31,9 +31,7 @@ using std::string;
 #include "Universal_System/instance_system.h"
 #include "Universal_System/graphics_object.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 
 #ifdef DEBUG_MODE
@@ -83,4 +81,3 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -29,9 +29,7 @@ using namespace std;
 #include "Universal_System/background_internal.h"
 #include "Collision_Systems/collision_types.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 namespace enigma_user {
 extern int room_width, room_height/*, sprite_idmax*/;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9tiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9tiles.cpp
@@ -30,9 +30,7 @@
     const enigma::background *const bck2d = enigma::backgroundstructarray[back];
 #endif
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 // Tile system
 #include "Universal_System/depth_draw.h"
@@ -484,4 +482,3 @@ bool tile_layer_shift(int layer_depth, int x, int y)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
@@ -75,7 +75,7 @@ void vertex_argb(int buffer, unsigned argb) {
 }
 
 void vertex_color(int buffer, int color, double alpha) {
-  enigma::color_t finalcol = (bind_alpha(alpha) << 24) | (__GETR(color) << 16) | (__GETG(color) << 8) | __GETB(color);
+  enigma::color_t finalcol = (CLAMP_ALPHA(alpha) << 24) | (COL_GET_R(color) << 16) | (COL_GET_G(color) << 8) | COL_GET_B(color);
   enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSbackground.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSbackground.cpp
@@ -15,9 +15,6 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <cstddef>
-
-#include <math.h>
 #include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GSbackground.h"
@@ -26,6 +23,10 @@
 #include "Universal_System/background_internal.h"
 #include "Universal_System/sprites_internal.h"
 #include "Universal_System/math_consts.h"
+
+#include <cstddef>
+#include <math.h>
+#include <string.h> // needed for querying ARB extensions
 
 //Note that this clamps between 0 and 1, not 0 and 255
 #define clamp_alpha(alpha) (alpha <= 0 ? 0: alpha >= 1? 1: alpha)
@@ -36,9 +37,6 @@ namespace enigma_user {
 namespace enigma {
   extern size_t background_idmax;
 }
-
-
-#include <string.h> // needed for querying ARB extensions
 
 namespace enigma_user
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSbackground.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSbackground.cpp
@@ -16,6 +16,7 @@
 **/
 
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GSbackground.h"
 #include "Graphics_Systems/General/GStextures.h"
@@ -27,9 +28,6 @@
 #include <cstddef>
 #include <math.h>
 #include <string.h> // needed for querying ARB extensions
-
-//Note that this clamps between 0 and 1, not 0 and 255
-#define clamp_alpha(alpha) (alpha <= 0 ? 0: alpha >= 1? 1: alpha)
 
 namespace enigma_user {
   extern int room_width, room_height;
@@ -43,7 +41,7 @@ namespace enigma_user
 
 void draw_background(int back, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d,back);
 
 	const gs_scalar tbx=bck2d->texturex,tby=bck2d->texturey,
@@ -58,7 +56,7 @@ void draw_background(int back, gs_scalar x, gs_scalar y, int color, gs_scalar al
 
 void draw_background_stretched(int back, gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d, back);
 
 	const gs_scalar tbx=bck2d->texturex,tby=bck2d->texturey,
@@ -73,7 +71,7 @@ void draw_background_stretched(int back, gs_scalar x, gs_scalar y, gs_scalar wid
 
 void draw_background_part(int back, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d, back);
 
 	const gs_scalar tbw = bck2d->width/(gs_scalar)bck2d->texturew, tbh = bck2d->height/(gs_scalar)bck2d->textureh,
@@ -91,7 +89,7 @@ void draw_background_part(int back, gs_scalar left, gs_scalar top, gs_scalar wid
 
 void draw_background_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_background(bck2d,back);
 
   rot *= M_PI/180;
@@ -120,7 +118,7 @@ void draw_background_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, g
 
 void draw_background_stretched_ext(int back, gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d,back);
 
 	const gs_scalar tbx=bck2d->texturex, tby=bck2d->texturey,
@@ -136,7 +134,7 @@ void draw_background_stretched_ext(int back, gs_scalar x, gs_scalar y, gs_scalar
 
 void draw_background_part_ext(int back, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d, back);
 
 	gs_scalar tbw = bck2d->width/(gs_scalar)bck2d->texturew, tbh = bck2d->height/(gs_scalar)bck2d->textureh,
@@ -156,7 +154,7 @@ void draw_background_part_ext(int back, gs_scalar left, gs_scalar top, gs_scalar
 
 void draw_background_general(int back, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int c1, int c2, int c3, int c4, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d, back);
   const gs_scalar tbx = bck2d->texturex,  tby = bck2d->texturey,
                   tbw = bck2d->texturew,  tbh = bck2d->textureh,
@@ -185,7 +183,7 @@ void draw_background_general(int back, gs_scalar left, gs_scalar top, gs_scalar 
 
 void draw_background_tiled(int back, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_background(bck2d,back);
     x = (x<0?0:bck2d->width)-fmod(x,bck2d->width);
     y = (y<0?0:bck2d->height)-fmod(y,bck2d->height);
@@ -218,7 +216,7 @@ void draw_background_tiled(int back, gs_scalar x, gs_scalar y, int color, gs_sca
 
 void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha, bool htiled, bool vtiled)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d,back);
 
 	const gs_scalar tbx = bck2d->texturex, tby = bck2d->texturey,
@@ -261,7 +259,7 @@ void draw_background_tiled_ext(int back, gs_scalar x, gs_scalar y, gs_scalar xsc
 
 void draw_background_tiled_area(int back, gs_scalar x, gs_scalar y, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d,back);
 
   const gs_scalar tbx=bck2d->texturex,tby=bck2d->texturey,
@@ -309,7 +307,7 @@ void draw_background_tiled_area(int back, gs_scalar x, gs_scalar y, gs_scalar x1
 
 void draw_background_tiled_area_ext(int back, gs_scalar x, gs_scalar y, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	get_background(bck2d,back);
 
   const gs_scalar tbx=bck2d->texturex,tby=bck2d->texturey,

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolor_macros.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolor_macros.h
@@ -1,20 +1,14 @@
 #ifndef ENIGMA_GSCOLOR_MACROS_H
 #define ENIGMA_GSCOLOR_MACROS_H
 
-// 24-bit color macros used for color constants (e.g. c_red, c_green, c_blue)
-// they lack an alpha component because alpha is traditionally specified in
-// floating point form between 0 and 1
-#define COL_GET_R(x) ((x & 0x0000FF))
-#define COL_GET_G(x) ((x & 0x00FF00)>>8)
-#define COL_GET_B(x) ((x & 0xFF0000)>>16)
-
-// 32-bit alpha-enabled color macros used for model and vertex functions
+// 32-bit alpha-enabled color macros used for color constants and
+// swizzling the color components for model and vertex functions
 // they are combined with the alpha component to minimize the bandwidth
 // necessary to send vertex data to the GPU
-#define COL_GET_R32(x) ((x & 0x000000FF))
-#define COL_GET_G32(x) ((x & 0x0000FF00)>>8)
-#define COL_GET_B32(x) ((x & 0x00FF0000)>>16)
-#define COL_GET_A32(x) ((x & 0xFF000000)>>24)
+#define COL_GET_R(x) ((x & 0x000000FF))
+#define COL_GET_G(x) ((x & 0x0000FF00)>>8)
+#define COL_GET_B(x) ((x & 0x00FF0000)>>16)
+#define COL_GET_A(x) ((x & 0xFF000000)>>24)
 
 // clamps a floating-point alpha (from 0 to 1) between 0 and 255
 #define CLAMP_ALPHA(alpha) (alpha>1?255:(alpha<0?0:(unsigned char)(alpha*255)))

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolor_macros.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolor_macros.h
@@ -1,20 +1,24 @@
 #ifndef ENIGMA_GSCOLOR_MACROS_H
 #define ENIGMA_GSCOLOR_MACROS_H
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00)>>8)
-#define __GETB(x) ((x & 0xFF0000)>>16)
+// 24-bit color macros used for color constants (e.g. c_red, c_green, c_blue)
+// they lack an alpha component because alpha is traditionally specified in
+// floating point form between 0 and 1
+#define COL_GET_R(x) ((x & 0x0000FF))
+#define COL_GET_G(x) ((x & 0x00FF00)>>8)
+#define COL_GET_B(x) ((x & 0xFF0000)>>16)
 
-// this is Goombert's abomination
-#define __GETR32(x) ((x & 0x000000FF))
-#define __GETG32(x) ((x & 0x0000FF00)>>8)
-#define __GETB32(x) ((x & 0x00FF0000)>>16)
-#define __GETA32(x) ((x & 0xFF000000)>>24)
+// 32-bit alpha-enabled color macros used for model and vertex functions
+// they are combined with the alpha component to minimize the bandwidth
+// necessary to send vertex data to the GPU
+#define COL_GET_R32(x) ((x & 0x000000FF))
+#define COL_GET_G32(x) ((x & 0x0000FF00)>>8)
+#define COL_GET_B32(x) ((x & 0x00FF0000)>>16)
+#define COL_GET_A32(x) ((x & 0xFF000000)>>24)
 
-#define __GETRf(x) fmod(__GETR(x),256)
-#define __GETGf(x) fmod(x/256,256)
-#define __GETBf(x) fmod(x/65536,256)*
-
-#define bind_alpha(alpha) (alpha>1?255:(alpha<0?0:(unsigned char)(alpha*255)))
+// clamps a floating-point alpha (from 0 to 1) between 0 and 255
+#define CLAMP_ALPHA(alpha) (alpha>1?255:(alpha<0?0:(unsigned char)(alpha*255)))
+// clamps a floating-point alpha (from 0 to 1) between 0 and 1
+#define CLAMP_ALPHAF(alpha) (alpha <= 0 ? 0: alpha >= 1? 1: alpha)
 
 #endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.cpp
@@ -36,9 +36,9 @@ namespace enigma_user
 	int merge_color(int c1,int c2,double amount)
 	{
 		amount = amount > 1 ? 1 : (amount < 0 ? 0 : amount);
-		return (unsigned char)(fabs(__GETR(c1)+(__GETR(c2)-__GETR(c1))*amount))
-		|      (unsigned char)(fabs(__GETG(c1)+(__GETG(c2)-__GETG(c1))*amount))<<8
-		|      (unsigned char)(fabs(__GETB(c1)+(__GETB(c2)-__GETB(c1))*amount))<<16;
+		return (unsigned char)(fabs(COL_GET_R(c1)+(COL_GET_R(c2)-COL_GET_R(c1))*amount))
+		|      (unsigned char)(fabs(COL_GET_G(c1)+(COL_GET_G(c2)-COL_GET_G(c1))*amount))<<8
+		|      (unsigned char)(fabs(COL_GET_B(c1)+(COL_GET_B(c2)-COL_GET_B(c1))*amount))<<16;
 	}
 
 	int draw_get_color(){
@@ -52,13 +52,13 @@ namespace enigma_user
 	  return enigma::currentcolor[3] / 255.0;
 	}
 
-	int color_get_red  (int c){return __GETR(c);}
-	int color_get_green(int c){return __GETG(c);}
-	int color_get_blue (int c){return __GETB(c);}
+	int color_get_red  (int c){return COL_GET_R(c);}
+	int color_get_green(int c){return COL_GET_G(c);}
+	int color_get_blue (int c){return COL_GET_B(c);}
 
 	int color_get_hue(int c)
 	{
-		int r = __GETR(c),g = __GETG(c),b = __GETB(c);
+		int r = COL_GET_R(c),g = COL_GET_G(c),b = COL_GET_B(c);
 		int cmpmax = r>g ? (r>b?r:b) : (g>b?g:b);
 		if(!cmpmax) return 0;
 
@@ -68,12 +68,12 @@ namespace enigma_user
 	}
 	int color_get_value(int c)
 	{
-	  int r = __GETR(c), g = __GETG(c), b = __GETB(c);
+	  int r = COL_GET_R(c), g = COL_GET_G(c), b = COL_GET_B(c);
 		return r>g ? (r>b?r:b) : (g>b?g:b);
 	}
 	int color_get_saturation(int color)
 	{
-		int r = __GETR(color), g = __GETG(color), b = __GETB(color);
+		int r = COL_GET_R(color), g = COL_GET_G(color), b = COL_GET_B(color);
 		int cmpmax = r>g  ?  (r>b ? r : b)  :  (g>b ? g : b);
 		return cmpmax  ?  255 - int(255 * (r<g ? (r<b?r:b) : (g<b?g:b)) / double(cmpmax))  :  0;
 	}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScurves.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScurves.cpp
@@ -22,12 +22,7 @@
 #include "OpenGLHeaders.h"
 #include "GScolors.h"
 #include "GScurves.h"
-//#include "GStextures.h"
 #include "GSprimitives.h"
-
-//#define __GETR(x) (((x & 0x0000FF))/255.0)
-//#define __GETG(x) (((x & 0x00FF00)>>8)/255.0)
-//#define __GETB(x) (((x & 0xFF0000)>>16)/255.0)
 
 
 namespace enigma{
@@ -436,4 +431,3 @@ int draw_spline_optimized_end()
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSfont.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSfont.cpp
@@ -21,21 +21,18 @@
 #include <cstdint>
 #include "libEGMstd.h"
 #include "Universal_System/var4.h"
-#include "../General/GScolors.h"
-#include "../General/GSfont.h"
-#include "../General/GStextures.h"
-#include "../General/GSprimitives.h"
-#include "../General/GSsprite.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
+#include "Graphics_Systems/General/GSfont.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSprimitives.h"
+#include "Graphics_Systems/General/GSsprite.h"
 
 #include "Universal_System/math_consts.h"
 #include "Universal_System/fonts_internal.h"
 #include "Universal_System/sprites.h"
 
 using namespace std;
-
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
 
 namespace enigma {
   static int currentfont = -1;
@@ -224,7 +221,7 @@ unsigned int string_height_ext(variant vstr, gs_scalar sep, gs_scalar w)
       if (character == ' ' or g.empty()) {
         width += slen;
       }
-      
+
       tw = 0;
       for (size_t c = i+1; c < str.length(); c++) {
         character = getUnicodeCharacter(str, c);
@@ -1318,4 +1315,3 @@ int draw_get_font() {
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
@@ -15,15 +15,11 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <cmath>
-#include <cstdlib>
-#include <string>
-using std::string;
-
-#include "../General/GScolors.h"
-#include "../General/GSsprite.h"
-#include "../General/GStextures.h"
-#include "../General/GSprimitives.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
+#include "Graphics_Systems/General/GSsprite.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites.h"
@@ -31,9 +27,10 @@ using std::string;
 #include "Universal_System/graphics_object.h"
 #include "Universal_System/math_consts.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include <cmath>
+#include <cstdlib>
+#include <string>
+using std::string;
 
 //Note that this clamps between 0 and 1, not 0 and 255
 #define clamp_alpha(alpha) (alpha <= 0 ? 0: alpha >= 1? 1: alpha)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
@@ -32,9 +32,6 @@
 #include <string>
 using std::string;
 
-//Note that this clamps between 0 and 1, not 0 and 255
-#define clamp_alpha(alpha) (alpha <= 0 ? 0: alpha >= 1? 1: alpha)
-
 #ifdef DEBUG_MODE
   #include "libEGMstd.h"
   #include "Widget_Systems/widgets_mandatory.h"
@@ -67,7 +64,7 @@ namespace enigma_user
 
 void draw_sprite(int spr,int subimg, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -86,7 +83,7 @@ void draw_sprite(int spr,int subimg, gs_scalar x, gs_scalar y, int color, gs_sca
 
 void draw_sprite_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -116,7 +113,7 @@ void draw_sprite_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xs
 ///Maybe we should forget about GM compatibility once again and just modify this so it fits the others
 void draw_sprite_pos(int spr, int subimg, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar x3, gs_scalar y3, gs_scalar x4, gs_scalar y4, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -133,7 +130,7 @@ void draw_sprite_pos(int spr, int subimg, gs_scalar x1, gs_scalar y1, gs_scalar 
 
 void draw_sprite_part(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -151,7 +148,7 @@ void draw_sprite_part(int spr, int subimg, gs_scalar left, gs_scalar top, gs_sca
 
 void draw_sprite_part_offset(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -171,7 +168,7 @@ void draw_sprite_part_offset(int spr, int subimg, gs_scalar left, gs_scalar top,
 
 void draw_sprite_part_ext(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -191,7 +188,7 @@ void draw_sprite_part_ext(int spr, int subimg, gs_scalar left, gs_scalar top, gs
 
 void draw_sprite_general(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int c1, int c2, int c3, int c4, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -223,7 +220,7 @@ void draw_sprite_general(int spr, int subimg, gs_scalar left, gs_scalar top, gs_
 
 void draw_sprite_stretched(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -266,7 +263,7 @@ void d3d_draw_sprite(int spr,int subimg, gs_scalar x, gs_scalar y, gs_scalar z)
 //Draw padded
 void draw_sprite_padded(int spr, int subimg, gs_scalar left, gs_scalar top, gs_scalar right, gs_scalar bottom, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
   get_spritev(spr2d,spr);
   const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -388,7 +385,7 @@ namespace enigma_user
 
 void draw_sprite_tiled(int spr, int subimg, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 
@@ -424,7 +421,7 @@ void draw_sprite_tiled(int spr, int subimg, gs_scalar x, gs_scalar y, int color,
 
 void draw_sprite_tiled_ext(int spr, int subimg, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     get_spritev(spr2d,spr);
     const int usi = subimg >= 0 ? (subimg % spr2d->subcount) : int(((enigma::object_graphics*)enigma::instance_event_iterator->inst)->image_index) % spr2d->subcount;
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
@@ -29,9 +29,9 @@ using namespace std;
 #include "Collision_Systems/collision_types.h"
 #include "Universal_System/math_consts.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GSprimitives.h"
+#include "Graphics_Systems/General/GSsurface.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 //Note that this clamps between 0 and 1, not 0 and 255
 #define clamp_alpha(alpha) (alpha <= 0 ? 0: alpha >= 1? 1: alpha)
@@ -39,10 +39,6 @@ using namespace std;
 namespace enigma_user {
 extern int room_width, room_height/*, sprite_idmax*/;
 }
-
-#include "../General/GSprimitives.h"
-#include "../General/GSsurface.h"
-
 
 namespace enigma_user
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
@@ -33,9 +33,6 @@ using namespace std;
 #include "Graphics_Systems/General/GSsurface.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
 
-//Note that this clamps between 0 and 1, not 0 and 255
-#define clamp_alpha(alpha) (alpha <= 0 ? 0: alpha >= 1? 1: alpha)
-
 namespace enigma_user {
 extern int room_width, room_height/*, sprite_idmax*/;
 }
@@ -45,7 +42,7 @@ namespace enigma_user
 
 void draw_surface(int id, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	int w=surface_get_width(id);
 	int h=surface_get_height(id);
 
@@ -59,7 +56,7 @@ void draw_surface(int id, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 
 void draw_surface_ext(int id,gs_scalar x, gs_scalar y,gs_scalar xscale, gs_scalar yscale,double rot,int color,gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     const gs_scalar w=surface_get_width(id)*xscale, h=surface_get_height(id)*yscale;
     rot *= M_PI/180;
 
@@ -78,7 +75,7 @@ void draw_surface_ext(int id,gs_scalar x, gs_scalar y,gs_scalar xscale, gs_scala
 
 void draw_surface_stretched(int id, gs_scalar x, gs_scalar y, gs_scalar w, gs_scalar h, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	draw_primitive_begin_texture(pr_trianglestrip, surface_get_texture(id));
 	draw_vertex_texture_color(x,y,0,0,color,alpha);
 	draw_vertex_texture_color(x+w,y,1,0,color,alpha);
@@ -89,7 +86,7 @@ void draw_surface_stretched(int id, gs_scalar x, gs_scalar y, gs_scalar w, gs_sc
 
 void draw_surface_stretched_ext(int id, gs_scalar x, gs_scalar y, gs_scalar w, gs_scalar h, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	draw_primitive_begin_texture(pr_trianglestrip, surface_get_texture(id));
 	draw_vertex_texture_color(x,y,0,0,color,alpha);
 	draw_vertex_texture_color(x+w,y,1,0,color,alpha);
@@ -100,7 +97,7 @@ void draw_surface_stretched_ext(int id, gs_scalar x, gs_scalar y, gs_scalar w, g
 
 void draw_surface_part(int id, gs_scalar left, gs_scalar top, gs_scalar w, gs_scalar h, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	const gs_scalar tbw=surface_get_width(id),tbh=surface_get_height(id);
 
 	draw_primitive_begin_texture(pr_trianglestrip, surface_get_texture(id));
@@ -113,7 +110,7 @@ void draw_surface_part(int id, gs_scalar left, gs_scalar top, gs_scalar w, gs_sc
 
 void draw_surface_part_ext(int id, gs_scalar left, gs_scalar top, gs_scalar w, gs_scalar h, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale,int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	const gs_scalar tbw = surface_get_width(id), tbh = surface_get_height(id);
 	draw_primitive_begin_texture(pr_trianglestrip, surface_get_texture(id));
 	draw_vertex_texture_color(x,y,left/tbw,top/tbh,color,alpha);
@@ -125,7 +122,7 @@ void draw_surface_part_ext(int id, gs_scalar left, gs_scalar top, gs_scalar w, g
 
 void draw_surface_general(int id, gs_scalar left, gs_scalar top, gs_scalar width, gs_scalar height, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, double rot, int c1, int c2, int c3, int c4, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	const gs_scalar tbw = surface_get_width(id), tbh = surface_get_height(id),
 	  w = width*xscale, h = height*yscale;
 
@@ -148,7 +145,7 @@ void draw_surface_general(int id, gs_scalar left, gs_scalar top, gs_scalar width
 
 void draw_surface_tiled(int id, gs_scalar x, gs_scalar y, int color, gs_scalar alpha)
 {
-  alpha=clamp_alpha(alpha);
+  alpha=CLAMP_ALPHAF(alpha);
 	const gs_scalar tbw = surface_get_width(id), tbh = surface_get_height(id);
 	x=surface_get_width(id)-fmod(x,surface_get_width(id));
 	y=surface_get_height(id)-fmod(y,surface_get_height(id));
@@ -172,7 +169,7 @@ void draw_surface_tiled(int id, gs_scalar x, gs_scalar y, int color, gs_scalar a
 
 void draw_surface_tiled_ext(int id, gs_scalar x, gs_scalar y, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     const gs_scalar w=surface_get_width(id)*xscale, h=surface_get_height(id)*yscale;
     const int hortil= int (ceil(room_width/(surface_get_width(id)))),
         vertil= int (ceil(room_height/(surface_get_height(id))));
@@ -195,7 +192,7 @@ void draw_surface_tiled_ext(int id, gs_scalar x, gs_scalar y, gs_scalar xscale, 
 
 void draw_surface_tiled_area(int id, gs_scalar x, gs_scalar y, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     gs_scalar sw,sh,i,j,jj,left,top,width,height,X,Y;
     sw = surface_get_width(id);
     sh = surface_get_height(id);
@@ -235,7 +232,7 @@ void draw_surface_tiled_area(int id, gs_scalar x, gs_scalar y, gs_scalar x1, gs_
 
 void draw_surface_tiled_area_ext(int id, gs_scalar x, gs_scalar y, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar xscale, gs_scalar yscale, int color, gs_scalar alpha)
 {
-    alpha=clamp_alpha(alpha);
+    alpha=CLAMP_ALPHAF(alpha);
     gs_scalar sw,sh,i,j,jj,left,top,width,height,X,Y;
     sw = surface_get_width(id)*xscale;
     sh = surface_get_height(id)*yscale;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEModelStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEModelStruct.h
@@ -16,29 +16,27 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-#include "../General/GSd3d.h"
-#include "../General/GSmodel.h"
-#include "../General/GSprimitives.h"
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GSmodel.h"
+#include "Graphics_Systems/General/GSprimitives.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
+
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-
-using namespace std;
-
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
+#include "Universal_System/fileio.h"
+#include "Universal_System/estring.h"
 
 #include <iostream>
 #include <map>
 #include <list>
-#include "Universal_System/fileio.h"
-#include "Universal_System/estring.h"
-
 #include <vector>
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 using std::vector;
+using namespace std;
 
 namespace enigma
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEcolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEcolors.cpp
@@ -16,14 +16,9 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-#include "../General/GScolors.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include <math.h>
-
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
-
-#define bind_alpha(alpha) (alpha>1?255:(alpha<0?0:(unsigned char)(alpha*255)))
 
 namespace enigma
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEcolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEcolors.cpp
@@ -29,9 +29,9 @@ namespace enigma_user
 {
 	void draw_set_color(int color)
 	{
-		enigma::currentcolor[0] = __GETR(color);
-		enigma::currentcolor[1] = __GETG(color);
-		enigma::currentcolor[2] = __GETB(color);
+		enigma::currentcolor[0] = COL_GET_R(color);
+		enigma::currentcolor[1] = COL_GET_G(color);
+		enigma::currentcolor[2] = COL_GET_B(color);
 	}
 
 
@@ -44,7 +44,7 @@ namespace enigma_user
 
 	void draw_set_alpha(float alpha)
 	{
-		enigma::currentcolor[3] = bind_alpha(alpha);
+		enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 	}
 
 	void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blue,float alpha)
@@ -52,7 +52,7 @@ namespace enigma_user
 		enigma::currentcolor[0] = red;
 		enigma::currentcolor[1] = green;
 		enigma::currentcolor[2] = blue;
-		enigma::currentcolor[3] = bind_alpha(alpha);
+		enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 	}
 
 	void draw_set_color_write_enable(bool red, bool green, bool blue, bool alpha){}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEd3d.cpp
@@ -16,22 +16,15 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-#include "../General/GSd3d.h"
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
 #include <math.h>
 
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
+#include <floatcomp.h>
 
 using namespace std;
-
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
-
-#include <floatcomp.h>
 
 struct posi { // Homogenous point.
     gs_scalar x;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEmodel.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEmodel.cpp
@@ -17,29 +17,28 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 #include "NONEModelStruct.h"
-#include "../General/GSd3d.h"
-#include "../General/GStextures.h"
-#include "../General/GSmatrix.h" //For d3d_transform_add_translation
-#include "../General/GSmodel.h"
+
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSmatrix.h" //For d3d_transform_add_translation
+#include "Graphics_Systems/General/GSmodel.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
+
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-
-
-using namespace std;
-
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
+#include "Universal_System/fileio.h"
+#include "Universal_System/estring.h"
 
 #include <iostream>
 #include <map>
 #include <list>
 #include <vector>
-#include "Universal_System/fileio.h"
-#include "Universal_System/estring.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+using namespace std;
 
 vector<Mesh*> meshes(0);
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEscreen.cpp
@@ -16,36 +16,35 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-#include <string>
-#include <cstdio>
-#include "../General/GStextures.h"
-#include "../General/GSbackground.h"
-#include "../General/GSscreen.h"
-#include "../General/GSd3d.h"
-#include "../General/GSmatrix.h"
-#include "../General/GScolors.h"
-
-using namespace std;
+#include "Graphics_Systems/graphics_mandatory.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSbackground.h"
+#include "Graphics_Systems/General/GSscreen.h"
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GSmatrix.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #include "Universal_System/image_formats.h"
 #include "Universal_System/background_internal.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/estring.h"
 
-#define __GETR(x) (((unsigned int)x & 0x0000FF))
-#define __GETG(x) (((unsigned int)x & 0x00FF00) >> 8)
-#define __GETB(x) (((unsigned int)x & 0xFF0000) >> 16)
-
 #include "Universal_System/roomsystem.h"
 #include "Universal_System/instance_system.h"
 #include "Universal_System/graphics_object.h"
 #include "Universal_System/depth_draw.h"
 #include "Platforms/platforms_mandatory.h"
-#include "Graphics_Systems/graphics_mandatory.h"
+
+#include <string>
+#include <cstdio>
 #include <limits>
 
 using namespace enigma;
 using namespace enigma_user;
+
+using namespace std;
+
 namespace enigma_user {
   extern int window_get_width();
   extern int window_get_height();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLcolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLcolors.cpp
@@ -30,20 +30,20 @@ namespace enigma_user
 void draw_clear_alpha(int col,float alpha)
 {
   //Unfortunately, we lack a 255-based method for setting ClearColor.
-	glClearColor(__GETR(col)/255.0,__GETG(col)/255.0,__GETB(col)/255.0,alpha);
+	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,alpha);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 void draw_clear(int col)
 {
-	glClearColor(__GETR(col)/255.0,__GETG(col)/255.0,__GETB(col)/255.0,1);
+	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,1);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 
 void draw_set_color(int color)
 {
-	enigma::currentcolor[0] = __GETR(color);
-	enigma::currentcolor[1] = __GETG(color);
-	enigma::currentcolor[2] = __GETB(color);
+	enigma::currentcolor[0] = COL_GET_R(color);
+	enigma::currentcolor[1] = COL_GET_G(color);
+	enigma::currentcolor[2] = COL_GET_B(color);
 	glColor4ubv(enigma::currentcolor);
 }
 
@@ -57,7 +57,7 @@ void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue
 
 void draw_set_alpha(float alpha)
 {
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 	glColor4ubv(enigma::currentcolor);
 }
 
@@ -66,7 +66,7 @@ void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blu
 	enigma::currentcolor[0] = red;
 	enigma::currentcolor[1] = green;
 	enigma::currentcolor[2] = blue;
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 	glColor4ubv(enigma::currentcolor);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -15,19 +15,16 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "../General/OpenGLHeaders.h"
-#include "../General/GSd3d.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
+
 #include <math.h>
+#include <floatcomp.h>
 
 using namespace std;
-
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
-
-#include <floatcomp.h>
 
 namespace enigma {
   bool d3dMode = false;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -170,9 +170,9 @@ void d3d_set_fog_hint(int mode) {
 void d3d_set_fog_color(int color)
 {
    GLfloat fog_color[3];
-   fog_color[0] = __GETR(color);
-   fog_color[1] = __GETG(color);
-   fog_color[2] = __GETB(color);
+   fog_color[0] = COL_GET_R(color);
+   fog_color[1] = COL_GET_G(color);
+   fog_color[2] = COL_GET_B(color);
    glFogfv(GL_FOG_COLOR, fog_color);
 }
 
@@ -307,7 +307,7 @@ class d3d_lights
             ind_pos.insert(pair<int,posi>(ms, posi(-dx, -dy, -dz, 0.0f)));
         }
 
-        const float dir[4] = {float(-dx), float(-dy), float(-dz), 0.0f}, color[4] = {float(__GETR(col)), float(__GETG(col)), float(__GETB(col)), 1.0f};
+        const float dir[4] = {float(-dx), float(-dy), float(-dz), 0.0f}, color[4] = {float(COL_GET_R(col)), float(COL_GET_G(col)), float(COL_GET_B(col)), 1.0f};
         glLightfv(GL_LIGHT0+ms, GL_POSITION, dir);
         glLightfv(GL_LIGHT0+ms, GL_DIFFUSE, color);
         light_update_positions();
@@ -339,7 +339,7 @@ class d3d_lights
             light_ind.insert(pair<int,int>(id, ms));
             ind_pos.insert(pair<int,posi>(ms, posi(x, y, z, 1)));
         }
-        const float pos[4] = {(float)x, (float)y, (float)z, 1.0f}, color[4] = {float(__GETR(col)), float(__GETG(col)), float(__GETB(col)), 1.0f},
+        const float pos[4] = {(float)x, (float)y, (float)z, 1.0f}, color[4] = {float(COL_GET_R(col)), float(COL_GET_G(col)), float(COL_GET_B(col)), 1.0f},
             specular[4] = {0.0f, 0.0f, 0.0f, 0.0f}, ambient[4] = {0.0f, 0.0f, 0.0f, 0.0f};
         glLightfv(GL_LIGHT0+ms, GL_POSITION, pos);
         glLightfv(GL_LIGHT0+ms, GL_DIFFUSE, color);
@@ -490,7 +490,7 @@ void d3d_light_shininess(int facemode, int shine)
 
 void d3d_light_define_ambient(int col)
 {
-    float color[4] = {float(__GETR(col)), float(__GETG(col)), float(__GETB(col)), 1.0f};
+    float color[4] = {float(COL_GET_R(col)), float(COL_GET_G(col)), float(COL_GET_B(col)), 1.0f};
     glLightModelfv(GL_LIGHT_MODEL_AMBIENT, color);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLprimitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLprimitives.cpp
@@ -15,23 +15,19 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "../General/OpenGLHeaders.h"
-#include "../General/GStextures.h"
-#include "../General/GSprimitives.h"
 #include "GLTextureStruct.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSprimitives.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
-#include <string>
 #include "Widget_Systems/widgets_mandatory.h"
 
-#define GETR(x) ((x & 0x0000FF))
-#define GETG(x) ((x & 0x00FF00)>>8)
-#define GETB(x) ((x & 0xFF0000)>>16)
-
+#include <string>
 #include <math.h>
+#include <floatcomp.h>
 
 using namespace std;
-
-#include <floatcomp.h>
 
 GLenum ptypes_by_id[16] = {
   GL_POINTS, GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_TRIANGLES,
@@ -122,7 +118,7 @@ void d3d_vertex(gs_scalar x, gs_scalar y, gs_scalar z) {
 }
 
 void d3d_vertex_color(gs_scalar x, gs_scalar y, gs_scalar z, int color, double alpha) {
-  glColor4ub(GETR(color), GETG(color), GETB(color), (unsigned char)(alpha*255));
+  glColor4ub(__GETR(color), __GETG(color), __GETB(color), (unsigned char)(alpha*255));
   glVertex3d(x,y,z);
   glColor4ubv(enigma::currentcolor);
 }
@@ -133,7 +129,7 @@ void d3d_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar tx, gs_
 }
 
 void d3d_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar tx, gs_scalar ty, int color, double alpha) {
-  glColor4ub(GETR(color), GETG(color), GETB(color), (unsigned char)(alpha*255));
+  glColor4ub(__GETR(color), __GETG(color), __GETB(color), (unsigned char)(alpha*255));
   glTexCoord2f(tx,ty);
   glVertex3d(x,y,z);
   glColor4ubv(enigma::currentcolor);
@@ -147,7 +143,7 @@ void d3d_vertex_normal(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_s
 
 void d3d_vertex_normal_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_scalar ny, gs_scalar nz, int color, double alpha)
 {
-  glColor4ub(GETR(color), GETG(color), GETB(color), (unsigned char)(alpha*255));
+  glColor4ub(__GETR(color), __GETG(color), __GETB(color), (unsigned char)(alpha*255));
   glNormal3f(nx, ny, nz);
   glVertex3d(x,y,z);
   glColor4ubv(enigma::currentcolor);
@@ -162,7 +158,7 @@ void d3d_vertex_normal_texture(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar 
 
 void d3d_vertex_normal_texture_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_scalar ny, gs_scalar nz, gs_scalar tx, gs_scalar ty, int color, double alpha)
 {
-  glColor4ub(GETR(color), GETG(color), GETB(color), (unsigned char)(alpha*255));
+  glColor4ub(__GETR(color), __GETG(color), __GETB(color), (unsigned char)(alpha*255));
   glTexCoord2f(tx,ty);
   glNormal3f(nx, ny, nz);
   glVertex3d(x,y,z);
@@ -272,9 +268,9 @@ void d3d_draw_cylinder(gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar x2, g
   const double cx = (x1+x2)/2, cy = (y1+y2)/2, rx = (x2-x1)/2, ry = (y2-y1)/2, invstep = (1.0/steps)*hrep, pr = 2*M_PI/steps;
   double a, px, py, tp;
   int k;
-  
+
   texture_set(texId);
-  
+
   //SIDES
   glBegin(GL_TRIANGLE_STRIP);
   a = 0; px = cx+rx; py = cy; tp = 0; k = 0;
@@ -343,9 +339,9 @@ void d3d_draw_cone(gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar x2, gs_sc
   float t[(steps + 1)*3 + 1][2];
   double a, px, py, tp;
   int k = 0;
-  
+
   texture_set(texId);
-  
+
   glBegin(GL_TRIANGLE_STRIP);
   a = 0; px = cx+rx; py = cy; tp = 0;
   for (int i = 0; i <= steps; i++)
@@ -411,9 +407,9 @@ void d3d_draw_ellipsoid(gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar x2, 
       a += pr; tp += invstep;
   }
   int k = 0, kk;
-  
+
   texture_set(texId);
-  
+
   b = M_PI/2;
   cosb = cos(b);
   pz = rz*sin(b);
@@ -509,4 +505,3 @@ void d3d_draw_torus(gs_scalar x1, gs_scalar y1, gs_scalar z1, int texId, gs_scal
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLprimitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLprimitives.cpp
@@ -118,7 +118,7 @@ void d3d_vertex(gs_scalar x, gs_scalar y, gs_scalar z) {
 }
 
 void d3d_vertex_color(gs_scalar x, gs_scalar y, gs_scalar z, int color, double alpha) {
-  glColor4ub(__GETR(color), __GETG(color), __GETB(color), (unsigned char)(alpha*255));
+  glColor4ub(COL_GET_R(color), COL_GET_G(color), COL_GET_B(color), (unsigned char)(alpha*255));
   glVertex3d(x,y,z);
   glColor4ubv(enigma::currentcolor);
 }
@@ -129,7 +129,7 @@ void d3d_vertex_texture(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar tx, gs_
 }
 
 void d3d_vertex_texture_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar tx, gs_scalar ty, int color, double alpha) {
-  glColor4ub(__GETR(color), __GETG(color), __GETB(color), (unsigned char)(alpha*255));
+  glColor4ub(COL_GET_R(color), COL_GET_G(color), COL_GET_B(color), (unsigned char)(alpha*255));
   glTexCoord2f(tx,ty);
   glVertex3d(x,y,z);
   glColor4ubv(enigma::currentcolor);
@@ -143,7 +143,7 @@ void d3d_vertex_normal(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_s
 
 void d3d_vertex_normal_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_scalar ny, gs_scalar nz, int color, double alpha)
 {
-  glColor4ub(__GETR(color), __GETG(color), __GETB(color), (unsigned char)(alpha*255));
+  glColor4ub(COL_GET_R(color), COL_GET_G(color), COL_GET_B(color), (unsigned char)(alpha*255));
   glNormal3f(nx, ny, nz);
   glVertex3d(x,y,z);
   glColor4ubv(enigma::currentcolor);
@@ -158,7 +158,7 @@ void d3d_vertex_normal_texture(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar 
 
 void d3d_vertex_normal_texture_color(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar nx, gs_scalar ny, gs_scalar nz, gs_scalar tx, gs_scalar ty, int color, double alpha)
 {
-  glColor4ub(__GETR(color), __GETG(color), __GETB(color), (unsigned char)(alpha*255));
+  glColor4ub(COL_GET_R(color), COL_GET_G(color), COL_GET_B(color), (unsigned char)(alpha*255));
   glTexCoord2f(tx,ty);
   glNormal3f(nx, ny, nz);
   glVertex3d(x,y,z);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -14,28 +14,20 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-
-#include <string>
-#include <cstdio>
-#include "../General/OpenGLHeaders.h"
-#include "../General/GStextures.h"
-#include "../General/GSsprite.h"
-#include "../General/GSbackground.h"
-#include "../General/GSscreen.h"
-#include "../General/GSd3d.h"
-#include "../General/GSmatrix.h"
-#include "../General/GScolors.h"
-
-using namespace std;
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSsprite.h"
+#include "Graphics_Systems/General/GSbackground.h"
+#include "Graphics_Systems/General/GSscreen.h"
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GSmatrix.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #include "Universal_System/image_formats.h"
 #include "Universal_System/background.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/estring.h"
-
-#define __GETR(x) (((unsigned int)x & 0x0000FF))
-#define __GETG(x) (((unsigned int)x & 0x00FF00) >> 8)
-#define __GETB(x) (((unsigned int)x & 0xFF0000) >> 16)
 
 #include "Universal_System/roomsystem.h"
 #include "Universal_System/instance_system.h"
@@ -44,15 +36,21 @@ using namespace std;
 #include "Platforms/General/PFwindow.h"
 #include "Platforms/platforms_mandatory.h"
 #include "Graphics_Systems/graphics_mandatory.h"
+
+#include <string>
+#include <cstdio>
 #include <limits>
+
+using namespace enigma;
+using namespace enigma_user;
+
+using namespace std;
 
 //Fuck whoever did this to the spec
 #ifndef GL_BGR
   #define GL_BGR 0x80E0
 #endif
 
-using namespace enigma;
-using namespace enigma_user;
 namespace enigma_user {
   extern int window_get_width();
   extern int window_get_height();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -178,7 +178,7 @@ void clear_view(float x, float y, float w, float h, float angle, bool showcolor)
   if (showcolor)
   {
     int clearcolor = ((int)background_color) & 0x00FFFFFF;
-    glClearColor(__GETR(clearcolor) / 255.0, __GETG(clearcolor) / 255.0, __GETB(clearcolor) / 255.0, 1);
+    glClearColor(COL_GET_R(clearcolor) / 255.0, COL_GET_G(clearcolor) / 255.0, COL_GET_B(clearcolor) / 255.0, 1);
     clear_bits |= GL_COLOR_BUFFER_BIT;
   }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
@@ -14,14 +14,9 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-
-#include <cmath>
-#include <cstdlib>
-#include <string>
-using std::string;
-
-#include "../General/OpenGLHeaders.h"
-#include "../General/GSsprite.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GSsprite.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
@@ -29,10 +24,10 @@ using std::string;
 #include "Universal_System/instance_system.h"
 #include "Universal_System/graphics_object.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
-
+#include <cmath>
+#include <cstdlib>
+#include <string>
+using std::string;
 
 #ifdef DEBUG_MODE
   #include "libEGMstd.h"
@@ -85,9 +80,9 @@ int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool 
 	std::vector<unsigned char> rgbdata(4*patchSize);
 	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
-	
+
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
-	
+
 	enigma::spritestructarray_reallocate();
   int sprid=enigma::sprite_idmax;
   enigma::sprite_new_empty(sprid, 1, w, h, xorig, yorig, 0, h, 0, w, preload, smooth);
@@ -110,7 +105,7 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 	std::vector<unsigned char> rgbdata(4*patchSize);
 	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
-	
+
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
 
 	enigma::sprite_add_subimage(id, w, h, &data[0], &data[0], enigma::ct_precise); //TODO: Support toggling of precise.
@@ -119,4 +114,3 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
@@ -15,18 +15,16 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GSstdraw.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
+
+#include "Universal_System/roomsystem.h"
 
 #include <cstdlib>
 #include <math.h>
-#include "../General/OpenGLHeaders.h"
-#include "../General/GSstdraw.h"
-#include "../General/GStextures.h"
 #include <stdio.h>
-#include "Universal_System/roomsystem.h"
-
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
 
 //Proper calling convention is needed on Windows to prevent random crashing.
 //However, we assume that if CALLBACK is already defined then it is defined correctly.
@@ -271,4 +269,3 @@ bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColo
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsurface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsurface.cpp
@@ -16,37 +16,35 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "../General/OpenGLHeaders.h"
-#include "../General/GSscreen.h"
-#include "../General/GSmatrix.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GSscreen.h"
+#include "Graphics_Systems/General/GSmatrix.h"
 #include "Graphics_Systems/graphics_mandatory.h"
+#include "Graphics_Systems/General/GSsurface.h"
+#include "Graphics_Systems/General/GLSurfaceStruct.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "GLTextureStruct.h"
 
-using namespace std;
-#include <cstddef>
-#include <iostream>
-#include <math.h>
-#include <string.h>
-#include <unordered_map>
-
-#include <stdio.h> //for file writing (surface_save)
 #include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
 #include "Universal_System/background_internal.h"
 #include "Collision_Systems/collision_types.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include <unordered_map>
+#include <cstddef>
+#include <iostream>
+
+#include <math.h>
+#include <string.h>
+#include <stdio.h> //for file writing (surface_save)
+
+using namespace std;
 
 namespace enigma_user {
   extern int room_width, room_height/*, sprite_idmax*/;
 }
-#include "../General/GSsurface.h"
-#include "../General/GLSurfaceStruct.h"
-#include "../General/GStextures.h"
-#include "GLTextureStruct.h"
 
 #ifdef DEBUG_MODE
   #include <string>
@@ -449,4 +447,3 @@ void surface_copy(int destination, gs_scalar x, gs_scalar y, int source)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -39,12 +39,12 @@ void graphics_delete_vertex_buffer_peer(int buffer) {
 namespace enigma_user {
 
 void vertex_argb(int buffer, unsigned argb) {
-  enigma::color_t finalcol = (__GETA32(argb) << 24) | (__GETR32(argb) << 16) | (__GETG32(argb) << 8) | __GETB32(argb);
+  enigma::color_t finalcol = (COL_GET_A32(argb) << 24) | (COL_GET_R32(argb) << 16) | (COL_GET_G32(argb) << 8) | COL_GET_B32(argb);
   enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
 }
 
 void vertex_color(int buffer, int color, double alpha) {
-  enigma::color_t finalcol = color + (bind_alpha(alpha) << 24);
+  enigma::color_t finalcol = color + (CLAMP_ALPHA(alpha) << 24);
   enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -39,7 +39,7 @@ void graphics_delete_vertex_buffer_peer(int buffer) {
 namespace enigma_user {
 
 void vertex_argb(int buffer, unsigned argb) {
-  enigma::color_t finalcol = (COL_GET_A32(argb) << 24) | (COL_GET_R32(argb) << 16) | (COL_GET_G32(argb) << 8) | COL_GET_B32(argb);
+  enigma::color_t finalcol = (COL_GET_A(argb) << 24) | (COL_GET_R(argb) << 16) | (COL_GET_G(argb) << 8) | COL_GET_B(argb);
   enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3colors.cpp
@@ -15,21 +15,13 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "../General/OpenGLHeaders.h"
-#include "../General/GScolors.h"
-#include "../General/GStextures.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Bridges/General/GL3Context.h"
 
 #include <math.h>
-
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00)>>8)
-#define __GETB(x) ((x & 0xFF0000)>>16)
-/*#define __GETRf(x) fmod(x,256)
-#define __GETGf(x) fmod(x/256,256)
-#define __GETBf(x) fmod(x/65536,256)*/
-
-#define bind_alpha(alpha) (alpha>1?255:(alpha<0?0:(unsigned char)(alpha*255)))
 
 namespace enigma {
   extern unsigned char currentcolor[4];

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3colors.cpp
@@ -33,22 +33,22 @@ namespace enigma_user
 void draw_clear_alpha(int col,float alpha)
 {
   //Unfortunately, we lack a 255-based method for setting ClearColor.
-	glClearColor(__GETR(col)/255.0,__GETG(col)/255.0,__GETB(col)/255.0,alpha);
+	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,alpha);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 void draw_clear(int col)
 {
-	glClearColor(__GETR(col)/255.0,__GETG(col)/255.0,__GETB(col)/255.0,1);
+	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,1);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 
 void draw_set_color(int color)
 {
-	if (enigma::currentcolor[0] == __GETR(color) && enigma::currentcolor[1] == __GETG(color) && enigma::currentcolor[2] == __GETB(color)) return;
+	if (enigma::currentcolor[0] == COL_GET_R(color) && enigma::currentcolor[1] == COL_GET_G(color) && enigma::currentcolor[2] == COL_GET_B(color)) return;
 	oglmgr->ColorFunc();
-	enigma::currentcolor[0] = __GETR(color);
-	enigma::currentcolor[1] = __GETG(color);
-	enigma::currentcolor[2] = __GETB(color);
+	enigma::currentcolor[0] = COL_GET_R(color);
+	enigma::currentcolor[1] = COL_GET_G(color);
+	enigma::currentcolor[2] = COL_GET_B(color);
 }
 
 void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue)
@@ -62,19 +62,19 @@ void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue
 
 void draw_set_alpha(float alpha)
 {
-	if (enigma::currentcolor[3] == bind_alpha(alpha)) return;
+	if (enigma::currentcolor[3] == CLAMP_ALPHA(alpha)) return;
 	oglmgr->ColorFunc();
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 }
 
 void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blue,float alpha)
 {
-	if (enigma::currentcolor[0] == red && enigma::currentcolor[1] == green && enigma::currentcolor[2] == blue && enigma::currentcolor[3] == bind_alpha(alpha)) return;
+	if (enigma::currentcolor[0] == red && enigma::currentcolor[1] == green && enigma::currentcolor[2] == blue && enigma::currentcolor[3] == CLAMP_ALPHA(alpha)) return;
 	oglmgr->ColorFunc();
 	enigma::currentcolor[0] = red;
 	enigma::currentcolor[1] = green;
 	enigma::currentcolor[2] = blue;
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 }
 
 void draw_set_color_write_enable(bool red, bool green, bool blue, bool alpha)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -15,24 +15,21 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "../General/OpenGLHeaders.h"
-#include "../General/GSd3d.h"
-#include "../General/GSmatrix.h"
-#include "../General/GSmath.h"
 #include "GLSLshader.h"
+#include "GL3shader.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GSd3d.h"
+#include "Graphics_Systems/General/GSmatrix.h"
+#include "Graphics_Systems/General/GSmath.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
 #include "Bridges/General/GL3Context.h"
-#include "GL3shader.h"
+
 #include <math.h>
+#include <floatcomp.h>
 
 using namespace std;
-
-#define __GETR(x) ((x & 0x0000FF))/255.0
-#define __GETG(x) ((x & 0x00FF00)>>8)/255.0
-#define __GETB(x) ((x & 0xFF0000)>>16)/255.0
-
-#include <floatcomp.h>
 
 namespace enigma {
   bool d3dMode = false;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -390,9 +390,9 @@ class d3d_lights
       lights[id].position[1] = -dy;
       lights[id].position[2] = -dz;
       lights[id].position[3] = 0.0;
-      lights[id].diffuse[0] = __GETR(col);
-      lights[id].diffuse[1] = __GETG(col);
-      lights[id].diffuse[2] = __GETB(col);
+      lights[id].diffuse[0] = COL_GET_R(col);
+      lights[id].diffuse[1] = COL_GET_G(col);
+      lights[id].diffuse[2] = COL_GET_B(col);
       lights[id].diffuse[3] = 1.0f;
       lights[id].update = true;
       lightsource_update();
@@ -413,9 +413,9 @@ class d3d_lights
       lights[id].position[1] = y;
       lights[id].position[2] = z;
       lights[id].position[3] = range;
-      lights[id].diffuse[0] = __GETR(col);
-      lights[id].diffuse[1] = __GETG(col);
-      lights[id].diffuse[2] = __GETB(col);
+      lights[id].diffuse[0] = COL_GET_R(col);
+      lights[id].diffuse[1] = COL_GET_G(col);
+      lights[id].diffuse[2] = COL_GET_B(col);
       lights[id].diffuse[3] = 1.0f;
       lights[id].specular[0] = 0.0f;
       lights[id].specular[1] = 0.0f;
@@ -514,9 +514,9 @@ bool d3d_light_set_ambient(int id, int r, int g, int b, double a)
 
 void d3d_light_define_ambient(int col)
 {
-  enigma::d3d_lighting.global_ambient_color[0] = __GETR(col);
-  enigma::d3d_lighting.global_ambient_color[1] = __GETG(col);
-  enigma::d3d_lighting.global_ambient_color[2] = __GETB(col);
+  enigma::d3d_lighting.global_ambient_color[0] = COL_GET_R(col);
+  enigma::d3d_lighting.global_ambient_color[1] = COL_GET_G(col);
+  enigma::d3d_lighting.global_ambient_color[2] = COL_GET_B(col);
   enigma::d3d_lighting.light_update();
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -184,7 +184,7 @@ void clear_view(float x, float y, float w, float h, float angle, bool showcolor)
   if (showcolor)
   {
     int clearcolor = ((int)background_color) & 0x00FFFFFF;
-    glClearColor(__GETR(clearcolor) / 255.0, __GETG(clearcolor) / 255.0, __GETB(clearcolor) / 255.0, 1);
+    glClearColor(COL_GET_R(clearcolor) / 255.0, COL_GET_G(clearcolor) / 255.0, COL_GET_B(clearcolor) / 255.0, 1);
     clear_bits |= GL_COLOR_BUFFER_BIT;
   }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
@@ -15,13 +15,9 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <cmath>
-#include <cstdlib>
-#include <string>
-using std::string;
-
-#include "../General/OpenGLHeaders.h"
-#include "../General/GSsprite.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GSsprite.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
@@ -29,10 +25,10 @@ using std::string;
 #include "Universal_System/instance_system.h"
 #include "Universal_System/graphics_object.h"
 
-#define __GETR(x) (gs_scalar)(((x & 0x0000FF))/255.0)
-#define __GETG(x) (gs_scalar)(((x & 0x00FF00) >> 8)/255.0)
-#define __GETB(x) (gs_scalar)(((x & 0xFF0000) >> 16)/255.0)
-
+#include <cmath>
+#include <cstdlib>
+#include <string>
+using std::string;
 
 #ifdef DEBUG_MODE
   #include "libEGMstd.h"
@@ -85,9 +81,9 @@ int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool 
 	std::vector<unsigned char> rgbdata(4*patchSize);
 	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
-	
+
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
-	
+
 	enigma::spritestructarray_reallocate();
   int sprid=enigma::sprite_idmax;
   enigma::sprite_new_empty(sprid, 1, w, h, xorig, yorig, 0, h, 0, w, preload, smooth);
@@ -110,7 +106,7 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 	std::vector<unsigned char> rgbdata(4*patchSize);
 	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
-	
+
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
 
 	enigma::sprite_add_subimage(id, w, h, &data[0], &data[0], enigma::ct_precise); //TODO: Support toggling of precise.
@@ -119,4 +115,3 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
@@ -16,20 +16,17 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <stdio.h>
-#include <math.h>
-
-#include "../General/OpenGLHeaders.h"
-#include "../General/GSstdraw.h"
-#include "../General/GStextures.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GSstdraw.h"
+#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Universal_System/roomsystem.h"
 #include "Bridges/General/GL3Context.h"
 #include "GLSLshader.h"
 #include "GL3shader.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include <stdio.h>
+#include <math.h>
 
 namespace enigma {
   extern unsigned char currentcolor[4];
@@ -182,4 +179,3 @@ bool fill_complex_polygon(const std::list<PolyVertex>& vertices, int defaultColo
 
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3surface.cpp
@@ -16,36 +16,34 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "../General/OpenGLHeaders.h"
-#include "../General/GSscreen.h"
-#include "../General/GSmatrix.h"
 #include "Bridges/General/GL3Context.h"
+
+#include "GL3TextureStruct.h"
+#include "Graphics_Systems/General/OpenGLHeaders.h"
+#include "Graphics_Systems/General/GSscreen.h"
+#include "Graphics_Systems/General/GSmatrix.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Graphics_Systems/graphics_mandatory.h"
+#include "Graphics_Systems/General/GSsurface.h"
+#include "Graphics_Systems/General/GLSurfaceStruct.h"
+#include "Graphics_Systems/General/GStextures.h"
 
-using namespace std;
-#include <cstddef>
-#include <iostream>
-#include <cmath>
-#include <unordered_map>
-
-#include <stdio.h> //for file writing (surface_save)
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
 #include "Universal_System/background_internal.h"
 #include "Collision_Systems/collision_types.h"
 
-#define __GETR(x) (gs_scalar)(((x & 0x0000FF))/255.0)
-#define __GETG(x) (gs_scalar)(((x & 0x00FF00) >> 8)/255.0)
-#define __GETB(x) (gs_scalar)(((x & 0xFF0000) >> 16)/255.0)
+#include <cstddef>
+#include <iostream>
+#include <cmath>
+#include <unordered_map>
+#include <stdio.h> //for file writing (surface_save)
+
+using namespace std;
 
 namespace enigma_user {
   extern int room_width, room_height/*, sprite_idmax*/;
 }
-
-#include "../General/GSsurface.h"
-#include "../General/GLSurfaceStruct.h"
-#include "../General/GStextures.h"
-#include "GL3TextureStruct.h"
 
 #ifdef DEBUG_MODE
   #include <string>

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -65,7 +65,7 @@ static inline int graphics_find_attribute_location(std::string name, int usageIn
 namespace enigma_user {
 
 void vertex_argb(int buffer, unsigned argb) {
-  enigma::color_t finalcol = (COL_GET_A32(argb) << 24) | (COL_GET_R32(argb) << 16) | (COL_GET_G32(argb) << 8) | COL_GET_B32(argb);
+  enigma::color_t finalcol = (COL_GET_A(argb) << 24) | (COL_GET_R(argb) << 16) | (COL_GET_G(argb) << 8) | COL_GET_B(argb);
   enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -65,12 +65,12 @@ static inline int graphics_find_attribute_location(std::string name, int usageIn
 namespace enigma_user {
 
 void vertex_argb(int buffer, unsigned argb) {
-  enigma::color_t finalcol = (__GETA32(argb) << 24) | (__GETR32(argb) << 16) | (__GETG32(argb) << 8) | __GETB32(argb);
+  enigma::color_t finalcol = (COL_GET_A32(argb) << 24) | (COL_GET_R32(argb) << 16) | (COL_GET_G32(argb) << 8) | COL_GET_B32(argb);
   enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
 }
 
 void vertex_color(int buffer, int color, double alpha) {
-  enigma::color_t finalcol = color + (bind_alpha(alpha) << 24);
+  enigma::color_t finalcol = color + (CLAMP_ALPHA(alpha) << 24);
   enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESbackground.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESbackground.cpp
@@ -18,11 +18,8 @@
 #include <math.h>
 #include "OpenGLHeaders.h"
 #include "Universal_System/background_internal.h"
-#include "../General/GSbackground.h"
-
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GSbackground.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 extern int room_width, room_height;
 namespace enigma{extern unsigned bound_texture;}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLEScolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLEScolors.cpp
@@ -16,16 +16,8 @@
 **/
 
 #include "OpenGLESHeaders.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include <math.h>
-
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00)>>8)
-#define __GETB(x) ((x & 0xFF0000)>>16)
-/*#define __GETRf(x) fmod(x,256)
-#define __GETGf(x) fmod(x/256,256)
-#define __GETBf(x) fmod(x/65536,256)*/
-
-#define bind_alpha(alpha) (alpha>1?255:(alpha<0?0:(unsigned char)(alpha*255)))
 
 namespace enigma {
   extern unsigned char currentcolor[4];

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLEScolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLEScolors.cpp
@@ -28,20 +28,20 @@ namespace enigma_user {
 void draw_clear_alpha(int col,float alpha)
 {
   //Unfortunately, we lack a 255-based method for setting ClearColor.
-	glClearColor(__GETR(col)/255.0,__GETG(col)/255.0,__GETB(col)/255.0,alpha);
+	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,alpha);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 void draw_clear(int col)
 {
-	glClearColor(__GETR(col)/255.0,__GETG(col)/255.0,__GETB(col)/255.0,1);
+	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,1);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 
 void draw_set_color(int color)
 {
-	enigma::currentcolor[0] = __GETR(color);
-	enigma::currentcolor[1] = __GETG(color);
-	enigma::currentcolor[2] = __GETB(color);
+	enigma::currentcolor[0] = COL_GET_R(color);
+	enigma::currentcolor[1] = COL_GET_G(color);
+	enigma::currentcolor[2] = COL_GET_B(color);
 	glColor4ub(enigma::currentcolor[0],enigma::currentcolor[1],enigma::currentcolor[2],enigma::currentcolor[3]);
 }
 void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue)
@@ -54,7 +54,7 @@ void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue
 }
 void draw_set_alpha(float alpha)
 {
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 	glColor4ub(enigma::currentcolor[0],enigma::currentcolor[1],enigma::currentcolor[2],enigma::currentcolor[3]);
 
 }
@@ -63,7 +63,7 @@ void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blu
 	enigma::currentcolor[0] = red;
 	enigma::currentcolor[1] = green;
 	enigma::currentcolor[2] = blue;
-	enigma::currentcolor[3] = bind_alpha(alpha);
+	enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
 	glColor4ub(enigma::currentcolor[0],enigma::currentcolor[1],enigma::currentcolor[2],enigma::currentcolor[3]);
 }
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLEScurves.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLEScurves.cpp
@@ -16,15 +16,11 @@
 **/
 
 #include "OpenGLHeaders.h"
-#include "../General/GScolors.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include <stack>
 #include <vector>
 #include <math.h>
-
-#define __GETR(x) (((x & 0x0000FF))/255.0)
-#define __GETG(x) (((x & 0x00FF00)>>8)/255.0)
-#define __GETB(x) (((x & 0xFF0000)>>16)/255.0)
-
 
 namespace enigma{
     extern unsigned bound_texture;
@@ -311,7 +307,7 @@ void draw_spline_end()
               draw_spline_part(arr[i-3].x, arr[i-3].y, arr[i-2].x, arr[i-2].y, arr[i-1].x, arr[i-1].y, arr[i].x, arr[i].y, arr[i-2].col, arr[i-1].col, arr[i-2].al, arr[i-1].al);
       glEnd();
     glPopAttrib();
-    glColor4ubv(enigma::currentcolor); 
+    glColor4ubv(enigma::currentcolor);
     delete &arr;
     startedSplines.pop();
     startedSplinesMode.pop();*/

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLEScurves.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLEScurves.cpp
@@ -91,7 +91,7 @@ void draw_bezier_quadratic(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y
         al = pr_curve_alpha1 + (pr_curve_alpha2-pr_curve_alpha1)*b;
         col = merge_color(pr_curve_color1, pr_curve_color2, b);
 
-        glColor4f(__GETR(col),__GETG(col),__GETB(col),al);
+        glColor4f(COL_GET_R(col),COL_GET_G(col),COL_GET_B(col),al);
         glVertex2f(x, y);
 
         a -= det;
@@ -119,7 +119,7 @@ void draw_bezier_cubic(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, g
         al = pr_curve_alpha1 + (pr_curve_alpha2-pr_curve_alpha1)*b;
         col = merge_color(pr_curve_color1, pr_curve_color2, b);
 
-        glColor4f(__GETR(col),__GETG(col),__GETB(col),al);
+        glColor4f(COL_GET_R(col),COL_GET_G(col),COL_GET_B(col),al);
         glVertex2f(x, y);
 
         a -= det;
@@ -176,7 +176,7 @@ void draw_spline_part(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs
         ( -x1 + 3.0 * x2 - 3.0 * x3 + x4 ) * t3 );
         y = 0.5 * ( ( 2.0 * y2 ) + ( -y1 + y3 ) * t + ( 2.0 * y1 - 5.0 * y2 + 4 * y3 - y4 ) * t2 +
         ( -y1 + 3.0 * y2 - 3.0 * y3 + y4 ) * t3 );
-        glColor4f(__GETR(col),__GETG(col),__GETB(col),al);
+        glColor4f(COL_GET_R(col),COL_GET_G(col),COL_GET_B(col),al);
      //   glVertex2f(x, y);
         t += det;
     }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESfont.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESfont.cpp
@@ -18,14 +18,11 @@
 #include <math.h>
 #include <string>
 #include "OpenGLHeaders.h"
-#include "../General/GScolors.h"
+#include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 using namespace std;
 #include "Universal_System/fontstruct.h"
-
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
 
 namespace enigma {
   static int currentfont = -1;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESfont.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESfont.cpp
@@ -349,17 +349,17 @@ void draw_text_transformed_color(gs_scalar x, gs_scalar y, string str, gs_scalar
         const float lx = xx + g.y * svy;
         const float ly = yy + g.y * cvy;
 
-        glColor4ub(__GETR(hcol1),__GETG(hcol1),__GETB(hcol1),char(a*255));
+        glColor4ub(COL_GET_R(hcol1),COL_GET_G(hcol1),COL_GET_B(hcol1),char(a*255));
         glTexCoord2f(g.tx,  g.ty);
           glVertex2f(lx, ly);
-        glColor4ub(__GETR(hcol2),__GETG(hcol2),__GETB(hcol2),char(a*255));
+        glColor4ub(COL_GET_R(hcol2),COL_GET_G(hcol2),COL_GET_B(hcol2),char(a*255));
         glTexCoord2f(g.tx2, g.ty);
           glVertex2f(lx + w * cvx, ly - w * svx);
 
-        glColor4ub(__GETR(hcol3),__GETG(hcol3),__GETB(hcol3),char(a*255));
+        glColor4ub(COL_GET_R(hcol3),COL_GET_G(hcol3),COL_GET_B(hcol3),char(a*255));
         glTexCoord2f(g.tx2, g.ty2);
           glVertex2f(xx + w * cvx + g.y2 * svy, yy - w * svx + g.y2 * cvy);
-        glColor4ub(__GETR(hcol4),__GETG(hcol4),__GETB(hcol4),char(a*255));
+        glColor4ub(COL_GET_R(hcol4),COL_GET_G(hcol4),COL_GET_B(hcol4),char(a*255));
         glTexCoord2f(g.tx,  g.ty2);
           glVertex2f(xx + g.y2 * svy,  yy + g.y2 * cvy);
 
@@ -426,17 +426,17 @@ void draw_text_ext_transformed_color(gs_scalar x, gs_scalar y, string str, int s
         const float lx = xx + g.y * svy;
         const float ly = yy + g.y * cvy;
 
-        glColor4ub(__GETR(hcol1),__GETG(hcol1),__GETB(hcol1),char(a*255));
+        glColor4ub(COL_GET_R(hcol1),COL_GET_G(hcol1),COL_GET_B(hcol1),char(a*255));
         glTexCoord2f(g.tx,  g.ty);
           glVertex2f(lx, ly);
-        glColor4ub(__GETR(hcol2),__GETG(hcol2),__GETB(hcol2),char(a*255));
+        glColor4ub(COL_GET_R(hcol2),COL_GET_G(hcol2),COL_GET_B(hcol2),char(a*255));
         glTexCoord2f(g.tx2, g.ty);
           glVertex2f(lx + wi * cvx, ly - wi * svx);
 
-        glColor4ub(__GETR(hcol3),__GETG(hcol3),__GETB(hcol3),char(a*255));
+        glColor4ub(COL_GET_R(hcol3),COL_GET_G(hcol3),COL_GET_B(hcol3),char(a*255));
         glTexCoord2f(g.tx2, g.ty2);
           glVertex2f(xx + wi * cvx + g.y2 * svy, yy - wi * svx + g.y2 * cvy);
-        glColor4ub(__GETR(hcol4),__GETG(hcol4),__GETB(hcol4),char(a*255));
+        glColor4ub(COL_GET_R(hcol4),COL_GET_G(hcol4),COL_GET_B(hcol4),char(a*255));
         glTexCoord2f(g.tx,  g.ty2);
           glVertex2f(xx + g.y2 * svy,  yy + g.y2 * cvy);
 
@@ -481,19 +481,19 @@ void draw_text_color(gs_scalar x, gs_scalar y, string str, int c1, int c2, int c
       hcol2 = merge_color(c1,c2,tx2/sw);
       hcol3 = merge_color(c4,c3,tx1/sw);
       hcol4 = merge_color(c4,c3,tx2/sw);
-        glColor4ub(__GETR(hcol1),__GETG(hcol1),__GETB(hcol1),char(a*255));
+        glColor4ub(COL_GET_R(hcol1),COL_GET_G(hcol1),COL_GET_B(hcol1),char(a*255));
         glTexCoord2f(g.tx,  g.ty);
           glVertex2i(xx + g.x,  yy + g.y);
 
-        glColor4ub(__GETR(hcol2),__GETG(hcol2),__GETB(hcol2),char(a*255));
+        glColor4ub(COL_GET_R(hcol2),COL_GET_G(hcol2),COL_GET_B(hcol2),char(a*255));
         glTexCoord2f(g.tx2, g.ty);
           glVertex2i(xx + g.x2, yy + g.y);
 
-        glColor4ub(__GETR(hcol3),__GETG(hcol3),__GETB(hcol3),char(a*255));
+        glColor4ub(COL_GET_R(hcol3),COL_GET_G(hcol3),COL_GET_B(hcol3),char(a*255));
         glTexCoord2f(g.tx2, g.ty2);
           glVertex2i(xx + g.x2, yy + g.y2);
 
-        glColor4ub(__GETR(hcol4),__GETG(hcol4),__GETB(hcol4),char(a*255));
+        glColor4ub(COL_GET_R(hcol4),COL_GET_G(hcol4),COL_GET_B(hcol4),char(a*255));
         glTexCoord2f(g.tx,  g.ty2);
           glVertex2i(xx + g.x,  yy + g.y2);
       xx += g.xs;
@@ -539,16 +539,16 @@ void draw_text_ext_color(gs_scalar x, gs_scalar y,string str, gs_scalar sep, gs_
       hcol2 = merge_color(c1,c2,double(width+g.xs)/sw);
       hcol3 = merge_color(c4,c3,double(width)/sw);
       hcol4 = merge_color(c4,c3,double(width+g.xs)/sw);
-        glColor4ub(__GETR(hcol1),__GETG(hcol1),__GETB(hcol1),char(a*255));
+        glColor4ub(COL_GET_R(hcol1),COL_GET_G(hcol1),COL_GET_B(hcol1),char(a*255));
         glTexCoord2f(g.tx,  g.ty);
           glVertex2i(xx + g.x,  yy + g.y);
-        glColor4ub(__GETR(hcol2),__GETG(hcol2),__GETB(hcol2),char(a*255));
+        glColor4ub(COL_GET_R(hcol2),COL_GET_G(hcol2),COL_GET_B(hcol2),char(a*255));
         glTexCoord2f(g.tx2, g.ty);
           glVertex2i(xx + g.x2, yy + g.y);
-        glColor4ub(__GETR(hcol3),__GETG(hcol3),__GETB(hcol3),char(a*255));
+        glColor4ub(COL_GET_R(hcol3),COL_GET_G(hcol3),COL_GET_B(hcol3),char(a*255));
         glTexCoord2f(g.tx2, g.ty2);
           glVertex2i(xx + g.x2, yy + g.y2);
-        glColor4ub(__GETR(hcol4),__GETG(hcol4),__GETB(hcol4),char(a*255));
+        glColor4ub(COL_GET_R(hcol4),COL_GET_G(hcol4),COL_GET_B(hcol4),char(a*255));
         glTexCoord2f(g.tx,  g.ty2);
           glVertex2i(xx + g.x,  yy + g.y2);
       xx += g.xs;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESscreen.cpp
@@ -19,23 +19,19 @@
 int screen_redraw(int dontswap)
 **********************************************/
 
-#include <string>
 #include "OpenGLHeaders.h"
-#include "../General/GSbackground.h"
-
-using namespace std;
+#include "Graphics_Systems/General/GSbackground.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #include "Universal_System/background_internal.h"
 #include "Universal_System/var4.h"
-
-#define __GETR(x) (((unsigned int)x & 0x0000FF))
-#define __GETG(x) (((unsigned int)x & 0x00FF00) >> 8)
-#define __GETB(x) (((unsigned int)x & 0xFF0000) >> 16)
-
-
 #include "Universal_System/roomsystem.h"
 #include "Universal_System/instance_system.h"
 #include "graphics_object.h"
+
+#include <string>
+
+using namespace std;
 
 //Fuck whoever did this to the spec
 #ifndef GL_BGR
@@ -79,9 +75,9 @@ int screen_redraw()
 		glOrthof(0,room_width-1,0,room_height-1,0,1); //OPENGLES put f back in
 #else
 		glOrtho(-1,room_width,-1,room_height,0,1); //OPENGLES put f back in
-#endif 
-       
-	
+#endif
+
+
       if (background_showcolor)
       {
          int clearcolor=((int)background_color)&0xFFFFFF;
@@ -89,25 +85,25 @@ int screen_redraw()
          glClear(GL_COLOR_BUFFER_BIT);
       }
         draw_back();
-        
+
       for (enigma::instance_event_iterator = event_draw->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next)
         enigma::instance_event_iterator->inst->myevent_draw();
     }
-    else 
+    else
     for (view_current=0; view_current<7; view_current++)
     if (view_visible[(int)view_current])
     {
       int vc=(int)view_current;
       int vob=(int)view_object[vc];
-      
+
       if (vob != -1)
       {
         object_basic *instanceexists = fetch_instance_by_int(vob);
-        
+
         if (instanceexists)
         {
           object_planar* vobr = (object_planar*)instanceexists;
-          
+
           int vobx=(int)(vobr->x),voby=(int)(vobr->y);
           //int bbl=*vobr.x+*vobr.bbox_left,bbr=*vobr.x+*vobr.bbox_right,bbt=*vobr.y+*vobr.bbox_top,bbb=*vobr.y+*vobr.bbox_bottom;
           //if (bbl<view_xview[vc]+view_hbor[vc]) view_xview[vc]=bbl-view_hbor[vc];
@@ -121,7 +117,7 @@ int screen_redraw()
           if (view_yview[vc]>room_height-view_hview[vc]) view_yview[vc]=room_height-view_hview[vc];
         }
       }
-      
+
       glViewport((int)view_xport[vc],(int)view_yport[vc],(int)view_wport[vc],(int)view_hport[vc]);
       glLoadIdentity();
       glScalef(1,-1,1);
@@ -129,7 +125,7 @@ int screen_redraw()
 		glOrthof((int)view_xview[vc],(int)view_wview[vc]+(int)view_xview[vc],(int)view_yview[vc],(int)view_hview[vc]+(int)view_yview[vc],0,1); //OPENGLES put f back in
 #else
       glOrtho((int)view_xview[vc],(int)view_wview[vc]+(int)view_xview[vc],(int)view_yview[vc],(int)view_hview[vc]+(int)view_yview[vc],0,1); //OPENGLES put f back in
-#endif    
+#endif
       if (background_showcolor)
       {
          int clearcolor=((int)background_color)&0xFFFFFF;
@@ -137,11 +133,11 @@ int screen_redraw()
          glClear(GL_COLOR_BUFFER_BIT);
       }
       draw_back();
-        
+
       for (enigma::instance_event_iterator = event_draw->next; enigma::instance_event_iterator != NULL; enigma::instance_event_iterator = enigma::instance_event_iterator->next)
         enigma::instance_event_iterator->inst->myevent_draw();
     }
-    
+
     return 0;
 }
 
@@ -159,13 +155,13 @@ int screen_save(string filename) //Assumes native integers are little endian
 	if(!bmp) return -1;
 	fwrite("BM",2,1,bmp);
 	sz<<=2;
-	
+
 	fwrite(&sz,4,1,bmp);
 	fwrite("\0\0\0\0\x36\0\0\0\x28\0\0",12,1,bmp);
 	fwrite(&w,4,1,bmp);
 	fwrite(&h,4,1,bmp);
 	fwrite("\1\0\x18\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",28,1,bmp);
-	
+
 	if(w&3)
 	{
 		size_t pad=w&3;
@@ -190,14 +186,14 @@ int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h
 	FILE *bmp=fopen(filename.c_str(),"wb");
 	if(!bmp) return -1;
 	fwrite("BM",2,1,bmp);
-	
+
 	sz <<= 2;
 	fwrite(&sz,4,1,bmp);
 	fwrite("\0\0\0\0\x36\0\0\0\x28\0\0",12,1,bmp);
 	fwrite(&w,4,1,bmp);
 	fwrite(&h,4,1,bmp);
 	fwrite("\1\0\x18\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",28,1,bmp);
-	
+
 	if(w&3)
 	{
 		size_t pad=w&3;
@@ -210,11 +206,10 @@ int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h
 		}
 	}
 	else fwrite(scrbuf,w*3,h,bmp);
-	
+
 	fclose(bmp);
 	delete[] scrbuf;
 	return 0;
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESscreen.cpp
@@ -141,11 +141,6 @@ int screen_redraw()
     return 0;
 }
 
-
-#undef COL_GET_R
-#undef COL_GET_G
-#undef COL_GET_B
-
 int screen_save(string filename) //Assumes native integers are little endian
 {
 	unsigned int w=window_get_width(),h=window_get_height(),sz=w*h;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESscreen.cpp
@@ -81,7 +81,7 @@ int screen_redraw()
       if (background_showcolor)
       {
          int clearcolor=((int)background_color)&0xFFFFFF;
-         glClearColor(__GETR(clearcolor)/255.0,__GETG(clearcolor)/255.0,__GETB(clearcolor)/255.0, 1);
+         glClearColor(COL_GET_R(clearcolor)/255.0,COL_GET_G(clearcolor)/255.0,COL_GET_B(clearcolor)/255.0, 1);
          glClear(GL_COLOR_BUFFER_BIT);
       }
         draw_back();
@@ -129,7 +129,7 @@ int screen_redraw()
       if (background_showcolor)
       {
          int clearcolor=((int)background_color)&0xFFFFFF;
-         glClearColor(__GETR(clearcolor)/255.0,__GETG(clearcolor)/255.0,__GETB(clearcolor)/255.0, 1);
+         glClearColor(COL_GET_R(clearcolor)/255.0,COL_GET_G(clearcolor)/255.0,COL_GET_B(clearcolor)/255.0, 1);
          glClear(GL_COLOR_BUFFER_BIT);
       }
       draw_back();
@@ -142,9 +142,9 @@ int screen_redraw()
 }
 
 
-#undef __GETR
-#undef __GETG
-#undef __GETB
+#undef COL_GET_R
+#undef COL_GET_G
+#undef COL_GET_B
 
 int screen_save(string filename) //Assumes native integers are little endian
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESsprite.cpp
@@ -20,14 +20,11 @@
 
 #include "OpenGLHeaders.h"
 
-#include "../General/GSsprite.h"
+#include "Graphics_Systems/General/GSsprite.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Universal_System/sprites_internal.h"
 #include "Universal_System/instance_system.h"
 #include "Universal_System/graphics_object.h"
-
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
 
 namespace enigma{extern unsigned bound_texture;}
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESstdraw.cpp
@@ -16,13 +16,12 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <math.h>
-#include "OpenGLHeaders.h"
-#include <stdio.h>
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "OpenGLHeaders.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
+
+#include <math.h>
+#include <stdio.h>
 
 namespace enigma{
 float circleprecision=24;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/GLESstdraw.cpp
@@ -55,7 +55,7 @@ int draw_point_color(gs_scalar x, gs_scalar y, int col)
 {
 	untexture();
 	/*glPushAttrib(GL_CURRENT_BIT);
-	glColor4ub(__GETR(col),__GETG(col),__GETB(col),enigma::currentcolor[3]);
+	glColor4ub(COL_GET_R(col),COL_GET_G(col),COL_GET_B(col),enigma::currentcolor[3]);
 	glBegin(GL_POINTS);
 	glVertex2f(x,y);
 	glEnd();
@@ -90,9 +90,9 @@ int draw_line_color(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, int 
 {
 	untexture();
 	/*glBegin(GL_LINES);
-    glColor4ub(__GETR(c1),__GETG(c1),__GETB(c1),enigma::currentcolor[3]);
+    glColor4ub(COL_GET_R(c1),COL_GET_G(c1),COL_GET_B(c1),enigma::currentcolor[3]);
       glVertex2f(x1,y1);
-    glColor4ub(__GETR(c2),__GETG(c2),__GETB(c2),enigma::currentcolor[3]);
+    glColor4ub(COL_GET_R(c2),COL_GET_G(c2),COL_GET_B(c2),enigma::currentcolor[3]);
       glVertex2f(x2,y2);
 	glEnd();
 	glColor4ubv(enigma::currentcolor); OPENGLES */
@@ -104,9 +104,9 @@ int draw_line_width_color(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2
 	/*glPushAttrib(GL_LINE_BIT);
     glLineWidth(width);
     glBegin(GL_LINES);
-      glColor4ub(__GETR(c1),__GETG(c1),__GETB(c1),enigma::currentcolor[3]);
+      glColor4ub(COL_GET_R(c1),COL_GET_G(c1),COL_GET_B(c1),enigma::currentcolor[3]);
       glVertex2f(x1,y1);
-      glColor4ub(__GETR(c2),__GETG(c2),__GETB(c2),enigma::currentcolor[3]);
+      glColor4ub(COL_GET_R(c2),COL_GET_G(c2),COL_GET_B(c2),enigma::currentcolor[3]);
       glVertex2f(x2,y2);
     glEnd();
 	glPopAttrib();
@@ -165,13 +165,13 @@ int draw_rectangle_color(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2,
 {
 	untexture();
 	/*glBegin(outline?GL_LINE_LOOP:GL_QUADS);
-    glColor4ub(__GETR(c1),__GETG(c1),__GETB(c1),enigma::currentcolor[3]);
+    glColor4ub(COL_GET_R(c1),COL_GET_G(c1),COL_GET_B(c1),enigma::currentcolor[3]);
       glVertex2f(x1,y1);
-    glColor4ub(__GETR(c2),__GETG(c2),__GETB(c2),enigma::currentcolor[3]);
+    glColor4ub(COL_GET_R(c2),COL_GET_G(c2),COL_GET_B(c2),enigma::currentcolor[3]);
       glVertex2f(x2,y1);
-    glColor4ub(__GETR(c4),__GETG(c4),__GETB(c4),enigma::currentcolor[3]);
+    glColor4ub(COL_GET_R(c4),COL_GET_G(c4),COL_GET_B(c4),enigma::currentcolor[3]);
       glVertex2f(x2,y2);
-    glColor4ub(__GETR(c3),__GETG(c3),__GETB(c3),enigma::currentcolor[3]);
+    glColor4ub(COL_GET_R(c3),COL_GET_G(c3),COL_GET_B(c3),enigma::currentcolor[3]);
       glVertex2f(x1,y2);
 	glEnd();
 	glColor4ubv(enigma::currentcolor); OPENGLES*/
@@ -233,11 +233,11 @@ int draw_circle_color(gs_scalar x, gs_scalar y, float rad, int c1, int c2, bool 
 	else
 	{
 		glBegin(GL_TRIANGLE_FAN);
-      glColor4ub(__GETR(c1),__GETG(c1),__GETB(c1),enigma::currentcolor[3]);
+      glColor4ub(COL_GET_R(c1),COL_GET_G(c1),COL_GET_B(c1),enigma::currentcolor[3]);
         glVertex2f(x,y);
 	}
 	//Bagan above
-    glColor4ub(__GETR(c2),__GETG(c2),__GETB(c2),enigma::currentcolor[3]);
+    glColor4ub(COL_GET_R(c2),COL_GET_G(c2),COL_GET_B(c2),enigma::currentcolor[3]);
       float pr=2*M_PI/enigma::circleprecision;
       glVertex2f(x+rad,y);
       for(float i=pr;i<2*M_PI;i+=pr)
@@ -276,7 +276,7 @@ int draw_circle_color_perfect(gs_scalar x, gs_scalar y, float rad, int c1, int c
 	/*if(outline)
 	{
 		glBegin(GL_POINTS);
-      glColor4ub(__GETR(c2),__GETG(c2),__GETB(c2),enigma::currentcolor[3]);
+      glColor4ub(COL_GET_R(c2),COL_GET_G(c2),COL_GET_B(c2),enigma::currentcolor[3]);
         gs_scalar r12=rad*M_SQRT1_2;
         for(float xc=0,yc=rad;xc<=r12;xc++)
         {
@@ -294,9 +294,9 @@ int draw_circle_color_perfect(gs_scalar x, gs_scalar y, float rad, int c1, int c
 	else
 	{
 		glBegin(GL_TRIANGLE_FAN);
-      glColor4ub(__GETR(c1),__GETG(c1),__GETB(c1),enigma::currentcolor[3]);
+      glColor4ub(COL_GET_R(c1),COL_GET_G(c1),COL_GET_B(c1),enigma::currentcolor[3]);
         glVertex2f(x,y);
-      glColor4ub(__GETR(c2),__GETG(c2),__GETB(c2),enigma::currentcolor[3]);
+      glColor4ub(COL_GET_R(c2),COL_GET_G(c2),COL_GET_B(c2),enigma::currentcolor[3]);
         glVertex2f(x-rad,y);
         for(float xc=-rad+1;xc<r;xc++)
           glVertex2f(x+xc,y+sqrt(r2-(xc*xc)));
@@ -359,11 +359,11 @@ int draw_ellipse_color(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, i
 	else
 	{
 		glBegin(GL_TRIANGLE_FAN);
-		glColor4ub(__GETR(c1),__GETG(c1),__GETB(c1),enigma::currentcolor[3]);
+		glColor4ub(COL_GET_R(c1),COL_GET_G(c1),COL_GET_B(c1),enigma::currentcolor[3]);
 		glVertex2f(x,y);
 	}
 
-    glColor4ub(__GETR(c2),__GETG(c2),__GETB(c2),enigma::currentcolor[3]);
+    glColor4ub(COL_GET_R(c2),COL_GET_G(c2),COL_GET_B(c2),enigma::currentcolor[3]);
       glVertex2f(x+hr,0);
     for(float i=pr;i<2*M_PI;i+=pr)
       glVertex2f(x+hr*cos(i),y+vr*sin(i));
@@ -408,11 +408,11 @@ int draw_triangle_color(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, g
 {
 	untexture();
 	/*glBegin(outline?GL_LINE_LOOP:GL_TRIANGLES);
-	glColor4ub(__GETR(col1),__GETG(col1),__GETB(col1),enigma::currentcolor[3]);
+	glColor4ub(COL_GET_R(col1),COL_GET_G(col1),COL_GET_B(col1),enigma::currentcolor[3]);
 	glVertex2f(x1,y1);
-	glColor4ub(__GETR(col2),__GETG(col2),__GETB(col2),enigma::currentcolor[3]);
+	glColor4ub(COL_GET_R(col2),COL_GET_G(col2),COL_GET_B(col2),enigma::currentcolor[3]);
 	glVertex2f(x2,y2);
-	glColor4ub(__GETR(col3),__GETG(col3),__GETB(col3),enigma::currentcolor[3]);
+	glColor4ub(COL_GET_R(col3),COL_GET_G(col3),COL_GET_B(col3),enigma::currentcolor[3]);
 	glVertex2f(x3,y3);
 	glEnd();
 	glColor4ubv(enigma::currentcolor); OPENGLES*/
@@ -507,7 +507,7 @@ int draw_roundrect_color(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2,
    /* glBegin(GL_LINES);
     if(outline)
     {
-        glColor4ub(__GETR(col2),__GETG(col2),__GETB(col2),enigma::currentcolor[3]);
+        glColor4ub(COL_GET_R(col2),COL_GET_G(col2),COL_GET_B(col2),enigma::currentcolor[3]);
         glVertex2f(x1,by1);glVertex2f(x1,by2);
         glVertex2f(x2,by1);glVertex2f(x2,by2);
         glVertex2f(bx1,y1);glVertex2f(bx2,y1);
@@ -530,7 +530,7 @@ int draw_roundrect_color(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2,
     }
     else
     {
-        glColor4ub(__GETR(col2),__GETG(col2),__GETB(col2),enigma::currentcolor[3]);
+        glColor4ub(COL_GET_R(col2),COL_GET_G(col2),COL_GET_B(col2),enigma::currentcolor[3]);
         for(float xc=0,yc=rad;xc<=r12;xc++)
         {
             if(xc*xc+yc*yc>r2) yc--;
@@ -545,9 +545,9 @@ int draw_roundrect_color(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2,
         }
         glEnd();
         glBegin(GL_TRIANGLE_FAN);
-        glColor4ub(__GETR(col1),__GETG(col1),__GETB(col1),enigma::currentcolor[3]);
+        glColor4ub(COL_GET_R(col1),COL_GET_G(col1),COL_GET_B(col1),enigma::currentcolor[3]);
         glVertex2f(x1+(x2-x1)/2,y1+(y2-y1)/2);
-        glColor4ub(__GETR(col2),__GETG(col2),__GETB(col2),enigma::currentcolor[3]);
+        glColor4ub(COL_GET_R(col2),COL_GET_G(col2),COL_GET_B(col2),enigma::currentcolor[3]);
         glVertex2f(x1,by1);
         glVertex2f(bx1,y1);
         glVertex2f(bx2,y1);
@@ -652,7 +652,7 @@ int draw_healthbar(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, float
 	untexture();
 	/*if(showborder)
 	{
-		glColor4ub(__GETR(backcol),__GETG(backcol),__GETB(backcol),enigma::currentcolor[3]);
+		glColor4ub(COL_GET_R(backcol),COL_GET_G(backcol),COL_GET_B(backcol),enigma::currentcolor[3]);
 		glBegin(GL_LINE_LOOP);
       glVertex2f(x1-1,y1-1);
       glVertex2f(x1-1,y2+1);
@@ -664,7 +664,7 @@ int draw_healthbar(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, float
     goto showback_no;
 	}
 	if(showback) {
-		glColor4ub(__GETR(backcol),__GETG(backcol),__GETB(backcol),enigma::currentcolor[3]);
+		glColor4ub(COL_GET_R(backcol),COL_GET_G(backcol),COL_GET_B(backcol),enigma::currentcolor[3]);
 		showback_yes: glRectf(x1,y1,x2,y2);
 	} showback_no:
 
@@ -676,11 +676,11 @@ int draw_healthbar(gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, float
 	}
 
 	const int
-		R = __GETR(mincol),
-		G = __GETG(mincol),
-		B = __GETB(mincol);
+		R = COL_GET_R(mincol),
+		G = COL_GET_G(mincol),
+		B = COL_GET_B(mincol);
 
-	glColor4ub(R+(unsigned char)((__GETR(maxcol)-R)*amount),G+(unsigned char)((__GETG(maxcol)-G)*amount),B+(unsigned char)((__GETB(maxcol)-B)*amount),enigma::currentcolor[3]);
+	glColor4ub(R+(unsigned char)((COL_GET_R(maxcol)-R)*amount),G+(unsigned char)((COL_GET_G(maxcol)-G)*amount),B+(unsigned char)((COL_GET_B(maxcol)-B)*amount),enigma::currentcolor[3]);
 	printf("%d\n",mincol);
 	glRectf(x1,y1,x2,y2);
 	glColor4ubv(enigma::currentcolor);OPENGLES */

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/motion_planning.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/motion_planning.cpp
@@ -251,9 +251,6 @@ bool mp_grid_path(unsigned id,unsigned pathid,double xstart,double ystart,double
 }
 
 #include "Universal_System/var4.h"
-#define __GETR(x) (((x & 0x0000FF)))
-#define __GETG(x) (((x & 0x00FF00)>>8))
-#define __GETB(x) (((x & 0xFF0000)>>16))
 
 namespace enigma_user
 {
@@ -337,4 +334,3 @@ void mp_grid_draw(unsigned int id, unsigned int mode, unsigned int color_mode)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_Direct3D11.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_Direct3D11.h
@@ -21,6 +21,7 @@
 #include "Graphics_Systems/General/GSsprite.h"
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "PS_particle_instance.h"
 #include "PS_particle_sprites.h"
 #include <vector>
@@ -33,26 +34,22 @@
 namespace enigma {
   namespace particle_bridge {
     void initialize_particle_bridge() {} // Do nothing, nothing to initialize.
-    inline int __GETR(int x) {return x & 0x0000FF;}
-    inline int __GETG(int x) {return (x & 0x00FF00) >> 8;}
-    inline int __GETB(int x) {return (x & 0xFF0000) >> 16;}
     double wiggle;
     int subimage_index;
     double x_offset;
     double y_offset;
-    
+
     static void draw_particle(particle_instance* it)
     {
-     
+
     }
-    
+
     void draw_particles(std::vector<particle_instance>& pi_list, bool oldtonew, double a_wiggle, int a_subimage_index,
         double a_x_offset, double a_y_offset)
     {
-     
+
     }
   }
 }
 
 #endif // ENIGMA_PS_PARTICLE_BRIDGE_OPENGL1_H
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_Direct3D9.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_Direct3D9.h
@@ -21,6 +21,7 @@
 #include "Graphics_Systems/General/GSsprite.h"
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "PS_particle_instance.h"
 #include "PS_particle_sprites.h"
 #include <vector>
@@ -33,26 +34,22 @@
 namespace enigma {
   namespace particle_bridge {
     void initialize_particle_bridge() {} // Do nothing, nothing to initialize.
-    inline int __GETR(int x) {return x & 0x0000FF;}
-    inline int __GETG(int x) {return (x & 0x00FF00) >> 8;}
-    inline int __GETB(int x) {return (x & 0xFF0000) >> 16;}
     double wiggle;
     int subimage_index;
     double x_offset;
     double y_offset;
-    
+
     static void draw_particle(particle_instance* it)
     {
-     
+
     }
-    
+
     void draw_particles(std::vector<particle_instance>& pi_list, bool oldtonew, double a_wiggle, int a_subimage_index,
         double a_x_offset, double a_y_offset)
     {
-     
+
     }
   }
 }
 
 #endif // ENIGMA_PS_PARTICLE_BRIDGE_OPENGL1_H
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_OpenGL1.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_OpenGL1.h
@@ -22,6 +22,7 @@
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GLTextureStruct.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "PS_particle_instance.h"
 #include "PS_particle_sprites.h"
 #include <vector>
@@ -39,14 +40,11 @@
 namespace enigma {
   namespace particle_bridge {
     void initialize_particle_bridge() {} // Do nothing, nothing to initialize.
-    inline int __GETR(int x) {return x & 0x0000FF;}
-    inline int __GETG(int x) {return (x & 0x00FF00) >> 8;}
-    inline int __GETB(int x) {return (x & 0xFF0000) >> 16;}
     double wiggle;
     int subimage_index;
     double x_offset;
     double y_offset;
-    
+
     static void draw_particle(particle_instance* it)
     {
       int color = it->color;
@@ -106,7 +104,7 @@ namespace enigma {
               glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
           }
 
-          glColor4ub(__GETR(color),__GETG(color),__GETB(color), alpha);
+          glColor4ub(COL_GET_R(color),COL_GET_G(color),COL_GET_B(color), alpha);
 
           const double rot = rot_degrees*M_PI/180.0;
 
@@ -149,7 +147,7 @@ namespace enigma {
         enigma_user::texture_set(textureStructs[ps->texture]->gltex);
 
         glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
-        glColor4ub(__GETR(color),__GETG(color),__GETB(color), alpha);
+        glColor4ub(COL_GET_R(color),COL_GET_G(color),COL_GET_B(color), alpha);
 
         const double rot = rot_degrees*M_PI/180.0;
 
@@ -182,7 +180,7 @@ namespace enigma {
         glEnd();
       }
     }
-    
+
     void draw_particles(std::vector<particle_instance>& pi_list, bool oldtonew, double a_wiggle, int a_subimage_index,
         double a_x_offset, double a_y_offset)
     {
@@ -222,4 +220,3 @@ namespace enigma {
 }
 
 #endif // ENIGMA_PS_PARTICLE_BRIDGE_OPENGL1_H
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_OpenGL3.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_OpenGL3.h
@@ -23,6 +23,7 @@
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GLTextureStruct.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GScolor_macros.h"
 #include "Graphics_Systems/General/GSd3d.h"
 #include "PS_particle_instance.h"
 #include "PS_particle_sprites.h"
@@ -128,9 +129,6 @@ namespace enigma {
       glLinkProgram(shader_program);
       glUseProgram(shader_program);
     }
-    inline int __GETR(int x) {return x & 0x0000FF;}
-    inline int __GETG(int x) {return (x & 0x00FF00) >> 8;}
-    inline int __GETB(int x) {return (x & 0xFF0000) >> 16;}
     double wiggle;
     int subimage_index;
     double x_offset;
@@ -294,7 +292,7 @@ namespace enigma {
           points.push_back(v3y);
           points.push_back(v4x);
           points.push_back(v4y);
-          const GLfloat r = __GETR(color)/255.0, g = __GETG(color)/255.0, b = __GETB(color)/255.0;
+          const GLfloat r = COL_GET_R(color)/255.0, g = COL_GET_G(color)/255.0, b = COL_GET_B(color)/255.0;
           const GLfloat a = alpha/255.0;
           colors.push_back(r);
           colors.push_back(g);
@@ -448,4 +446,3 @@ namespace enigma {
 }
 
 #endif // ENIGMA_PS_PARTICLE_BRIDGE_OPENGL3_H
-

--- a/ENIGMAsystem/SHELL/Universal_System/background_internal.h
+++ b/ENIGMAsystem/SHELL/Universal_System/background_internal.h
@@ -92,8 +92,6 @@ namespace enigma
     enigma::background *bck2d = enigma::backgroundstructarray[back];
 #endif
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00) >> 8)
-#define __GETB(x) ((x & 0xFF0000) >> 16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 #endif //ENIGMA_BACKGROUND_INTERNAL_H

--- a/ENIGMAsystem/SHELL/Universal_System/backgroundstruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/backgroundstruct.cpp
@@ -181,9 +181,9 @@ int background_create_color(unsigned w, unsigned h, int col, bool preload) {
   unsigned char *surfbuf = new unsigned char[sz * 4];
 
   for (unsigned int i = 0; i + 3 < sz * 4; i += 4) {
-    surfbuf[i] = __GETR(col);
-    surfbuf[i + 1] = __GETG(col);
-    surfbuf[i + 2] = __GETB(col);
+    surfbuf[i] = COL_GET_R(col);
+    surfbuf[i + 1] = COL_GET_G(col);
+    surfbuf[i + 2] = COL_GET_B(col);
     surfbuf[i + 3] = 255;
   }
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -34,9 +34,7 @@ using namespace std;
 
 #include "../General/WSdialogs.h"
 
-#define __GETR(x) ((x & 0x0000FF))
-#define __GETG(x) ((x & 0x00FF00)>>8)
-#define __GETB(x) ((x & 0xFF0000)>>16)
+#include "Graphics_Systems/General/GScolor_macros.h"
 
 static string gs_cap;
 static string gs_def;
@@ -256,7 +254,7 @@ void message_text_charset(int type, int charset) {
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) {
   LoadLibrary(TEXT("Riched32.dll"));
-  
+
   // Center Information Window to the Middle of the Screen
   if (left < 0) {
     left = (GetSystemMetrics(SM_CXSCREEN) - width)/2;
@@ -264,7 +262,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
   if (top < 0) {
     top = (GetSystemMetrics(SM_CYSCREEN) - height)/2;
   }
-  
+
   HWND parent;
   if (embedGameWindow) {
     parent = enigma::hWnd;
@@ -272,7 +270,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
     WNDCLASS wc = {CS_VREDRAW|CS_HREDRAW,(WNDPROC)ShowInfoProc,0,0,enigma::hInstance,0,
       0,GetSysColorBrush(COLOR_WINDOW),0,"infodialog"};
     RegisterClass(&wc);
-    
+
     DWORD flags = WS_VISIBLE|WS_POPUP|WS_SYSMENU|WS_TABSTOP|WS_CLIPCHILDREN; // DS_3DLOOK|DS_CENTER|DS_FIXEDSYS
     if (showBorder) {
       flags |= WS_BORDER | WS_DLGFRAME | WS_CAPTION;
@@ -283,10 +281,10 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
     if (stayOnTop) {
       flags |= DS_MODALFRAME; // Same as WS_EX_TOPMOST
     }
-  
+
     parent = CreateWindow("infodialog", TEXT(caption.c_str()),
       flags, left, top, width, height, enigma::hWnd, 0, enigma::hInstance, 0);
-      
+
     if (showBorder) {
       // Set Window Information Icon
       HICON hIcon = LoadIcon(enigma::hInstance, "infoicon");
@@ -296,49 +294,49 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
       }
     }
   }
-    
+
   enigma::infore=CreateWindowEx(WS_EX_TOPMOST,"RICHEDIT",TEXT("information text"),
     ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | ES_READONLY | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_VSCROLL | WS_HSCROLL | WS_TABSTOP,
     0, 0, width, height, parent, 0, enigma::hInstance, 0);
-    
+
   // Size the RTF Component to the Window
   RECT rectParent;
   GetClientRect(parent, &rectParent);
-  MoveWindow(enigma::infore, rectParent.top, rectParent.left, rectParent.right, rectParent.bottom, TRUE); 
-  
+  MoveWindow(enigma::infore, rectParent.top, rectParent.left, rectParent.right, rectParent.bottom, TRUE);
+
   // Set RTF Editor Background Color
   SendMessage(enigma::infore, EM_SETBKGNDCOLOR, (WPARAM)0, (LPARAM)RGB(__GETR(bgcolor), __GETG(bgcolor), __GETB(bgcolor)));
-  
+
   // Set RTF Information Text
   SETTEXTEX se;
   se.codepage = CP_ACP;
   se.flags = ST_DEFAULT;
   SendMessage(enigma::infore, EM_SETTEXTEX, (WPARAM)&se, (LPARAM)info.c_str());
-    
+
   //TODO: Figure out how to block if we need to pause the game, otherwise ShowWindowAsync
   ShowWindow(parent, SW_SHOWDEFAULT);
   if (!embedGameWindow) {
     SetFocus(enigma::infore);
   }
-  
+
   /*
   MSG msg;
   BOOL bRet;
 
   bool bQuit = false;
   while (!bQuit)
-  { 
+  {
     bRet = PeekMessage(&msg, main, 0, 0, PM_REMOVE);
     if (bRet == -1) {
       // handle the error and possibly exit
     } else if (msg.message == WM_CLOSE) {
       bQuit = true;
     } else {
-      TranslateMessage(&msg); 
-      DispatchMessage(&msg); 
+      TranslateMessage(&msg);
+      DispatchMessage(&msg);
     }
   }*/
-  
+
   /* Round two...
   MSG msg;
   BOOL bRet;
@@ -352,7 +350,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
       // handle the error and possibly exit
       PostMessage(embedGameWindow ? infore : main, WM_CLOSE, 0, 0);
       bQuit = true;
-    } else { 
+    } else {
       if (msg.message == WM_KEYUP) {
         switch(msg.wParam)
         {
@@ -362,11 +360,11 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
           break;
         }
       } else {
-        TranslateMessage(&msg); 
-        DispatchMessage(&msg); 
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
       }
     }
-    
+
     // If game information was showed in a separate window, then handle the messages for sizing and stuff
     if (!embedGameWindow) {
       bRet = PeekMessage(&msg, main, 0, 0, PM_REMOVE);
@@ -374,7 +372,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
         // handle the error and possibly exit
         PostMessage(main, WM_CLOSE, 0, 0);
         bQuit = true;
-      } else { 
+      } else {
         if (msg.message == WM_KEYUP) {
           switch(msg.wParam)
             {
@@ -386,14 +384,14 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
         } else if (msg.message == WM_SIZE) {
           RECT rectParent;
           GetClientRect(main, &rectParent);
-          MoveWindow(infore, rectParent.top, rectParent.left, rectParent.right, rectParent.bottom, TRUE); 
+          MoveWindow(infore, rectParent.top, rectParent.left, rectParent.right, rectParent.bottom, TRUE);
         } else {
-          TranslateMessage(&msg); 
-          DispatchMessage(&msg); 
+          TranslateMessage(&msg);
+          DispatchMessage(&msg);
         }
       }
     }
-    
+
 
   }
   */
@@ -402,7 +400,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
 int show_message(string str)
 {
   //NOTE: This will not work with a fullscreen application, it is an issue with Windows
-  //this could be why GM8.1, unlike Studio, did not use native dialogs and custom 
+  //this could be why GM8.1, unlike Studio, did not use native dialogs and custom
   //rendered its own message boxes like most game engines.
   //In Studio this function will cause the window to be minimized and the message shown, fullscreen will not be restored.
   //A possible alternative is fake fullscreen for Win32, but who knows if we have to do that on XLIB or anywhere else.
@@ -555,27 +553,27 @@ string get_directory(string dname, string caption)
 
   DWORD options;
   fileDialog->GetOptions(&options);
-  options &= ~FOS_FILEMUSTEXIST;  
+  options &= ~FOS_FILEMUSTEXIST;
   options &= ~FOS_PATHMUSTEXIST;
   fileDialog->SetOptions(options | FOS_PICKFOLDERS);
   //TODO: Set default directory to dname
   //fileDialog->SetDefaultFolder(std::wstring(dname.begin(), dname.end()).c_str());
   fileDialog->SetTitle(std::wstring(caption.begin(), caption.end()).c_str());
-  
+
   fileDialog->Show(enigma::hWnd);
-  
+
   string res = "";
   IShellItem *psi;
-  
+
   if (SUCCEEDED(fileDialog->GetResult(&psi))) {
     LPWSTR wideres;
     psi->GetDisplayName(SIGDN_DESKTOPABSOLUTEPARSING, &wideres);
     psi->Release();
-    
+
     std::wstring wstr = wideres;
     res = string(wstr.begin(), wstr.end());
   }
-  
+
   return res;
 }
 
@@ -584,17 +582,17 @@ string get_directory_alt(string message, string root, bool modern, string captio
   bool f_selected = false;
 
   char szDir [MAX_PATH];
-  BROWSEINFO bi;        
-  LPITEMIDLIST pidl;        
+  BROWSEINFO bi;
+  LPITEMIDLIST pidl;
   LPMALLOC pMalloc;
 
   if (SUCCEEDED (::SHGetMalloc (&pMalloc)))
   {
-    ::ZeroMemory (&bi,sizeof(bi)); 
+    ::ZeroMemory (&bi,sizeof(bi));
 
     bi.lpszTitle = message.c_str();
     bi.hwndOwner = enigma::hWnd;
-    bi.pszDisplayName = 0;           
+    bi.pszDisplayName = 0;
     bi.pidlRoot = 0;
     bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_STATUSTEXT;
     if (modern) {
@@ -603,7 +601,7 @@ string get_directory_alt(string message, string root, bool modern, string captio
     gs_cap = caption;
     bi.lpfn =  GetDirectoryAltProc;      //callback to set window caption
 
-    pidl = ::SHBrowseForFolder(&bi);           
+    pidl = ::SHBrowseForFolder(&bi);
     if (pidl) {
       if (::SHGetPathFromIDList(pidl, szDir)) {
         f_selected = true;
@@ -611,7 +609,7 @@ string get_directory_alt(string message, string root, bool modern, string captio
 
       pMalloc->Free(pidl);
       pMalloc->Release();
-    }     
+    }
   }
 
   if (f_selected) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -305,7 +305,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
   MoveWindow(enigma::infore, rectParent.top, rectParent.left, rectParent.right, rectParent.bottom, TRUE);
 
   // Set RTF Editor Background Color
-  SendMessage(enigma::infore, EM_SETBKGNDCOLOR, (WPARAM)0, (LPARAM)RGB(__GETR(bgcolor), __GETG(bgcolor), __GETB(bgcolor)));
+  SendMessage(enigma::infore, EM_SETBKGNDCOLOR, (WPARAM)0, (LPARAM)RGB(COL_GET_R(bgcolor), COL_GET_G(bgcolor), COL_GET_B(bgcolor)));
 
   // Set RTF Information Text
   SETTEXTEX se;


### PR DESCRIPTION
We had these color swizzling macros in like 5 million places. In #1249 I began moving them to a general header `Graphics_Systems/General/GScolor_macros.h` and I am now finishing that task. In addition to deleting the duplicate macros, I am also reorganizing the include order to put our includes before standard includes in source files, as I was told to do so by Josh and Rusky, because that should lead to smaller executable sizes since headers that are likely to be included by other headers should be ordered towards the bottom/end of includes.

There is a specific order to my changes here:
1) Deduplicate all of the color macros and use only the ones in `GScolor_macros.h`
2) Combine the 24 bit and 32 bit color macros, and only use the 32 bit ones everywhere (since they work everywhere but the 24 bit ones don't).
3) Rename the color macros to a non-reserved identifier. This extends #1174 I did recently to remove a lot of other reserved identifiers, since a bot on GitHub complained to us back in #650. `__GETR` has become `COL_GET_R` and `clamp_alpha` has become `CLAMP_ALPHAF` with `bind_alpha` becoming `CLAMP_ALPHA`.
4) Delete `__GETRf` and its buddies since they are no longer used _anywhere_ in the source.
5) Add some comments explaining each set of macros.

When I was done, I went back and tested an empty game on all 4 graphics systems, and did not see any issues. I also tested, on the 3 _working_ graphics systems, several games as well as the vertex buffer functions I added in #1249, and did not notice any regressions.

Once this is done/merged, it will make it easier for me to generify the model class and finish #1238.