### PR TITLE
Fix Proto2ES Zlib Compression

### DIFF
--- a/CommandLine/emake/Proto2ES.cpp
+++ b/CommandLine/emake/Proto2ES.cpp
@@ -237,12 +237,14 @@ std::string Actions2Code(const ::google::protobuf::RepeatedPtrField< buffers::re
 
 #include <zlib.h>
 
-unsigned char* zlib_compress(unsigned char* inbuffer,int actualsize)
+unsigned char* zlib_compress(unsigned char* inbuffer,int &actualsize)
 {
     uLongf outsize=(int)(actualsize*1.1)+12;
     Bytef* outbytef=new Bytef[outsize];
 
     compress(outbytef,&outsize,(Bytef*)inbuffer,actualsize);
+
+    actualsize = outsize;
 
     return (unsigned char*)outbytef;
 }
@@ -281,8 +283,8 @@ Image AddImage(const std::string fname) {
   free(image);
   i.width  = pngwidth;
   i.height = pngheight;
-  i.data = reinterpret_cast<char*>(zlib_compress(bitmap, bitmap_size));
   i.dataSize = bitmap_size;
+  i.data = reinterpret_cast<char*>(zlib_compress(bitmap, i.dataSize));
 
   return i;
 }


### PR DESCRIPTION
This fixes #1254 to the fullest. @JoshDreamland correctly discovered for me that the block size was being written incorrectly. I traced it down to my copy of `zlib_compress` in Proto2ES not returning the outsize with the correct size of the compressed data.

With this one fixed, I have added a new game to my list of emake projects that now work. The platforming engine from the EDC: https://enigma-dev.org/edc/games.php?game=69

Game exhibiting problems: [platform_engine.zip](https://github.com/enigma-dev/enigma-dev/files/2079012/platform_engine.zip)

```
./emake "C:/Users/Owner/Desktop/GMGames/platform_engine.gmk" -o /tmp/test.exe -r -c Precise
```

![image](https://user-images.githubusercontent.com/3212801/41079109-4a9fe7a0-69ee-11e8-915d-0066091e9590.png)
