### PR TITLE
Overloads for String Functions

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Android/AndroidWindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Android/AndroidWindow.cpp
@@ -306,20 +306,20 @@ namespace enigma {
 	void set_room_speed(int rs)
 	{
 		timeval tv;
-
+		
 		for (int i=1; i<hielem+1; i++) {
 			last_microsecond[i-1] = last_microsecond[i];
 			last_second[i-1] = last_second[i];
 		}
-
+		
 		//How many microseconds since 1970? herp
 		gettimeofday(&tv, NULL);
-
+		
 		// I'm feeling hacky, so we'll give the processor a millisecond to take care
 		// of these calculations and hop threads. I'd rather be fast than slow.
 		int sdur = 1000000/rs - 1000 - (tv.tv_sec - last_second[hielem]) * 1000000 - (tv.tv_usec - last_microsecond[hielem]);
 		if (sdur > 0 and sdur < 1000000) usleep(sdur);
-
+		
 		// Store this time for diff next time
 		gettimeofday(&tv, NULL);
 		last_second[hielem] = tv.tv_sec, last_microsecond[hielem] = tv.tv_usec;
@@ -336,12 +336,12 @@ namespace enigma {
  display_get_frequency() Returns the refresh frequency of the display.
  display_set_colordepth(coldepth) Sets the color depth. In general only 16 and 32 are allowed values. Returns whether successful.
  display_set_frequency(frequency) Sets the refresh frequency for the display. Only few frequencies are allowed. Typically you could set this to 60 with a same room speed to get smooth 60 frames per second motion. Returns whether successful.
-
+ 
  display_set_all(w,h,frequency,coldepth) Sets all at once. Use -1 for values you do not want to change. Returns whether successful.
  display_test_all(w,h,frequency,coldepth) Tests whether the indicated settings are allowed. It does not change the settings. Use -1 for values you do not want to change. Returns whether the settings are allowed.
  display_reset() Resets the display settings to the ones when the program was started.
-
-
+ 
+ 
  window_default()
  window_get_cursor()
  window_set_color(color)

--- a/ENIGMAsystem/SHELL/Platforms/Android/AndroidWindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Android/AndroidWindow.cpp
@@ -87,7 +87,7 @@ int window_get_visible()
 	return wa.map_state != IsUnmapped;*/
 }
 
-int window_set_caption(string caption)
+int window_set_caption(const string &caption)
 {
 	/*XStoreName(disp,win,caption.c_str());
 	return 0;*/
@@ -306,20 +306,20 @@ namespace enigma {
 	void set_room_speed(int rs)
 	{
 		timeval tv;
-		
+
 		for (int i=1; i<hielem+1; i++) {
 			last_microsecond[i-1] = last_microsecond[i];
 			last_second[i-1] = last_second[i];
 		}
-		
+
 		//How many microseconds since 1970? herp
 		gettimeofday(&tv, NULL);
-		
+
 		// I'm feeling hacky, so we'll give the processor a millisecond to take care
 		// of these calculations and hop threads. I'd rather be fast than slow.
 		int sdur = 1000000/rs - 1000 - (tv.tv_sec - last_second[hielem]) * 1000000 - (tv.tv_usec - last_microsecond[hielem]);
 		if (sdur > 0 and sdur < 1000000) usleep(sdur);
-		
+
 		// Store this time for diff next time
 		gettimeofday(&tv, NULL);
 		last_second[hielem] = tv.tv_sec, last_microsecond[hielem] = tv.tv_usec;
@@ -336,12 +336,12 @@ namespace enigma {
  display_get_frequency() Returns the refresh frequency of the display.
  display_set_colordepth(coldepth) Sets the color depth. In general only 16 and 32 are allowed values. Returns whether successful.
  display_set_frequency(frequency) Sets the refresh frequency for the display. Only few frequencies are allowed. Typically you could set this to 60 with a same room speed to get smooth 60 frames per second motion. Returns whether successful.
- 
+
  display_set_all(w,h,frequency,coldepth) Sets all at once. Use -1 for values you do not want to change. Returns whether successful.
  display_test_all(w,h,frequency,coldepth) Tests whether the indicated settings are allowed. It does not change the settings. Use -1 for values you do not want to change. Returns whether the settings are allowed.
  display_reset() Resets the display settings to the ones when the program was started.
- 
- 
+
+
  window_default()
  window_get_cursor()
  window_set_color(color)

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaWindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaWindow.cpp
@@ -112,14 +112,14 @@ namespace enigma_user {
   }
 
 
-  int window_set_caption(string caption)
+  int window_set_caption(const string &caption)
   {
-	cocoa_window_set_caption(caption.c_str());
-	return 0; // TODO, this function should be void in all files
+    cocoa_window_set_caption(caption.c_str());
+    return 0; // TODO, this function should be void in all files
   }
   string window_get_caption()
   {
-	return string(cocoa_window_get_caption());
+    return string(cocoa_window_get_caption());
   }
 
 
@@ -503,4 +503,3 @@ namespace enigma_user {
     return cocoa_get_screen_size(false);
   }
 }
-

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
@@ -18,8 +18,8 @@
 #ifndef ENIGMA_PLATFORM_WINDOW_H
 #define ENIGMA_PLATFORM_WINDOW_H
 
+#include "libEGMstd.h"
 #include "Platforms/platforms_mandatory.h"
-#include "Universal_System/var4.h" // for variant
 
 #include <string>
 
@@ -210,10 +210,8 @@ int window_get_y();
 int window_get_width();
 int window_get_height();
 
-void window_set_caption(std::string caption);
-inline void window_set_caption(variant caption) {
-  window_set_caption(caption.sval);
-}
+void window_set_caption(const std::string &caption);
+template<typename T> void window_set_caption(T caption) { return window_set_caption(enigma_user::toString(caption)); }
 std::string window_get_caption();
 void window_set_color(int color);
 int window_get_color();

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
@@ -19,6 +19,7 @@
 #define ENIGMA_PLATFORM_WINDOW_H
 
 #include "Platforms/platforms_mandatory.h"
+#include "Universal_System/var4.h" // for variant
 
 #include <string>
 
@@ -210,6 +211,9 @@ int window_get_width();
 int window_get_height();
 
 void window_set_caption(std::string caption);
+inline void window_set_caption(variant caption) {
+  window_set_caption(caption.sval);
+}
 std::string window_get_caption();
 void window_set_color(int color);
 int window_get_color();

--- a/ENIGMAsystem/SHELL/Platforms/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/None/fillin.cpp
@@ -88,7 +88,7 @@ int display_get_height() { return 0; }
 
 void window_set_visible(bool visible) {}
 int window_get_visible() { return false; }
-void window_set_caption(string caption) {}
+void window_set_caption(const string &caption) {}
 string window_get_caption() { return ""; }
 int window_mouse_get_x() { return -1; }
 int window_mouse_get_y() { return -1; }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -77,7 +77,7 @@ int window_get_height()
   return rc.bottom-rc.top;
 }
 
-void window_set_caption(string caption)
+void window_set_caption(const string &caption)
 {
 /*  if (caption == "")
       if (score != 0)

--- a/ENIGMAsystem/SHELL/Platforms/iPhone/CocoaWindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/iPhone/CocoaWindow.cpp
@@ -107,7 +107,7 @@ string window_get_caption()
 int imousex,imousey;
 inline int getMouse(int i)
 {
-
+	
 	switch(i)
 	{
 		case 0:  return imousex;
@@ -312,20 +312,20 @@ namespace enigma {
 	void set_room_speed(int rs)
 	{
 		timeval tv;
-
+		
 		for (int i=1; i<hielem+1; i++) {
 			last_microsecond[i-1] = last_microsecond[i];
 			last_second[i-1] = last_second[i];
 		}
-
+		
 		//How many microseconds since 1970? herp
 		gettimeofday(&tv, NULL);
-
+		
 		// I'm feeling hacky, so we'll give the processor a millisecond to take care
 		// of these calculations and hop threads. I'd rather be fast than slow.
 		int sdur = 1000000/rs - 1000 - (tv.tv_sec - last_second[hielem]) * 1000000 - (tv.tv_usec - last_microsecond[hielem]);
 		if (sdur > 0 and sdur < 1000000) usleep(sdur);
-
+		
 		// Store this time for diff next time
 		gettimeofday(&tv, NULL);
 		last_second[hielem] = tv.tv_sec, last_microsecond[hielem] = tv.tv_usec;
@@ -342,12 +342,12 @@ namespace enigma {
  display_get_frequency() Returns the refresh frequency of the display.
  display_set_colordepth(coldepth) Sets the color depth. In general only 16 and 32 are allowed values. Returns whether successful.
  display_set_frequency(frequency) Sets the refresh frequency for the display. Only few frequencies are allowed. Typically you could set this to 60 with a same room speed to get smooth 60 frames per second motion. Returns whether successful.
-
+ 
  display_set_all(w,h,frequency,coldepth) Sets all at once. Use -1 for values you do not want to change. Returns whether successful.
  display_test_all(w,h,frequency,coldepth) Tests whether the indicated settings are allowed. It does not change the settings. Use -1 for values you do not want to change. Returns whether the settings are allowed.
  display_reset() Resets the display settings to the ones when the program was started.
-
-
+ 
+ 
  window_default()
  window_get_cursor()
  window_set_color(color)

--- a/ENIGMAsystem/SHELL/Platforms/iPhone/CocoaWindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/iPhone/CocoaWindow.cpp
@@ -91,7 +91,7 @@ int window_get_visible()
 	return wa.map_state != IsUnmapped;*/
 }
 
-int window_set_caption(string caption)
+int window_set_caption(const string &caption)
 {
 	/*XStoreName(disp,win,caption.c_str());
 	return 0;*/
@@ -107,7 +107,7 @@ string window_get_caption()
 int imousex,imousey;
 inline int getMouse(int i)
 {
-	
+
 	switch(i)
 	{
 		case 0:  return imousex;
@@ -312,20 +312,20 @@ namespace enigma {
 	void set_room_speed(int rs)
 	{
 		timeval tv;
-		
+
 		for (int i=1; i<hielem+1; i++) {
 			last_microsecond[i-1] = last_microsecond[i];
 			last_second[i-1] = last_second[i];
 		}
-		
+
 		//How many microseconds since 1970? herp
 		gettimeofday(&tv, NULL);
-		
+
 		// I'm feeling hacky, so we'll give the processor a millisecond to take care
 		// of these calculations and hop threads. I'd rather be fast than slow.
 		int sdur = 1000000/rs - 1000 - (tv.tv_sec - last_second[hielem]) * 1000000 - (tv.tv_usec - last_microsecond[hielem]);
 		if (sdur > 0 and sdur < 1000000) usleep(sdur);
-		
+
 		// Store this time for diff next time
 		gettimeofday(&tv, NULL);
 		last_second[hielem] = tv.tv_sec, last_microsecond[hielem] = tv.tv_usec;
@@ -342,12 +342,12 @@ namespace enigma {
  display_get_frequency() Returns the refresh frequency of the display.
  display_set_colordepth(coldepth) Sets the color depth. In general only 16 and 32 are allowed values. Returns whether successful.
  display_set_frequency(frequency) Sets the refresh frequency for the display. Only few frequencies are allowed. Typically you could set this to 60 with a same room speed to get smooth 60 frames per second motion. Returns whether successful.
- 
+
  display_set_all(w,h,frequency,coldepth) Sets all at once. Use -1 for values you do not want to change. Returns whether successful.
  display_test_all(w,h,frequency,coldepth) Tests whether the indicated settings are allowed. It does not change the settings. Use -1 for values you do not want to change. Returns whether the settings are allowed.
  display_reset() Resets the display settings to the ones when the program was started.
- 
- 
+
+
  window_default()
  window_get_cursor()
  window_set_color(color)

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -155,7 +155,7 @@ int window_get_visible() {
   return wa.map_state != IsUnmapped;
 }
 
-void window_set_caption(string caption) { XStoreName(disp, win, caption.c_str()); }
+void window_set_caption(const string &caption) { XStoreName(disp, win, caption.c_str()); }
 
 string window_get_caption() {
   char* caption;

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletRigidBody.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletRigidBody.h
@@ -16,20 +16,8 @@
 **/
 
 #ifdef DEBUG_MODE
-
-/*
-#ifndef stringinclude
-#define stringinclude
-#include <string>
-using std::string;
-#endif
-
-  #include "libEGMstd.h"
-*/
-#define toString(s) \
-  s
-
   #include "Widget_Systems/widgets_mandatory.h"
+  #include "libEGMstd.h"
   #define get_bodyr(w,id,r) \
     if (unsigned(id) >= bulletBodies.size() || id < 0) { \
       show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletShape.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletShape.h
@@ -16,20 +16,8 @@
 **/
 
 #ifdef DEBUG_MODE
-
-/*
-#ifndef stringinclude
-#define stringinclude
-#include <string>
-using std::string;
-#endif
-
-  #include "libEGMstd.h"
-*/
-#define toString(s) \
-  s
-
   #include "Widget_Systems/widgets_mandatory.h"
+  #include "libEGMstd.h"
   #define get_shaper(s,id,r) \
     if (unsigned(id) >= bulletShapes.size() || id < 0) { \
       show_error("Cannot access Bullet Dynamics physics shape with id " + toString(id), false); \

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletSoftBody.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletSoftBody.h
@@ -16,20 +16,8 @@
 **/
 
 #ifdef DEBUG_MODE
-
-/*
-#ifndef stringinclude
-#define stringinclude
-#include <string>
-using std::string;
-#endif
-
-  #include "libEGMstd.h"
-*/
-#define toString(s) \
-  s
-
   #include "Widget_Systems/widgets_mandatory.h"
+  #include "libEGMstd.h"
   #define get_softbodyr(w,id,r) \
     if (unsigned(id) >= bulletSoftBodies.size() || id < 0) { \
       show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletWorld.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletWorld.h
@@ -16,20 +16,8 @@
 **/
 
 #ifdef DEBUG_MODE
-
-/*
-#ifndef stringinclude
-#define stringinclude
-#include <string>
-using std::string;
-#endif
-
-  #include "libEGMstd.h"
-*/
-#define toString(s) \
-  s
-
   #include "Widget_Systems/widgets_mandatory.h"
+  #include "libEGMstd.h"
   #define get_worldr(w,id,r) \
     if (unsigned(id) >= bulletWorlds.size() || id < 0) { \
       show_error("Cannot access Bullet Dynamics physics world with id " + toString(id), false); \

--- a/ENIGMAsystem/SHELL/Universal_System/background_internal.h
+++ b/ENIGMAsystem/SHELL/Universal_System/background_internal.h
@@ -71,8 +71,8 @@ namespace enigma
 } //namespace enigma
 
 #ifdef DEBUG_MODE
-  #include "libEGMstd.h"
   #include "Widget_Systems/widgets_mandatory.h"
+  #include "libEGMstd.h"
   #define get_background(bck2d,back)\
     if (back < 0 or size_t(back) >= enigma::background_idmax or !enigma::backgroundstructarray[back]) {\
       show_error("Attempting to draw non-existing background " + toString(back), false);\

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -62,22 +62,22 @@ enum {
     void message_mouse_color(int col);
     void message_position(int x, int y);
     void message_size(int w, int h);
-    void message_text_font(string name, int size, int color, int style);
-	void message_text_charset(int type, int charset);
-
+    void message_text_font(string name, int size, int color, int style); 
+	void message_text_charset(int type, int charset); 
+	
 	int show_message_ext(string str, string but1, string but2, string but3);
-
+  
 	bool show_question(string str);
 	inline bool action_if_question(string str)
 	{
 		return show_question(str);
 	}
-
+	
 	// IMPLEMENTS from widgets_mandatory:
 	// void show_error(string errortext, const bool fatal);
 
 	int get_color(int defcol, bool advanced = false);
-
+	
 	string get_open_filename(string filter, string fname, string caption="");
 	string get_save_filename(string filter, string fname, string caption="");
 	string get_directory(string dname, string caption="Select Folder");

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -62,22 +62,22 @@ enum {
     void message_mouse_color(int col);
     void message_position(int x, int y);
     void message_size(int w, int h);
-    void message_text_font(string name, int size, int color, int style); 
-	void message_text_charset(int type, int charset); 
-	
+    void message_text_font(string name, int size, int color, int style);
+	void message_text_charset(int type, int charset);
+
 	int show_message_ext(string str, string but1, string but2, string but3);
-  
+
 	bool show_question(string str);
 	inline bool action_if_question(string str)
 	{
 		return show_question(str);
 	}
-	
+
 	// IMPLEMENTS from widgets_mandatory:
 	// void show_error(string errortext, const bool fatal);
 
 	int get_color(int defcol, bool advanced = false);
-	
+
 	string get_open_filename(string filter, string fname, string caption="");
 	string get_save_filename(string filter, string fname, string caption="");
 	string get_directory(string dname, string caption="Select Folder");

--- a/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
@@ -36,7 +36,7 @@ using namespace std;
 #  include <termios.h>
 #  include <unistd.h>
 #endif
- 
+
 class PasswordContext {
 # ifdef TC_WINDOWS
   DWORD old_attrs = 0;
@@ -44,7 +44,7 @@ class PasswordContext {
 # else
   termios old_attrs;
 # endif
- 
+
  public:
   PasswordContext() {
 #   ifdef TC_WINDOWS
@@ -58,7 +58,7 @@ class PasswordContext {
       tcsetattr(STDIN_FILENO, TCSANOW, &new_attrs);
 #   endif
   }
- 
+
   ~PasswordContext() {
 #   ifdef TC_WINDOWS
       SetConsoleMode(hStdin, old_attrs);
@@ -92,7 +92,7 @@ void show_error(string err, const bool fatal)
 
 namespace enigma_user {
 
-int show_message(string message)
+int show_message(const string &message)
 {
   printf("show_message: %s\n", message.c_str());
   return 0;

--- a/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
@@ -36,7 +36,7 @@ using namespace std;
 #  include <termios.h>
 #  include <unistd.h>
 #endif
-
+ 
 class PasswordContext {
 # ifdef TC_WINDOWS
   DWORD old_attrs = 0;
@@ -44,7 +44,7 @@ class PasswordContext {
 # else
   termios old_attrs;
 # endif
-
+ 
  public:
   PasswordContext() {
 #   ifdef TC_WINDOWS
@@ -58,7 +58,7 @@ class PasswordContext {
       tcsetattr(STDIN_FILENO, TCSANOW, &new_attrs);
 #   endif
   }
-
+ 
   ~PasswordContext() {
 #   ifdef TC_WINDOWS
       SetConsoleMode(hStdin, old_attrs);

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -397,7 +397,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
   */
 }
 
-int show_message(string str)
+int show_message(const string &str)
 {
   //NOTE: This will not work with a fullscreen application, it is an issue with Windows
   //this could be why GM8.1, unlike Studio, did not use native dialogs and custom

--- a/ENIGMAsystem/SHELL/Widget_Systems/widgets_mandatory.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/widgets_mandatory.h
@@ -19,6 +19,8 @@
 #ifndef ENIGMA_WIDGETS_MANDATORY_H
 #define ENIGMA_WIDGETS_MANDATORY_H
 
+#include "Universal_System/var4.h"
+
 #include <string>
 using std::string;
 
@@ -38,8 +40,10 @@ void show_error(std::string msg, const bool fatal);
 namespace enigma_user {
 
 int show_message(string str);
-inline int action_show_message(string str)
-{
+inline int show_message(variant str) {
+  return show_message(str.sval);
+}
+inline int action_show_message(string str) {
   return show_message(str);
 }
 void show_info(string text=enigma::gameInfoText, int bgcolor=enigma::gameInfoBackgroundColor, int left=enigma::gameInfoLeft, int top=enigma::gameInfoTop, int width=enigma::gameInfoWidth, int height=enigma::gameInfoHeight,

--- a/ENIGMAsystem/SHELL/Widget_Systems/widgets_mandatory.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/widgets_mandatory.h
@@ -19,7 +19,7 @@
 #ifndef ENIGMA_WIDGETS_MANDATORY_H
 #define ENIGMA_WIDGETS_MANDATORY_H
 
-#include "Universal_System/var4.h"
+#include "libEGMstd.h"
 
 #include <string>
 using std::string;
@@ -39,12 +39,10 @@ void show_error(std::string msg, const bool fatal);
 
 namespace enigma_user {
 
-int show_message(string str);
-inline int show_message(variant str) {
-  return show_message(str.sval);
-}
-inline int action_show_message(string str) {
-  return show_message(str);
+int show_message(const std::string &msg);
+template<typename T> int show_message(T msg) { return show_message(enigma_user::toString(msg)); }
+inline int action_show_message(string msg) {
+  return show_message(msg);
 }
 void show_info(string text=enigma::gameInfoText, int bgcolor=enigma::gameInfoBackgroundColor, int left=enigma::gameInfoLeft, int top=enigma::gameInfoTop, int width=enigma::gameInfoWidth, int height=enigma::gameInfoHeight,
 	bool embedGameWindow=enigma::gameInfoEmbedGameWindow, bool showBorder=enigma::gameInfoShowBorder, bool allowResize=enigma::gameInfoAllowResize, bool stayOnTop=enigma::gameInfoStayOnTop,


### PR DESCRIPTION
This pull request attempts to resolve #928 

The decision we are making here is that the following functions should accept constants, literals, and variables that are not of string type. We are choosing these functions because they seem to be the most common ones that people tend to do this with, but are leaving the rest as still accepting only string (requiring `string(var)` to be passed) since they usually involve more complex messages anyway.

1) show_message
2) window_set_caption (because e.g. `window_set_caption(fps)` is common)
