### PR TITLE
Vertex/Index Buffer Tweaks

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
@@ -103,7 +103,7 @@ void graphics_prepare_index_buffer(const int buffer) {
   if (indexBuffer->dirty) {
     LPDIRECT3DINDEXBUFFER9 indexBufferPeer = NULL;
     auto it = indexBufferPeers.find(buffer);
-    size_t size = enigma_user::index_get_size(buffer);
+    size_t size = enigma_user::index_get_buffer_size(buffer);
 
     // if we have already created a native "peer" ibo for this user buffer,
     // then we have to release it if it isn't big enough to hold the new contents

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
@@ -57,7 +57,7 @@ void graphics_prepare_vertex_buffer(const int buffer) {
   if (vertexBuffer->dirty) {
     LPDIRECT3DVERTEXBUFFER9 vertexBufferPeer = NULL;
     auto it = vertexBufferPeers.find(buffer);
-    size_t size = enigma_user::vertex_get_size(buffer);
+    size_t size = enigma_user::vertex_get_buffer_size(buffer);
 
     // if we have already created a native "peer" vbo for this user buffer,
     // then we have to release it if it isn't big enough to hold the new contents

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -273,7 +273,7 @@ void index_delete_buffer(int buffer) {
   enigma::indexBuffers[buffer] = nullptr;
 }
 
-unsigned index_get_size(int buffer) {
+unsigned index_get_buffer_size(int buffer) {
   return enigma::indexBuffers[buffer]->indices.size() * sizeof(uint16_t);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -104,7 +104,7 @@ void vertex_delete_buffer(int buffer) {
   enigma::vertexBuffers[buffer] = nullptr;
 }
 
-unsigned vertex_get_size(int buffer) {
+unsigned vertex_get_buffer_size(int buffer) {
   return enigma::vertexBuffers[buffer]->number * sizeof(gs_scalar);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -104,6 +104,10 @@ void vertex_delete_buffer(int buffer) {
   enigma::vertexBuffers[buffer] = nullptr;
 }
 
+bool vertex_exists(int id) {
+  return (id >= 0 && (unsigned)id < enigma::vertexBuffers.size() && enigma::vertexBuffers[id] != nullptr);
+}
+
 unsigned vertex_get_buffer_size(int buffer) {
   return enigma::vertexBuffers[buffer]->number * sizeof(gs_scalar);
 }
@@ -271,6 +275,10 @@ void index_delete_buffer(int buffer) {
   enigma::graphics_delete_index_buffer_peer(buffer);
   delete enigma::indexBuffers[buffer];
   enigma::indexBuffers[buffer] = nullptr;
+}
+
+bool index_exists(int id) {
+  return (id >= 0 && (unsigned)id < enigma::indexBuffers.size() && enigma::indexBuffers[id] != nullptr);
 }
 
 unsigned index_get_buffer_size(int buffer) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
@@ -98,7 +98,7 @@ enum {
 int index_create_buffer();
 int index_create_buffer_ext(unsigned size);
 void index_delete_buffer(int buffer);
-unsigned index_get_size(int buffer);
+unsigned index_get_buffer_size(int buffer);
 unsigned index_get_number(int buffer);
 void index_freeze(int buffer);
 void index_clear(int buffer);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
@@ -66,6 +66,7 @@ void vertex_format_add_custom(int type, int usage);
 int vertex_create_buffer();
 int vertex_create_buffer_ext(unsigned size);
 void vertex_delete_buffer(int buffer);
+bool vertex_exists(int id);
 unsigned vertex_get_buffer_size(int buffer);
 unsigned vertex_get_number(int buffer);
 void vertex_freeze(int buffer);
@@ -98,6 +99,7 @@ enum {
 int index_create_buffer();
 int index_create_buffer_ext(unsigned size);
 void index_delete_buffer(int buffer);
+bool index_exists(int id);
 unsigned index_get_buffer_size(int buffer);
 unsigned index_get_number(int buffer);
 void index_freeze(int buffer);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
@@ -66,7 +66,7 @@ void vertex_format_add_custom(int type, int usage);
 int vertex_create_buffer();
 int vertex_create_buffer_ext(unsigned size);
 void vertex_delete_buffer(int buffer);
-unsigned vertex_get_size(int buffer);
+unsigned vertex_get_buffer_size(int buffer);
 unsigned vertex_get_number(int buffer);
 void vertex_freeze(int buffer);
 void vertex_clear(int buffer);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -54,7 +54,7 @@ void graphics_prepare_buffer(const int buffer, const bool isIndex) {
   // if the contents of the buffer are dirty then we need to update
   // our native buffer object "peer"
   if (dirty) {
-    size_t size = isIndex ? enigma_user::index_get_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
+    size_t size = isIndex ? enigma_user::index_get_buffer_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
     // if we haven't created a native "peer" for this buffer yet,
     // then we need to do so now

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -54,7 +54,7 @@ void graphics_prepare_buffer(const int buffer, const bool isIndex) {
   // if the contents of the buffer are dirty then we need to update
   // our native buffer object "peer"
   if (dirty) {
-    size_t size = isIndex ? enigma_user::index_get_size(buffer) : enigma_user::vertex_get_size(buffer);
+    size_t size = isIndex ? enigma_user::index_get_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
     // if we haven't created a native "peer" for this buffer yet,
     // then we need to do so now

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -81,7 +81,7 @@ void graphics_prepare_buffer(const int buffer, const bool isIndex) {
   // if the contents of the buffer are dirty then we need to update
   // our native buffer object "peer"
   if (dirty) {
-    size_t size = isIndex ? enigma_user::index_get_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
+    size_t size = isIndex ? enigma_user::index_get_buffer_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
     // if we haven't created a native "peer" for this buffer yet,
     // then we need to do so now

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -81,7 +81,7 @@ void graphics_prepare_buffer(const int buffer, const bool isIndex) {
   // if the contents of the buffer are dirty then we need to update
   // our native buffer object "peer"
   if (dirty) {
-    size_t size = isIndex ? enigma_user::index_get_size(buffer) : enigma_user::vertex_get_size(buffer);
+    size_t size = isIndex ? enigma_user::index_get_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
     // if we haven't created a native "peer" for this buffer yet,
     // then we need to do so now


### PR DESCRIPTION
I made some minor mistakes in #1283 and #1249 that I want to address before continuing.

* I mistakenly named one function `vertex_get_size` where it's actually `vertex_get_buffer_size` in GMS1.4
https://docs.yoyogames.com/source/dadiospice/002_reference/shaders/primitive%20building/vertex_get_buffer_size.html
* I copied the same mistake when adding `index_get_size` which I've renamed to `index_get_buffer_size` to follow the same naming convention.
* Since I already added `vertex_format_exists` for my own use internally, I figured I see no reason not to have `vertex_exists` and `index_exists` as well, even though GM doesn't.