### PR TITLE
Fix mistakes in Compiler ey files

### DIFF
--- a/Compilers/Linux/AndroidSym.ey
+++ b/Compilers/Linux/AndroidSym.ey
@@ -1,3 +1,5 @@
+%e-yaml
+---
 Name: Android Simulator
 Native: No
 Maintainer: TGMG,IsmAvatar

--- a/Compilers/Linux/clang.ey
+++ b/Compilers/Linux/clang.ey
@@ -23,7 +23,7 @@ Parser-Vars:
   searchdirs-start: "#include <...> search starts here:"
   searchdirs-end: "End of search list."
 
-Exe-Vars:
+EXE-Vars:
   resources: $exe
   Build-Extension:
   Run-output: $tempfile

--- a/Compilers/Linux/clang32.ey
+++ b/Compilers/Linux/clang32.ey
@@ -23,7 +23,7 @@ Parser-Vars:
   searchdirs-start: "#include <...> search starts here:"
   searchdirs-end: "End of search list."
 
-Exe-Vars:
+EXE-Vars:
   resources: $exe
   Build-Extension:
   Run-output: $tempfile


### PR DESCRIPTION
This pull request addresses some mistakes fundies made that were merged as part of #1278 

Although the EYAML reader is case insensitive for key names, because it converts them to lower case, I decided to change `Exe-Vars` to `EXE-Vars` in `clang.ey` and `clang32.ey` to match the other Linux Compiler ey files anyway. I also added the required prefix back to `AndroidSym.ey` which fundies removed for some reason.