### PR TITLE
Fix Game Icon For Win32

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -153,7 +153,6 @@ MSG msg;
 bool initGameWindow() {
   int wid = (int)enigma_user::room_width, hgt = (int)enigma_user::room_height;
   if (!wid || !hgt) wid = 640, hgt = 480;
-  enigma::hInstance = hInstance;
   enigma::mainthread = GetCurrentThread();
 
   //Register window class
@@ -432,6 +431,12 @@ void action_webpage(const std::string &url) {
 }  // namespace enigma_user
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int iCmdShow) {
+  // DO NOT move this out of WinMain like a fucking idiot
+  // we are setting the hInstance in the enigma namespace
+  // to the local one passed as a parameter here so that
+  // we can use it for the CreateWindow call and icon
+  enigma::hInstance = hInstance;
+
   int argc = 0;
   std::vector<const char*> argv;
   std::vector<string> shortened;


### PR DESCRIPTION
Took me a while to track this one down, but I went on a hunt to find out why the game icon was no longer working. I tracked it down to 15fce1a894de6c2f5ec1b4443fd1cdb5a02dbf9c which was merged from #1259.

In case you can't spot the issue, fundies did not keep the initialization of `hInstance` inside `WinMain` where it's actually a parameter. Hence, he had it just being set to its uninitialized self, which means it was undefined behavior. To prevent this from being broken again, I've added a comment that will make any contributor think twice before breaking it in the future.