### PR TITLE
Regression Tests Fix

### DIFF
--- a/CommandLine/testing/main.cpp
+++ b/CommandLine/testing/main.cpp
@@ -7,8 +7,6 @@
 std::string gitMasterDir = "/tmp/enigma-master";
 
 int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-
   if (argc == 1) {
     int ret = system(("bash ./ci-regression.sh " + gitMasterDir).c_str());
     if (ret != 0) {
@@ -17,5 +15,6 @@ int main(int argc, char **argv) {
     }
   }
 
+  ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/CommandLine/testing/main.cpp
+++ b/CommandLine/testing/main.cpp
@@ -7,6 +7,9 @@
 std::string gitMasterDir = "/tmp/enigma-master";
 
 int main(int argc, char **argv) {
+  std::cerr << "who da bitch: " << argc << std::endl;
+  std::cerr << std::flush;
+
   if (argc == 1) {
     int ret = system(("bash ./ci-regression.sh " + gitMasterDir).c_str());
     if (ret != 0) {

--- a/CommandLine/testing/main.cpp
+++ b/CommandLine/testing/main.cpp
@@ -7,7 +7,7 @@
 std::string gitMasterDir = "/tmp/enigma-master";
 
 int main(int argc, char **argv) {
-  std::cerr << "who da bitch: " << argc << std::endl;
+  std::cerr << "who da bitch 2: " << argc << std::endl;
   std::cerr << std::flush;
 
   if (argc == 1) {

--- a/CommandLine/testing/main.cpp
+++ b/CommandLine/testing/main.cpp
@@ -7,9 +7,6 @@
 std::string gitMasterDir = "/tmp/enigma-master";
 
 int main(int argc, char **argv) {
-  std::cerr << "who da bitch 2: " << argc << std::endl;
-  std::cerr << std::flush;
-
   if (argc == 1) {
     int ret = system(("bash ./ci-regression.sh " + gitMasterDir).c_str());
     if (ret != 0) {


### PR DESCRIPTION
This is a fix to #1299 for a mistake we made. `::testing::InitGoogleTest(&argc, argv);` apparently mutates its first parameter which was screwing up fundies check to see if we passed any parameters **_AT ALL_** to the `ci-regression.sh` script. This must be merged before #1305 or it will continue to build the outdated master's test harness.