### PR TITLE
Fix Test Harness Exit Code Evaluation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,7 +191,7 @@ script:
       Xvfb :1 -screen 0 1024x768x24 &
       xfwm4 &
       export ASAN_OPTIONS=detect_leaks=0;
-      if ! ./test-runner ; then
+      if [ ./test-runner -ne 0 ]; then
         if [ -f "/tmp/enigma_draw_diff.png" ]; then
           ./CommandLine/testing/GitHub-ImageDiff.sh
         fi

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -22,10 +22,12 @@ cp -p -r "${PWD}" "${TEST_HARNESS_MASTER_DIR}"
 
 pushd "${TEST_HARNESS_MASTER_DIR}"
 
+# git gets triggered by our chmod calls for some of the sh scripts
+# stash changes before checking stuff out
+git stash
 
 if [[ -n "$TRAVIS_PULL_REQUEST_SHA" ]] && [[ -n "$TRAVIS_BRANCH" ]]; then
   echo "This appears to be a Travis pull request integration run; checking out '$TRAVIS_BRANCH' for the comparison."
-  git stash
   git checkout "$TRAVIS_BRANCH"
 elif [[ -n "$TRAVIS_COMMIT_RANGE" ]]; then
   prev=${TRAVIS_COMMIT_RANGE%%.*}~1
@@ -36,7 +38,6 @@ elif [[ "${GIT_BRANCH}" == "master" && "${GIT_DETACHED}" == "FALSE" ]]; then
   git checkout HEAD~1
 else
   echo "You appear to be on branch ${GIT_BRANCH}. Checking out branch master for the comparison"
-  git stash
   git checkout master
 fi
 


### PR DESCRIPTION
Apparently the negation operator does not result in the logic I would have thought it does, which would be to evaluate the body if the return value is non-zero. I also had to make all of the git checkout calls in the `ci-regression.sh` script call git stash first because git wants to complain about us calling `chmod +x` on some of the shell scripts during the install phase.
https://travis-ci.org/enigma-dev/enigma-dev/jobs/401940294#L2149