### PR TITLE
Continuous Integration Workdir/Codegen Fix

### DIFF
--- a/CommandLine/testing/Platform/TestHarness-X11.cpp
+++ b/CommandLine/testing/Platform/TestHarness-X11.cpp
@@ -175,9 +175,9 @@ int build_game(const string &game, TestConfig* tc, const string &out) {
   using TC = TestConfig;
   string emake_cmd = "./emake";
   tc->workdir = (tc->workdir.empty() ? std::string(env_workdir) : tc->workdir);
-  string workdir = (tc->workdir.empty() ? std::string() : ("--workdir=" + workdir));
+  string workdir = (tc->workdir.empty() ? std::string() : ("--workdir=" + tc->workdir));
   tc->codegen = (tc->codegen.empty() ? std::string(env_codegen) : tc->codegen);
-  string codegen = (tc->codegen.empty() ? std::string() : ("--codegen=" + codegen));
+  string codegen = (tc->codegen.empty() ? std::string() : ("--codegen=" + tc->codegen));
   string compiler = "--compiler=" + tc->get_or(&TC::compiler, "TestHarness");
   string mode = "--mode=" + tc->get_or(&TC::mode, "Debug");
   string graphics = "--graphics=" + tc->get_or(&TC::graphics, "OpenGL1");


### PR DESCRIPTION
Alright, I made a slight mistake in #1310 and this pull request fixes it.

I noticed it on the integration build:
https://travis-ci.org/enigma-dev/enigma-dev/jobs/403311028#L7196
```
`WORKDIR=/home/travis/build/enigma-dev/enigma-dev/--workdir=/`
```

I just forgot to prefix the right-most argument to the ternary assignment of local workdir with `tc->`, since I obviously don't want to initialize the local `workdir` to its uninitialized self.