### PR TITLE
Travis range commit parent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,7 +189,7 @@ script:
       xfwm4 &
       export ASAN_OPTIONS=detect_leaks=0;
       if ! ./test-runner ; then
-        if [ -f "/tmp/enigma_draw_diff.png" ]; then
+        if [ -f "/tmp/enigma_draw_diff.png" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
           ./CommandLine/testing/GitHub-ImageDiff.sh
         fi
         travis_terminate 1

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -27,7 +27,7 @@ if [[ -n "$TRAVIS_PULL_REQUEST_SHA" ]] && [[ -n "$TRAVIS_BRANCH" ]]; then
   git stash
   git checkout "$TRAVIS_BRANCH"
 elif [[ -n "$TRAVIS_COMMIT_RANGE" ]]; then
-  prev=${TRAVIS_COMMIT_RANGE%%.*}~1
+  prev=${TRAVIS_COMMIT_RANGE%%.*}
   echo "This appears to be a Travis push integration run; checking out '$prev' for the comparison."
   git checkout "$prev"
 elif [[ "${GIT_BRANCH}" == "master" && "${GIT_DETACHED}" == "FALSE" ]]; then


### PR DESCRIPTION
As I discovered in #1314, the first commit in TRAVIS_COMMIT_RANGE is actually the parent of the first commit in the range of the pull request/push/merge commit in all the various scenarios. This means we can just use the first commit in range directly, since it already is the parent. I also changed the Travis script to not have the bot make a comment when TRAVIS_PULL_REQUEST is "false" since I use that variable to form the URL, and without it the build will fail otherwise.