### PR TITLE
Fix Code Coverage For Regression Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,9 +195,7 @@ script:
         travis_terminate 1
       fi
       # upload coverage report for regression tests
-      bash <(curl -s https://codecov.io/bash) -f "*.info" -s "/tmp/enigma-master"
-      # upload coverage report for normal tests
-      bash <(curl -s https://codecov.io/bash) -f "*.info"
+      bash <(curl -s https://codecov.io/bash) -f "*.info" -s . -s "/tmp/enigma-master"
     else
       ./ci-build.sh
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,9 +189,6 @@ script:
       xfwm4 &
       export ASAN_OPTIONS=detect_leaks=0;
       if ! ./test-runner ; then
-        if [ -f "/tmp/enigma_draw_diff.png" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-          ./CommandLine/testing/GitHub-ImageDiff.sh
-        fi
         travis_terminate 1
       fi
       # upload coverage report for regression tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,10 @@ script:
         fi
         travis_terminate 1
       fi
+      # upload coverage report for regression tests
       bash <(curl -s https://codecov.io/bash) -f "*.info" -s "/tmp/enigma-master"
+      # upload coverage report for normal tests
+      bash <(curl -s https://codecov.io/bash) -f "*.info"
     else
       ./ci-build.sh
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,7 @@ script:
         fi
         travis_terminate 1
       fi
-      bash <(curl -s https://codecov.io/bash) -f "*.info"
+      bash <(curl -s https://codecov.io/bash) -f "*.info" -s "/tmp/enigma-master"
     else
       ./ci-build.sh
     fi

--- a/CommandLine/testing/main.cpp
+++ b/CommandLine/testing/main.cpp
@@ -8,10 +8,9 @@ std::string gitMasterDir = "/tmp/enigma-master";
 
 int main(int argc, char **argv) {
   if (argc == 1) {
-    int ret = system(("bash ./ci-regression.sh " + gitMasterDir).c_str());
-    if (ret != 0) {
-      std::cerr << "Error: ci-regression.sh returned non-zero " << ret << std::endl;
-      return 1;
+    int regression = system(("bash ./ci-regression.sh " + gitMasterDir).c_str());
+    if (regression != 0) {
+      std::cerr << "Error: ci-regression.sh returned non-zero " << regression << std::endl;
     }
 
     // have the regular tests output to a different directory now to avoid
@@ -21,10 +20,17 @@ int main(int argc, char **argv) {
 
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::GTEST_FLAG(filter) = "-RegressionCompare.*";
-    ret = RUN_ALL_TESTS();
+    int ret = RUN_ALL_TESTS();
     if (ret) return ret; // non-zero = error condition
-    ::testing::GTEST_FLAG(filter) = "RegressionCompare.*";
-    return RUN_ALL_TESTS();
+    // if there wasn't an error with the earlier regression tests
+    // we can now run a comparison for the regression tests
+    if (!regression) {
+      ::testing::GTEST_FLAG(filter) = "RegressionCompare.*";
+      ret = RUN_ALL_TESTS();
+      if (ret && strcmp(getenv("TRAVIS_PULL_REQUEST"), "false") != 0)
+        system("bash ./CommandLine/testing/GitHub-ImageDiff.sh");
+    }
+    return ret;
   }
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -43,7 +43,5 @@ fi
 make all
 # run only the regression tests now
 ./test-runner --gtest_filter=Regression.draw_test
-# upload coverage reports from regression tests before we pop the directory
-bash <(curl -s https://codecov.io/bash) -f "*.info"
 
 popd

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -39,7 +39,11 @@ else
   git checkout master
 fi
 
-make all #rebuild emake and plugin incase we changed something there
+# rebuild emake and plugin in case we changed something there
+make all
+# run only the regression tests now
 ./test-runner --gtest_filter=Regression.draw_test
+# upload coverage reports from regression tests before we pop the directory
+bash <(curl -s https://codecov.io/bash) -f "*.info"
 
 popd


### PR DESCRIPTION
I am attempting to fix the 6% code coverage issue that started in #1313 or #1310.

We can see that the issue is caused by uploading only 10 code coverage reports when we are running 11 tests in total. This is the result of the fact that we only upload code coverage reports in the main yaml after the first instance of the test harness returns (which doesn't look in the regression tests directory at all for `*.info` files).
https://travis-ci.org/enigma-dev/enigma-dev/jobs/404073149#L7628