### PR TITLE
Array Tests & Improvements

### DIFF
--- a/CommandLine/testing/SimpleTests/math_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/math_test.sog/create.edl
@@ -221,7 +221,7 @@ gtest_assert_eq(array_length_2d(user_array_2d, 4), 3);
 gtest_assert_eq(array_height_2d(user_array_2d), 5);
 for (i = 0; i < 5; i += 1) {
   for (j = 0; j < 3; j += 1) {
-    gtest_assert_eq(user_array_2d[i][j], 256);
+    gtest_assert_eq(user_array_2d[i,j], 256);
   }
 }
 

--- a/CommandLine/testing/SimpleTests/math_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/math_test.sog/create.edl
@@ -185,6 +185,46 @@ gtest_assert_true(point_in_rectangle(-2, -2, -3, -3, -1, -1));
 gtest_assert_true(point_in_rectangle(-3, -3, -3, -3, -1, -1));
 gtest_assert_false(point_in_rectangle(-4, -4, -3, -3, -1, -1));
 
+// Simple array function tests
+var user_array = array_create(5, 555);
+gtest_assert_true(is_array(user_array));
+for (i = 0; i < 5; i += 1) {
+  gtest_assert_eq(user_array[i], 555);
+}
+var user_array_smaller = array_create(3, 555);
+gtest_assert_eq(array_length_1d(user_array_smaller), 3);
+gtest_assert_false(array_equals(user_array, user_array_smaller));
+var user_array_larger = array_create(7, 555);
+gtest_assert_eq(array_length_1d(user_array_larger), 7);
+gtest_assert_false(array_equals(user_array, user_array_larger));
+var user_array_same = array_create(5, 555);
+gtest_assert_eq(array_length_1d(user_array_same), 5);
+gtest_assert_true(array_equals(user_array, user_array_same));
+var user_array_copy = array_create(3, 24);
+var user_array_copy2 = array_create(7, 347);
+array_copy(user_array_same, 0, user_array_copy, 0, 3);
+array_copy(user_array_same, 3, user_array_copy2, 6, 1);
+gtest_assert_eq(user_array_same[0], 24);
+gtest_assert_eq(user_array_same[1], 24);
+gtest_assert_eq(user_array_same[2], 24);
+gtest_assert_eq(user_array_same[3], 347);
+gtest_assert_eq(user_array_same[4], 555);
+
+// Simple 2D array tests
+var user_array_2d = array_create_2d(3, 5, 256);
+gtest_assert_true(is_array(user_array_2d));
+gtest_assert_eq(array_length_2d(user_array_2d, 0), 3);
+gtest_assert_eq(array_length_2d(user_array_2d, 1), 3);
+gtest_assert_eq(array_length_2d(user_array_2d, 2), 3);
+gtest_assert_eq(array_length_2d(user_array_2d, 3), 3);
+gtest_assert_eq(array_length_2d(user_array_2d, 4), 3);
+gtest_assert_eq(array_height_2d(user_array_2d), 5);
+for (i = 0; i < 5; i += 1) {
+  for (j = 0; j < 7; j += 1) {
+    gtest_assert_eq(user_array_2d[i][j], 256);
+  }
+}
+
 // These are common variable names that happen to conflict with Bessel functions.
 j0 = 1;
 y0 = 2;

--- a/CommandLine/testing/SimpleTests/math_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/math_test.sog/create.edl
@@ -220,7 +220,7 @@ gtest_assert_eq(array_length_2d(user_array_2d, 3), 3);
 gtest_assert_eq(array_length_2d(user_array_2d, 4), 3);
 gtest_assert_eq(array_height_2d(user_array_2d), 5);
 for (i = 0; i < 5; i += 1) {
-  for (j = 0; j < 7; j += 1) {
+  for (j = 0; j < 3; j += 1) {
     gtest_assert_eq(user_array_2d[i][j], 256);
   }
 }

--- a/ENIGMAsystem/SHELL/Universal_System/var4.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.cpp
@@ -269,7 +269,7 @@ var::var(variant x, size_t length, size_t length2) : values(NULL) {
   initialize();
   for (size_t j = 0; j < length2; ++j) {
     for (size_t i = 0; i < length; ++i) {
-      (*this)(i, j) = x; 
+      (*this)(j, i) = x; 
     }
   }
 }

--- a/ENIGMAsystem/SHELL/Universal_System/var4.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.cpp
@@ -265,7 +265,6 @@ var::operator const variant&() const { return **this; }
 
 var::var() : values(NULL) { initialize(); }
 var::var(variant x) : values(NULL) { initialize(); **this = x; }
-//TODO: Overload var for std::array
 var::var(variant x, size_t length, size_t length2) : values(NULL) {
   initialize();
   for (size_t j = 0; j < length2; ++j) {

--- a/ENIGMAsystem/SHELL/Universal_System/var4.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.cpp
@@ -265,9 +265,9 @@ var::operator const variant&() const { return **this; }
 
 var::var() : values(NULL) { initialize(); }
 var::var(variant x) : values(NULL) { initialize(); **this = x; }
-var::var(variant x, size_t length, size_t length2) : values(NULL) {
+var::var(variant x, size_t length, size_t height) : values(NULL) {
   initialize();
-  for (size_t j = 0; j < length2; ++j) {
+  for (size_t j = 0; j < height; ++j) {
     for (size_t i = 0; i < length; ++i) {
       (*this)(j, i) = x; 
     }

--- a/ENIGMAsystem/SHELL/Universal_System/var4.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.h
@@ -209,7 +209,7 @@ struct var
   
   var();
   var(const var&);
-  var(variant value, size_t length, size_t length2 = 1);
+  var(variant value, size_t length, size_t height = 1);
   types_extrapolate_alldec(var)
   
   types_extrapolate_alldec(variant& operator=)

--- a/ENIGMAsystem/SHELL/Universal_System/var4.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.h
@@ -209,7 +209,6 @@ struct var
   
   var();
   var(const var&);
-  //TODO: Overload var for std::array
   var(variant value, size_t length, size_t length2 = 1);
   types_extrapolate_alldec(var)
   

--- a/ENIGMAsystem/SHELL/Universal_System/var_array.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var_array.cpp
@@ -30,6 +30,20 @@
 
 namespace enigma_user {
 
+var array_create(size_t size, variant value) { return var(value, size); }
+var array_create_2d(size_t length, size_t height, variant value) { return var(value, length, height); }
+bool array_equals(const var& arr1, const var& arr2) {
+  if (arr1.array_len() != arr2.array_len()) return false;
+  for (size_t i = 0; i < arr1.array_len(); i++) {
+    if (arr1[i] != arr2[i]) return false;
+  }
+  return true;
+}
+void array_copy(var& dest, size_t dest_index, var& src, size_t src_index, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    dest[dest_index + i] = src[src_index + i];
+  }
+}
 int array_length_1d(const var& v) { return v.array_len(); }
 int array_length_2d(const var& v, int n) { return v.array_len(n); }
 int array_height_2d(const var& v) { return v.array_height(); }

--- a/ENIGMAsystem/SHELL/Universal_System/var_array.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var_array.h
@@ -31,6 +31,10 @@
 #include "var4.h"
 
 namespace enigma_user {
+var array_create(size_t size, variant value=0);
+var array_create_2d(size_t length, size_t height, variant value=0);
+bool array_equals(const var& arr1, const var& arr2);
+void array_copy(var& dest, size_t dest_index, var& src, size_t src_index, size_t length);
 int array_length_1d(const var& v);
 int array_length_2d(const var& v, int n);
 int array_height_2d(const var& v);


### PR DESCRIPTION
Ok, a couple of changes here to address #1331 as well as add other functions I think are useful.

* Added `array_equals` from GMS
https://docs2.yoyogames.com/source/_build/3_scripting/3_gml_overview/arrays/array_equals.html
* Added `array_copy` from GMS
https://docs2.yoyogames.com/source/_build/3_scripting/3_gml_overview/arrays/array_copy.html
* Added `array_create` from GMS
https://docs2.yoyogames.com/source/_build/3_scripting/3_gml_overview/arrays/array_create.html
* Added `array_create_2d(length, height, value)` that is unique to ENIGMA
* Removed old comments about overloading `std::array` that I added since they are no longer relevant.
* Fixed the 2d var array constructor that I apparently never noticed was initializing backwards. It caused `array_create` not to work right after I added it.
* Renamed the `length2` parameter I added a while ago on the var array constructor to `height` for clarity.
* Added a regression test for all of the array functions we currently have implemented, which happens to include all of the ones GMS has currently too.
