### PR TITLE
Remove Room Caption/Mouse Update From Bridges

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
@@ -46,8 +46,6 @@ namespace enigma {
   }
 }
 
-#include "Universal_System/roomsystem.h" // update_mouse_variables
-
 namespace enigma_user {
   // Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
   int display_aa = 14;
@@ -63,7 +61,6 @@ namespace enigma_user {
 
   void screen_refresh() {
     cocoa_screen_refresh();
-    enigma::update_mouse_variables();
     cocoa_flush_opengl();
   }
 

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
@@ -18,7 +18,6 @@
 #include <GL/glxew.h>
 #include "Platforms/Cocoa/CocoaMain.h"
 #include "Graphics_Systems/graphics_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
 
 #include <iostream>
@@ -33,7 +32,7 @@ extern "C" {
 
 namespace enigma {
   GLuint msaa_fbo = 0;
-  
+
   extern void (*WindowResizedCallback)();
   void WindowResized() {
     // clear the window color, viewport does not need set because backbuffer was just recreated
@@ -47,8 +46,7 @@ namespace enigma {
   }
 }
 
-#include "Platforms/General/PFwindow.h" // window_set_caption
-#include "Universal_System/roomsystem.h" // room_caption, update_mouse_variables
+#include "Universal_System/roomsystem.h" // update_mouse_variables
 
 namespace enigma_user {
   // Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
@@ -57,12 +55,12 @@ namespace enigma_user {
   void set_synchronization(bool enable) {
 
   }
-    
+
   void display_reset(int samples, bool vsync) {
     set_synchronization(vsync);
     //TODO: Copy over from the Win32 bridge
   }
-    
+
   void screen_refresh() {
     cocoa_screen_refresh();
     enigma::update_mouse_variables();
@@ -70,4 +68,3 @@ namespace enigma_user {
   }
 
 }
-

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
@@ -46,8 +46,6 @@ namespace enigma {
   }
 }
 
-#include "Universal_System/roomsystem.h" // update_mouse_variables
-
 namespace enigma_user {
   // Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
   int display_aa = 14;
@@ -63,7 +61,6 @@ namespace enigma_user {
 
   void screen_refresh() {
     cocoa_screen_refresh();
-    enigma::update_mouse_variables();
     cocoa_flush_opengl();
   }
 

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
@@ -18,7 +18,6 @@
 #include <GL/glxew.h>
 #include "Platforms/Cocoa/CocoaMain.h"
 #include "Graphics_Systems/graphics_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
 
 #include <iostream>
@@ -33,7 +32,7 @@ extern "C" {
 
 namespace enigma {
   GLuint msaa_fbo = 0;
-  
+
   extern void (*WindowResizedCallback)();
   void WindowResized() {
     // clear the window color, viewport does not need set because backbuffer was just recreated
@@ -47,8 +46,7 @@ namespace enigma {
   }
 }
 
-#include "Platforms/General/PFwindow.h" // window_set_caption
-#include "Universal_System/roomsystem.h" // room_caption, update_mouse_variables
+#include "Universal_System/roomsystem.h" // update_mouse_variables
 
 namespace enigma_user {
   // Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
@@ -57,12 +55,12 @@ namespace enigma_user {
   void set_synchronization(bool enable) {
 
   }
-    
+
   void display_reset(int samples, bool vsync) {
     set_synchronization(vsync);
     //TODO: Copy over from the Win32 bridge
   }
-    
+
   void screen_refresh() {
     cocoa_screen_refresh();
     enigma::update_mouse_variables();
@@ -70,4 +68,3 @@ namespace enigma_user {
   }
 
 }
-

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -19,7 +19,6 @@
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/platforms_mandatory.h"
 #include "Platforms/General/PFwindow.h"
-#include "Universal_System/roomsystem.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Bridges/General/DX11Context.h"
 #include "Graphics_Systems/General/GScolors.h"
@@ -203,8 +202,6 @@ namespace enigma
 
 }
 
-#include "Universal_System/roomsystem.h"
-
 namespace enigma_user
 {
   int display_aa = 0;
@@ -214,7 +211,6 @@ namespace enigma_user
   }
 
   void screen_refresh() {
-    enigma::update_mouse_variables();
     m_swapChain->Present(0, 0);
   }
 

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -17,8 +17,8 @@
 
 #include "libEGMstd.h"
 #include "Widget_Systems/widgets_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Platforms/platforms_mandatory.h"
+#include "Platforms/General/PFwindow.h"
 #include "Universal_System/roomsystem.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Bridges/General/DX11Context.h"
@@ -214,7 +214,6 @@ namespace enigma_user
   }
 
   void screen_refresh() {
-    window_set_caption(room_caption);
     enigma::update_mouse_variables();
     m_swapChain->Present(0, 0);
   }

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -19,7 +19,6 @@
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/platforms_mandatory.h"
 #include "Platforms/General/PFwindow.h"
-#include "Universal_System/roomsystem.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/Direct3D9/DX9SurfaceStruct.h"
 #include "Bridges/General/DX9Context.h"
@@ -134,8 +133,6 @@ namespace enigma
   }
 }
 
-#include "Universal_System/roomsystem.h"
-
 namespace enigma_user
 {
 int display_aa = 0;
@@ -166,7 +163,6 @@ void display_reset(int samples, bool vsync) {
 }
 
 void screen_refresh() {
-  enigma::update_mouse_variables();
   d3dmgr->Present(NULL, NULL, NULL, NULL);
 }
 

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -17,8 +17,8 @@
 
 #include "libEGMstd.h"
 #include "Widget_Systems/widgets_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Platforms/platforms_mandatory.h"
+#include "Platforms/General/PFwindow.h"
 #include "Universal_System/roomsystem.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/Direct3D9/DX9SurfaceStruct.h"
@@ -166,7 +166,6 @@ void display_reset(int samples, bool vsync) {
 }
 
 void screen_refresh() {
-  window_set_caption(room_caption);
   enigma::update_mouse_variables();
   d3dmgr->Present(NULL, NULL, NULL, NULL);
 }

--- a/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <cstring>
 #include <stdio.h>
-#include <Universal_System/roomsystem.h> // update_mouse_variables
 
 namespace enigma_user {
   int display_aa = 14;

--- a/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
@@ -15,21 +15,19 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 #include "Graphics_Systems/graphics_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
 
 #include <iostream>
 #include <cstring>
 #include <stdio.h>
-#include <Universal_System/roomsystem.h> // room_caption, update_mouse_variables
+#include <Universal_System/roomsystem.h> // update_mouse_variables
 
 namespace enigma_user {
   int display_aa = 14;
 
   void set_synchronization(bool enable){}
-    
+
   void display_reset(int samples, bool vsync){}
-    
+
   void screen_refresh(){}
 }
-

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -18,10 +18,9 @@
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GScolors.h"
 
-#include "Platforms/General/PFwindow.h"
 #include "Platforms/SDL/Window.h"
 
-#include "Universal_System/roomsystem.h" // room_caption, update_mouse_variables
+#include "Universal_System/roomsystem.h" // update_mouse_variables
 
 #include <SDL2/SDL.h>
 
@@ -65,16 +64,14 @@ namespace enigma_user {
   void set_synchronization(bool enable) {
     SDL_GL_SetSwapInterval(enable);
   }
-    
+
   void display_reset(int samples, bool vsync) {
     set_synchronization(vsync);
   }
-    
+
   void screen_refresh() {
     SDL_GL_SwapWindow(enigma::windowHandle);
-    window_set_caption(room_caption);
     enigma::update_mouse_variables();
   }
 
 }
-

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -20,8 +20,6 @@
 
 #include "Platforms/SDL/Window.h"
 
-#include "Universal_System/roomsystem.h" // update_mouse_variables
-
 #include <SDL2/SDL.h>
 
 #include <iostream>
@@ -71,7 +69,6 @@ namespace enigma_user {
 
   void screen_refresh() {
     SDL_GL_SwapWindow(enigma::windowHandle);
-    enigma::update_mouse_variables();
   }
 
 }

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
@@ -57,8 +57,6 @@ bool is_ext_swapcontrol_supported() {
 
 }
 
-#include "Universal_System/roomsystem.h"
-
 namespace enigma_user {
 
 int display_aa = 0;
@@ -105,7 +103,6 @@ void display_reset(int samples, bool vsync) {
 }
 
 void screen_refresh() {
-  enigma::update_mouse_variables();
   SwapBuffers(enigma::window_hDC);
 }
 

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
@@ -105,7 +105,6 @@ void display_reset(int samples, bool vsync) {
 }
 
 void screen_refresh() {
-  window_set_caption(room_caption);
   enigma::update_mouse_variables();
   SwapBuffers(enigma::window_hDC);
 }

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -118,8 +118,6 @@ namespace enigma {
   }
 }
 
-#include <Universal_System/roomsystem.h> // update_mouse_variables
-
 namespace enigma_user {
   // Don't know where to query this on XLIB, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
   int display_aa = 14;
@@ -161,7 +159,6 @@ namespace enigma_user {
 
   void screen_refresh() {
     glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
-    enigma::update_mouse_variables();
   }
 
 }

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -19,7 +19,6 @@
 #include <GL/glxew.h>
 #include "Platforms/xlib/XLIBwindow.h"
 #include "Graphics_Systems/graphics_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/General/GScolors.h"
 
 #include <iostream>
@@ -32,14 +31,14 @@ namespace enigma {
   GLuint msaa_fbo = 0;
   GLXContext glxc;
   XVisualInfo *vi;
-  
+
   extern void (*WindowResizedCallback)();
   void WindowResized() {
     glViewport(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
     glScissor(0,0,enigma_user::window_get_width(),enigma_user::window_get_height());
     enigma_user::draw_clear(enigma_user::window_get_color());
   }
-  
+
   XVisualInfo* CreateVisualInfo() {
     // Prepare openGL
     GLint att[] = { GLX_RGBA, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, None };
@@ -53,18 +52,18 @@ namespace enigma {
 
   void EnableDrawing(void* handle) {
     WindowResizedCallback = &WindowResized;
-    
+
     //give us a GL context
     glxc = glXCreateContext(enigma::x11::disp, vi, NULL, True);
     if (!glxc){
         printf("Failed to Create Graphics Context\n");
         return;
     }
-    
+
     //apply context
     glXMakeCurrent(enigma::x11::disp,enigma::x11::win,glxc); //flushes
     glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_ACCUM_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
-    
+
     #ifdef DEBUG_MODE
     GLenum err = glewInit();
     if (GLEW_OK != err)
@@ -75,7 +74,7 @@ namespace enigma {
     glewInit();
     #endif
   }
-  
+
   void DisableDrawing(void* handle) {
    glXDestroyContext(enigma::x11::disp,glxc);
       /*
@@ -87,7 +86,7 @@ namespace enigma {
     XCloseDisplay(disp);
     return 0;*/
   }
-  
+
   namespace swaphandling {
     static bool has_checked_extensions = false;
     static bool ext_swapcontrol_supported;
@@ -119,8 +118,7 @@ namespace enigma {
   }
 }
 
-#include <Platforms/xlib/XLIBwindow.h> // window_set_caption
-#include <Universal_System/roomsystem.h> // room_caption, update_mouse_variables
+#include <Universal_System/roomsystem.h> // update_mouse_variables
 
 namespace enigma_user {
   // Don't know where to query this on XLIB, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
@@ -155,16 +153,15 @@ namespace enigma_user {
       // See http://www.opengl.org/registry/specs/SGI/swap_control.txt for more information.
     }
   }
-    
+
   void display_reset(int samples, bool vsync) {
     set_synchronization(vsync);
     //TODO: Copy over from the Win32 bridge
   }
-    
+
   void screen_refresh() {
     glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
     enigma::update_mouse_variables();
-    window_set_caption(room_caption);
   }
 
 }

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -69,7 +69,8 @@ int enigma_main(int argc, char** argv) {
   showWindow();
 
   while (!game_isending) {
-    enigma_user::window_set_caption(enigma_user::room_caption);
+    if (!((std::string)enigma_user::room_caption).empty())
+      enigma_user::window_set_caption(enigma_user::room_caption);
     update_mouse_variables();
 
     if (updateTimer() != 0) continue;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -1,6 +1,8 @@
 #include "PFmain.h"
 
 #include "Platforms/platforms_mandatory.h"
+#include "Platforms/General/PFwindow.h"
+#include "Universal_System/roomsystem.h"
 
 #include <unistd.h>  //getcwd, usleep
 
@@ -67,6 +69,9 @@ int enigma_main(int argc, char** argv) {
   showWindow();
 
   while (!game_isending) {
+    enigma_user::window_set_caption(enigma_user::room_caption);
+    update_mouse_variables();
+
     if (updateTimer() != 0) continue;
     if (handleEvents() != 0) break;
     if (gameWait() != 0) continue;


### PR DESCRIPTION
As I described in #1336 this has been a while coming too. I first removed all traces of `room_caption`, `window_set_caption`, and `update_mouse_variables` from all bridges. Then I added them both to the generic `main()` and the caption seems to continue behaving as it always did.

I tested, specifically, the game of life example, which required the mouse update be added to `main()` as well, that's how I knew it was still required. Without that the game was not recognizing any mouse clicks.
![Game Of Life Consistent Mouse/Caption](https://user-images.githubusercontent.com/3212801/43317523-1c7b1a76-916b-11e8-87a1-39f08bca986b.png)
