### PR TITLE
Use General Include for None Graphics System

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/include.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/include.h
@@ -1,15 +1,3 @@
 #include "NONEStd.h"
 #include "Info/graphics_info.h"
-#include "../General/GSsprite.h"
-#include "../General/GSbackground.h"
-#include "../General/GStextures.h"
-#include "../General/GStiles.h"
-#include "../General/GSmodel.h"
-#include "../General/GSmatrix.h"
-
-#include "../General/GSfont.h"
-#include "../General/GScurves.h"
-#ifdef TARGET_OS_MAC
-#include "../General/GSsurface.h"
-#endif
-#include "../General/actions.h"
+#include "Graphics_Systems/General/include.h"


### PR DESCRIPTION
I'm silly, I know. I forgot about the `None` graphics system in #1333 when making a single general include header and this pr fixes it.