### PR TITLE
XLIB Resizeable Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -276,10 +276,8 @@ void window_set_sizeable(bool sizeable) {
   enigma::isSizeable = sizeable;
 
   XSizeHints hints;
-  hints.min_width = 640;
-  hints.min_height = 480;
-  hints.max_width = 641;
-  hints.max_height = 481;
+  hints.min_width = hints.max_width = (sizeable ? 0 : window_get_width());
+  hints.min_height = hints.max_height = (sizeable ? 0 : window_get_height());
   XSetWMNormalHints(disp, win, &hints);
 }
 


### PR DESCRIPTION
Ok, so this function _never_ worked on xlib, and I first tried to add it in 4c735ab6ac5a128467f485d1342190d2fb7ab7e1, but obviously never tested it. The issue was recently reported in #1334 and I'd like to get it fixed since it does work on SDL/Win32, but the user is on Linux and also has an issue with SDL because of #1340.

Apparently the way to disable resizing in XLIB is to set the min/max size hints of the window equal to each other, in this case I set them both to the dimensions of the window. It's not clear to me, and I could find no information pertaining to it on the web, whether setting the min/max to 0 will allow the window to be resizeable again or not. If not, then enabling the sizeable property of the window should be fixed if somebody can figure it out.


