### PR TITLE
Array Copy Protection

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/var_array.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var_array.cpp
@@ -39,7 +39,7 @@ bool array_equals(const var& arr1, const var& arr2) {
   }
   return true;
 }
-void array_copy(var& dest, size_t dest_index, var& src, size_t src_index, size_t length) {
+void array_copy(var& dest, size_t dest_index, const var& src, size_t src_index, size_t length) {
   for (size_t i = 0; i < length; i++) {
     dest[dest_index + i] = src[src_index + i];
   }

--- a/ENIGMAsystem/SHELL/Universal_System/var_array.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var_array.h
@@ -34,7 +34,7 @@ namespace enigma_user {
 var array_create(size_t size, variant value=0);
 var array_create_2d(size_t length, size_t height, variant value=0);
 bool array_equals(const var& arr1, const var& arr2);
-void array_copy(var& dest, size_t dest_index, var& src, size_t src_index, size_t length);
+void array_copy(var& dest, size_t dest_index, const var& src, size_t src_index, size_t length);
 int array_length_1d(const var& v);
 int array_length_2d(const var& v, int n);
 int array_height_2d(const var& v);


### PR DESCRIPTION
Simple change here, when I did #1335, I should have made the source array a const reference since it is not mutated. This is more similar to C++ conventions like `strcpy`.
http://www.cplusplus.com/reference/cstring/strcpy/