### PR TITLE
Fix Threading Issues In libEGM for GMK

### DIFF
--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -52,7 +52,6 @@ std::string writeTempDataFile(char *bytes, size_t length) {
   char temp[] = "gmk_data.XXXXXX";
   int fd = mkstemp(temp);
   if (fd == -1) return "";
-  tempFilesCreated.push_back(temp);
   write(fd, bytes, length);
   close(fd);
   return temp;
@@ -186,7 +185,9 @@ class Decoder {
 
   void processTempFileFutures() {
     for (auto &tempFilePair : tempFileFuturesCreated) {
-      tempFilePair.second->append(tempFilePair.first.get());
+      std::string temp_file_path = tempFilePair.first.get();
+      tempFilePair.second->append(temp_file_path);
+      tempFilesCreated.push_back(temp_file_path);
     }
   }
 


### PR DESCRIPTION
This should fix the emake/gmk issues fundies has been complaining about. This changes it to not modify the global vector I use as a list of all temp files I created from the std::async thread used to write the temp file. Instead, I add the temp file to the vector when I go to process all of the futures to ensure the proto has all paths set before returning the loaded project. The temp files are still only cleaned up when the process exits of course, but this should make it even possible to load two GMKs at the same time.