### PR TITLE
Emake Default Workdir Fix for Windows

### DIFF
--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -79,7 +79,7 @@ OptionsParser::OptionsParser() : _desc("Options")
   std::string def_platform, def_workdir, def_compiler;
   #if CURRENT_PLATFORM_ID == OS_WINDOWS
     def_platform = "Win32";
-    def_workdir = "%LOCALAPPDATA%/ENIGMA/";
+    def_workdir = std::string(getenv("LOCALAPPDATA")) + "/ENIGMA/";
     def_compiler = "gcc";
   #elif CURRENT_PLATFORM_ID ==  OS_MACOSX
     def_platform = "Cocoa";


### PR DESCRIPTION
This one has really been getting on my nerves, I know we still need settings support, but I need this fixed for now. It has caused me to screw up a commit a couple of times now by having all the codegen stuff in my ENIGMA clone. I simply use `getenv` to expand `LOCALAPPDATA` which is the same place LGM defaults to.