### PR TITLE
Screen Initialization Cleanup

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
@@ -52,7 +52,7 @@ void draw_set_msaa_enabled(bool enable)
 
 }
 
-void draw_enable_alphablend(bool enable) {
+void draw_set_blend(bool enable) {
 
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -47,31 +47,6 @@ void scene_end() {
 namespace enigma_user
 {
 
-void screen_init()
-{
-  enigma::gui_width = window_get_region_width();
-  enigma::gui_height = window_get_region_height();
-
-  m_deviceContext->ClearDepthStencilView(m_depthStencilView, D3D11_CLEAR_DEPTH, 1.0f, 0);
-
-  if (!view_enabled)
-  {
-    screen_set_viewport(0, 0, window_get_region_width(), window_get_region_height());
-    d3d_set_projection_ortho(0, 0, window_get_region_width(), window_get_region_height(), 0);
-  } else {
-    for (view_current = 0; view_current < 7; view_current++) {
-      if (view_visible[(int)view_current]) {
-        int vc = (int)view_current;
-
-        screen_set_viewport(view_xport[vc], view_yport[vc],
-          (window_get_region_width_scaled() - view_xport[vc]), (window_get_region_height_scaled() - view_yport[vc]));
-        d3d_set_projection_ortho(view_xview[vc], view_wview[vc] + view_xview[vc], view_yview[vc], view_hview[vc] + view_yview[vc], view_angle[vc]);
-        break;
-      }
-    }
-  }
-}
-
 int screen_save(string filename) //Assumes native integers are little endian
 {
 
@@ -100,12 +75,6 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   viewport.MaxDepth = 1.0f;
 
   m_deviceContext->RSSetViewports(1, &viewport);
-}
-
-//TODO: These need to be in some kind of General
-void display_set_gui_size(unsigned int width, unsigned int height) {
-  enigma::gui_width = width;
-  enigma::gui_height = height;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -16,20 +16,17 @@
 **/
 
 #include "Bridges/General/DX11Context.h"
-#include "Direct3D11Headers.h"
 #include "Graphics_Systems/General/GSscreen.h"
-#include "Graphics_Systems/General/GSmatrix.h"
-#include "Graphics_Systems/General/GStextures.h"
-#include "Graphics_Systems/General/GScolors.h"
+#include "Direct3D11Headers.h"
 
 #include "Universal_System/roomsystem.h"
 #include "Platforms/General/PFwindow.h"
 
 #include <string>
-#include <cstdio>
 
 using namespace enigma;
-using namespace std;
+
+using std::string;
 
 namespace enigma
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -84,7 +84,6 @@ void d3d_set_software_vertex_processing(bool software) {
 
 void d3d_set_hidden(bool enable)
 {
-	//d3d_set_zwriteenable(enable);
 	d3dmgr->SetRenderState(D3DRS_ZENABLE, enable); // enable/disable the z-buffer
     enigma::d3dHidden = enable;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -53,7 +53,7 @@ void draw_set_msaa_enabled(bool enable)
 
 }
 
-void draw_enable_alphablend(bool enable) {
+void draw_set_blend(bool enable) {
 	d3dmgr->SetRenderState(D3DRS_ALPHABLENDENABLE, enable);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -46,46 +46,6 @@ void scene_end() {
 namespace enigma_user
 {
 
-void screen_init()
-{
-  enigma::gui_width = window_get_region_width();
-  enigma::gui_height = window_get_region_height();
-
-  d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
-  d3dmgr->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
-
-  if (!view_enabled)
-  {
-    screen_set_viewport(0, 0, window_get_region_width(), window_get_region_height());
-    d3d_set_projection_ortho(0, 0, window_get_region_width(), window_get_region_height(), 0);
-  } else {
-    for (view_current = 0; view_current < 7; view_current++) {
-      if (view_visible[(int)view_current]) {
-        int vc = (int)view_current;
-
-        screen_set_viewport(view_xport[vc], view_yport[vc],
-          (window_get_region_width_scaled() - view_xport[vc]), (window_get_region_height_scaled() - view_yport[vc]));
-        d3d_set_projection_ortho(view_xview[vc], view_wview[vc] + view_xview[vc], view_yview[vc], view_hview[vc] + view_yview[vc], view_angle[vc]);
-        break;
-      }
-    }
-  }
-
-  d3dmgr->SetRenderState(D3DRS_LIGHTING, FALSE);
-  d3dmgr->SetRenderState(D3DRS_ZENABLE, FALSE);
-  // make the same default as GL, keep in mind GM uses reverse depth ordering for ortho projections, where the higher the z value the further into the screen you are
-  // but that is currently taken care of by using 32000/-32000 for znear/zfar respectively
-  d3dmgr->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESS);
-  d3dmgr->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
-  d3dmgr->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
-  d3dmgr->SetRenderState(D3DRS_ALPHAREF, (DWORD)0x00000001);
-  d3dmgr->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
-  d3dmgr->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
-  d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
-  d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
-  draw_set_color(c_white);
-}
-
 int screen_save(string filename) //Assumes native integers are little endian
 {
 	string ext = enigma::image_get_format(filename);
@@ -153,12 +113,6 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   sy = (window_get_height() - window_get_region_height_scaled()) / 2;
 	D3DVIEWPORT9 pViewport = { sx + x, sy + y, width, height, 0, 1.0f };
 	d3dmgr->SetViewport(&pViewport);
-}
-
-//TODO: These need to be in some kind of General
-void display_set_gui_size(unsigned int width, unsigned int height) {
-	enigma::gui_width = width;
-	enigma::gui_height = height;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -16,18 +16,18 @@
 **/
 
 #include "Bridges/General/DX9Context.h"
-#include "Direct3D9Headers.h"
 #include "Graphics_Systems/General/GSscreen.h"
-#include "Graphics_Systems/General/GSmatrix.h"
-#include "Graphics_Systems/General/GScolors.h"
+#include "Direct3D9Headers.h"
 
 #include "Universal_System/image_formats.h"
 #include "Universal_System/roomsystem.h"
-
 #include "Platforms/General/PFwindow.h"
 
+#include <string>
+
 using namespace enigma;
-using namespace std;
+
+using std::string;
 
 namespace enigma
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -37,7 +37,6 @@
 #include "Graphics_Systems/graphics_mandatory.h"
 
 #include <string>
-#include <cstdio>
 #include <limits>
 
 using namespace enigma;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -252,6 +252,7 @@ void screen_init()
   // configure default rendering state
   texture_reset();
   draw_set_color(c_white);
+  draw_set_color_write_enable(true, true, true, true);
   draw_set_alpha(1.0);
   draw_set_alpha_test(false);
   draw_set_alpha_test_ref_value(0);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -214,19 +214,42 @@ unsigned int display_get_gui_height(){
   return enigma::gui_height;
 }
 
-void screen_init()
-{
+void screen_init_state() {
   // this function is for generically initializing render state that
-  // applies to all of the graphics systems
+  // applies to all of the graphics systems a SINGLE time during startup
   // if a system has state that needs initiailized that is unique to
   // that graphics system only, then it should be dealt with from
-  // graphicssystem_initialize
+  // graphicssystem_initialize during startup
+  // NOTE: DO NOT call this during room transition (GameMaker/GMS doesn't)
+
+  // configure default rendering state
+  texture_reset();
+  draw_set_color(c_white);
+  draw_set_color_write_enable(true, true, true, true);
+  draw_set_alpha(1.0);
+  draw_set_alpha_test(false);
+  draw_set_alpha_test_ref_value(0);
+  draw_set_blend(true);
+  draw_set_blend_mode(bm_normal);
+
+  // configure default 3D-related rendering state
+  d3d_set_hidden(false);
+  d3d_set_culling(false);
+  d3d_set_shading(true);
+  d3d_set_lighting(false);
+  d3d_set_zwriteenable(true);
+}
+
+void screen_init()
+{
+  // this function is for resetting the views and projection matrix
+  // during a room transition
 
   enigma::gui_width = window_get_region_width();
   enigma::gui_height = window_get_region_height();
 
   // first we clear the color and depth buffers to the window color from game settings
-  enigma_user::draw_clear(c_black);
+  enigma_user::draw_clear(window_get_color());
   enigma_user::d3d_clear_depth();
 
   if (!view_enabled)
@@ -248,23 +271,6 @@ void screen_init()
       }
     }
   }
-
-  // configure default rendering state
-  texture_reset();
-  draw_set_color(c_white);
-  draw_set_color_write_enable(true, true, true, true);
-  draw_set_alpha(1.0);
-  draw_set_alpha_test(false);
-  draw_set_alpha_test_ref_value(0);
-  draw_set_blend(true);
-  draw_set_blend_mode(bm_normal);
-
-  // configure default 3D-related rendering state
-  d3d_set_hidden(false);
-  d3d_set_culling(false);
-  d3d_set_shading(true);
-  d3d_set_lighting(false);
-  d3d_set_zwriteenable(true);
 }
 
 void screen_redraw()

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -217,6 +217,12 @@ unsigned int display_get_gui_height(){
 
 void screen_init()
 {
+  // this function is for generically initializing render state that
+  // applies to all of the graphics systems
+  // if a system has state that needs initiailized that is unique to
+  // that graphics system only, then it should be dealt with from
+  // graphicssystem_initialize
+
   enigma::gui_width = window_get_region_width();
   enigma::gui_height = window_get_region_height();
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.h
@@ -41,6 +41,7 @@ namespace enigma_user {
   void screen_redraw();
   void screen_refresh();
   void screen_init();
+  void screen_init_state();
   void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height);
 
   unsigned int display_get_gui_width();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.h
@@ -33,7 +33,7 @@ namespace enigma_user
   unsigned draw_get_alpha_test_ref_value();
   void draw_set_alpha_test(bool enable);
   void draw_set_alpha_test_ref_value(unsigned val);
-  void draw_enable_alphablend(bool enable);
+  void draw_set_blend(bool enable);
   void draw_set_line_pattern(int pattern, int scale);
   void draw_point(gs_scalar x, gs_scalar y);
   void draw_point_color(gs_scalar x, gs_scalar y, int color);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
@@ -199,7 +199,6 @@ namespace enigma_user
 	extern int window_get_region_width();
 	extern int window_get_region_height();
 
-	void screen_init(){}
 	int screen_save(string filename){return -1;}
 	int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h){return -1;}
 	void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height){}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
@@ -154,7 +154,7 @@ namespace enigma_user
 	int draw_get_msaa_maxlevel(){return 0;}
 	bool draw_get_msaa_supported(){return false;}
 	void draw_set_msaa_enabled(bool enable){}
-	void draw_enable_alphablend(bool enable){}
+	void draw_set_blend(bool enable){}
 	bool draw_get_alpha_test(){return false;}
 	unsigned draw_get_alpha_test_ref_value(){return 0;}
 	void draw_set_alpha_test(bool enable){}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
@@ -141,7 +141,6 @@ namespace enigma_user
 	int draw_get_msaa_maxlevel();
 	bool draw_get_msaa_supported();
 	void draw_set_msaa_enabled(bool enable);
-	void draw_enable_alphablend(bool enable);
 	bool draw_get_alpha_test();
 	unsigned draw_get_alpha_test_ref_value();
 	void draw_set_alpha_test(bool enable);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
@@ -175,7 +175,6 @@ namespace enigma_user
 	extern int window_get_region_height();
 
 	void screen_redraw();
-	void screen_init();
 	int screen_save(string filename);
 	int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h);
 	void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -14,26 +14,18 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
+#include "Graphics_Systems/General/GSscreen.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/OpenGLHeaders.h"
-#include "Graphics_Systems/General/GSscreen.h"
-#include "Graphics_Systems/General/GStextures.h"
-#include "Graphics_Systems/General/GSd3d.h"
-#include "Graphics_Systems/General/GSvertex.h"
-#include "Graphics_Systems/General/GSprimitives.h"
-#include "Graphics_Systems/General/GSmatrix.h"
-#include "Graphics_Systems/General/GScolors.h"
 
 #include "Universal_System/image_formats.h"
-#include "Universal_System/var4.h"
-#include "Universal_System/roomsystem.h"
 #include "Platforms/General/PFwindow.h"
 
 #include <string>
-#include <cstdio>
 
-using namespace std;
 using namespace enigma;
+
+using std::string;
 
 namespace enigma
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -55,47 +55,6 @@ void scene_end() {
 namespace enigma_user
 {
 
-void screen_init()
-{
-  enigma::gui_width = window_get_region_width();
-  enigma::gui_height = window_get_region_height();
-
-  glClearColor(0,0,0,0);
-  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-  if (!view_enabled)
-  {
-    glClearColor(0,0,0,0);
-    screen_set_viewport(0, 0, window_get_region_width(), window_get_region_height());
-    d3d_set_projection_ortho(0, 0, room_width, room_height, 0);
-  } else {
-    for (view_current = 0; view_current < 7; view_current++)
-    {
-      if (view_visible[(int)view_current])
-      {
-        int vc = (int)view_current;
-
-        glClearColor(0,0,0,0);
-
-        screen_set_viewport(view_xport[vc], view_yport[vc], view_wport[vc], view_hport[vc]);
-        d3d_set_projection_ortho(view_xview[vc], view_yview[vc], view_wview[vc], view_hview[vc], view_angle[vc]);
-        break;
-      }
-    }
-  }
-
-  glDisable(GL_DEPTH_TEST);
-  glDisable(GL_CULL_FACE);
-  glEnable(GL_BLEND);
-  glEnable(GL_SCISSOR_TEST);
-  glEnable(GL_ALPHA_TEST);
-  glEnable(GL_TEXTURE_2D);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glAlphaFunc(GL_ALWAYS,0);
-  texture_reset();
-  draw_set_color(c_white);
-}
-
 int screen_save(string filename) { //Assumes native integers are little endian
 	unsigned int w=window_get_width(),h=window_get_height(),sz=w*h;
 
@@ -149,12 +108,6 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   //NOTE: OpenGL viewports are bottom left unlike Direct3D viewports which are top left
   glViewport(viewport_x, viewport_y, viewport_w, viewport_h);
   glScissor(viewport_x, viewport_y, viewport_w, viewport_h);
-}
-
-//TODO: These need to be in some kind of General
-void display_set_gui_size(unsigned int width, unsigned int height) {
-	enigma::gui_width = width;
-	enigma::gui_height = height;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
@@ -62,7 +62,7 @@ void draw_set_msaa_enabled(bool enable)
   (enable?glEnable:glDisable)(GL_MULTISAMPLE);
 }
 
-void draw_enable_alphablend(bool enable) {
+void draw_set_blend(bool enable) {
 	(enable?glEnable:glDisable)(GL_BLEND);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -36,28 +36,11 @@ namespace enigma
   void graphicssystem_initialize()
   {
     //enigma::pbo_isgo=GL_ARB_pixel_buffer_object;
-    glMatrixMode(GL_PROJECTION);
-    glClearColor(0,0,0,0);
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-
-    using enigma_user::room_width;
-    using enigma_user::room_height;
-    glViewport(0,0,(int)room_width,(int)room_height);
-    glOrtho(-1,(int)room_width,-1,(int)room_height,0,1);
-    glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-    glDisable(GL_DEPTH_TEST);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     glEnable(GL_BLEND);
-    glEnable(GL_ALPHA_TEST);
     glEnable(GL_TEXTURE_2D);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glAlphaFunc(GL_ALWAYS,0);
-
-    glColor4f(0,0,0,1);
-    glBindTexture(GL_TEXTURE_2D,0);
 
 	  init_shaders();
 	  // read shaders into graphics system structure and compile and link them if needed

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -16,10 +16,7 @@
 **/
 
 #include "Bridges/General/GL3Context.h"
-#include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GSscreen.h"
-#include "Graphics_Systems/General/GSmatrix.h"
-#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 
 #include "Universal_System/image_formats.h"
@@ -27,13 +24,11 @@
 #include "Platforms/General/PFwindow.h"
 
 #include <string>
-#include <cstdio>
-
-//WE SHOULDN'T DO THIS! Don't specify namespaces like this - Harijs
-using namespace std;
 
 using namespace enigma;
 using namespace enigma_user;
+
+using std::string;
 
 namespace enigma
 {
@@ -56,7 +51,11 @@ void scene_end() {
     glBindFramebuffer(GL_READ_FRAMEBUFFER, enigma::msaa_fbo);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
     //TODO: Change the code below to fix this to size properly to views
-    glBlitFramebuffer(0, 0, window_get_region_width_scaled(), window_get_region_height_scaled(), 0, 0, window_get_region_width_scaled(), window_get_region_height_scaled(), GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    glBlitFramebuffer(
+      0, 0, window_get_region_width_scaled(), window_get_region_height_scaled(),
+      0, 0, window_get_region_width_scaled(), window_get_region_height_scaled(),
+      GL_COLOR_BUFFER_BIT, GL_NEAREST
+    );
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
     // glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, pixels);
   }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -67,46 +67,6 @@ void scene_end() {
 namespace enigma_user
 {
 
-void screen_init()
-{
-  oglmgr->EndShapesBatching();
-  enigma::gui_width = window_get_region_width();
-  enigma::gui_height = window_get_region_height();
-
-  glClearColor(0,0,0,0);
-  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-  if (!view_enabled)
-  {
-    glClearColor(0,0,0,0);
-    screen_set_viewport(0, 0, window_get_region_width(), window_get_region_height());
-    d3d_set_projection_ortho(0, 0, room_width, room_height, 0);
-  } else {
-    for (view_current = 0; view_current < 7; view_current++)
-    {
-      if (view_visible[(int)view_current])
-      {
-        int vc = (int)view_current;
-
-        glClearColor(0,0,0,0);
-
-        screen_set_viewport(view_xport[vc], view_yport[vc], view_wport[vc], view_hport[vc]);
-        d3d_set_projection_ortho(view_xview[vc], view_yview[vc], view_wview[vc], view_hview[vc], view_angle[vc]);
-        break;
-      }
-    }
-  }
-
-  glDisable(GL_DEPTH_TEST);
-  glDisable(GL_CULL_FACE);
-  glEnable(GL_BLEND);
-  glEnable(GL_SCISSOR_TEST);
-
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  texture_reset();
-  draw_set_color(c_white);
-}
-
 int screen_save(string filename) //Assumes native integers are little endian
 {
   oglmgr->EndShapesBatching();
@@ -164,12 +124,6 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   //NOTE: OpenGL viewports are bottom left unlike Direct3D viewports which are top left
   glViewport(viewport_x, viewport_y, viewport_w, viewport_h);
   glScissor(viewport_x, viewport_y, viewport_w, viewport_h);
-}
-
-//TODO: These need to be in some kind of General
-void display_set_gui_size(unsigned int width, unsigned int height) {
-  enigma::gui_width = width;
-  enigma::gui_height = height;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
@@ -54,7 +54,7 @@ void draw_set_msaa_enabled(bool enable)
   (enable?glEnable:glDisable)(GL_MULTISAMPLE);
 }
 
-void draw_enable_alphablend(bool enable) {
+void draw_set_blend(bool enable) {
 	(enable?glEnable:glDisable)(GL_BLEND);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
@@ -54,14 +54,8 @@ namespace enigma
   {
     oglmgr = new ContextManager();
 
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-    glDisable(GL_DEPTH_TEST);
-
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
-    glBindTexture(GL_TEXTURE_2D,0);
 
     init_shaders();
     // read shaders into graphics system structure and compile and link them if needed
@@ -112,11 +106,6 @@ namespace enigma
     //END DEFAULT SHADER
 
     graphics_initialize_samplers();
-
-    using enigma_user::room_width;
-    using enigma_user::room_height;
-    glViewport(0,0,(int)room_width,(int)room_height);
-    enigma_user::d3d_set_projection_ortho(0,(int)room_width,0,(int)room_height, 0);
 
     //In GL3.3 Core VAO is mandatory. So we create one and never change it
     GLuint vertexArrayObject;

--- a/ENIGMAsystem/SHELL/Universal_System/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/loading.cpp
@@ -28,6 +28,7 @@
 #include "Audio_Systems/audio_mandatory.h"
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Graphics_Systems/graphics_mandatory.h"
+#include "Graphics_Systems/General/GSscreen.h"
 
 #include <time.h>
 #include <stdio.h>
@@ -39,7 +40,7 @@ namespace enigma_user
   extern int mtrandom_seed(int x);
 } //namespace enigma_user
 
-namespace enigma 
+namespace enigma
 {
   extern int event_system_initialize(); //Leave this here until you can find a more brilliant way to include it; it's pretty much not-optional.
   extern void timeline_system_initialize();
@@ -56,6 +57,7 @@ namespace enigma
     enigma::game_settings_initialize();
 
     graphicssystem_initialize();
+    enigma_user::screen_init_state();
     audiosystem_initialize();
 
     #if defined(BUILDMODE) && BUILDMODE


### PR DESCRIPTION
This pull request addresses issue #1337 and moves `screen_init` as well as `display_set_gui_size` to the general graphics folder.

One major issue this pull request addresses is that drawing color and alpha should **NOT** be reset when switching rooms as I tested in both GM8 and GMS.
Download: [render-state-room-transition-test.zip](https://github.com/enigma-dev/enigma-dev/files/2257383/render-state-room-transition-test.zip)

* All `screen_init` implementations were deleted and I made a single one in `General/`
* I separated `screen_init_state` out of `screen_init` as a secondary user function.
    * `screen_init_state` initializes all of the default render state (e.g, drawing color/alpha) that applies to all generic graphics during startup just after `graphicssystem_initialize`
    * `screen_init` resets the projections/viewports and clears the room background color for all generic graphics and is intended to be called during room transition

