### PR TITLE
CI Regression/Test Harness Binaries Linking Fix

### DIFF
--- a/CommandLine/testing/Makefile
+++ b/CommandLine/testing/Makefile
@@ -23,10 +23,12 @@ OBJECTS := $(patsubst $(SRC_DIR)/%, $(OBJ_DIR)/%, $(patsubst %.cpp, %.o, $(SOURC
 OBJDIRS := $(sort $(OBJ_DIR) $(dir $(OBJECTS)))
 DEPENDS := $(OBJECTS:.o=.d)
 
-$(BINARY): $(OBJECTS)
+$(BINARY): $(OBJECTS) | .FORCE
 	g++ $^ -o $@ $(LDFLAGS)
 
-.PHONY: all clean obj_dirs
+.PHONY: all clean obj_dirs .FORCE
+
+.FORCE:
 
 all: $(BINARY)
 clean:


### PR DESCRIPTION
Ran into one more issue with the test harness and drawing tests while working on #1350. That was a new drawing test I was adding which should have only been run on the pull request, but it was being run twice. It was being run on the pull request and on master (which new tests should not be run on).

The reason this occurs now with new tests is because the binary of the cpp still exists until you make clean. When we do the git checkout, the cpp file is removed, but the binary remains. After discussing this with Rusky and Fundies on Discord, I decided upon this fix to just always force relinking of the binaries for the test harness since it's least pita. If you would prefer it be done another way, please tell me.

When I tested this change in #1350, Travis did then correctly report the 3D shapes test as a new test and stopped trying to run it on master.