### PR TITLE
Fixed GL1, DX9, DX11 and NONE not compiling with surface_create

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "xiosbase": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "xiosbase": "cpp"
+    }
+}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11surface.cpp
@@ -55,7 +55,7 @@ bool surface_is_supported()
   return true;
 }
 
-int surface_create(int width, int height, bool depthbuffer)
+int surface_create(int width, int height, bool depthbuffer, bool, bool)
 {
   ID3D11Texture2D *renderTargetTexture;
   ID3D11RenderTargetView* renderTargetView;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -57,7 +57,7 @@ bool surface_is_supported()
   return true;
 }
 
-int surface_create(int width, int height, bool depthbuffer)
+int surface_create(int width, int height, bool depthbuffer, bool, bool)
 {
   LPDIRECT3DTEXTURE9 texture = NULL;
   d3dmgr->CreateTexture(width, height, 1, D3DUSAGE_RENDERTARGET, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &texture, NULL);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
@@ -127,7 +127,7 @@ namespace enigma_user
 	void texture_anisotropy_filter(int sampler, gs_scalar levels){}
 
 	bool surface_is_supported(){return false;}
-	int surface_create(int width, int height, bool depthbuffer){return -1;}
+	int surface_create(int width, int height, bool depthbuffer, bool, bool){return -1;}
 	int surface_create_msaa(int width, int height, int samples){return -1;}
 	void surface_set_target(int id){}
 	void surface_reset_target(void){}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsurface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsurface.cpp
@@ -84,7 +84,7 @@ bool surface_is_supported()
     return GLEW_EXT_framebuffer_object;
 }
 
-int surface_create(int width, int height, bool depthbuffer)
+int surface_create(int width, int height, bool depthbuffer, bool, bool)
 {
     if (!GLEW_EXT_framebuffer_object) {
     return -1;


### PR DESCRIPTION
Fixed GL1, DX9, DX11 and NONE not compiling with surface_create due to new parameters

Surface create on the newer renderers has
`int surface_create(int width, int height, bool depthbuffer, bool stencilbuffer, bool writeonly)`
However, with older renderers stencilbuffer and writeonly are not present. Quick workaround allows games to be compiled as normal using these renderers.

The following line is now present in the 4 listed renderer's surface cpp files, adding the two bool parameters.
`int surface_create(int width, int height, bool depthbuffer, bool, bool)`