### PR TITLE
Direct3D9 Render State Cache

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
+++ b/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
@@ -230,8 +230,6 @@ void LightEnable(DWORD Index, BOOL bEnable) {
 void BeginScene() {
 	last_depth = 0;
 	device->BeginScene();
-	// Reapply the stored render states and what not
-	RestoreState();
 }
 
 void EndScene() {
@@ -249,13 +247,17 @@ void Release() {
 
 void Reset(D3DPRESENT_PARAMETERS *pPresentationParameters) {
 	HRESULT hr = device->Reset(pPresentationParameters);
-		if(FAILED(hr)){
-			MessageBox(enigma::hWnd,
-               "Failed to reset Direct3D 9.0 Device",
-			   DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
-               MB_ICONERROR | MB_OK);
-			return;  // should probably force the game closed
-		}
+	if (FAILED(hr)) {
+		MessageBox(
+			enigma::hWnd,
+			"Failed to reset Direct3D 9.0 Device",
+			DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
+			MB_ICONERROR | MB_OK
+		);
+		return;  // should probably force the game closed
+	}
+	// Reapply the stored render states and what not
+	RestoreState();
 }
 
 void DrawIndexedPrimitive(D3DPRIMITIVETYPE Type, INT BaseVertexIndex, UINT MinIndex, UINT NumVertices, UINT StartIndex, UINT PrimitiveCount) {


### PR DESCRIPTION
So back when I originally wrote this system, I thought that BeginScene/EndScene do not persist SetRenderState. The reason I thought that was because on startup ENIGMA does a window resize causing a lost device which we handle with a device reset. That caused me to erroneously think BeginScene/EndScene were resetting the render states. That is not correct, the device reset is the one doing it.

So this is just a minor optimization to not restore all the rendering state every frame, but to simply do it right after the device reset. Understand that this does not fix the device resetting and it's still broke just as before this pull request. Regardless, even when somebody does fix the device reset, we don't need to restore the render state every frame.

This makes the API trace a lot cleaner and closer to our OpenGL one. Much much saner. Don't give me much guff on this pull request, lots of other things to fix here, but please don't conflate issues. This pull request is **only** about changing it to not reset the render state _every_ frame.