### PR TITLE
Tiles Comparison Functor Warning Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStiles.cpp
@@ -35,9 +35,15 @@
 #include <algorithm>
 
 namespace {
-    bool tiles_are_dirty = true;
-    enigma::bkinxop bkinxcomp;
-}
+
+bool tiles_are_dirty = true;
+
+struct bkinxop
+{
+  bool operator() (const enigma::tile& a, const enigma::tile& b) {return (a.bckid < b.bckid);}
+} bkinxcomp;
+
+} // anonymous namespace
 
 namespace enigma
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStilestruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStilestruct.h
@@ -32,13 +32,6 @@ namespace enigma
     extern int tile_vertex_buffer, tile_index_buffer;
     extern std::map<int,std::vector<std::vector<int> > > tile_layer_metadata;
 
-    struct bkinxop
-    {
-        bool operator() (const tile a, const tile b) {return (a.bckid < b.bckid);}
-    };
-
-    extern bkinxop bkinxcomp;
-
     void draw_tile();
     void delete_tiles();
     void load_tiles();


### PR DESCRIPTION
Simple change, I was getting annoyed seeing the following warning in the tiles sources.
```bash
Graphics_Systems/General/GStiles.cpp:39:21: warning: '{anonymous}::bkinxcomp' defined but not used [-Wunused-variable]
     enigma::bkinxop bkinxcomp;
                     ^~~~~~~~~
```

The reason was because when I moved `bkinxcomp` to an anonymous namespace, I forgot to remove the namespace enigma extern for it in the header. This pull request just safely moves all of it to the anonymous namespace since it's not used outside of these sources or in any other translation unit. I also changed the parameters to be const references.