### PR TITLE
Added support for underscores in strings

### DIFF
--- a/ENIGMAsystem/SHELL/Widget_Systems/TinyFileDialogs/linux.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/TinyFileDialogs/linux.cpp
@@ -10,6 +10,9 @@ namespace enigma
 {
   string tfd_add_escaping(string str)
   {
-    return string_replace_all(str, "\"", "\\\"");
+    string result;
+    result = string_replace_all(str, "\"", "\\\"");
+    result += string_replace_all(str, "_", "__");
+    return result;
   }
 }


### PR DESCRIPTION
Zenity requires double underscores to represent a single underscore in a string. Therefore, this change replaces all underscores in a string with double underscores, so that the correct string will be used and displayed in the dialogs.