### PR TITLE
File System Cleanup and Boost Fallback for libEGM

### DIFF
--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -18,8 +18,16 @@ OBJ_DIR   := .eobjs
 #if gcc >= 8 use std::filesystem instead of boost
 ifeq ($(shell expr $(GCCVER) \>= 8), 1)
 	override CXXFLAGS += -std=c++17
+	FS_LIBS=-lstdc++fs
 else
 	override CXXFLAGS += -std=c++14 -DUSE_BOOST_FS
+	ifeq ($(OS), Linux)
+		FS_LIBS=-lboost_filesystem
+	else ifeq ($(OS), Darwin)
+		FS_LIBS=-lboost_filesystem
+	else
+		FS_LIBS=-lboost_filesystem-mt
+	endif
 endif
 
 rwildcard=$(wildcard $1/$2) $(foreach d,$(wildcard $1/*),$(call rwildcard,$d,$2))
@@ -42,7 +50,7 @@ clean:
 # --libs-only-L is specified because the Trusty Tahr package for pugixml does not have a proper pkg-config
 # hence we only use pkg-config for the lib dirs and just always link pugixml whether in travis, on ubuntu, or in msys2
 $(LIBRARY): $(OBJECTS)
-	$(CXX) -shared -o $@ $^ -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -lstdc++fs -L$(SHARED_SOURCES)/lodepng -llodepng
+	$(CXX) -shared -o $@ $^ $(FS_LIBS) -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -lstdc++fs -L$(SHARED_SOURCES)/lodepng -llodepng
 
 # Create the object directories
 $(OBJDIRS):

--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -11,9 +11,10 @@ GCCVER := $(shell gcc -dumpversion | cut -c 1)
 SHARED_SOURCES := ../../shared
 LIBRARY   := ../../libEGM$(EXT)
 PROTO_DIR := ../protos
-CXXFLAGS  := $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -I$(SHARED_SOURCES)/lodepng -Wall -Wextra -Wpedantic -g -fPIC
 SRC_DIR   := .
 OBJ_DIR   := .eobjs
+
+CXXFLAGS  := -I$(SRC_DIR) $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -I$(SHARED_SOURCES)/lodepng -Wall -Wextra -Wpedantic -g -fPIC
 
 #if gcc >= 8 use std::filesystem instead of boost
 ifeq ($(shell expr $(GCCVER) \>= 8), 1)

--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -22,11 +22,11 @@ ifeq ($(shell expr $(GCCVER) \>= 8), 1)
 else
 	override CXXFLAGS += -std=c++14 -DUSE_BOOST_FS
 	ifeq ($(OS), Linux)
-		FS_LIBS=-lboost_filesystem
+		FS_LIBS=-lboost_system -lboost_filesystem
 	else ifeq ($(OS), Darwin)
-		FS_LIBS=-lboost_filesystem
+		FS_LIBS=-lboost_system -lboost_filesystem
 	else
-		FS_LIBS=-lboost_filesystem-mt
+		FS_LIBS=-lboost_system-mt -lboost_filesystem-mt
 	endif
 endif
 

--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -15,6 +15,7 @@ SRC_DIR   := .
 OBJ_DIR   := .eobjs
 
 CXXFLAGS  := -I$(SRC_DIR) $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -I$(SHARED_SOURCES)/lodepng -Wall -Wextra -Wpedantic -g -fPIC
+LDFLAGS   := -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -lstdc++fs -L$(SHARED_SOURCES)/lodepng -llodepng
 
 #if gcc >= 8 use std::filesystem instead of boost
 ifeq ($(shell expr $(GCCVER) \>= 8), 1)
@@ -30,6 +31,8 @@ else
 		FS_LIBS=-lboost_system-mt -lboost_filesystem-mt
 	endif
 endif
+
+LDFLAGS += $(FS_LIBS)
 
 rwildcard=$(wildcard $1/$2) $(foreach d,$(wildcard $1/*),$(call rwildcard,$d,$2))
 
@@ -51,7 +54,7 @@ clean:
 # --libs-only-L is specified because the Trusty Tahr package for pugixml does not have a proper pkg-config
 # hence we only use pkg-config for the lib dirs and just always link pugixml whether in travis, on ubuntu, or in msys2
 $(LIBRARY): $(OBJECTS)
-	$(CXX) -shared -o $@ $^ $(FS_LIBS) -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -lstdc++fs -L$(SHARED_SOURCES)/lodepng -llodepng
+	$(CXX) $(CXXFLAGS) -shared -o $@ $^ $(LDFLAGS)
 
 # Create the object directories
 $(OBJDIRS):

--- a/CommandLine/libEGM/filesystem.cpp
+++ b/CommandLine/libEGM/filesystem.cpp
@@ -59,7 +59,7 @@ string TempFileName(const string &pattern) {
       prefix += std::to_string(rand() % 10);
   }
   std::string name = prefix + pattern + std::to_string(increment++);
-  return (fs::temp_directory_path().string() + name);
+  return (fs::temp_directory_path().string() + '/' + name);
 }
 
 void DeleteFile(const string &fName) {

--- a/CommandLine/libEGM/filesystem.cpp
+++ b/CommandLine/libEGM/filesystem.cpp
@@ -1,0 +1,58 @@
+#include "filesystem.h"
+
+#include <iostream>
+
+bool StartsWith(const string &str, const string &prefix) {
+  if (prefix.length() > str.length()) return false;
+  return str.substr(0, prefix.length()) == prefix;
+}
+
+string StripPath(string fName) {
+  size_t pos = fName.find_last_of('/');
+  if (pos == string::npos)
+    return fName;
+
+  return fName.substr(pos+1, fName.length());
+}
+
+bool CreateDirectory(const fs::path &directory) {
+  errc ec;
+  if (fs::create_directory(directory, ec) || !ec) return true;
+  std::cerr << "Failed to create directory " << directory << std::endl;
+  return false;
+}
+
+fs::path InternalizeFile(const fs::path &file,
+                         const fs::path &directory, const fs::path &egm_root) {
+  const fs::path data = "data";
+  fs::path demistified = fs::canonical(fs::absolute(file));
+  if (StartsWith(demistified.string(), egm_root.string())) {
+    return fs::relative(demistified, directory);
+  }
+  if (!CreateDirectory(directory/data)) {
+    std::cerr << "Failed to copy \"" << file
+              << "\" into EGM: could not create output directory." << std::endl;
+    return "";
+  }
+  fs::path relative = data/StripPath(file.string());
+
+  #ifdef USE_BOOST_FS
+    fs::copy_file(file, directory/relative);
+  #else
+    if (!fs::copy_file(file, directory/relative)) {
+      std::cerr << "Failed to copy \"" << file << "\" into EGM." << std::endl;
+      return "";
+    }
+  #endif
+
+  return relative;
+}
+
+void DeleteFile(const string &fName) {
+#ifdef USE_BOOST_FS
+  fs::remove(fName.c_str());
+#else
+  std::remove(fName.c_str());
+#endif
+
+}

--- a/CommandLine/libEGM/filesystem.cpp
+++ b/CommandLine/libEGM/filesystem.cpp
@@ -48,6 +48,20 @@ fs::path InternalizeFile(const fs::path &file,
   return relative;
 }
 
+string TempFileName(const string &pattern) {
+  static int increment = 0;
+  static std::string prefix = "";
+  if (prefix.empty()) {
+    // init random seed
+    srand(time(NULL));
+    // prefix 5 random digits
+    for (size_t i = 0; i < 5; ++i)
+      prefix += std::to_string(rand() % 10);
+  }
+  std::string name = prefix + pattern + std::to_string(increment++);
+  return (fs::temp_directory_path().string() + name);
+}
+
 void DeleteFile(const string &fName) {
 #ifdef USE_BOOST_FS
   fs::remove(fName.c_str());

--- a/CommandLine/libEGM/filesystem.h
+++ b/CommandLine/libEGM/filesystem.h
@@ -19,6 +19,7 @@ using std::string;
 
 bool StartsWith(const string &str, const string &prefix);
 string StripPath(string fName);
+string TempFileName(const string &pattern);
 bool CreateDirectory(const fs::path &directory);
 fs::path InternalizeFile(const fs::path &file,
                          const fs::path &directory, const fs::path &egm_root);

--- a/CommandLine/libEGM/filesystem.h
+++ b/CommandLine/libEGM/filesystem.h
@@ -1,0 +1,25 @@
+#ifdef USE_BOOST_FS
+  #include <boost/filesystem.hpp>
+  #include <boost/system/error_code.hpp>
+  namespace fs = boost::filesystem;
+  using errc = boost::system::error_code;
+  namespace boost {
+    template<class ForwardIt>
+    ForwardIt next(
+        ForwardIt it,
+        typename std::iterator_traits<ForwardIt>::difference_type n = 1);
+  }  // namespace boost
+#else
+  #include <filesystem>
+  namespace fs = std::filesystem;
+  using errc = std::error_code;
+#endif
+
+using std::string;
+
+bool StartsWith(const string &str, const string &prefix);
+string StripPath(string fName);
+bool CreateDirectory(const fs::path &directory);
+fs::path InternalizeFile(const fs::path &file,
+                         const fs::path &directory, const fs::path &egm_root);
+void DeleteFile(const string &fName);

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -16,6 +16,7 @@
 **/
 
 #include "gmk.h"
+#include "filesystem.h"
 
 #include "lodepng.h"
 #include <zlib.h>
@@ -47,8 +48,8 @@ ostream err(nullptr);
 static vector<std::string> tempFilesCreated;
 static bool atexit_tempdata_cleanup_registered = false;
 static void atexit_tempdata_cleanup() {
-  for (std::string &tempFile : tempFilesCreated)
-    std::remove(tempFile.c_str());
+  for (const std::string &tempFile : tempFilesCreated)
+    DeleteFile(tempFile);
 }
 
 std::string writeTempDataFile(char *bytes, size_t length) {

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -29,6 +29,9 @@
 #include <vector>
 #include <set>
 
+#include <cstdlib>     /* srand, rand */
+#include <ctime>       /* time */
+
 using namespace buffers;
 using namespace buffers::resources;
 using namespace std;
@@ -44,20 +47,25 @@ ostream err(nullptr);
 static vector<std::string> tempFilesCreated;
 static bool atexit_tempdata_cleanup_registered = false;
 static void atexit_tempdata_cleanup() {
-  //for (std::string &tempFile : tempFilesCreated)
-    //unlink(tempFile.c_str());
+  for (std::string &tempFile : tempFilesCreated)
+    unlink(tempFile.c_str());
 }
 
 std::string writeTempDataFile(char *bytes, size_t length) {
-  char name[L_tmpnam];
-  if (!std::tmpnam(name)) return "";
-  err << "TEMP FILE NAME: " << name << std::endl;
+  static int increment = 0;
+  static std::string prefix = "";
+  if (prefix.empty()) {
+    // init random seed
+    srand(time(NULL));
+    // prefix 5 random digits
+    for (size_t i = 0; i < 5; ++i)
+      prefix += std::to_string(rand() % 10);
+  }
+  std::string name = prefix + "gmk_data" + std::to_string(increment++);
   std::fstream fs(name, std::fstream::out | std::fstream::binary);
   if (!fs.is_open()) return "";
-  err << "TEMP FILE OPENED: " << name << std::endl;
   fs.write(bytes, length);
-  //fs.close();
-  err << "TEMP FILE CREATED: " << name << std::endl;
+  fs.close();
   return name;
 }
 

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -53,16 +53,7 @@ static void atexit_tempdata_cleanup() {
 }
 
 std::string writeTempDataFile(char *bytes, size_t length) {
-  static int increment = 0;
-  static std::string prefix = "";
-  if (prefix.empty()) {
-    // init random seed
-    srand(time(NULL));
-    // prefix 5 random digits
-    for (size_t i = 0; i < 5; ++i)
-      prefix += std::to_string(rand() % 10);
-  }
-  std::string name = prefix + "gmk_data" + std::to_string(increment++);
+  std::string name = TempFileName("gmk_data");
   std::fstream fs(name, std::fstream::out | std::fstream::binary);
   if (!fs.is_open()) return "";
   fs.write(bytes, length);

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -48,7 +48,7 @@ static vector<std::string> tempFilesCreated;
 static bool atexit_tempdata_cleanup_registered = false;
 static void atexit_tempdata_cleanup() {
   for (std::string &tempFile : tempFilesCreated)
-    unlink(tempFile.c_str());
+    std::remove(tempFile.c_str());
 }
 
 std::string writeTempDataFile(char *bytes, size_t length) {

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -44,17 +44,21 @@ ostream err(nullptr);
 static vector<std::string> tempFilesCreated;
 static bool atexit_tempdata_cleanup_registered = false;
 static void atexit_tempdata_cleanup() {
-  for (std::string &tempFile : tempFilesCreated)
-    unlink(tempFile.c_str());
+  //for (std::string &tempFile : tempFilesCreated)
+    //unlink(tempFile.c_str());
 }
 
 std::string writeTempDataFile(char *bytes, size_t length) {
-  char temp[] = "gmk_data.XXXXXX";
-  int fd = mkstemp(temp);
-  if (fd == -1) return "";
-  write(fd, bytes, length);
-  close(fd);
-  return temp;
+  char name[L_tmpnam];
+  if (!std::tmpnam(name)) return "";
+  err << "TEMP FILE NAME: " << name << std::endl;
+  std::fstream fs(name, std::fstream::out | std::fstream::binary);
+  if (!fs.is_open()) return "";
+  err << "TEMP FILE OPENED: " << name << std::endl;
+  fs.write(bytes, length);
+  //fs.close();
+  err << "TEMP FILE CREATED: " << name << std::endl;
+  return name;
 }
 
 std::string writeTempDataFile(std::unique_ptr<char[]> bytes, size_t length) {


### PR DESCRIPTION
Uses 5 random digits (unique to each emake process) prefixed to the string "gmk_data" with a postfix of the increment of the file number being written. Fundies wants the prefix so he can sort with the file manager. This version does not rely on any POSIX functions or non-standard C++ features.