### PR TITLE
Empty Primitives Fix & Better Graphical Debug Messages

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel_impl.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel_impl.h
@@ -67,7 +67,7 @@ struct Model {
 
   Model(int type, bool use_draw_color):
     type(type), vertex_buffer(-1), current_primitive(0), vertex_started(false), use_draw_color(use_draw_color),
-    vertex_colored(false), vertex_color(enigma_user::c_white), vertex_alpha(1.0) {}
+    vertex_colored(true), vertex_color(enigma_user::c_white), vertex_alpha(1.0) {}
 };
 
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -33,8 +33,6 @@
 
 #include <unordered_map>
 
-#define RESOURCE_EXISTS(id, container) return (id >= 0 && (unsigned)id < enigma::container.size() && enigma::container[id] != nullptr);
-
 namespace {
 
 // cache of all vertex formats that are logically unique
@@ -44,6 +42,8 @@ std::unordered_map<size_t, int> vertexFormatCache;
 // current vertex format being specified
 // NOTE: this is NULl outside of vertex_format_begin and vertex_format_end
 enigma::VertexFormat* currentVertexFormat = 0;
+
+#define RESOURCE_EXISTS(id, container) return (id >= 0 && (unsigned)id < enigma::container.size() && enigma::container[id] != nullptr);
 
 } // anonymous namespace
 
@@ -58,6 +58,10 @@ vector<IndexBuffer*> indexBuffers;
 namespace enigma_user {
 
 void vertex_format_begin() {
+  #ifdef DEBUG_MODE
+  if (currentVertexFormat)
+    show_error("vertex_format_begin called before vertex_format_end on the previous format", false);
+  #endif
   currentVertexFormat = new enigma::VertexFormat();
 }
 
@@ -99,6 +103,13 @@ void vertex_format_add_custom(int type, int usage) {
 
 int vertex_format_end() {
   int id = -1;
+  #ifdef DEBUG_MODE
+  if (!currentVertexFormat) {
+    show_error("vertex_format_end called and no current vertex format exists!\n" \
+               "This can occur if you call end without actually calling begin.", false);
+    return id;
+  }
+  #endif
   auto search = vertexFormatCache.find(currentVertexFormat->hash);
   if (search != vertexFormatCache.end()) {
     id = search->second;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -61,8 +61,7 @@ void vertex_format_begin() {
   #ifdef DEBUG_MODE
   if (currentVertexFormat) {
     show_error("vertex_format_begin called again without ending the previous format", false);
-    delete currentVertexFormat;
-    currentVertexFormat = 0;
+    vertex_format_end();
   }
   #endif
   currentVertexFormat = new enigma::VertexFormat();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -59,8 +59,11 @@ namespace enigma_user {
 
 void vertex_format_begin() {
   #ifdef DEBUG_MODE
-  if (currentVertexFormat)
-    show_error("vertex_format_begin called before vertex_format_end on the previous format", false);
+  if (currentVertexFormat) {
+    show_error("vertex_format_begin called again without ending the previous format", false);
+    delete currentVertexFormat;
+    currentVertexFormat = 0;
+  }
   #endif
   currentVertexFormat = new enigma::VertexFormat();
 }
@@ -105,7 +108,7 @@ int vertex_format_end() {
   int id = -1;
   #ifdef DEBUG_MODE
   if (!currentVertexFormat) {
-    show_error("vertex_format_end called and no current vertex format exists!\n" \
+    show_error("vertex_format_end called and no current vertex format exists! " \
                "This can occur if you call end without actually calling begin.", false);
     return id;
   }


### PR DESCRIPTION
Hahaha, that one thing that I thought would never bite me, bit me. I am talking about empty primitives and such things as ending a vertex format without beginning one. I found this in the Minecraft-esque game that somebody made in GM and used to work in ENIGMA. As a result of this, I decided to go the extra mile and add more debugging messages for graphics, because they are really useful and we need them.

![Vertex Format Error](https://user-images.githubusercontent.com/3212801/44528013-7c08a480-a6b6-11e8-9ce3-74920f8913d0.png)

After some deliberation, I did decide to make it a non-fatal error message to begin and end a primitive without specifying any vertex data when you don't specify a valid format. It's effectively a no-op, but the user is still being inefficient and misusing the API by doing so (and there's absolutely **zero** reason to do this).
![Vertex Format Cannot Be Determined](https://user-images.githubusercontent.com/3212801/44559609-3b8e4280-a719-11e8-8f2f-117bfd3b1e90.png)


This is a fix to what you would call a regression that was introduced by #1289 in which I created the new generic 3D models. I know because I checked out e1e3e0a080d56f5c9950afb5c24b08f29937b34b, which was the last commit before #1289 was merged, and the Minecraft-like game runs fine. I then checked out 16807a76050455a379d2c434047dc7db12fb4bfc, which was the commit that merged #1289, and was able to quickly reproduce the exact same crash in debug mode. So definitely a confirmed regression fix here.

With these changes, the Minecraft example works again in ENIGMA. I also tested several games in debug mode to make sure the above warnings do not become annoying as a result of any batching logic we have internally, and this is the only game I get the message and in this case it's specifically caused by the user.
![Minecraft Game Fixed](https://user-images.githubusercontent.com/3212801/44528260-123cca80-a6b7-11e8-90af-6b25e67610f9.png)

### Noteworthy changes
* Defaulted `vertex_colored` to true so we only add a color if you did specify a vertex but didn't specify a color (to prevent us adding a color if you didn't specify any vertex; safety for empty primitives basically)
* Added a debug message to `d3d_model_primitive_begin` to warn you if you didn't end the last primitive
* Added a debug message to `d3d_model_primitive_end` to warn you if you didn't even start a primitive
* Added a debug message to `d3d_model_primitive_end` to warn you if you didn't specify any vertex data and did not specify a valid vertex format, because one cannot be guessed based on the specification
* Added a debug message to `d3d_model_primitive_end` to warn you if you didn't specify any vertex data but you did specify a valid vertex format and the primitive is effectively empty
* Added a debug message to `vertex_format_begin` to warn you if you didn't end the last vertex format
* Added a debug message to `vertex_format_end` to warn you if you didn't even start a vertex format
* Moved `RESOURCE_EXISTS` macro inside anonymous namespace