### PR TITLE
Graphics Primitive Stack & Same Allocation Optimization

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.h
@@ -53,7 +53,6 @@ enum {
 
 void vertex_format_begin();
 int vertex_format_end();
-bool vertex_format_exists();
 bool vertex_format_exists(int id);
 unsigned vertex_format_get_hash(int id);
 unsigned vertex_format_get_stride(int id);


### PR DESCRIPTION
I was curious to try out what Josh suggested in #1365 because I had already thought about it once. Turns out it worked and gives some great benefits.

### Noteworthy changes
* `current_primitive` of Model is now in the same allocation avoiding unnecessary memory allocation and overhead
* `currentVertexFormat` global is now stack allocated to avoid allocation overhead
* Calling `vertex_format_end` without calling begin is no longer an error
* Calling `vertex_format_begin` twice is no longer an error, but less efficient because `currentVertexFormat` will be reinitialized twice
* Calling `d3d_model_primitive_end` without calling begin is no longer an error
* Calling `d3d_model_primitive_begin` twice is no longer an error, but less efficient because `current_primitive` will be reinitialized twice
* `std::vector::emplace_back` is now used instead of `push_back` to keep the current primitive or vertex format for obvious reasons
* Removed `vertex_format_exists()` that takes no parameters because it doesn't make sense now

Master
======
I am showing this pull request relative to the master prior to #1357 because this pull request is addressing limitations of that pr relative to master as far as performance is concerned.

##### `draw_sprite` benchmark
| Branch     | FPS | CPU RAM (MB) | GPU RAM (MB) |
|------------|-----|--------------|--------------|
| GMS v1.4   | 645 | 28.8         | 22           |
| ENIGMA GL1 | 242 | 44.0         | 13           |
| ENIGMA GL3 | 373 | 56.5         | 34           |
| ENIGMA DX9 | 384 | 17.3         | 26           |

##### `draw_rectangle` outlined benchmark
| Branch     | FPS | CPU RAM (MB) | GPU RAM (MB) |
|------------|-----|--------------|--------------|
| GMS v1.4   | 25  | 34.9         | 22           |
| ENIGMA GL1 | 79  | 27.2         | 13           |
| ENIGMA GL3 | 17  | 74.5         | 29           |
| ENIGMA DX9 | 68  | 17.4         | 22           |

Pull request
======
##### `draw_sprite` benchmark
| Branch                   | FPS | CPU RAM (MB) | GPU RAM (MB) |
|--------------------------|-----|--------------|--------------|
| ENIGMA GL1 Vertex Arrays | :heavy_check_mark: 359 | :heavy_check_mark: 41.2         | :small_red_triangle_down: 27           |
| ENIGMA GL1 VBO           | :heavy_check_mark: 388 | :heavy_check_mark: 40.1         | :small_red_triangle_down: 22           |
| ENIGMA GL3               | :heavy_check_mark: 386 | :heavy_check_mark: 51.6         | :heavy_check_mark: 22           |
| ENIGMA DX9               | :heavy_check_mark: 415 | :small_red_triangle_down: 17.6         | :heavy_check_mark: 11           |

##### `draw_rectangle` outlined benchmark
| Branch                   | FPS | CPU RAM (MB) | GPU RAM (MB) |
|--------------------------|-----|--------------|--------------|
| ENIGMA GL1 Vertex Arrays | :heavy_check_mark: 164 | :heavy_check_mark: 24.6         | :small_red_triangle_down: 21           |
| ENIGMA GL1 VBO           | :heavy_check_mark: 137 | :small_red_triangle_down: 38.8         | :small_red_triangle_down: 22           |
| ENIGMA GL3               | :heavy_check_mark: 082  | :heavy_check_mark: 50.5         | :small_red_triangle_down: 38           |
| ENIGMA DX9               | :heavy_check_mark: 123 | :heavy_check_mark: 16.9         | :small_red_triangle_down: 23           |