### PR TITLE
Clean Regression Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,11 +84,9 @@ before_install:
 
 # build JDI and the CLI
 install:
-  - make -j4
   - |
-    if [ "$TEST_HARNESS" == true ]; then
-      make -j4 emake
-    else
+    if [ "$TEST_HARNESS" != true ]; then
+      make -j4
       CLI_ENABLE_EGM=FALSE make -j4 emake
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ script:
   - |
     if [ "$TEST_HARNESS" == true ]; then
       export ASAN_OPTIONS=detect_leaks=0;
-      ./ci-regression.sh "/tmp/enigma-master"
+      ./ci-regression.sh "/tmp/enigma-master" 2
     else
       ./ci-build.sh
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ script:
   - |
     if [ "$TEST_HARNESS" == true ]; then
       export ASAN_OPTIONS=detect_leaks=0;
-      ./ci-regression.sh "/tmp/enigma-master" 2
+      ./ci-regression.sh "/tmp/enigma-master" 4
     else
       ./ci-build.sh
     fi

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean: .FORCE
 	$(MAKE) -C CommandLine/protos/ clean
 	$(MAKE) -C CommandLine/testing/ clean
 	$(MAKE) -C shared/lodepng/ clean
-	rm ./gm2egm
+	rm -f ./gm2egm
 
 all: liblodepng libProtocols libEGM ENIGMA emake test-runner .FORCE
 

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -9,7 +9,7 @@ fi
 export TEST_HARNESS_MASTER_DIR="$1"
 
 if [ -z "$2" ]; then
-  MAKE_CORES=$2
+  MAKE_JOBS=$2
 fi
 
 GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
@@ -33,7 +33,7 @@ cp -p -r "${PWD}" "${TEST_HARNESS_MASTER_DIR}"
 
 PREVIOUS_PWD=${PWD}
 pushd "${TEST_HARNESS_MASTER_DIR}"
-make all -j$MAKE_CORES
+make all -j$MAKE_JOBS
 ./test-runner
 if [[ "$TRAVIS" -eq "true" ]]; then
   # upload coverage report before running regression tests
@@ -64,7 +64,7 @@ if [[ "${PWD}" == "${TEST_HARNESS_MASTER_DIR}" ]]; then
   git clean -f -d
 
   echo "Rebuilding plugin and harness from last commit..."
-  make all -j$MAKE_CORES
+  make all -j$MAKE_JOBS
   echo "Generating regression comparison images..."
   mkdir -p "${PWD}/test-harness-out"
   ./test-runner --gtest_filter=Regression.*

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -9,7 +9,7 @@ fi
 export TEST_HARNESS_MASTER_DIR="$1"
 
 if [ -z "$2" ]; then
-  MAKE_CORES="-j$2"
+  MAKE_CORES=$2
 fi
 
 GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
@@ -33,7 +33,7 @@ cp -p -r "${PWD}" "${TEST_HARNESS_MASTER_DIR}"
 
 PREVIOUS_PWD=${PWD}
 pushd "${TEST_HARNESS_MASTER_DIR}"
-make all $MAKE_CORES
+make all -j$MAKE_CORES
 ./test-runner
 if [[ "$TRAVIS" -eq "true" ]]; then
   # upload coverage report before running regression tests
@@ -63,7 +63,7 @@ if [[ "${PWD}" == "${TEST_HARNESS_MASTER_DIR}" ]]; then
 
   echo "Rebuilding plugin and harness from last commit..."
   make clean
-  make all $MAKE_CORES
+  make all -j$MAKE_CORES
   echo "Generating regression comparison images..."
   mkdir -p "${PWD}/test-harness-out"
   ./test-runner --gtest_filter=Regression.*

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -8,6 +8,10 @@ if [ -z "$1" ]; then
 fi
 export TEST_HARNESS_MASTER_DIR="$1"
 
+if [ -z "$2" ]; then
+  MAKE_CORES=-j$2
+fi
+
 GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 if [ -z "$(git status | grep detached)" ]; then
   GIT_DETACHED="FALSE"
@@ -29,7 +33,7 @@ cp -p -r "${PWD}" "${TEST_HARNESS_MASTER_DIR}"
 
 PREVIOUS_PWD=${PWD}
 pushd "${TEST_HARNESS_MASTER_DIR}"
-make all
+make all $MAKE_CORES
 ./test-runner
 if [[ "$TRAVIS" -eq "true" ]]; then
   # upload coverage report before running regression tests
@@ -58,7 +62,8 @@ if [[ "${PWD}" == "${TEST_HARNESS_MASTER_DIR}" ]]; then
   git clean -f -d
 
   echo "Rebuilding plugin and harness from last commit..."
-  make all
+  make clean
+  make all $MAKE_CORES
   echo "Generating regression comparison images..."
   mkdir -p "${PWD}/test-harness-out"
   ./test-runner --gtest_filter=Regression.*

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -9,7 +9,7 @@ fi
 export TEST_HARNESS_MASTER_DIR="$1"
 
 if [ -z "$2" ]; then
-  MAKE_CORES=-j$2
+  MAKE_CORES="-j$2"
 fi
 
 GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -41,6 +41,8 @@ if [[ "$TRAVIS" -eq "true" ]]; then
 fi
 # move output to safe space until we can compare
 mv ./test-harness-out ${PREVIOUS_PWD}
+# clean before we checkout
+make clean
 
 if [[ "${PWD}" == "${TEST_HARNESS_MASTER_DIR}" ]]; then
   git stash
@@ -62,7 +64,6 @@ if [[ "${PWD}" == "${TEST_HARNESS_MASTER_DIR}" ]]; then
   git clean -f -d
 
   echo "Rebuilding plugin and harness from last commit..."
-  make clean
   make all -j$MAKE_CORES
   echo "Generating regression comparison images..."
   mkdir -p "${PWD}/test-harness-out"

--- a/shared/lodepng/Makefile
+++ b/shared/lodepng/Makefile
@@ -4,6 +4,6 @@ liblodepng.a: .FORCE
 	mkdir -p .eobjs/
 	$(CXX) $(subst -ftest-coverage,, $(CXXFLAGS)) -fPIC -MMD -c -o .eobjs/lodepng.o lodepng.cpp
 	$(AR) rvs liblodepng.a .eobjs/lodepng.o
-	
+
 clean:
-	rm .eobjs/lodepng.o liblodepng.a
+	rm -f .eobjs/lodepng.o liblodepng.a


### PR DESCRIPTION
Alright, I am sick of all the issues from us not doing a make clean before checking out master. This bites us every time we want to add or remove a source file or even a header because make sucks. I am not only adding the make clean to stop all this nonsense but also adding a second command line argument to the `ci-regression.sh` script to pass the number of jobs. Because of that, this shouldn't have much of an effect on the regression test job time.

This needs merged prior to #1367 so that pr doesn't fail CI tests.

### Changes
* No longer call make for the test-harness job during the install phase at all. It's completely handled by the `ci-regression.sh` script now. I hadn't noticed this before or I would have removed it sooner (the second make is just redundant and time costly).
* Pass 4 as the number of threads to `ci-regression.sh` because the Travis sudo-enabled images have 2 cores. This facilitates people running the tests locally who may want more or less threads than what we set Travis to use and should also decrease the build time slightly for the test-harness job.
* Accept number of threads to invoke make with as a second argument to the `ci-regression.sh` script.
* Fixed the make clean rules for `lodepng` and `gm2egm` because they were resulting in an error if they did not exist. The critical mistake fundies made when he added these rules is that he forgot to add `-f` to force the deletion, which does not error when the file does not exist.
* Added a call to `make clean` just before we checkout master and after we've run the tests on the pull request. This should fix all of the issues with adding and removing headers and the CI build failing because make sucks.