### PR TITLE
Vertex Format Reset Optimization

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -41,7 +41,7 @@ std::unordered_map<size_t, int> vertexFormatCache;
 
 // current vertex format being specified
 // NOTE: this is not reset until the next vertex_format_begin
-// NOTE: this uses the stack until vertex_format_end to speed up creation
+// NOTE: this is allocated once and not a pointer to avoid reallocation
 enigma::VertexFormat currentVertexFormat;
 
 #define RESOURCE_EXISTS(id, container) return (id >= 0 && (unsigned)id < enigma::container.size() && enigma::container[id] != nullptr);
@@ -62,10 +62,7 @@ void vertex_format_begin() {
   // resetting the current vertex format this way is faster
   // than simply calling the default constructor because we
   // avoid reallocating the flags vector this way
-  currentVertexFormat.hash = 0;
-  currentVertexFormat.stride = 0;
-  currentVertexFormat.stride_size = 0;
-  currentVertexFormat.flags.clear();
+  currentVertexFormat.Clear();
 }
 
 unsigned vertex_format_get_hash() {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -59,7 +59,13 @@ vector<IndexBuffer*> indexBuffers;
 namespace enigma_user {
 
 void vertex_format_begin() {
-  currentVertexFormat = enigma::VertexFormat();
+  // resetting the current vertex format this way is faster
+  // than simply calling the default constructor because we
+  // avoid reallocating the flags vector this way
+  currentVertexFormat.hash = 0;
+  currentVertexFormat.stride = 0;
+  currentVertexFormat.stride_size = 0;
+  currentVertexFormat.flags.clear();
 }
 
 unsigned vertex_format_get_hash() {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex.cpp
@@ -41,7 +41,7 @@ std::unordered_map<size_t, int> vertexFormatCache;
 
 // current vertex format being specified
 // NOTE: this is not reset until the next vertex_format_begin
-// NOTE: this is allocated once and not a pointer to avoid reallocation
+// NOTE: this has static storage duration to avoid reallocation overhead (e.g, new is slow)
 enigma::VertexFormat currentVertexFormat;
 
 #define RESOURCE_EXISTS(id, container) return (id >= 0 && (unsigned)id < enigma::container.size() && enigma::container[id] != nullptr);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex_impl.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSvertex_impl.h
@@ -55,6 +55,11 @@ struct VertexFormat {
 
   VertexFormat(): stride(0), stride_size(0), hash(0) {}
 
+  void Clear() {
+    hash = stride = stride_size = 0;
+    flags.clear();
+  }
+
   void AddAttribute(int type, int attribute) {
     using namespace enigma_user;
 


### PR DESCRIPTION
This pull request can be considered a continuation of #1366. We want declaring a vertex format to be extremely fast.

Alright, I found the final nugget that has been holding us back, and it was `vertex_format_begin`. With this change, I get the same performance boost as I do by specifying the format up front but without requiring as many changes. As my comment states, the issue is basically that each time we begin a new vertex format, if I call the default constructor, that gives us a new vector and requires a whole new allocation. Hence, we can just clear the flags and reset the vertex format manually to speed it up for dynamic primitives.

This pull request basically gives the same results as #1369. We may still want to also merge that pr later though because common vertex formats are still a nice elegant way to express a simple vertex format.

Master
======
I am showing this pull request relative to the master prior to #1357 because this pull request is addressing limitations of that pr relative to master as far as performance is concerned.

##### `draw_sprite` benchmark
| Branch     | FPS | CPU RAM (MB) | GPU RAM (MB) |
|------------|-----|--------------|--------------|
| GMS v1.4   | 645 | 28.8         | 22           |
| ENIGMA GL1 | 242 | 44.0         | 13           |
| ENIGMA GL3 | 373 | 56.5         | 34           |
| ENIGMA DX9 | 384 | 17.3         | 26           |

##### `draw_rectangle` outlined benchmark
| Branch     | FPS | CPU RAM (MB) | GPU RAM (MB) |
|------------|-----|--------------|--------------|
| GMS v1.4   | 25  | 34.9         | 22           |
| ENIGMA GL1 | 79  | 27.2         | 13           |
| ENIGMA GL3 | 17  | 74.5         | 29           |
| ENIGMA DX9 | 68  | 17.4         | 22           |

Pull request
======
##### `draw_sprite` benchmark
| Branch                   | FPS | CPU RAM (MB) | GPU RAM (MB) |
|--------------------------|-----|--------------|--------------|
| ENIGMA GL1 Vertex Arrays | :heavy_check_mark: 504 | :small_red_triangle_down: 44.1         | :small_red_triangle_down: 35           |
| ENIGMA GL1 VBO           | :heavy_check_mark: 565 | :heavy_check_mark: 39.9         | :small_red_triangle_down: 31           |
| ENIGMA GL3               | :heavy_check_mark: 583 | :heavy_check_mark: 51.7         | ➖ 34           |
| ENIGMA DX9               | :heavy_check_mark: 645 | :small_red_triangle_down: 18.1         | :heavy_check_mark: 23           |

##### `draw_rectangle` outlined benchmark
| Branch                   | FPS | CPU RAM (MB) | GPU RAM (MB) |
|--------------------------|-----|--------------|--------------|
| ENIGMA GL1 Vertex Arrays | :heavy_check_mark: 206 | :heavy_check_mark: 24.0         | :small_red_triangle_down: 20           |
| ENIGMA GL1 VBO           | :heavy_check_mark: 162 | :small_red_triangle_down: 38.8         | :small_red_triangle_down: 40           |
| ENIGMA GL3               | :heavy_check_mark: 091 | :heavy_check_mark: 51.4         | :heavy_check_mark: 27           |
| ENIGMA DX9               | :heavy_check_mark: 143 | :heavy_check_mark: 17.2         | :heavy_check_mark: 10           |