### PR TITLE
Direct3D11 Improvements and Matrices Using GLM

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D11/Makefile
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D11/Makefile
@@ -1,2 +1,2 @@
 SOURCES += Bridges/General/Win32-Direct3D11.cpp $(wildcard Bridges/Win32-Direct3D11/*.cpp)
-override LDLIBS += -ldxgi -ld3d11 -ld3dx11
+override LDLIBS += -ldxgi -ld3d11

--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D11/Makefile
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D11/Makefile
@@ -1,2 +1,1 @@
 SOURCES += Bridges/General/Win32-Direct3D11.cpp $(wildcard Bridges/Win32-Direct3D11/*.cpp)
-override LDLIBS += -ldxgi -ld3d11

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11TextureStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11TextureStruct.h
@@ -25,10 +25,11 @@ using std::vector;
 
 struct TextureStruct {
   ID3D11Texture2D *texture;
+  ID3D11ShaderResourceView *view;
   unsigned width,height;
 	unsigned fullwidth,fullheight;
 
-  TextureStruct(ID3D11Texture2D *ntexture): texture(ntexture) {
+  TextureStruct(ID3D11Texture2D *ntexture, ID3D11ShaderResourceView *view): texture(ntexture), view(view) {
 
   }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11matrix.cpp
@@ -15,13 +15,15 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 #include "Bridges/General/DX11Context.h"
-#include "Graphics_Systems/General/GSd3d.h"
 #include "Direct3D11Headers.h"
-#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSmatrix.h"
 
-#include "../General/GSmodel.h"
-#include "Universal_System/var4.h"
-#include "Universal_System/roomsystem.h"
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/glm.hpp>
+
+namespace enigma {
+    glm::mat4 world, view, projection;
+}
 
 namespace enigma_user
 {
@@ -33,7 +35,7 @@ void d3d_set_perspective(bool enable)
 
 void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs_scalar xto, gs_scalar yto, gs_scalar zto,gs_scalar xup, gs_scalar yup, gs_scalar zup)
 {
-
+    enigma::projection = glm::lookAt(glm::vec3(xfrom, yfrom, zfrom), glm::vec3(xto, yto, zto), glm::vec3(xup, yup, zup));
 }
 
 void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs_scalar xto, gs_scalar yto, gs_scalar zto,gs_scalar xup, gs_scalar yup, gs_scalar zup, gs_scalar angle, gs_scalar aspect, gs_scalar znear, gs_scalar zfar)
@@ -43,7 +45,8 @@ void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs
 
 void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-	
+    enigma::projection = glm::ortho(x, x + width, y + height, y, 0.1f, 32000.0f);
+    enigma::projection = glm::rotate(enigma::projection, angle, glm::vec3(0.0f, 0.0f, 1.0f));
 }
 
 void d3d_set_projection_perspective(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
@@ -60,7 +63,7 @@ void d3d_transform_set_identity()
 
 void d3d_transform_add_translation(gs_scalar xt, gs_scalar yt, gs_scalar zt)
 {
-	
+
 }
 
 void d3d_transform_add_scaling(gs_scalar xs, gs_scalar ys, gs_scalar zs)
@@ -121,8 +124,14 @@ void d3d_transform_set_rotation_axis(gs_scalar x, gs_scalar y, gs_scalar z, gs_s
 }
 
 #include <stack>
+
+namespace {
+
 stack<bool> trans_stack;
 int trans_stack_size = 0;
+
+}
+
 
 namespace enigma_user
 {
@@ -152,11 +161,9 @@ bool d3d_transform_stack_top()
 
 }
 
-bool d3d_transform_stack_disgard()
+bool d3d_transform_stack_discard()
 {
-    if (trans_stack_size == 0) return false;
     trans_stack.push(0);
-    trans_stack_size--;
     return true;
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11matrix.cpp
@@ -1,4 +1,4 @@
-/** Copyright (C) 2013-2014 Robert B. Colton
+/** Copyright (C) 2013-2014, 2018 Robert Colton
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***
@@ -21,9 +21,19 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/glm.hpp>
 
+#include <stack>
+
+namespace {
+
+stack<glm::mat4> trans_stack;
+
+} // namespace anonymous
+
 namespace enigma {
-    glm::mat4 world, view, projection;
-}
+  glm::mat4 world = glm::mat4(1.0f),
+            view  = glm::mat4(1.0f),
+            projection = glm::mat4(1.0f);
+} // namespace enigma
 
 namespace enigma_user
 {
@@ -33,138 +43,137 @@ void d3d_set_perspective(bool enable)
 
 }
 
-void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs_scalar xto, gs_scalar yto, gs_scalar zto,gs_scalar xup, gs_scalar yup, gs_scalar zup)
+void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,
+                        gs_scalar xto, gs_scalar yto, gs_scalar zto,
+                        gs_scalar xup, gs_scalar yup, gs_scalar zup)
 {
-    enigma::projection = glm::lookAt(glm::vec3(xfrom, yfrom, zfrom), glm::vec3(xto, yto, zto), glm::vec3(xup, yup, zup));
+  enigma::view = glm::lookAt(glm::vec3(xfrom, yfrom, zfrom), glm::vec3(xto, yto, zto), glm::vec3(xup, yup, zup));
 }
 
-void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs_scalar xto, gs_scalar yto, gs_scalar zto,gs_scalar xup, gs_scalar yup, gs_scalar zup, gs_scalar angle, gs_scalar aspect, gs_scalar znear, gs_scalar zfar)
+void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,
+                            gs_scalar xto, gs_scalar yto, gs_scalar zto,
+                            gs_scalar xup, gs_scalar yup, gs_scalar zup,
+                            gs_scalar angle, gs_scalar aspect, gs_scalar znear, gs_scalar zfar)
 {
-
+  enigma::view = glm::lookAt(glm::vec3(xfrom, yfrom, zfrom), glm::vec3(xto, yto, zto), glm::vec3(xup, yup, zup));
+  enigma::projection = glm::perspective(angle, aspect, znear, zfar);
 }
 
 void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-    enigma::projection = glm::ortho(x, x + width, y + height, y, 0.1f, 32000.0f);
-    enigma::projection = glm::rotate(enigma::projection, angle, glm::vec3(0.0f, 0.0f, 1.0f));
+  enigma::view = glm::ortho(x, x + width, y + height, y, 0.1f, 32000.0f);
+  enigma::projection = glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 0.0f, 1.0f));
 }
 
 void d3d_set_projection_perspective(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-
+  enigma::view = glm::ortho(x, x + width, y + height, y, 0.1f, 32000.0f);
+  enigma::projection = glm::perspective(angle, width/height, 0.1f, 32000.0f);
 }
 
-
-// ***** TRANSFORMATIONS BEGIN *****
 void d3d_transform_set_identity()
 {
-
+  enigma::world = glm::mat4(1.0f);
 }
 
 void d3d_transform_add_translation(gs_scalar xt, gs_scalar yt, gs_scalar zt)
 {
-
+  enigma::world *= glm::translate(glm::mat4(1.0f), glm::vec3(xt, yt, zt));
 }
 
 void d3d_transform_add_scaling(gs_scalar xs, gs_scalar ys, gs_scalar zs)
 {
-
+  enigma::world *= glm::scale(glm::mat4(1.0f), glm::vec3(xs, ys, zs));
 }
 
 void d3d_transform_add_rotation_x(gs_scalar angle)
 {
-
+  enigma::world *= glm::rotate(glm::mat4(1.0f), angle, glm::vec3(1.0f, 0.0f, 0.0f));
 }
 
 void d3d_transform_add_rotation_y(gs_scalar angle)
 {
-
+  enigma::world *= glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 1.0f, 0.0f));
 }
 
 void d3d_transform_add_rotation_z(gs_scalar angle)
 {
-
+  enigma::world *= glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 0.0f, 1.0f));
 }
 
 void d3d_transform_add_rotation_axis(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar angle)
 {
-
+  enigma::world *= glm::rotate(glm::mat4(1.0f), angle, glm::vec3(x, y, z));
 }
 
 void d3d_transform_set_translation(gs_scalar xt, gs_scalar yt, gs_scalar zt)
 {
-
+  enigma::world = glm::translate(glm::mat4(1.0f), glm::vec3(xt, yt, zt));
 }
 
 void d3d_transform_set_scaling(gs_scalar xs, gs_scalar ys, gs_scalar zs)
 {
-
+  enigma::world = glm::scale(glm::mat4(1.0f), glm::vec3(xs, ys, zs));
 }
 
 void d3d_transform_set_rotation_x(gs_scalar angle)
 {
-
+  enigma::world = glm::rotate(glm::mat4(1.0f), angle, glm::vec3(1.0f, 0.0f, 0.0f));
 }
 
 void d3d_transform_set_rotation_y(gs_scalar angle)
 {
-
+  enigma::world = glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 1.0f, 0.0f));
 }
 
 void d3d_transform_set_rotation_z(gs_scalar angle)
 {
-
+  enigma::world = glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 0.0f, 1.0f));
 }
 
 void d3d_transform_set_rotation_axis(gs_scalar x, gs_scalar y, gs_scalar z, gs_scalar angle)
 {
-
-}
-
-}
-
-#include <stack>
-
-namespace {
-
-stack<bool> trans_stack;
-int trans_stack_size = 0;
-
-}
-
-
-namespace enigma_user
-{
-
-bool d3d_transform_stack_push()
-{
-
-}
-
-bool d3d_transform_stack_pop()
-{
-
+  enigma::world = glm::rotate(glm::mat4(1.0f), angle, glm::vec3(x, y, z));
 }
 
 void d3d_transform_stack_clear()
 {
-
+  while (!trans_stack.empty()) {
+    trans_stack.pop();
+  }
 }
 
 bool d3d_transform_stack_empty()
 {
-    return (trans_stack_size == 0);
+  return trans_stack.empty();
+}
+
+bool d3d_transform_stack_push()
+{
+  trans_stack.emplace(enigma::world);
+  return true;
 }
 
 bool d3d_transform_stack_top()
 {
+  if (trans_stack.empty()) return false;
+  enigma::world = trans_stack.top();
+  return true;
+}
 
+bool d3d_transform_stack_pop()
+{
+  if (trans_stack.empty()) return false;
+  enigma::world = trans_stack.top();
+  trans_stack.pop();
+  return true;
 }
 
 bool d3d_transform_stack_discard()
 {
-    trans_stack.push(0);
-    return true;
+  if (trans_stack.empty()) return false;
+  trans_stack.pop();
+  return true;
 }
 
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11surface.cpp
@@ -107,7 +107,7 @@ int surface_create(int width, int height, bool depthbuffer, bool, bool)
   }
 
   enigma::Surface* surface = new enigma::Surface();
-  TextureStruct* gmTexture = new TextureStruct(renderTargetTexture);
+  TextureStruct* gmTexture = new TextureStruct(renderTargetTexture, shaderResourceView);
   textureStructs.push_back(gmTexture);
   surface->renderTargetView = renderTargetView;
   surface->tex = textureStructs.size() - 1;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
@@ -184,7 +184,6 @@ void graphics_prepare_buffer(const int buffer, const bool isIndex) {
       m_deviceContext->Map(bufferPeer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource);
       memcpy(mappedResource.pData, data, size);
       m_deviceContext->Unmap(bufferPeer, 0);
-      //m_deviceContext->UpdateSubresource(bufferPeer, 0, NULL, data, size, 1);
     }
 
     if (isIndex) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
@@ -70,8 +70,8 @@ PixelInputType VS(VertexInputType input) {
 )";
 
 const char* g_strPS = R"(
-Texture2D gm_BaseTexture;
-SamplerState SampleType;
+Texture2D gm_BaseTextureObject : register(t0);
+SamplerState gm_BaseTexture : register(S0);
 
 struct PixelInputType {
   float4 position : SV_POSITION;
@@ -79,7 +79,7 @@ struct PixelInputType {
   float4 color : COLOR;
 };
 float4 PS(PixelInputType input) : SV_TARGET {
-  float4 textureColor = gm_BaseTexture.Sample(SampleType, input.tex);
+  float4 textureColor = gm_BaseTextureObject.Sample(gm_BaseTexture, input.tex);
   return input.color * textureColor;
 }
 )";

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/Makefile
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/Makefile
@@ -1,2 +1,2 @@
 SOURCES += $(wildcard Graphics_Systems/Direct3D11/*.cpp) $(wildcard Graphics_Systems/General/*.cpp)
-override LDLIBS += -ld3dx11 -lD3dcompiler
+override LDLIBS += -ldxgi -ldxguid -ld3d11 -lD3DCompiler

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.h
@@ -24,6 +24,7 @@
 #include "Universal_System/var4.h"
 #include <string>
 
+/*
 namespace enigma
 {
   //Forward declare
@@ -35,7 +36,7 @@ namespace enigma
   extern Matrix3 normal_matrix;
   extern bool transform_needs_update;
   extern void transformation_update();
-}
+}*/
 
 namespace enigma_user
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.h
@@ -1,5 +1,5 @@
 /** Copyright (C) 2008-2012 Josh Ventura
-*** Copyright (C) 2013-2014 Robert B. Colton, Harijs Grinbergs
+*** Copyright (C) 2013-2014 Robert Colton, Harijs Grinbergs
 *** Copyright (C) 2015 Harijs Grinbergs
 ***
 *** This file is a part of the ENIGMA Development Environment.
@@ -23,20 +23,6 @@
 #include "Universal_System/scalar.h"
 #include "Universal_System/var4.h"
 #include <string>
-
-/*
-namespace enigma
-{
-  //Forward declare
-  struct Matrix3;
-  struct Matrix4;
-
-  extern Matrix4 projection_matrix, view_matrix, model_matrix;
-  extern Matrix4 mv_matrix, mvp_matrix;
-  extern Matrix3 normal_matrix;
-  extern bool transform_needs_update;
-  extern void transformation_update();
-}*/
 
 namespace enigma_user
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -18,6 +18,7 @@
 #include "Bridges/General/GL3Context.h"
 #include "GLSLshader.h"
 #include "GL3shader.h"
+#include "GL3matrix.h"
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSd3d.h"
 #include "Graphics_Systems/General/GSprimitives.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.cpp
@@ -16,6 +16,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "GL3matrix.h"
 #include "Bridges/General/GL3Context.h"
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSmatrix.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.h
@@ -1,0 +1,30 @@
+/** Copyright (C) 2013-2014 Harijs Grinbergs
+*** Copyright (C) 2015 Harijs Grinbergs
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+namespace enigma
+{
+  //Forward declare
+  struct Matrix3;
+  struct Matrix4;
+
+  extern Matrix4 projection_matrix, view_matrix, model_matrix;
+  extern Matrix4 mv_matrix, mvp_matrix;
+  extern Matrix3 normal_matrix;
+  extern bool transform_needs_update;
+  extern void transformation_update();
+}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -20,6 +20,7 @@
 #include "GL3profiler.h"
 #include "GL3shader.h"
 #include "GLSLshader.h"
+#include "GL3matrix.h"
 
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSvertex_impl.h"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,11 +52,11 @@ install:
   - set MINGW_CHOST=x86_64-w64-mingw32
   - set PKG_CONFIG_PATH=/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig
   - >
-    pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis
-    mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme
-    mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2 mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet mingw-w64-x86_64-glew
-    mingw-w64-x86_64-protobuf mingw-w64-x86_64-grpc mingw-w64-x86_64-pugixml mingw-w64-x86_64-rapidjson mingw-w64-x86_64-yaml-cpp
-    mingw-w64-x86_64-SDL2
+    pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-glm mingw-w64-x86_64-openal mingw-w64-x86_64-dumb
+    mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123
+    mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme mingw-w64-x86_64-sfml mingw-w64-x86_64-gtk2
+    mingw-w64-x86_64-box2d mingw-w64-x86_64-bullet mingw-w64-x86_64-glew mingw-w64-x86_64-protobuf mingw-w64-x86_64-grpc
+    mingw-w64-x86_64-pugixml mingw-w64-x86_64-rapidjson mingw-w64-x86_64-yaml-cpp mingw-w64-x86_64-SDL2
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {


### PR DESCRIPTION
The goal here was to get Direct3D11 actually working with some texturing support and all. In order to do this I had to use GLM to implement the matrix functions. The idea is that once we get matrices working perfectly in this system, we can move them to general and use them for all of the graphics systems.

* Moved render target initialization logic to a helper method to properly implement the window resized handling in the D3D11 bridge
* Implemented vertical synchronization functionality for D3D11
* Implemented all projection/transform/transform stack functions for D3D11 using GLM
* Fixed `graphics_create_texture` to use BGRA format and deleted unused code for D3D11
* Added `getDefaultWhiteTexture` helper to implement `texture_set_stage` behavior. This is so that sampling unset textures in a D3D11 shader gives you white and not black (this is dictated by OpenGL's standard but not Direct3D's). This is the best way to offer GM compatibility for this without requiring users to change their shaders to be compatible in ENIGMA.
* Added `gm_BaseTexture` sampling to the default D3D11 shader
* Fixed vertex buffer writing using `Map`/`Unmap` instead of `UpdateSubresource`
* Rewrote input layout generation using shader reflection. Basically we reflect over the current shader in order to create an input layout that matches the user's vertex format up to the expected shader inputs. This is a requirement for D3D11, unlike the other systems, because the API/runtime requires you supply at least the minimum inputs (you can supply more but not less inputs than the shader expects).
* Moved the GL3 matrix stuff out of `GSmatrix.h` and into `GL3matrix.h` because it doesn't apply to the other systems and doesn't belong there

In order to build Direct3D11 now you will need to have the GLM dependency, it's just a single header.
```bash
pacman -Sy mingw-w64-i686-glm # 32 bit
pacman -Sy mingw-w64-x86_64-glm # 64 bit
```

![D3D11 3D Cubes Demo](https://user-images.githubusercontent.com/3212801/45457716-57ed2180-b6be-11e8-84bf-f2e415db2fd4.png)
![D3D11 Sprite Benchmark](https://user-images.githubusercontent.com/3212801/45457770-8cf97400-b6be-11e8-8255-61bdf6b1f253.png)
![D3D11 FPS Game](https://user-images.githubusercontent.com/3212801/45457826-c29e5d00-b6be-11e8-8bd2-6657213dcf1a.png)
![D3D11 Game of Life](https://user-images.githubusercontent.com/3212801/45457689-3d1aad00-b6be-11e8-9f88-fdc743526fb0.png)
![D3D11 Tile Add Benchmark](https://user-images.githubusercontent.com/3212801/45460171-de5b3080-b6c9-11e8-9559-615199098d2a.png)
![D3D11 Tile Collision Demo](https://user-images.githubusercontent.com/3212801/45460192-f8950e80-b6c9-11e8-815b-b79d7a8bb8bd.png)
![D3D11 Animation Platform](https://user-images.githubusercontent.com/3212801/45457744-76531d00-b6be-11e8-90df-6a64e2b6ed9e.png)
