### PR TITLE
GMK Byte Evaluation Order Fix

### DIFF
--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -229,18 +229,21 @@ class Decoder {
     return byte;
   }
 
+  // NOTE: for read[2-4] the order of initialization is
+  // guaranteed, but order of evaluation is not
+
   int read2() {
-    int one = read(); int two = read();
+    int one = read(), two = read();
     return (one | (two << 8));
   }
 
   int read3() {
-    int one = read(); int two = read(); int three = read();
+    int one = read(), two = read(), three = read();
     return (one | (two << 8) | (three << 16));
   }
 
   int read4() {
-    int one = read(); int two = read(); int three = read(); int four = read();
+    int one = read(), two = read(), three = read(), four = read();
     return (one | (two << 8) | (three << 16) | (four << 24));
   }
 

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -230,15 +230,18 @@ class Decoder {
   }
 
   int read2() {
-    return (read() | (read() << 8));
+    int one = read(); int two = read();
+    return (one | (two << 8));
   }
 
   int read3() {
-    return (read() | (read() << 8) | (read() << 16));
+    int one = read(); int two = read(); int three = read();
+    return (one | (two << 8) | (three << 16));
   }
 
   int read4() {
-    return (read() | (read() << 8) | (read() << 16) | (read() << 24));
+    int one = read(); int two = read(); int three = read(); int four = read();
+    return (one | (two << 8) | (three << 16) | (four << 24));
   }
 
   bool readBool() {


### PR DESCRIPTION
So I guess MSVC and MinGW/GCC have different order of evaluation. With this change, the MSVC build of RadialGM can load GMK projects successfully. Let's get this merged as quickly as possible.