### PR TITLE
AppVeyor Build Number

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@
 shallow_clone: true
 # disable automatic tests
 test: off
+# only increment the build number when building master
+pull_requests:
+  do_not_increment_build_number: true
 # don't build "feature" branches
 skip_branch_with_pr: true
 branches:


### PR DESCRIPTION
The build number should not be increased for pull requests or it's completely unusable by us. Also, increasing it for every pull request makes it excessively large.