### PR TITLE
Use Pacboy to find MSYS2 Packages in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ environment:
     #   PACKAGES: "bullet:x"}
   #END WINDOWS
 install:
-  - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
+  - set PATH=C:\msys64;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;%PATH%
   - > # Install packages common to all builds
     pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
   - gcc -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,7 @@ environment:
 install:
   - set PATH=C:\msys64;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;%PATH%
   - > # Install packages common to all builds
-    C:\msys64\msys2_shell.cmd -defterm -mingw64 -no-start -here -lc "pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%"
+    "C:\msys64\usr\bin\pacboy" --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,28 +33,28 @@ environment:
 
     # Platforms
     - {COMPILER: gcc, PLATFORM: SDL, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-       PACKAGES: SDL2:x}
+       PACKAGES: "SDL2:x"}
 
     # Graphics
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D11, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-       PACKAGES: glm:x}
+       PACKAGES: "glm:x"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: OpenGL1, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-       PACKAGES: glew:x}
+       PACKAGES: "glew:x"}
 
     # Audio
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: DirectSound, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
     #TODO: Fix SFML on Windows
     #- {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: SFML, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-    #   PACKAGES: sfml:x}
+    #   PACKAGES: "sfml:x"}
     #TODO: Fix OpenAL on Windows
     #- {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: OpenAL, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-    #   PACKAGES: openal:x dum:x libvorbis:x libogg:x flac:x mpg123:x libsndfile:x libgme:x}
+    #   PACKAGES: "openal:x dum:x libvorbis:x libogg:x flac:x mpg123:x libsndfile:x libgme:x"}
 
     # Widgets
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: Win32, EXTENSIONS: "None"}
     #TODO: Fix GTK+ on Windows
     #- {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: GTK+, EXTENSIONS: "None",
-    #   PACKAGES: gtk2:x}
+    #   PACKAGES: "gtk2:x"}
 
     # Extensions
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "DirectShow"}
@@ -62,12 +62,12 @@ environment:
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "XInput"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "Box2DPhysics",
-       PACKAGES: box2d:x}
+       PACKAGES: "box2d:x"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "StudioPhysics",
-       PACKAGES: box2d:x}
+       PACKAGES: "box2d:x"}
     #TODO: Fix Bullet Physics on Windows
     #- {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "BulletDynamics",
-    #   PACKAGES: bullet:x}
+    #   PACKAGES: "bullet:x"}
   #END WINDOWS
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,7 @@ environment:
 install:
   - set PATH=C:\msys64;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;%PATH%
   - > # Install packages common to all builds
-    C:\msys64\usr\bin\pacboy.exe --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
+    C:\msys64\usr\bin\pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,7 @@ environment:
 install:
   - set PATH=C:\msys64;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;%PATH%
   - > # Install packages common to all builds
-    C:\msys64\usr\bin\pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
+    C:\msys64\msys2_shell.cmd -defterm -mingw64 -no-start -here -lc "pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%"
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,29 +33,28 @@ environment:
 
     # Platforms
     - {COMPILER: gcc, PLATFORM: SDL, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-       PACKAGES: mingw-w64-x86_64-SDL2}
+       PACKAGES: SDL2:x}
 
     # Graphics
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D11, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-       PACKAGES: mingw-w64-x86_64-glm}
+       PACKAGES: glm:x}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: OpenGL1, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-       PACKAGES: mingw-w64-x86_64-glew}
+       PACKAGES: glew:x}
 
     # Audio
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: DirectSound, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None"}
     #TODO: Fix SFML on Windows
     #- {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: SFML, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-    #   PACKAGES: mingw-w64-x86_64-sfml}
+    #   PACKAGES: sfml:x}
     #TODO: Fix OpenAL on Windows
     #- {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: OpenAL, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "None",
-    #   PACKAGES: mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123
-    #             mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme}
+    #   PACKAGES: openal:x dum:x libvorbis:x libogg:x flac:x mpg123:x libsndfile:x libgme:x}
 
     # Widgets
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: Win32, EXTENSIONS: "None"}
     #TODO: Fix GTK+ on Windows
     #- {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: GTK+, EXTENSIONS: "None",
-    #   PACKAGES: mingw-w64-x86_64-gtk2}
+    #   PACKAGES: gtk2:x}
 
     # Extensions
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "DirectShow"}
@@ -63,18 +62,17 @@ environment:
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "XInput"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "MediaControlInterface"}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "Box2DPhysics",
-       PACKAGES: mingw-w64-x86_64-box2d}
+       PACKAGES: box2d:x}
     - {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "StudioPhysics",
-       PACKAGES: mingw-w64-x86_64-box2d}
+       PACKAGES: box2d:x}
     #TODO: Fix Bullet Physics on Windows
     #- {COMPILER: gcc, PLATFORM: Win32, MODE: Debug, GRAPHICS: Direct3D9, AUDIO: None, COLLISION: None, NETWORK: None, WIDGETS: None, EXTENSIONS: "BulletDynamics",
-    #   PACKAGES: mingw-w64-x86_64-bullet}
+    #   PACKAGES: bullet:x}
   #END WINDOWS
 install:
   - set PATH=c:\msys64;C:\msys64\mingw64\bin;c:\msys64\usr\local\bin;c:\msys64\usr\bin;%PATH%
   - > # Install packages common to all builds
-    pacman --noconfirm -S mingw-w64-x86_64-boost mingw-w64-x86_64-pugixml mingw-w64-x86_64-rapidjson
-    mingw-w64-x86_64-yaml-cpp mingw-w64-x86_64-grpc mingw-w64-x86_64-protobuf %PACKAGES%
+    pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,7 @@ environment:
 install:
   - set PATH=C:\msys64;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;%PATH%
   - > # Install packages common to all builds
-    pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
+    C:\msys64\usr\bin\pacboy.exe --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,7 @@ environment:
 install:
   - set PATH=C:\msys64;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;%PATH%
   - > # Install packages common to all builds
-    "C:\msys64\usr\bin\pacboy" --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%
+    bash -lc "pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x %PACKAGES%"
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {


### PR DESCRIPTION
This change uses the pacboy bash script, instead of pacman, to find and install the packages in our AppVeyor build. The reason for this change is to make the lists of dependencies easier to read. I have already changed ENIGMA's wiki to also use pacboy because the repeated `mingw-w64-x86_64-` is really hard to look at.
https://enigma-dev.org/docs/Wiki/Install:Windows#Dependencies