### PR TITLE
Fix 3D Perspective Mode

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -41,6 +41,7 @@ void d3d_start()
 {
     draw_batch_flush(batch_flush_deferred);
 	enigma::d3dMode = true;
+    enigma::d3dPerspective = true;
 	enigma::d3dCulling =  rs_none;
 	d3d_set_hidden(false);
 }
@@ -49,6 +50,7 @@ void d3d_end()
 {
     draw_batch_flush(batch_flush_deferred);
 	enigma::d3dMode = false;
+    enigma::d3dPerspective = false;
 	enigma::d3dCulling = rs_none;
 	d3d_set_hidden(false);
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11matrix.cpp
@@ -38,11 +38,6 @@ namespace enigma {
 namespace enigma_user
 {
 
-void d3d_set_perspective(bool enable)
-{
-
-}
-
 void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,
                         gs_scalar xto, gs_scalar yto, gs_scalar zto,
                         gs_scalar xup, gs_scalar yup, gs_scalar zup)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -58,6 +58,7 @@ void d3d_start()
 {
     draw_batch_flush(batch_flush_deferred);
 	enigma::d3dMode = true;
+    enigma::d3dPerspective = true;
 	enigma::d3dCulling =  rs_none;
 	d3dmgr->device->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
 	d3d_set_hidden(false);
@@ -72,6 +73,7 @@ void d3d_end()
 {
     draw_batch_flush(batch_flush_deferred);
 	enigma::d3dMode = false;
+    enigma::d3dPerspective = false;
 	enigma::d3dCulling = rs_none;
 	d3d_set_hidden(false);
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9matrix.cpp
@@ -34,21 +34,6 @@ void graphics_set_transform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX *pMatri
 namespace enigma_user
 {
 
-void d3d_set_perspective(bool enable)
-{
-  D3DXMATRIX matProjection;
-  if (enable) {
-    D3DXMatrixPerspectiveFovLH(&matProjection, 45, -view_wview[view_current] / (double)view_hview[view_current], 32000, -32000);
-  } else {
-    D3DXMatrixPerspectiveFovLH(&matProjection, 0, 1, 0, 1);
-  }
-  //set projection matrix
-  graphics_set_transform(D3DTS_PROJECTION, &matProjection);
-  // Unverified note: Perspective not the same as in GM when turning off perspective and using d3d projection
-  // Unverified note: GM has some sort of dodgy behaviour where this function doesn't affect anything when calling after d3d_set_projection_ext
-  // See also OpenGL3/GL3d3d.cpp Direct3D9/DX9d3d.cpp OpenGL1/GLd3d.cpp
-}
-
 void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs_scalar xto, gs_scalar yto, gs_scalar zto,gs_scalar xup, gs_scalar yup, gs_scalar zup)
 {
 	D3DXVECTOR3 vEyePt( xfrom, yfrom, zfrom );

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
@@ -26,6 +26,7 @@ namespace enigma {
   extern bool d3dMode;
   extern bool d3dHidden;
   extern bool d3dZWriteEnable;
+  extern bool d3dPerspective;
   extern int d3dCulling;
   void d3d_light_update_positions();
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
@@ -15,6 +15,9 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "GSmatrix.h"
+#include "GSd3d.h"
+
 namespace enigma {
   bool d3dPerspective;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
@@ -19,7 +19,7 @@
 #include "GSd3d.h"
 
 namespace enigma {
-  bool d3dPerspective;
+  bool d3dPerspective = false;
 }
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
@@ -1,0 +1,34 @@
+/** Copyright (C) 2018 Robert Colton
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+namespace enigma {
+  bool d3dPerspective;
+}
+
+namespace enigma_user {
+
+void d3d_set_perspective(bool enable) {
+  // in GM8.1 and GMS v1.4 this does not take effect
+  // until the next frame in screen_redraw
+  enigma::d3dPerspective = enable;
+}
+
+bool d3d_get_perspective() {
+  return enigma::d3dPerspective;
+}
+
+}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.h
@@ -36,6 +36,7 @@ enum {
 //TODO: Transformation functions should probably not use gs_scalar as the angular type but implement their own scalar to avoid
 //losing precision with math functions.
 void d3d_set_perspective(bool enable);
+bool d3d_get_perspective();
 void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs_scalar xto, gs_scalar yto, gs_scalar zto,gs_scalar xup, gs_scalar yup, gs_scalar zup);
 void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,gs_scalar xto, gs_scalar yto, gs_scalar zto, gs_scalar xup, gs_scalar yup, gs_scalar zup, gs_scalar angle, gs_scalar aspect, gs_scalar znear, gs_scalar zfar);
 void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -153,7 +153,10 @@ static inline int draw_tiles()
 
 void clear_view(float x, float y, float w, float h, float angle, bool showcolor)
 {
-  d3d_set_projection_ortho(x, y, w, h, angle);
+  if (enigma::d3dMode && enigma::d3dPerspective)
+    d3d_set_projection_perspective(x, y, w, h, angle);
+  else
+    d3d_set_projection_ortho(x, y, w, h, angle);
 
   if (showcolor)
     enigma_user::draw_clear(background_color);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEd3d.cpp
@@ -49,6 +49,7 @@ namespace enigma_user
 	void d3d_start()
 	{
 		enigma::d3dMode = true;
+		enigma::d3dPerspective = true;
 		enigma::d3dHidden = true;
 		enigma::d3dZWriteEnable = true;
 		enigma::d3dCulling = rs_none;
@@ -57,6 +58,7 @@ namespace enigma_user
 	void d3d_end()
 	{
 		enigma::d3dMode = false;
+		enigma::d3dPerspective = false;
 		enigma::d3dHidden = false;
 		enigma::d3dZWriteEnable = false;
 		enigma::d3dCulling = rs_none;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
@@ -205,7 +205,6 @@ namespace enigma_user
 	void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height){}
 	void display_set_gui_size(unsigned int width, unsigned int height){}
 
-	void d3d_set_perspective(bool enable){}
 	void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, gs_scalar xto, gs_scalar yto, gs_scalar zto, gs_scalar xup, gs_scalar yup, gs_scalar zup){}
 	void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, gs_scalar xto, gs_scalar yto, gs_scalar zto, gs_scalar xup, gs_scalar yup, gs_scalar zup, gs_scalar angle, gs_scalar aspect, gs_scalar znear, gs_scalar zfar){}
 	void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle){}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
@@ -165,7 +165,6 @@ namespace enigma_user
 	void d3d_set_fog_end(double end);
 	void d3d_set_fog_density(double density);
 
-	void d3d_set_perspective(bool enable);
 	void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, gs_scalar xto, gs_scalar yto, gs_scalar zto, gs_scalar xup, gs_scalar yup, gs_scalar zup);
 	void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, gs_scalar xto, gs_scalar yto, gs_scalar zto, gs_scalar xup, gs_scalar yup, gs_scalar zup, gs_scalar angle, gs_scalar aspect, gs_scalar znear, gs_scalar zfar);
 	void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -83,6 +83,7 @@ void d3d_start()
 
   // Enable depth buffering
   enigma::d3dMode = true;
+  enigma::d3dPerspective = true;
   enigma::d3dHidden = true;
   enigma::d3dZWriteEnable = true;
   enigma::d3dCulling = rs_none;
@@ -110,6 +111,7 @@ void d3d_end()
   draw_batch_flush(batch_flush_deferred);
 
   enigma::d3dMode = false;
+  enigma::d3dPerspective = false;
   enigma::d3dHidden = false;
   enigma::d3dZWriteEnable = false;
   enigma::d3dCulling = rs_none;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLmatrix.cpp
@@ -58,21 +58,6 @@ namespace enigma
 namespace enigma_user
 {
 
-void d3d_set_perspective(bool enable)
-{
-    if (enable) {
-      enigma::projection_matrix.init_perspective_proj_transform(45, -view_wview[view_current] / (gs_scalar)view_hview[view_current], 1, 32000);
-    } else {
-      //projection_matrix.init_perspective_proj_transform(0, 1, 0, 1); //they cannot be zeroes!
-    }
-    glMatrixMode(GL_PROJECTION);
-    glLoadMatrix(enigma::projection_matrix);
-    glMatrixMode(GL_MODELVIEW);
-  // Unverified note: Perspective not the same as in GM when turning off perspective and using d3d projection
-  // Unverified note: GM has some sort of dodgy behaviour where this function doesn't affect anything when calling after d3d_set_projection_ext
-  // See also OpenGL3/GL3d3d.cpp Direct3D9/DX9d3d.cpp OpenGL1/GLd3d.cpp
-}
-
 void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, gs_scalar xto, gs_scalar yto, gs_scalar zto, gs_scalar xup, gs_scalar yup, gs_scalar zup)
 {
     (enigma::d3dHidden?glEnable:glDisable)(GL_DEPTH_TEST);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -91,6 +91,7 @@ void d3d_start()
 
   // Enable depth buffering
   enigma::d3dMode = true;
+  enigma::d3dPerspective = true;
   enigma::d3dHidden = true;
   enigma::d3dZWriteEnable = true;
   enigma::d3dCulling = rs_none;
@@ -112,6 +113,7 @@ void d3d_end()
   draw_batch_flush(batch_flush_deferred);
 
   enigma::d3dMode = false;
+  enigma::d3dPerspective = false;
   enigma::d3dHidden = false;
   enigma::d3dZWriteEnable = false;
   enigma::d3dCulling = rs_none;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3matrix.cpp
@@ -71,20 +71,6 @@ namespace enigma
 
 namespace enigma_user
 {
-  void d3d_set_perspective(bool enable)
-  {
-      enigma::transformation_mark_dirty();
-      if (enable) {
-        enigma::projection_matrix.init_perspective_proj_transform(45, -view_wview[view_current] / (gs_scalar)view_hview[view_current], 1, 32000);
-      } else {
-        //projection_matrix.init_perspective_proj_transform(0, 1, 0, 1); //they cannot be zeroes!
-      }
-
-    // Unverified note: Perspective not the same as in GM when turning off perspective and using d3d projection
-    // Unverified note: GM has some sort of dodgy behaviour where this function doesn't affect anything when calling after d3d_set_projection_ext
-    // See also OpenGL3/GL3d3d.cpp Direct3D9/DX9d3d.cpp OpenGL1/GLd3d.cpp
-  }
-
   void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom, gs_scalar xto, gs_scalar yto, gs_scalar zto, gs_scalar xup, gs_scalar yup, gs_scalar zup)
   {
       enigma::transformation_mark_dirty();


### PR DESCRIPTION
This one is going to be a little bit complicated to explain, but from my testing, `d3d_set_perspective` in GM8.1 and GMSv1.4 should **never** take effect until the next frame/`screen_redraw`. It should also only take effect if we are actually in d3d mode meaning that `d3d_start()` has been called.

The newer GMS manual describes this function as if it affects the "default" room projection because it mentions the view:
https://docs.yoyogames.com/source/dadiospice/002_reference/drawing/drawing%203d/3d%20setup/d3d_set_perspective.html

>This turns on (or off) perspective projection. With a perspective projection instances that have a greater depth will appear smaller, so when the depth is 0 it is equal to the original size and the viewpoint for the camera is placed at a distance above the room. This default distance is equal to the width of the room as that gives a reasonable starting projection, and only instances in front of the camera are drawn. Don't use instances with a depth smaller than 0 (or at least not smaller than -w where w is the width of the room or the view).

I've tested this on several games which make use of the `d3d_set_perspective` function including the High Polygonal 3D Cubes Demo, House Effects Demo, Animation Platform Example (DarkAceZ game). I did not discover any regressions as a result of these changes here. However, I should also mention that I notice no improvements in any game that makes use of this function either (probably due to the generally poor understanding of how it was supposed to work even in GM8.1).

To clarify: `d3d_set_perspective` only affects the **_starting_** projection at the beginning of every frame when in 3D mode

As usual, I have created a test GMK: [perspective-projection-test.zip](https://github.com/enigma-dev/enigma-dev/files/2386685/perspective-projection-test.zip)

In GM8.1, GMSv1.4, and ENIGMA (with this pr applied) the game draws the text inverted. This means that the orthographic projection set immediately after `d3d_start` does not take effect because it is overridden by the perspective projection that GM sets before each draw event. If we move the setting of the orthographic projection into the draw event of each, then the text is drawn normally and not inverted. If we run this test project on ENIGMA master, the text is just always drawn normal without being inverted (incorrect because the perspective projection is never applied).

Another example that proves `d3d_set_perspective` does not have any effect until the **_next_** frame is the following:
```gml
d3d_set_projection_ortho(0, 0, room_width, room_height, 0);
d3d_set_perspective(true); // no effect in 8.1 or GMS
draw_text(0, 0, "ABCDEFGHIJKLMNOP!");
```