### PR TITLE
Fix Event Handling/Input Lag for Win32 and Xlib

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -76,7 +76,7 @@ int enigma_main(int argc, char** argv) {
     update_mouse_variables();
 
     if (updateTimer() != 0) continue;
-    if (handleEvents() != 0) continue;
+    if (handleEvents() != 0) break;
     if (gameWait() != 0) continue;
 
     // if any extensions need updated, update them now

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -76,7 +76,7 @@ int enigma_main(int argc, char** argv) {
     update_mouse_variables();
 
     if (updateTimer() != 0) continue;
-    if (handleEvents() != 0) break;
+    if (handleEvents() != 0) continue;
     if (gameWait() != 0) continue;
 
     // if any extensions need updated, update them now

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -270,16 +270,14 @@ int updateTimer() {
 int handleEvents() {
   if (enigma::game_isending) PostQuitMessage(enigma::game_return);
 
-  if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+  while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
     if (msg.message == WM_QUIT) {
       enigma::game_return = msg.wParam;
-      enigma::game_isending = true;
+      return 1;
     } else {
       TranslateMessage(&msg);
       DispatchMessage(&msg);
     }
-
-    return 1;
   }
 
   return 0;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -273,13 +273,13 @@ int handleEvents() {
   if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
     if (msg.message == WM_QUIT) {
       enigma::game_return = msg.wParam;
-      return 1;
+      enigma::game_isending = true;
     } else {
       TranslateMessage(&msg);
       DispatchMessage(&msg);
     }
 
-    return 0;
+    return 1;
   }
 
   return 0;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -56,7 +56,7 @@ int handleEvents() {
     switch (e.type) {
       case KeyPress: {
         gk = XLookupKeysym(&e.xkey, 0);
-        if (gk == NoSymbol) return 0;
+        if (gk == NoSymbol) continue;
 
         if (!(gk & 0xFF00))
           actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0xFF]);
@@ -79,16 +79,16 @@ int handleEvents() {
         enigma_user::keyboard_key = actualKey;
         if (enigma::last_keybdstatus[actualKey] == 1 && enigma::keybdstatus[actualKey] == 0) {
           enigma::keybdstatus[actualKey] = 1;
-          return 0;
+          continue;
         }
         enigma::last_keybdstatus[actualKey] = enigma::keybdstatus[actualKey];
         enigma::keybdstatus[actualKey] = 1;
-        return 0;
+        continue;
       }
       case KeyRelease: {
         enigma_user::keyboard_key = 0;
         gk = XLookupKeysym(&e.xkey, 0);
-        if (gk == NoSymbol) return 0;
+        if (gk == NoSymbol) continue;
 
         if (!(gk & 0xFF00))
           actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0xFF]);
@@ -97,7 +97,7 @@ int handleEvents() {
 
         enigma::last_keybdstatus[actualKey] = enigma::keybdstatus[actualKey];
         enigma::keybdstatus[actualKey] = 0;
-        return 0;
+        continue;
       }
       case ButtonPress: {
         if (e.xbutton.button < 4)
@@ -118,7 +118,7 @@ int handleEvents() {
               break;
             default:;
           }
-        return 0;
+        continue;
       }
       case ButtonRelease: {
         if (e.xbutton.button < 4)
@@ -139,7 +139,7 @@ int handleEvents() {
               break;
             default:;
           }
-        return 0;
+        continue;
       }
       case ConfigureNotify: {
         enigma::windowWidth = e.xconfigure.width;
@@ -148,17 +148,17 @@ int handleEvents() {
         if (WindowResizedCallback != NULL) {
           WindowResizedCallback();
         }
-        return 0;
+        continue;
       }
       case FocusIn:
         input_initialize();
         init_joysticks();
         game_window_focused = true;
         pausedSteps = 0;
-        return 0;
+        continue;
       case FocusOut:
         game_window_focused = false;
-        return 0;
+        continue;
       case ClientMessage:
         if ((Atom)e.xclient.data.l[0] ==
             wm_delwin)  //For some reason, this line warns whether we cast to unsigned or not.
@@ -168,7 +168,7 @@ int handleEvents() {
 #ifdef DEBUG_MODE
         printf("Unhandled xlib event: %d\n", e.type);
 #endif
-        return 0;
+        continue;
     }
     //Move/Resize = ConfigureNotify
     //Min = UnmapNotify


### PR DESCRIPTION
This fixes the event handling issues and input lag reported in #1375 for Windows and Xlib. This has been bugging everybody and I finally tracked it down to 15fce1a894de6c2f5ec1b4443fd1cdb5a02dbf9c (#1259) where fundies generalized the main loop.

The mistake made was very minor, when PeekMessage was handled, fundies continued to return 0 from `handleEvents` which allowed the regular game events to continue being processed. We actually need `handleEvents` to remove all the native messages from the queue. Only when all native events are cleared should the main loop proceed to handle ENIGMA's events.
https://github.com/enigma-dev/enigma-dev/commit/15fce1a894de6c2f5ec1b4443fd1cdb5a02dbf9c#diff-a46c22f2e9ae6a84c51d776c9e2b7308L326
https://github.com/enigma-dev/enigma-dev/commit/15fce1a894de6c2f5ec1b4443fd1cdb5a02dbf9c#diff-65042ee974c747357858fd8fb1f2b0ffR74

A similar mistake was made in the `handleEvents` fundies copied for Xlib. It was already written this way but fundies introduced a while to `handleEvents` in Xlib without considering that it should continue instead of `return 0` to process ALL of the Xlib events before returning.
https://github.com/enigma-dev/enigma-dev/commit/15fce1a894de6c2f5ec1b4443fd1cdb5a02dbf9c#diff-83a6b7748c18eabdcd3d45d4148386d0R51

This change seems technically correct according to the following site:
http://www.directxtutorial.com/Lesson.aspx?lessonid=9-1-4

I guess a game loop is supposed to remove all messages from the queue in a nested while loop when it comes to Win32/Xlib. I know this fixes Xlib as well because I had hugar test the change and he is confirming that this change fixes the input lag without having to change his system settings.

Finally, I want to mention that if anybody remembers me complaining about some of my graphics benchmarks having a higher FPS when the window was not in focus, I believe it was because of this issue. With this change I went back and ran several of the benchmarks again in the various systems and I no longer see this weird behavior of the FPS changing when the window goes out of focus. I am able to reproduce this on master, so this must have been the cause.

Overall this makes both Win32 and Xlib behave more like SDL now. Definitely an improvement here.