### PR TITLE
Color Macro Fixes

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11colors.cpp
@@ -35,9 +35,9 @@ void draw_clear_alpha(int col, float alpha)
 	float color[4];
 
 	// Setup the color to clear the buffer to.
-	color[0] = COL_GET_R(col)/255.0;
-	color[1] = COL_GET_G(col)/255.0;
-	color[2] = COL_GET_B(col)/255.0;
+	color[0] = COL_GET_Rf(col);
+	color[1] = COL_GET_Gf(col);
+	color[2] = COL_GET_Bf(col);
 	color[3] = alpha;
 
 	// Clear the back buffer.
@@ -50,9 +50,9 @@ void draw_clear(int col)
 	float color[4];
 
 	// Setup the color to clear the buffer to.
-	color[0] = COL_GET_R(col)/255.0;
-	color[1] = COL_GET_G(col)/255.0;
-	color[2] = COL_GET_B(col)/255.0;
+	color[0] = COL_GET_Rf(col);
+	color[1] = COL_GET_Gf(col);
+	color[2] = COL_GET_Bf(col);
 	color[3] = 1;
 
 	// Clear the back buffer.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
@@ -36,7 +36,7 @@ namespace enigma_user
 void draw_clear_alpha(int col, float alpha)
 {
 	draw_batch_flush(batch_flush_deferred);
-	d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_COLORVALUE(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col), alpha), 1.0f, 0);
+	d3dmgr->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_RGBA(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col), CLAMP_ALPHA(alpha)), 1.0f, 0);
 }
 
 void draw_clear(int col)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -135,7 +135,7 @@ void d3d_set_fog_color(int color)
 {
     draw_batch_flush(batch_flush_deferred);
 	d3dmgr->SetRenderState(D3DRS_FOGCOLOR,
-                    D3DCOLOR_COLORVALUE(COL_GET_R(color), COL_GET_G(color), COL_GET_B(color), 1.0f)); // Highest 8 bits are not used.
+                    D3DCOLOR_RGBA(COL_GET_R(color), COL_GET_G(color), COL_GET_B(color), 255)); // Highest 8 bits are not used.
 }
 
 void d3d_set_fog_start(double start)
@@ -276,21 +276,12 @@ class d3d_lights
             ind_pos.insert(pair<int,posi>(ms, posi(-dx, -dy, -dz, 0.0f)));
         }
 
-		D3DLIGHT9 light;    // create the light struct
-
-		ZeroMemory(&light, sizeof(light));    // clear out the light struct for use
-		light.Type = D3DLIGHT_DIRECTIONAL;    // make the light type 'directional light'
-		light.Diffuse = D3DXCOLOR(COL_GET_R(col), COL_GET_R(col), COL_GET_B(col), 1.0f);    // set the light's color
-		light.Direction = D3DXVECTOR3(dx, dy, dz);
+		D3DLIGHT9 light = { };
+		light.Type = D3DLIGHT_DIRECTIONAL;
+		light.Diffuse = { COL_GET_Rf(col), COL_GET_Gf(col), COL_GET_Bf(col), 1.0f };
+		light.Direction = { dx, dy, dz };
 
 		d3dmgr->SetLight(ms, &light);    // send the light struct properties to nth light
-
-		D3DMATERIAL9 material;
-		ZeroMemory(&material, sizeof(D3DMATERIAL9));
-		material.Diffuse = D3DXCOLOR(1.0f, 1.0f, 1.0f, 1.0f);
-		material.Ambient = D3DXCOLOR(1.0f, 1.0f, 1.0f, 1.0f);
-
-		d3dmgr->SetMaterial(&material);
 
 		light_update_positions();
         return true;
@@ -321,12 +312,10 @@ class d3d_lights
             light_ind.insert(pair<int,int>(id, ms));
             ind_pos.insert(pair<int,posi>(ms, posi(x, y, z, 1)));
         }
-		D3DLIGHT9 light;    // create the light struct
-
-		ZeroMemory(&light, sizeof(light));    // clear out the light struct for use
-		light.Type = D3DLIGHT_POINT;    // make the light type 'directional light'
-		light.Diffuse = D3DXCOLOR(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col), 1.0f);    // set the light's color
-		light.Position = D3DXVECTOR3(x, y, z);
+		D3DLIGHT9 light = { };
+		light.Type = D3DLIGHT_POINT;
+		light.Diffuse = { COL_GET_Rf(col), COL_GET_Gf(col), COL_GET_Bf(col), 1.0f };
+		light.Position = { x, y, z };
 		light.Range = range;
 		light.Attenuation0 = 1.0f;    // no constant inverse attenuation
 		light.Attenuation1 = 0.0f;    // only .125 inverse attenuation
@@ -336,13 +325,6 @@ class d3d_lights
 		light.Falloff = 1.0f;    // use the typical falloff
 
 		d3dmgr->SetLight(ms, &light);    // send the light struct properties to nth light
-
-		D3DMATERIAL9 material;
-		ZeroMemory(&material, sizeof(D3DMATERIAL9));
-		material.Diffuse = D3DXCOLOR(1.0f, 1.0f, 1.0f, 1.0f);
-		material.Ambient = D3DXCOLOR(1.0f, 1.0f, 1.0f, 1.0f);
-
-		d3dmgr->SetMaterial(&material);
 
 		return true;
     }
@@ -431,7 +413,7 @@ void d3d_light_shininess(int facemode, int shine)
 void d3d_light_define_ambient(int col)
 {
     draw_batch_flush(batch_flush_deferred);
-    d3dmgr->SetRenderState(D3DRS_AMBIENT, D3DCOLOR_COLORVALUE(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col), 1));
+    d3dmgr->SetRenderState(D3DRS_AMBIENT, D3DCOLOR_RGBA(COL_GET_R(col), COL_GET_G(col), COL_GET_B(col), 255));
 }
 
 bool d3d_light_enable(int id, bool enable)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolor_macros.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolor_macros.h
@@ -10,6 +10,11 @@
 #define COL_GET_B(x) ((x & 0x00FF0000)>>16)
 #define COL_GET_A(x) ((x & 0xFF000000)>>24)
 
+#define COL_GET_Rf(x) (COL_GET_R(x)/255.0f)
+#define COL_GET_Gf(x) (COL_GET_G(x)/255.0f)
+#define COL_GET_Bf(x) (COL_GET_B(x)/255.0f)
+#define COL_GET_Af(x) (COL_GET_A(x)/255.0f)
+
 // clamps a floating-point alpha (from 0 to 1) between 0 and 255
 #define CLAMP_ALPHA(alpha) (alpha>1?255:(alpha<0?0:(unsigned char)(alpha*255)))
 // clamps a floating-point alpha (from 0 to 1) between 0 and 1

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLcolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLcolors.cpp
@@ -32,13 +32,13 @@ void draw_clear_alpha(int col,float alpha)
 {
 	draw_batch_flush(batch_flush_deferred);
   //Unfortunately, we lack a 255-based method for setting ClearColor.
-	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,alpha);
+	glClearColor(COL_GET_Rf(col),COL_GET_Gf(col),COL_GET_Bf(col),alpha);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 void draw_clear(int col)
 {
 	draw_batch_flush(batch_flush_deferred);
-	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,1);
+	glClearColor(COL_GET_Rf(col),COL_GET_Gf(col),COL_GET_Bf(col),1.0f);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -182,9 +182,9 @@ void d3d_set_fog_color(int color)
 {
   draw_batch_flush(batch_flush_deferred);
   GLfloat fog_color[3];
-  fog_color[0] = COL_GET_R(color);
-  fog_color[1] = COL_GET_G(color);
-  fog_color[2] = COL_GET_B(color);
+  fog_color[0] = COL_GET_Rf(color);
+  fog_color[1] = COL_GET_Gf(color);
+  fog_color[2] = COL_GET_Bf(color);
   glFogfv(GL_FOG_COLOR, fog_color);
 }
 
@@ -324,7 +324,7 @@ class d3d_lights
             ind_pos.insert(pair<int,posi>(ms, posi(-dx, -dy, -dz, 0.0f)));
         }
 
-        const float dir[4] = {float(-dx), float(-dy), float(-dz), 0.0f}, color[4] = {float(COL_GET_R(col)), float(COL_GET_G(col)), float(COL_GET_B(col)), 1.0f};
+        const float dir[4] = {float(-dx), float(-dy), float(-dz), 0.0f}, color[4] = {float(COL_GET_Rf(col)), float(COL_GET_Gf(col)), float(COL_GET_Bf(col)), 1.0f};
         glLightfv(GL_LIGHT0+ms, GL_POSITION, dir);
         glLightfv(GL_LIGHT0+ms, GL_DIFFUSE, color);
         light_update_positions();
@@ -356,7 +356,7 @@ class d3d_lights
             light_ind.insert(pair<int,int>(id, ms));
             ind_pos.insert(pair<int,posi>(ms, posi(x, y, z, 1)));
         }
-        const float pos[4] = {(float)x, (float)y, (float)z, 1.0f}, color[4] = {float(COL_GET_R(col)), float(COL_GET_G(col)), float(COL_GET_B(col)), 1.0f},
+        const float pos[4] = {(float)x, (float)y, (float)z, 1.0f}, color[4] = {float(COL_GET_Rf(col)), float(COL_GET_Gf(col)), float(COL_GET_Bf(col)), 1.0f},
             specular[4] = {0.0f, 0.0f, 0.0f, 0.0f}, ambient[4] = {0.0f, 0.0f, 0.0f, 0.0f};
         glLightfv(GL_LIGHT0+ms, GL_POSITION, pos);
         glLightfv(GL_LIGHT0+ms, GL_DIFFUSE, color);
@@ -515,7 +515,7 @@ void d3d_light_shininess(int facemode, int shine)
 void d3d_light_define_ambient(int col)
 {
   draw_batch_flush(batch_flush_deferred);
-  float color[4] = {float(COL_GET_R(col)), float(COL_GET_G(col)), float(COL_GET_B(col)), 1.0f};
+  float color[4] = {float(COL_GET_Rf(col)), float(COL_GET_Gf(col)), float(COL_GET_Bf(col)), 1.0f};
   glLightModelfv(GL_LIGHT_MODEL_AMBIENT, color);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3colors.cpp
@@ -34,13 +34,13 @@ void draw_clear_alpha(int col,float alpha)
 {
 	draw_batch_flush(batch_flush_deferred);
   //Unfortunately, we lack a 255-based method for setting ClearColor.
-	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,alpha);
+	glClearColor(COL_GET_Rf(col),COL_GET_Gf(col),COL_GET_Bf(col),alpha);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 void draw_clear(int col)
 {
 	draw_batch_flush(batch_flush_deferred);
-	glClearColor(COL_GET_R(col)/255.0,COL_GET_G(col)/255.0,COL_GET_B(col)/255.0,1);
+	glClearColor(COL_GET_Rf(col),COL_GET_Gf(col),COL_GET_Bf(col),1.0f);
 	glClear(GL_COLOR_BUFFER_BIT);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -402,9 +402,9 @@ class d3d_lights
       lights[id].position[1] = -dy;
       lights[id].position[2] = -dz;
       lights[id].position[3] = 0.0;
-      lights[id].diffuse[0] = COL_GET_R(col);
-      lights[id].diffuse[1] = COL_GET_G(col);
-      lights[id].diffuse[2] = COL_GET_B(col);
+      lights[id].diffuse[0] = COL_GET_Rf(col);
+      lights[id].diffuse[1] = COL_GET_Gf(col);
+      lights[id].diffuse[2] = COL_GET_Bf(col);
       lights[id].diffuse[3] = 1.0f;
       lights[id].update = true;
       lightsource_update();
@@ -425,9 +425,9 @@ class d3d_lights
       lights[id].position[1] = y;
       lights[id].position[2] = z;
       lights[id].position[3] = range;
-      lights[id].diffuse[0] = COL_GET_R(col);
-      lights[id].diffuse[1] = COL_GET_G(col);
-      lights[id].diffuse[2] = COL_GET_B(col);
+      lights[id].diffuse[0] = COL_GET_Rf(col);
+      lights[id].diffuse[1] = COL_GET_Gf(col);
+      lights[id].diffuse[2] = COL_GET_Bf(col);
       lights[id].diffuse[3] = 1.0f;
       lights[id].specular[0] = 0.0f;
       lights[id].specular[1] = 0.0f;
@@ -531,9 +531,9 @@ bool d3d_light_set_ambient(int id, int r, int g, int b, double a)
 void d3d_light_define_ambient(int col)
 {
   draw_batch_flush(batch_flush_deferred);
-  enigma::d3d_lighting.global_ambient_color[0] = COL_GET_R(col);
-  enigma::d3d_lighting.global_ambient_color[1] = COL_GET_G(col);
-  enigma::d3d_lighting.global_ambient_color[2] = COL_GET_B(col);
+  enigma::d3d_lighting.global_ambient_color[0] = COL_GET_Rf(col);
+  enigma::d3d_lighting.global_ambient_color[1] = COL_GET_Gf(col);
+  enigma::d3d_lighting.global_ambient_color[2] = COL_GET_Bf(col);
   enigma::d3d_lighting.light_update();
 }
 


### PR DESCRIPTION
This is bullshit, so I finally found the cause of what actually was wrong with the lighting. It appears as though I made some glaring mistakes in #1265 by overlooking sources that redefined the color macros to obtain them as floats. This pull request fixes those mistakes by adding a second set of color macros that will clamp the color component between 0 and 1 for functions that work with color components in that format.

* Replaced `D3DCOLOR_COLORVALUE` (4-component float -> D3DCOLOR) with `D3DCOLOR_RGBA` (4-component int -> D3DCOLOR) in certain areas where I already had integer (0-255) color components
* Replaced `COL_GET_R` with `COL_GET_Rf` anywhere we divide by 255.0 so that isn't duplicated everywhere
* Removed calls to `SetMaterial` in D3D9 because they are not actually necessary to the lighting functionality and it also appears from apitrace that GM8 and GMS do not call these functions
* Replaced usages of D3DXVECTOR3 and D3DXCOLOR with an initialization list because D3DX is deprecated

As you can see in the following images, this fixes the colored cubes demo which uses lighting. There are still transform differences, but those fixes are in my other branch. I will open a pull request for the transforms once this is merged.

### OpenGL1 Cubes (transform is broken but that's unrelated)
![OpenGL1 Cubes](https://user-images.githubusercontent.com/3212801/46193172-3c436700-c2cb-11e8-8483-0f07d2131830.png)

### OpenGL3 Cubes
![OpenGL3 Cubes](https://user-images.githubusercontent.com/3212801/46193242-6d239c00-c2cb-11e8-8933-5dc66417532a.png)

### Direct3D9 Cubes
![Direct3D9 Cubes](https://user-images.githubusercontent.com/3212801/46193397-0783df80-c2cc-11e8-9f8b-524ef2086669.png)

### Direct3D11 Cubes (no changes)
![Direct3D11 Cubes](https://user-images.githubusercontent.com/3212801/46193270-90e6e200-c2cb-11e8-9d9a-28b076980986.png)
