### PR TITLE
Cleanup Motion Planning & Paths Graphics

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/motion_planning.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/motion_planning.cpp
@@ -250,19 +250,14 @@ bool mp_grid_path(unsigned id,unsigned pathid,double xstart,double ystart,double
 
 }
 
+#include "Graphics_Systems/General/GSfont.h"
+#include "Graphics_Systems/General/GSprimitives.h"
+#include "Graphics_Systems/General/GScolors.h"
+
 #include "Universal_System/var4.h"
 
 namespace enigma_user
 {
-
-void draw_text(gs_scalar x,gs_scalar y,variant str);
-int merge_color(int c1,int c2,double amount);
-int draw_primitive_begin(int kind);
-int draw_vertex_color(gs_scalar x, gs_scalar y, int color, float alpha);
-int draw_primitive_end();
-int draw_set_color_rgba(unsigned char red, unsigned char green, unsigned char blue, float alpha);
-int draw_get_color();
-int draw_set_color(int col);
 
 void mp_grid_draw_neighbours(unsigned int id, unsigned int h, unsigned int v, unsigned int mode)
 {

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/path_functions.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/path_functions.cpp
@@ -31,6 +31,8 @@
 #include <floatcomp.h>
 #include <cmath>
 
+#include "Graphics_Systems/General/GScurves.h" // for draw_path
+#include "Graphics_Systems/General/GSprimitives.h"
 #include "Universal_System/math_consts.h"
 
 #ifdef DEBUG_MODE
@@ -450,19 +452,6 @@ void path_reverse(unsigned pathid)
     enigma::path_recalculate(pathid);
 }
 
-//Declare drawing functions here, so it works no matter if GL, GLES or D3D is used
-void draw_spline_begin(int mode);
-int draw_spline_vertex(gs_scalar x, gs_scalar y);
-void draw_bezier_quadratic_spline_end();
-/*void glBegin(GLenum mode);
-void glEnd(void);
-void glVertex2f(GLfloat  x,  GLfloat  y);
-void glPushAttrib(GLbitfield mask);
-void glPopAttrib(void);*/
-int draw_primitive_begin(int kind);
-int draw_vertex(gs_scalar x, gs_scalar y);
-int draw_primitive_end();
-
 void draw_path(unsigned pathid, gs_scalar x, gs_scalar y, bool absolute)
 {
     enigma::path *path = enigma::pathstructarray[pathid];
@@ -507,4 +496,3 @@ void draw_path(unsigned pathid, gs_scalar x, gs_scalar y, bool absolute)
 }
 
 }
-


### PR DESCRIPTION
This is just a small change I am pulling from #1369 since I am unsure about the other changes in that pull request but do not want this part to be forgotten. All this change does is delete the redundant declaration of drawing functions in the Motion Planning and Paths extensions. In place of the deleted declarations I have instead included the relevant general graphics systems headers which declare the functions. This prevents future issues from occurring that may stem from violation of the one definition rule.