### PR TITLE
GRPC Resources Fix

### DIFF
--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -31,7 +31,7 @@ class CompilerServiceImpl final : public Compiler::Service {
 
   Status GetResources(ServerContext* /*context*/, const Empty* /*request*/, ServerWriter<Resource>* writer) override {
     const char* raw = plugin.FirstResource();
-    while (raw != nullptr) {
+    while (!plugin.ResourcesAtEnd()) {
       Resource resource;
 
       resource.set_name(raw);


### PR DESCRIPTION
This is just a simple fix to the while loop in the server that gets us compiler resources. Without this change the loop never ends after printing all the keywords that I want to populate in the Scintilla script editor. It was just printing empty strings after the resource end. This fixes that and makes it like the `--list` option which was already working correctly.