### PR TITLE
GRPC Methods for System Info

### DIFF
--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
   if (server) {
     int port = options.GetOption("port").as<int>();
     string ip = options.GetOption("ip").as<std::string>();
-    return RunServer(ip + ":" + std::to_string(port), plugin);
+    return RunServer(ip + ":" + std::to_string(port), plugin, options);
   }
 #endif
 

--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -279,6 +279,11 @@ int OptionsParser::find_ey(const char* dir)
   return OPTIONS_SUCCESS;
 }
 
+const APIMap& OptionsParser::GetAPI() const
+{
+  return _api;
+}
+
 int OptionsParser::printInfo(const std::string &api)
 {
   auto it = _api.find(api);

--- a/CommandLine/emake/OptionsParser.hpp
+++ b/CommandLine/emake/OptionsParser.hpp
@@ -9,6 +9,8 @@ namespace opt = boost::program_options;
 using func_t = std::function<int(const std::string&)>;
 using list_t = std::vector<std::string>;
 
+using APIMap = std::map<std::string, list_t>;
+
 typedef enum
 {
   OPTIONS_HELP = 2,
@@ -25,6 +27,7 @@ public:
   std::string APIyaml();
   opt::variable_value GetOption(std::string option);
   bool HasOption(std::string option);
+  const APIMap& GetAPI() const;
 
 private:
   int find_ey(const char* dir);
@@ -54,7 +57,7 @@ private:
   opt::options_description _desc;
   opt::positional_options_description _positional;
   std::map<std::string, func_t> _handler;
-  std::map<std::string, list_t> _api;
+  APIMap _api;
 };
 
 #endif

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -60,11 +60,11 @@ class CompilerServiceImpl final : public Compiler::Service {
     return Status::OK;
   }
 
-  Status GetSystems(ServerContext* /*context*/, const Empty* /*request*/, ServerWriter<System>* writer) override {
+  Status GetSystems(ServerContext* /*context*/, const Empty* /*request*/, ServerWriter<SystemType>* writer) override {
     auto _api = this->options.GetAPI();
 
     for (auto systems : _api) {
-      System system;
+      SystemType system;
 
       system.set_name(systems.first);
 

--- a/CommandLine/emake/Server.hpp
+++ b/CommandLine/emake/Server.hpp
@@ -1,5 +1,6 @@
 #include "EnigmaPlugin.hpp"
+#include "OptionsParser.hpp"
 
 #include <string>
 
-int RunServer(const std::string& address, EnigmaPlugin& plugin);
+int RunServer(const std::string& address, EnigmaPlugin& plugin, OptionsParser& options);

--- a/CommandLine/protos/server.proto
+++ b/CommandLine/protos/server.proto
@@ -6,6 +6,7 @@ import "game.proto";
 service Compiler {
   rpc CompileBuffer (CompileRequest) returns (stream CompileReply);
   rpc GetResources (Empty) returns (stream Resource);
+  rpc GetSystems (Empty) returns (stream System);
 
   rpc SyntaxCheck(SyntaxCheckRequest) returns (SyntaxError);
   rpc SetDefinitions(SetDefinitionsRequest) returns (SyntaxError);
@@ -64,4 +65,16 @@ message SyntaxCheckRequest {
   optional string code = 1;
   optional int32 script_count = 2;
   repeated string script_names = 3;
+}
+
+message System {
+  optional string name = 1;
+  repeated SystemInfo subsystems = 2;
+}
+
+message SystemInfo {
+  optional string name = 1;
+  optional string id = 2;
+  optional string description = 3;
+  optional string target = 4;
 }

--- a/CommandLine/protos/server.proto
+++ b/CommandLine/protos/server.proto
@@ -6,7 +6,7 @@ import "game.proto";
 service Compiler {
   rpc CompileBuffer (CompileRequest) returns (stream CompileReply);
   rpc GetResources (Empty) returns (stream Resource);
-  rpc GetSystems (Empty) returns (stream System);
+  rpc GetSystems (Empty) returns (stream SystemType);
 
   rpc SyntaxCheck(SyntaxCheckRequest) returns (SyntaxError);
   rpc SetDefinitions(SetDefinitionsRequest) returns (SyntaxError);
@@ -67,14 +67,14 @@ message SyntaxCheckRequest {
   repeated string script_names = 3;
 }
 
-message System {
-  optional string name = 1;
-  repeated SystemInfo subsystems = 2;
+message SystemType {
+  optional string name = 1; ///< e.g, ("Graphics", "Platform", or "Extensions")
+  repeated SystemInfo subsystems = 2; ///< All of the systems found that are of this type.
 }
 
 message SystemInfo {
-  optional string name = 1;
-  optional string id = 2;
-  optional string description = 3;
-  optional string target = 4;
+  optional string name = 1; ///< The human-readable name of the system. e.g, ("Direct3D 9.0", "DirectSound", or "Windows")
+  optional string id = 2; ///< The internal identifier used by the buildsystems. e.g, ("Direct3D9", "DirectSound", or "Win32")
+  optional string description = 3; ///< A friendly description of the system and what it does.
+  optional string target = 4; ///< The target-platform of the system. Only used by compiler descriptions presently.
 }


### PR DESCRIPTION
Simple change here that's needed for additional RGM features. I am exposing the functionality of the `--info` option of emake as an RPC method for any frontend that is interacting with an emake server.

The new RPC method is called `GetSystems` and it returns information about all of the major systems and all of their subsystems structured as proto messages. The RPC method takes no arguments and there is a reason for this. I expect that the client only wants to obtain and update this information infrequently, and when it does so it wants to update things dependent on the information of other systems at the same time. So not only is there not a need to obtain information about just one system, I think it would be inefficient to allow that. The client is expected to request information of all the systems at once and cache it accordingly.