### PR TITLE
Fix Platform Inspection False Positives

### DIFF
--- a/CompilerSource/filesystem/file_find.cpp
+++ b/CompilerSource/filesystem/file_find.cpp
@@ -40,7 +40,7 @@ using namespace std;
 
   static bool ff_matches() {
     return found.dwFileAttributes == FILE_ATTRIBUTE_NORMAL
-        || (ff_attribs ^ found.dwFileAttributes);
+        || (ff_attribs & found.dwFileAttributes);
   }
 
   string file_find_first(string name,int attributes) 
@@ -73,10 +73,6 @@ using namespace std;
 
     FindClose(current_find);
     current_find = INVALID_HANDLE_VALUE;
-  }
-
-  bool file_exists(const string& name) {
-    return (GetFileAttributes(name.c_str()) != INVALID_FILE_ATTRIBUTES);
   }
 #else
   #include <sys/types.h>
@@ -156,10 +152,5 @@ using namespace std;
     if (fff_dir_open != NULL)
       closedir(fff_dir_open);
     fff_dir_open = NULL;
-  }
-
-  bool file_exists(const string& name) {
-    struct stat st;
-    return (stat(name.c_str(), &st) == 0) and !(S_ISDIR(st.st_mode));
   }
 #endif

--- a/CompilerSource/filesystem/file_find.cpp
+++ b/CompilerSource/filesystem/file_find.cpp
@@ -74,6 +74,10 @@ using namespace std;
     FindClose(current_find);
     current_find = INVALID_HANDLE_VALUE;
   }
+
+  bool file_exists(const string& name) {
+    return (GetFileAttributes(name.c_str()) != INVALID_FILE_ATTRIBUTES);
+  }
 #else
   #include <sys/types.h>
   #include <sys/stat.h>
@@ -152,5 +156,10 @@ using namespace std;
     if (fff_dir_open != NULL)
       closedir(fff_dir_open);
     fff_dir_open = NULL;
+  }
+
+  bool file_exists(const string& name) {
+    struct stat st;
+    return (stat(name.c_str(), &st) == 0) and !(S_ISDIR(st.st_mode));
   }
 #endif

--- a/CompilerSource/filesystem/file_find.h
+++ b/CompilerSource/filesystem/file_find.h
@@ -24,7 +24,7 @@
 **  or programs made in the environment.                                        **
 **                                                                              **
 \********************************************************************************/
-  
+
 const int fa_archive   = 0x000020;
 const int fa_directory = 0x000010;
 const int fa_hidden    = 0x000002;
@@ -36,3 +36,4 @@ const int fa_nofiles   = 0x800000;
 string file_find_next();
 string file_find_first(string name,int attrib);
 void file_find_close();
+bool file_exists(const string& name);

--- a/CompilerSource/filesystem/file_find.h
+++ b/CompilerSource/filesystem/file_find.h
@@ -36,4 +36,3 @@ const int fa_nofiles   = 0x800000;
 string file_find_next();
 string file_find_first(string name,int attrib);
 void file_find_close();
-bool file_exists(const string& name);

--- a/CompilerSource/settings-parse/crawler.cpp
+++ b/CompilerSource/settings-parse/crawler.cpp
@@ -148,27 +148,24 @@ namespace extensions
     for (string ef = file_find_first("ENIGMAsystem/SHELL/Platforms/*",fa_sysfile | fa_readonly | fa_directory | fa_nofiles); ef != ""; ef = file_find_next())
     {
       const string ef_path = "ENIGMAsystem/SHELL/Platforms/" + ef + "/Info/About.ey";
-      if (!file_exists(ef_path)) continue;
-      cout << " - " << ef_path << ": ";
       ifstream ext(ef_path.c_str(), ios_base::in);
-      if (ext.is_open())
-      {
-        cout << "Opened.\n";
-        ey_data dat = parse_eyaml(ext,ef);
-        eyit hasname = dat.values.find("represents");
-        if (hasname == dat.values.end()) {
-          cout << "Skipping invalid platform API under `" << ef << "': File does not specify an OS it represents.";
-          continue;
-        }
-        
-        sdk_descriptor& sdk = all_platforms[toUpper(ef)];
-        sdk.name   = dat.get("name");
-        sdk.author = dat.get("author");
-        sdk.build_platforms = dat.get("build-platforms");
-        sdk.description = dat.get("description");
-        sdk.identifier  = dat.get("identifier");
-        sdk.represents  = dat.get("represents");
-      } else cout << "Failed!\n";
+      if (!ext.is_open()) continue;
+
+      cout << " - " << ef_path << ": Opened.\n";
+      ey_data dat = parse_eyaml(ext,ef);
+      eyit hasname = dat.values.find("represents");
+      if (hasname == dat.values.end()) {
+        cout << "Skipping invalid platform API under `" << ef << "': File does not specify an OS it represents.";
+        continue;
+      }
+      
+      sdk_descriptor& sdk = all_platforms[toUpper(ef)];
+      sdk.name   = dat.get("name");
+      sdk.author = dat.get("author");
+      sdk.build_platforms = dat.get("build-platforms");
+      sdk.description = dat.get("description");
+      sdk.identifier  = dat.get("identifier");
+      sdk.represents  = dat.get("represents");
     }
     file_find_close();
     

--- a/CompilerSource/settings-parse/crawler.cpp
+++ b/CompilerSource/settings-parse/crawler.cpp
@@ -147,8 +147,10 @@ namespace extensions
     cout << "\n\n\n\nStarting platform inspection\n";
     for (string ef = file_find_first("ENIGMAsystem/SHELL/Platforms/*",fa_sysfile | fa_readonly | fa_directory | fa_nofiles); ef != ""; ef = file_find_next())
     {
-      cout << " - ENIGMAsystem/SHELL/Platforms/" + ef + "/Info/About.ey: ";
-      ifstream ext(("ENIGMAsystem/SHELL/Platforms/" + ef + "/Info/About.ey").c_str(), ios_base::in);
+      const string ef_path = "ENIGMAsystem/SHELL/Platforms/" + ef + "/Info/About.ey";
+      if (!file_exists(ef_path)) continue;
+      cout << " - " << ef_path << ": ";
+      ifstream ext(ef_path.c_str(), ios_base::in);
       if (ext.is_open())
       {
         cout << "Opened.\n";

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSfilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSfilemanip.cpp
@@ -65,7 +65,7 @@ float ini_read_real(std::string section, std::string key, float defaultValue)
 	char res[255];
 	char def[255];
 	sprintf(def, "%f", defaultValue);
-	GetPrivateProfileString(section.c_str(), key.c_str(), def, res, 255, iniFilename.c_str()); 
+	GetPrivateProfileString(section.c_str(), key.c_str(), def, res, 255, iniFilename.c_str());
 	return atof(res);
 	//return GetPrivateProfileInt(section.c_str(), key.c_str(), defaultValue, iniFilename.c_str());
 }
@@ -109,7 +109,7 @@ void ini_section_delete(std::string section)
 
 int file_exists(std::string fname) {
     DWORD attributes = GetFileAttributes(fname.c_str());
-    if(attributes == 0xFFFFFFFF) {
+    if(attributes == INVALID_FILE_ATTRIBUTES) {
         return 0;
     } else {
         return 1;
@@ -164,7 +164,7 @@ int file_copy(std::string fname, std::string newname) {
 int directory_exists(std::string dname) {
   DWORD dwAttrib = GetFileAttributes(dname.c_str());
 
-  return (dwAttrib != INVALID_FILE_ATTRIBUTES && 
+  return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
          (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
 }
 
@@ -298,4 +298,3 @@ time_t file_modified_time(std::string fname)
 }
 
 }
-


### PR DESCRIPTION
Ok I am very feisty about this one because people keep telling me it thinking it's a problem even though it really isn't. So the platform inspection, it has false positives because Josh's immature file find does silly stuff like return files and not directories on Win32 and it totally ignores the passed file attributes. However, I would have fixed this by just fixing the file find if that were the only problem. It also has issues because it returns the current directory and the parent directory as `.` and `..` which screws up the platform inspection.

The way I did fix this was by adding `file_exists` with a Win32 and POSIX implementation to `CompilerSource/filesystem/`. Yes, these are based on the ones in the engine, and I am not really concerned about duplicating the code at the moment. I recognize we're duplicating a lot of file stuff in a lot of areas, and I'd like to just slightly "poke" the can a little further down the road as the old saying goes.

The fix basically just involves checking if the file actually exists before even trying to open it in the platform inspection loop. If the file doesn't exist, we don't try opening it, hence we do not print an error. Now, if the file does exist, and there's some other issue opening the stream, we do print the old failed message. With this change, ENIGMA correctly passes platform inspection and reports no false positives as it rightfully should be doing.

I also happened to notice that Win32 has `INVALID_FILE_ATTRIBUTES` defined for checking if a file exists. I decided to change the engine's implementation of `file_exists` to use that instead of a hardcoded hex.

Finally, one argument I have to make for this change is that the presence of false positives about platform info files that don't even exist, makes it more difficult to diagnose when there's an actual issue with a platform info file. This could be a pain in the ass if somebody is adding a new platform/system or moving existing ones.

#### Current Master
![Current Master Platform Inspection False Positives](https://user-images.githubusercontent.com/3212801/46916757-cd356600-cf8c-11e8-855d-92d19727cebc.png)

#### Pull Request (no false positive failures)
![Pull Request Platform Inspection Passes](https://user-images.githubusercontent.com/3212801/46916721-58622c00-cf8c-11e8-8574-07d4467c2c51.png)
