### PR TITLE
Cleanup a few includes causing JDI errors

### DIFF
--- a/ENIGMAsystem/SHELL/Collision_Systems/BBox/include.h
+++ b/ENIGMAsystem/SHELL/Collision_Systems/BBox/include.h
@@ -1,5 +1,2 @@
-#include "BBOXutil.h"
-#include "BBOXimpl.h"
-#include "../General/CSfuncs.h"
+#include "Collision_Systems/General/CSfuncs.h"
 #include "Collision_Systems/actions.h"
-

--- a/ENIGMAsystem/SHELL/Collision_Systems/Precise/include.h
+++ b/ENIGMAsystem/SHELL/Collision_Systems/Precise/include.h
@@ -1,3 +1,2 @@
-#include "PRECimpl.h"
-#include "../General/CSfuncs.h"
+#include "Collision_Systems/General/CSfuncs.h"
 #include "Collision_Systems/actions.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
@@ -22,6 +22,7 @@
 #include "GSprimitives.h"
 
 #include "Universal_System/nlpo2.h"
+#include "Universal_System/sprites_internal.h"
 #include "Universal_System/sprites.h"
 #include "Universal_System/instance_system.h"
 #include "Universal_System/graphics_object.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.h
@@ -21,7 +21,6 @@
 #include "GScolors.h"
 
 #include "Universal_System/scalar.h"
-#include "Universal_System/sprites_internal.h"
 
 #if GM_COMPATIBILITY_VERSION <= 81
 #  define DEFAULT_ALPHA 1

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/mp_movement.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/mp_movement.h
@@ -24,9 +24,6 @@
 **  or programs made in the environment.                                        **
 **                                                                              **
 \********************************************************************************/
-#include "Universal_System/collisions_object.h"
-//#include "Universal_System/instance_system.h"
-#include <cmath>
 
 namespace enigma_user
 {
@@ -57,4 +54,3 @@ inline bool mp_linear_path(int path, const double x, const double y, const doubl
 }
 
 }
-


### PR DESCRIPTION
I went in here to try to cleanup up a few of the JDI `ERROR` messages when starting up. I only actually managed to fix one of them but I did cleanup some other include mistakes we've made.

This is the message that this pull request fixes, but there's still 2 of the 3 occurrences of it left with the exact same message.
```
ERROR(ENIGMAsystem/SHELL//Universal_System/sprites_internal.h,22,92): #error This file includes non-ENIGMA STL headers and should not be included from SHELLmain.
```

#### Summary of Changes
1) Removed BBox/Precise implementation header includes from each system's respective `include.h` where they didn't need to be included. I think I may have been the one who originally made the mistake while I was moving their `enigma_user` function declarations to `Collision_Systems/General`.
2) Moved the include of `sprites_internal.h` from `GSsprite.h` to `GSsprite.cpp`. This change is what actually got rid of one of the JDI false-positive errors.
3) Removed unused includes from `mp_movement.h` since they are already included from the source which needs them.