### PR TITLE
Fix GRPC Access of Non-function Resources

### DIFF
--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -37,9 +37,11 @@ class CompilerServiceImpl final : public Compiler::Service {
 
       resource.set_name(raw);
       resource.set_is_function(plugin.ResourceIsFunction());
-      resource.set_arg_count_min(plugin.ResourceArgCountMin());
-      resource.set_arg_count_max(plugin.ResourceArgCountMax());
-      resource.set_overload_count(plugin.ResourceOverloadCount());
+      if (resource.is_function()) {
+        resource.set_arg_count_min(plugin.ResourceArgCountMin());
+        resource.set_arg_count_max(plugin.ResourceArgCountMax());
+        resource.set_overload_count(plugin.ResourceOverloadCount());
+      }
       resource.set_is_type_name(plugin.ResourceIsTypeName());
       resource.set_is_global(plugin.ResourceIsGlobal());
 


### PR DESCRIPTION
So, I went in here looking for why RGM was printing all the keywords to its output window with messages like "Attempt to use X which is Y as Z." I looked and it's apparently because the `GetResources` RPC I wrote is attempting to access overloads and the function signature for globals and other non-function resources. The simple fix here is to just nest the arg count stuff under a check of the is function just like the `--list` command does and `lgmplugin` does.

These are the messages this pull request gets rid of in RGM:
![RGM Resource Access Warnings](https://user-images.githubusercontent.com/3212801/47189802-51c91100-d30c-11e8-9814-35a34b5f1c41.png)
