### PR TITLE
Aliases for System Info 

### DIFF
--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -348,22 +348,18 @@ int OptionsParser::printInfo(const std::string &api)
         if (id.empty())
           id = about.get("id"); // allow alias
         if (id.empty()) {
-          // compiler descriptors use filename as id
+          // compilers use filename minus ext as id
           boost::filesystem::path ey(p);
           id = ey.stem().string();
         }
 
-        if (!target.empty() && !name.empty())
-        {
-          boost::filesystem::path ey(p);
-          outputStream << '\t' << name << " (" << ey.stem().string() << "):" << std::endl;
-          outputStream << "\t\t Target: " << target << std::endl << std::endl;
-        }
-        else if (!name.empty() && !desc.empty() && !id.empty())
-        {
+        if (!name.empty() && !id.empty())
           outputStream << '\t' << name << " (" << id << "):" << std::endl;
+
+        if (!target.empty())
+          outputStream << "\t\t Target: " << target << std::endl << std::endl;
+        else if (!desc.empty())
           outputStream << "\t\t" << word_wrap(desc, 80) << std::endl << std::endl;
-        }
       }
     }
   }

--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -347,8 +347,11 @@ int OptionsParser::printInfo(const std::string &api)
 
         if (id.empty())
           id = about.get("id"); // allow alias
-        if (id.empty())
-          id = p; // compiler descriptors use filename as id
+        if (id.empty()) {
+          // compiler descriptors use filename as id
+          boost::filesystem::path ey(p);
+          id = ey.stem().string();
+        }
 
         if (!target.empty() && !name.empty())
         {
@@ -477,8 +480,6 @@ int OptionsParser::searchAPI(const std::string &api, const std::string &target)
     std::string id = about.get("identifier");
     if (id.empty())
       id = about.get("id"); // allow alias
-    if (id.empty())
-      id = a; // compiler descriptors use filename as id
     return (id == target);
   });
 

--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -345,9 +345,10 @@ int OptionsParser::printInfo(const std::string &api)
         std::string id = about.get("identifier");
         std::string target = about.get("target-platform");
 
-        // Why is this different in extensions?
         if (id.empty())
-          id = about.get("id");
+          id = about.get("id"); // allow alias
+        if (id.empty())
+          id = p; // compiler descriptors use filename as id
 
         if (!target.empty() && !name.empty())
         {
@@ -474,9 +475,10 @@ int OptionsParser::searchAPI(const std::string &api, const std::string &target)
     std::ifstream ifabout(a, std::ios_base::in);
     ey_data about = parse_eyaml(ifabout, a);
     std::string id = about.get("identifier");
-    // Why is this different in extensions?
     if (id.empty())
-      id = about.get("id");
+      id = about.get("id"); // allow alias
+    if (id.empty())
+      id = a; // compiler descriptors use filename as id
     return (id == target);
   });
 

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -12,6 +12,8 @@
 #include <grpc++/server_builder.h>
 #include <grpc++/server_context.h>
 
+#include <boost/filesystem.hpp>
+
 #include <memory>
 
 using namespace grpc;
@@ -81,13 +83,16 @@ class CompilerServiceImpl final : public Compiler::Service {
         std::string name = about.get("name");
         std::string id = about.get("identifier");
         std::string desc = about.get("description");
-        std::string target = about.get("target-platform");
         std::string author = about.get("author");
+        std::string target = about.get("target-platform");
 
         if (id.empty())
           id = about.get("id"); // allow alias
-        if (id.empty())
-          id = subsystem; // compiler descriptors use filename as id
+        if (id.empty()) {
+          // compilers use filename minus ext as id
+          boost::filesystem::path ey(subsystem);
+          id = ey.stem().string();
+        }
 
         // allow author alias used by compiler descriptors
         if (author.empty())
@@ -96,6 +101,7 @@ class CompilerServiceImpl final : public Compiler::Service {
         subInfo->set_name(name);
         subInfo->set_id(id);
         subInfo->set_description(desc);
+        subInfo->set_author(author);
         subInfo->set_target(target);
       }
 

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -82,6 +82,16 @@ class CompilerServiceImpl final : public Compiler::Service {
         std::string id = about.get("identifier");
         std::string desc = about.get("description");
         std::string target = about.get("target-platform");
+        std::string author = about.get("author");
+
+        if (id.empty())
+          id = about.get("id"); // allow alias
+        if (id.empty())
+          id = subsystem; // compiler descriptors use filename as id
+
+        // allow author alias used by compiler descriptors
+        if (author.empty())
+          author = about.get("maintainer");
 
         subInfo->set_name(name);
         subInfo->set_id(id);

--- a/CommandLine/protos/server.proto
+++ b/CommandLine/protos/server.proto
@@ -83,5 +83,6 @@ message SystemInfo {
   optional string name = 1; ///< The human-readable name of the system. e.g, ("Direct3D 9.0", "DirectSound", or "Windows")
   optional string id = 2; ///< The internal identifier used by the buildsystems. e.g, ("Direct3D9", "DirectSound", or "Win32")
   optional string description = 3; ///< A friendly description of the system and what it does.
-  optional string target = 4; ///< The target-platform of the system. Only used by compiler descriptions presently.
+  optional string author = 4; ///< Name of the system author or maintainer (e.g, "John Doe")
+  optional string target = 5; ///< The target-platform of the system. Only used by compiler descriptions presently.
 }


### PR DESCRIPTION
This is a continuation of #1402 in which I am proposing a fix for the compiler targets. Because all of the combos I am using in RGM use name/id, and because I include compilers in that group, I need the compilers to have valid ids in order to select them. This is a bit tricky, because unlike the SHELL systems, compiler descriptors have historically been identified using their filename minus the extension (so Windows/gcc.ey has an identifier "gcc" in LGM and emake). The simple solution I am proposing here is to use this id, which emake already has, if neither "id" nor "identifier" appears in the compiler descriptors ey to provide the identifier.

* Removed comments asking why id/identifier is different between extensions and systems. I actually fixed this on master at some point, because they are all now "identifier" if you look. This was just a failure of communication between IsmAvatar and JoshDreamland that I've pointed out already many times, as I have looked at the specification written by both on the Wiki. Regardless, the comment is outdated because they are consistent now, but we also explicitly allow aliasing id as "identifier" with emake/RGM just in case.
* Continue to allow aliasing `identifier` as `id` if `identifier` does not appear in the about ey file.
* Use the system name (derived from the filename minus extension) if neither `id` nor `identifier` appear in the about ey file. I changed fundies logic in `OptionsParser::printInfo` to work this way too for consistency. This is the main thing that fixes the compiler selection for my RGM branch.
* Provide the author or maintainer name in the system info proto returned by the GRPC method. This allows me to display the author name and description in RadialGM's UI like LGM used to.
* Allow aliasing "author" with "maintainer" because compiler descriptors apparently use the latter.
