### PR TITLE
libEGM GMK Transparency Fix

### DIFF
--- a/CommandLine/emake/Proto2ES.cpp
+++ b/CommandLine/emake/Proto2ES.cpp
@@ -385,7 +385,7 @@ void AddSprite(const char* name, const buffers::resources::Sprite& spr) {
   s.name = name;
   s.id = spr.id();
 
-  s.transparent = spr.transparent();
+  s.transparent = false;
   s.shape = spr.shape();
   s.alphaTolerance = spr.alpha_tolerance();
   s.separateMask = spr.separate_mask();
@@ -451,7 +451,7 @@ void AddBackground(const char* name, const buffers::resources::Background& bkg) 
   b.name = name;
   b.id = bkg.id();
 
-  b.transparent = bkg.transparent();
+  b.transparent = false;
   b.smoothEdges = bkg.smooth_edges();
   b.preload = bkg.preload();
   b.useAsTileset = bkg.use_as_tileset();

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -106,10 +106,10 @@ std::string writeTempBMPFile(std::unique_ptr<char[]> bytes, size_t length, bool 
   std::vector<unsigned char> rgba(w * h * 4);
 
   // get the bottom left pixel for transparency
-  unsigned t_pos = pixeloffset + (h-1)*w*numChannels;
-  unsigned char t_pixel_r = bmp[t_pos+0];
-  unsigned char t_pixel_g = bmp[t_pos+1];
-  unsigned char t_pixel_b = bmp[t_pos+2];
+  // NOTE: bmp is obviously upside down, so it's just the first pixel
+  unsigned char t_pixel_r = bmp[pixeloffset+0],
+                t_pixel_g = bmp[pixeloffset+1],
+                t_pixel_b = bmp[pixeloffset+2];
 
   /*
   There are 3 differences between BMP and the raw image buffer for LodePNG:
@@ -128,7 +128,7 @@ std::string writeTempBMPFile(std::unique_ptr<char[]> bytes, size_t length, bool 
         rgba[newpos + 0] = bmp[bmpos + 2]; //R<-B
         rgba[newpos + 1] = bmp[bmpos + 1]; //G<-G
         rgba[newpos + 2] = bmp[bmpos + 0]; //B<-R
-        rgba[newpos + 3] = 255; //A<-A
+        rgba[newpos + 3] = 255;            //A<-A
       } else {
         rgba[newpos + 0] = bmp[bmpos + 3]; //R<-A
         rgba[newpos + 1] = bmp[bmpos + 2]; //G<-B

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -65,7 +65,7 @@ std::string writeTempDataFile(std::unique_ptr<char[]> bytes, size_t length) {
   return writeTempDataFile(bytes.get(), length);
 }
 
-std::string writeTempBMPFile(std::unique_ptr<char[]> bytes, size_t length) {
+std::string writeTempBMPFile(std::unique_ptr<char[]> bytes, size_t length, bool transparent=false) {
   static const unsigned MINHEADER = 54; //minimum BMP header size
   auto bmp = reinterpret_cast<const unsigned char*>(bytes.get()); // all of the following logic expects unsigned
 
@@ -105,6 +105,12 @@ std::string writeTempBMPFile(std::unique_ptr<char[]> bytes, size_t length) {
 
   std::vector<unsigned char> rgba(w * h * 4);
 
+  // get the bottom left pixel for transparency
+  unsigned t_pos = pixeloffset + (h-1)*w*numChannels;
+  unsigned char t_pixel_r = bmp[t_pos+0];
+  unsigned char t_pixel_g = bmp[t_pos+1];
+  unsigned char t_pixel_b = bmp[t_pos+2];
+
   /*
   There are 3 differences between BMP and the raw image buffer for LodePNG:
   -it's upside down
@@ -122,12 +128,19 @@ std::string writeTempBMPFile(std::unique_ptr<char[]> bytes, size_t length) {
         rgba[newpos + 0] = bmp[bmpos + 2]; //R<-B
         rgba[newpos + 1] = bmp[bmpos + 1]; //G<-G
         rgba[newpos + 2] = bmp[bmpos + 0]; //B<-R
-        rgba[newpos + 3] = 255;            //A<-A
+        rgba[newpos + 3] = 255; //A<-A
       } else {
         rgba[newpos + 0] = bmp[bmpos + 3]; //R<-A
         rgba[newpos + 1] = bmp[bmpos + 2]; //G<-B
         rgba[newpos + 2] = bmp[bmpos + 1]; //B<-G
         rgba[newpos + 3] = bmp[bmpos + 0]; //A<-R
+      }
+
+      if (transparent &&
+        bmp[bmpos + 0] == t_pixel_r &&
+        bmp[bmpos + 1] == t_pixel_g &&
+        bmp[bmpos + 2] == t_pixel_b) {
+        rgba[newpos + 3] = 0; //A<-A
       }
     }
   }
@@ -344,10 +357,14 @@ class Decoder {
     readData(data_file_path, false);
   }
 
-  void readZlibImage(std::string *data_file_path=nullptr) {
+  void readZlibImage(std::string *data_file_path, bool transparent) {
     size_t length = read4();
     std::unique_ptr<char[]> bytes = decompress(length);
-    if (data_file_path && bytes) threadTempFileWrite(writeTempBMPFile, data_file_path, std::move(bytes), length);
+    if (data_file_path && bytes) threadTempFileWrite(writeTempBMPFile, data_file_path, std::move(bytes), length, transparent);
+  }
+
+  void readZlibImage(bool transparent=false) {
+    readZlibImage(nullptr, transparent);
   }
 
   void readBGRAImage(std::string *data_file_path=nullptr, size_t width=0, size_t height=0) {
@@ -621,6 +638,7 @@ std::unique_ptr<Sprite> LoadSprite(Decoder &dec, int ver) {
   auto sprite = std::make_unique<Sprite>();
 
   int w = 0, h = 0;
+  bool transparent = false;
   if (ver < 800) {
     w = dec.read4();
     h = dec.read4();
@@ -628,7 +646,7 @@ std::unique_ptr<Sprite> LoadSprite(Decoder &dec, int ver) {
     sprite->set_bbox_right(dec.read4());
     sprite->set_bbox_bottom(dec.read4());
     sprite->set_bbox_top(dec.read4());
-    sprite->set_transparent(dec.readBool());
+    transparent = dec.readBool();
     if (ver > 400) {
       sprite->set_smooth_edges(dec.readBool());
       sprite->set_preload(dec.readBool());
@@ -641,7 +659,7 @@ std::unique_ptr<Sprite> LoadSprite(Decoder &dec, int ver) {
       sprite->set_preload(!dec.readBool());
     }
   } else {
-    sprite->set_transparent(false);
+    transparent = false;
   }
   sprite->set_origin_x(dec.read4());
   sprite->set_origin_y(dec.read4());
@@ -661,7 +679,7 @@ std::unique_ptr<Sprite> LoadSprite(Decoder &dec, int ver) {
         dec.readBGRAImage(sprite->add_subimages(), w, h);
     } else {
       if (dec.read4() == -1) continue;
-      dec.readZlibImage(sprite->add_subimages());
+      dec.readZlibImage(sprite->add_subimages(), transparent);
     }
   }
   sprite->set_width(w);
@@ -685,10 +703,11 @@ std::unique_ptr<Background> LoadBackground(Decoder &dec, int ver) {
   auto background = std::make_unique<Background>();
 
   int w = 0, h = 0;
+  bool transparent = false;
   if (ver < 710) {
     w = dec.read4();
     h = dec.read4();
-    background->set_transparent(dec.readBool());
+    transparent = dec.readBool();
     if (ver > 400) {
       background->set_smooth_edges(dec.readBool());
       background->set_preload(dec.readBool());
@@ -711,7 +730,7 @@ std::unique_ptr<Background> LoadBackground(Decoder &dec, int ver) {
   if (ver < 710) {
     if (dec.readBool()) {
       if (dec.read4() != -1)
-        dec.readZlibImage(background->mutable_image());
+        dec.readZlibImage(background->mutable_image(), transparent);
     }
   } else { // >= 710
     int dataver = dec.read4();

--- a/CommandLine/protos/Background.proto
+++ b/CommandLine/protos/Background.proto
@@ -4,27 +4,26 @@ package buffers.resources;
 import "options.proto";
 
 message Background {
-  optional int32 id = 2 [(gmx) = "GMX_DEPRECATED"];
+  optional int32 id = 1 [(gmx) = "GMX_DEPRECATED"];
 
-  optional bool preload = 4 [(gmx) = "GMX_DEPRECATED"];
-  optional bool transparent = 5 [(gmx) = "GMX_DEPRECATED"];
-  optional bool smooth_edges = 6 [(gmx) = "GMX_DEPRECATED"];
+  optional bool preload = 2 [(gmx) = "GMX_DEPRECATED"];
+  optional bool smooth_edges = 3 [(gmx) = "GMX_DEPRECATED"];
 
-  optional bool use_as_tileset = 7 [(gmx) = "istileset"];
+  optional bool use_as_tileset = 4 [(gmx) = "istileset"];
 
-  optional int32 tile_width         = 11 [(gmx) = "tilewidth"];
-  optional int32 tile_height        = 12 [(gmx) = "tileheight"];
-  optional int32 horizontal_offset  = 13 [(gmx) = "tilexoff"];
-  optional int32 vertical_offset    = 14 [(gmx) = "tileyoff"];
-  optional int32 horizontal_spacing = 15 [(gmx) = "tilehsep"];
-  optional int32 vertical_spacing   = 16 [(gmx) = "tilevsep"];
+  optional int32 tile_width         = 5 [(gmx) = "tilewidth"];
+  optional int32 tile_height        = 6 [(gmx) = "tileheight"];
+  optional int32 horizontal_offset  = 7 [(gmx) = "tilexoff"];
+  optional int32 vertical_offset    = 8 [(gmx) = "tileyoff"];
+  optional int32 horizontal_spacing = 9 [(gmx) = "tilehsep"];
+  optional int32 vertical_spacing   = 10 [(gmx) = "tilevsep"];
 
-  optional int32 h_tile = 17 [(gmx) = "HTile"];
-  optional int32 v_tile = 18 [(gmx) = "VTile"];
-  optional int32 texture_group = 19 [(gmx) = "TextureGroups/TextureGroup0"];
-  optional bool for3D = 20 [(gmx) = "For3D"];
-  optional uint32 width = 21;
-  optional uint32 height = 22;
+  optional int32 h_tile = 11 [(gmx) = "HTile"];
+  optional int32 v_tile = 12 [(gmx) = "VTile"];
+  optional int32 texture_group = 13 [(gmx) = "TextureGroups/TextureGroup0"];
+  optional bool for3D = 14 [(gmx) = "For3D"];
+  optional uint32 width = 15;
+  optional uint32 height = 16;
 
-  optional string image = 3 [(gmx) = "data", (file_path) = true];
+  optional string image = 17 [(gmx) = "data", (file_path) = true];
 }

--- a/CommandLine/protos/Sprite.proto
+++ b/CommandLine/protos/Sprite.proto
@@ -4,37 +4,36 @@ package buffers.resources;
 import "options.proto";
 
 message Sprite {
-  optional int32 id = 2 [(gmx) = "GMX_DEPRECATED"];
+  optional int32 id = 1 [(gmx) = "GMX_DEPRECATED"];
 
-  optional bool preload = 4 [(gmx) = "GMX_DEPRECATED"];
-  optional bool transparent = 5 [(gmx) = "GMX_DEPRECATED"];
-  optional bool smooth_edges = 6 [(gmx) = "GMX_DEPRECATED"];
+  optional bool preload = 2 [(gmx) = "GMX_DEPRECATED"];
+  optional bool smooth_edges = 3 [(gmx) = "GMX_DEPRECATED"];
 
-  optional int32 alpha_tolerance = 7 [(gmx) = "coltolerance"];
-  optional bool separate_mask = 8 [(gmx) = "sepmasks"];
-  optional int32 origin_x = 9 [(gmx) = "xorig"];
-  optional int32 origin_y = 10 [(gmx) = "yorigin"];
+  optional int32 alpha_tolerance = 4 [(gmx) = "coltolerance"];
+  optional bool separate_mask = 5 [(gmx) = "sepmasks"];
+  optional int32 origin_x = 6 [(gmx) = "xorig"];
+  optional int32 origin_y = 7 [(gmx) = "yorigin"];
 
   enum Shape { PRECISE = 0; RECTANGLE = 1; DISK = 2; DIAMOND = 3; }
 
-  optional Shape shape = 11 [(gmx) = "colkind"];
+  optional Shape shape = 8 [(gmx) = "colkind"];
 
   enum BoundingBox { AUTOMATIC = 0; FULL_IMAGE = 1; MANUAL = 2; }
 
-  optional BoundingBox bbox_mode = 12 [(gmx) = "bboxmode"];
+  optional BoundingBox bbox_mode = 9 [(gmx) = "bboxmode"];
 
-  optional int32 bbox_left = 13;
-  optional int32 bbox_right = 14;
-  optional int32 bbox_top = 15;
-  optional int32 bbox_bottom = 16;
+  optional int32 bbox_left = 10;
+  optional int32 bbox_right = 11;
+  optional int32 bbox_top = 12;
+  optional int32 bbox_bottom = 13;
 
-  optional int32 type = 17;
-  optional int32 h_tile = 18 [(gmx) = "HTile"];
-  optional int32 v_tile = 19 [(gmx) = "VTile"];
-  optional int32 texture_group = 20 [(gmx) = "TextureGroups/TextureGroup0"];
-  optional bool for3D = 21 [(gmx) = "For3D"];
-  optional uint32 width = 22;
-  optional uint32 height = 23;
+  optional int32 type = 14;
+  optional int32 h_tile = 15 [(gmx) = "HTile"];
+  optional int32 v_tile = 16 [(gmx) = "VTile"];
+  optional int32 texture_group = 17 [(gmx) = "TextureGroups/TextureGroup0"];
+  optional bool for3D = 18 [(gmx) = "For3D"];
+  optional uint32 width = 19;
+  optional uint32 height = 20;
 
-  repeated string subimages = 3 [(gmx) = "frames/frame", (file_path) = true];
+  repeated string subimages = 21 [(gmx) = "frames/frame", (file_path) = true];
 }


### PR DESCRIPTION
This is a remake of #1279 that we were just discussing. Josh wants to fix it this alternative way, by deprecating this kind of transparency and for now fixing it in the GMK reader only. The whole "transparent" option was deprecated sometime after GMK version 710. All later versions of GMK used BGRA images, so I only had to add support for it in the BMP reader.

* Explicitly initialize `transparent` to false in Proto2ES for safety.
* Accept `transparent` as a parameter to the BMP temp file writer in GMK.
* Remove the `transparent` field from Sprite & Background protos.
* Reorder all the fields of the Sprite & Background protos to have consecutive field numbers.

![FPS GMK Transparency Fixed](https://user-images.githubusercontent.com/3212801/47259722-c2427000-d47b-11e8-8140-41bc0833cf87.png)
![Destructible Blocks GMK Transparency Fixed](https://user-images.githubusercontent.com/3212801/47259738-f9188600-d47b-11e8-809d-90980891a318.png)
![Game of Life GM6 Transparency Fixed](https://user-images.githubusercontent.com/3212801/47259752-2402da00-d47c-11e8-9599-3c75481dbe40.png)
![Tile Collision Demo GMK Transparency Fixed](https://user-images.githubusercontent.com/3212801/47259761-557ba580-d47c-11e8-8e5d-96a86d071c81.png)
![Platform Engine GMK Transparency Fix](https://user-images.githubusercontent.com/3212801/47259979-ae4d3d00-d480-11e8-9914-89d40728e56f.png)
