### PR TITLE
Async Compile & Remote Logging

### DIFF
--- a/CommandLine/emake/EnigmaCallbacks.cpp
+++ b/CommandLine/emake/EnigmaCallbacks.cpp
@@ -26,23 +26,22 @@ const ProgressMessage& CallBack::GetProgress() const {
   return progressMessage;
 }
 
-const LogMessage& CallBack::GetFirstLogMessage(bool &end) const {
-  if (logMessages.empty()) { end = true; return std::move(LogMessage()); }
+const LogMessage CallBack::GetFirstLogMessage(bool &end) const {
+  if (logMessages.empty()) { end = true; return LogMessage(); }
   end = false;
   logMutex.lock();
   logIt = logMessages.begin();
   return *logIt;
 }
 
-const LogMessage& CallBack::GetNextLogMessage(bool &end) const {
+const LogMessage CallBack::GetNextLogMessage(bool &end) const {
   ++logIt;
   if (logIt == logMessages.end()) {
     end = true;
-    return std::move(LogMessage());
+    return LogMessage();
   } else {
     end = false;
-    const LogMessage& ret = *logIt;
-    return ret;
+    return *logIt;
   }
 }
 

--- a/CommandLine/emake/EnigmaCallbacks.cpp
+++ b/CommandLine/emake/EnigmaCallbacks.cpp
@@ -31,15 +31,15 @@ const LogMessage& CallBack::GetFirstLogMessage(bool &end) const {
 }
 
 const LogMessage& CallBack::GetNextLogMessage(bool &end) const {
+  ++logIt;
   if (logIt == logMessages.end()) {
     end = true;
-    // grab the reference value before unlocking
-    const LogMessage& ret = *logIt;
     logMutex.unlock();
-    return ret;
+    return LogMessage();
   } else {
     end = false;
-    return *(++logIt);
+    const LogMessage& ret = *logIt;
+    return ret;
   }
 }
 

--- a/CommandLine/emake/EnigmaCallbacks.cpp
+++ b/CommandLine/emake/EnigmaCallbacks.cpp
@@ -34,7 +34,6 @@ const LogMessage& CallBack::GetNextLogMessage(bool &end) const {
   ++logIt;
   if (logIt == logMessages.end()) {
     end = true;
-    logMutex.unlock();
     return LogMessage();
   } else {
     end = false;
@@ -44,7 +43,6 @@ const LogMessage& CallBack::GetNextLogMessage(bool &end) const {
 }
 
 void CallBack::ClearLogMessages() {
-  logMutex.lock();
   logMessages.clear();
   logMutex.unlock();
 }

--- a/CommandLine/emake/EnigmaCallbacks.cpp
+++ b/CommandLine/emake/EnigmaCallbacks.cpp
@@ -27,7 +27,7 @@ const ProgressMessage& CallBack::GetProgress() const {
 }
 
 const LogMessage& CallBack::GetFirstLogMessage(bool &end) const {
-  if (logMessages.empty()) { end = true; return LogMessage(); }
+  if (logMessages.empty()) { end = true; return std::move(LogMessage()); }
   end = false;
   logMutex.lock();
   logIt = logMessages.begin();
@@ -38,7 +38,7 @@ const LogMessage& CallBack::GetNextLogMessage(bool &end) const {
   ++logIt;
   if (logIt == logMessages.end()) {
     end = true;
-    return LogMessage();
+    return std::move(LogMessage());
   } else {
     end = false;
     const LogMessage& ret = *logIt;

--- a/CommandLine/emake/EnigmaCallbacks.hpp
+++ b/CommandLine/emake/EnigmaCallbacks.hpp
@@ -6,12 +6,30 @@
 //Should be:
 //#include "backend/EnigmaCallbacks.h"
 
+#include "codegen/server.pb.h"
+
 #include <fstream>
+#include <string>
+#include <vector>
+#include <mutex>
+
+using ProgressMessage = buffers::ProgressMessage;
+using LogMessage = buffers::LogMessage;
 
 class CallBack : public EnigmaCallbacks
 {
 public:
   CallBack();
+  const ProgressMessage& GetProgress() const;
+  const LogMessage& GetFirstLogMessage(bool &end) const;
+  const LogMessage& GetNextLogMessage(bool &end) const;
+  void ClearLogMessages();
+
+private:
+  static ProgressMessage progressMessage;
+  static std::vector<LogMessage> logMessages;
+  static std::vector<LogMessage>::iterator logIt;
+  static std::mutex logMutex;
 
   static void FrameOpen();
   static void AppendFrame(const char*);

--- a/CommandLine/emake/EnigmaCallbacks.hpp
+++ b/CommandLine/emake/EnigmaCallbacks.hpp
@@ -24,12 +24,14 @@ public:
   const LogMessage& GetFirstLogMessage(bool &end) const;
   const LogMessage& GetNextLogMessage(bool &end) const;
   void ClearLogMessages();
+  void ProcessOutput();
 
 private:
   static ProgressMessage progressMessage;
   static std::vector<LogMessage> logMessages;
   static std::vector<LogMessage>::iterator logIt;
   static std::mutex logMutex;
+  static std::ifstream outFile;
 
   static void FrameOpen();
   static void AppendFrame(const char*);
@@ -40,8 +42,6 @@ private:
   static void ResetRedirect();
   static int Execute(const char*, const char**, bool);
   static Image* CompressImage(char *, int);
-  static void* OutputThread(void*);
-  static std::ifstream _outFile;
 };
 
 #endif

--- a/CommandLine/emake/EnigmaCallbacks.hpp
+++ b/CommandLine/emake/EnigmaCallbacks.hpp
@@ -21,8 +21,8 @@ class CallBack : public EnigmaCallbacks
 public:
   CallBack();
   const ProgressMessage& GetProgress() const;
-  const LogMessage& GetFirstLogMessage(bool &end) const;
-  const LogMessage& GetNextLogMessage(bool &end) const;
+  const LogMessage GetFirstLogMessage(bool &end) const;
+  const LogMessage GetNextLogMessage(bool &end) const;
   void ClearLogMessages();
   void ProcessOutput();
 

--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -45,7 +45,7 @@ int EnigmaPlugin::Load()
 #endif
 
   std::string pluginName = "./" + prefix + "compileEGMf" + extension;
-  
+
   _handle = dlopen(pluginName.c_str(), RTLD_LAZY);
 
   if (!_handle)
@@ -83,10 +83,9 @@ int EnigmaPlugin::Load()
   return PLUGIN_SUCCESS;
 }
 
-const char* EnigmaPlugin::Init()
+const char* EnigmaPlugin::Init(CallBack *ecb)
 {
-  CallBack ecb;
-  return plugin_Init(&ecb);
+  return plugin_Init(ecb);
 }
 
 syntax_error* EnigmaPlugin::SetDefinitions(const char* def, const char* yaml)
@@ -171,29 +170,29 @@ void EnigmaPlugin::PrintBuiltins(std::string& fName)
   std::vector<std::string> types;
   std::vector<std::string> globals;
   std::map<std::string, std::string> functions;
-  
+
   const char* currentResource = plugin_FirstResource();
   while (!plugin_ResourcesAtEnd()) {
-    
+
     if (plugin_ResourceIsFunction()) {
       //for (int i = 0; i < plugin_ResourceOverloadCount(); i++) // FIXME: JDI can't print overloads
         functions[currentResource] = plugin_ResourceParameters(0);
     }
-    
+
     if (plugin_ResourceIsGlobal())
       globals.push_back(currentResource);
-      
+
     if (plugin_ResourceIsTypeName())
       types.push_back(currentResource);
-    
+
     currentResource = plugin_NextResource();
   }
 
   std::sort(types.begin(), types.end());
-  
+
   std::ostream out(std::cout.rdbuf());
   std::filebuf fb;
-  
+
   if (!fName.empty()) {
     std::cout << "Writing builtins..." << std::endl;
     fb.open(fName.c_str(), std::ios::out);
@@ -203,20 +202,19 @@ void EnigmaPlugin::PrintBuiltins(std::string& fName)
   out << "[Types]" << std::endl;
   for (const std::string& t : types)
     out << t << std::endl;
-  
+
   std::sort(globals.begin(), globals.end());
-  
+
   out << "[Globals]" << std::endl;
   for (const std::string& g : globals)
     out << g << std::endl;
-  
+
   out << "[Functions]" << std::endl;
   for (const auto& f : functions)
     out << f.second << std::endl;
-    
+
   if (!fName.empty()) {
     fb.close();
     std::cout << "Done writing builtins" << std::endl;
   }
 }
-

--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -57,7 +57,8 @@ int EnigmaPlugin::Load()
 
   // Bind Functions
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-#	define BindFunc(x, y) GetProcAddress(static_cast<HMODULE>(x), y)
+                        // LOL fucking Winblows
+#	define BindFunc(x, y) reinterpret_cast<void*>(GetProcAddress(static_cast<HMODULE>(x), y))
 #else
 #	define BindFunc(x, y) dlsym(x, y)
 #endif

--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -57,8 +57,8 @@ int EnigmaPlugin::Load()
 
   // Bind Functions
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-                        // LOL fucking Winblows
-#	define BindFunc(x, y) reinterpret_cast<void*>(GetProcAddress(static_cast<HMODULE>(x), y))
+                        // LOL fucking Winblows warnings
+#	define BindFunc(x, y) reinterpret_cast<void(*)()>(GetProcAddress(static_cast<HMODULE>(x), y))
 #else
 #	define BindFunc(x, y) dlsym(x, y)
 #endif

--- a/CommandLine/emake/EnigmaPlugin.hpp
+++ b/CommandLine/emake/EnigmaPlugin.hpp
@@ -30,7 +30,7 @@ class EnigmaPlugin
 public:
   EnigmaPlugin();
   int Load();
-  const char* Init();
+  const char* Init(CallBack *cb);
   syntax_error* SetDefinitions(const char* def, const char* yaml);
   syntax_error* SetDefinitions(const char* yaml);
   syntax_error* SyntaxCheck(int count, const char** names, const char* code);

--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -57,7 +57,8 @@ int main(int argc, char* argv[])
   gmx::bind_output_streams(outputStream, errorStream);
   gmk::bind_output_streams(outputStream, errorStream);
 #endif
-  plugin.Init();
+  CallBack ecb;
+  plugin.Init(&ecb);
   plugin.SetDefinitions(options.APIyaml().c_str());
 
   std::string output_file;
@@ -78,7 +79,7 @@ int main(int argc, char* argv[])
   if (server) {
     int port = options.GetOption("port").as<int>();
     string ip = options.GetOption("ip").as<std::string>();
-    return RunServer(ip + ":" + std::to_string(port), plugin, options);
+    return RunServer(ip + ":" + std::to_string(port), plugin, options, ecb);
   }
 #endif
 

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -43,11 +43,11 @@ class CompilerServiceImpl final : public Compiler::Service {
       reply.mutable_progress()->CopyFrom(ecb.GetProgress());
 
       bool end = false;
-      const LogMessage& msg = ecb.GetFirstLogMessage(end);
+      const LogMessage msg = ecb.GetFirstLogMessage(end);
       if (end) continue;
       reply.add_message()->CopyFrom(msg);
       while (true) {
-        const LogMessage& nxt = ecb.GetNextLogMessage(end);
+        const LogMessage nxt = ecb.GetNextLogMessage(end);
         if (end) { ecb.ClearLogMessages(); break; }
         reply.add_message()->CopyFrom(nxt);
       }

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -16,7 +16,6 @@
 
 #include <memory>
 #include <future>
-#include <sstream>
 
 using namespace grpc;
 using namespace buffers;

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -38,6 +38,8 @@ class CompilerServiceImpl final : public Compiler::Service {
     while (future.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
       CompileReply reply;
 
+      ecb.ProcessOutput();
+
       reply.mutable_progress()->CopyFrom(ecb.GetProgress());
 
       bool end = false;

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -154,7 +154,7 @@ class CompilerServiceImpl final : public Compiler::Service {
 
   Status SetCurrentConfig(ServerContext* /*context*/, const SetCurrentConfigRequest* request, Empty* /*reply*/) override {
     std::string yaml = this->options.APIyaml(&request->settings());
-    syntax_error* err = plugin.SetDefinitions("", yaml.c_str());
+    /*syntax_error* err = */plugin.SetDefinitions("", yaml.c_str());
     return Status::OK;
   }
 

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -42,13 +42,13 @@ class CompilerServiceImpl final : public Compiler::Service {
       reply.mutable_progress()->CopyFrom(ecb.GetProgress());
 
       bool end = false;
-      LogMessage msg = ecb.GetFirstLogMessage(end);
+      const LogMessage& msg = ecb.GetFirstLogMessage(end);
       if (end) continue;
       reply.add_message()->CopyFrom(msg);
       while (true) {
-        msg = ecb.GetNextLogMessage(end);
+        const LogMessage& nxt = ecb.GetNextLogMessage(end);
         if (end) break;
-        reply.add_message()->CopyFrom(msg);
+        reply.add_message()->CopyFrom(nxt);
       }
 
       ecb.ClearLogMessages();

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -32,10 +32,13 @@ class CompilerServiceImpl final : public Compiler::Service {
     }
 
   Status CompileBuffer(ServerContext* /*context*/, const CompileRequest* request, ServerWriter<CompileReply>* writer) override {
-    CompileBufferFuture.get(); // block until the last CompileBuffer rpc finishes
+    // block until the last CompileBuffer rpc finishes
+    if (CompileBufferFuture.valid()) CompileBufferFuture.get();
+    // use lambda capture to contain compile logic
     auto fnc = [=] {
       plugin.BuildGame(const_cast<buffers::Game*>(&request->game()), emode_run, request->name().c_str());
     };
+    // asynchronously launch the compile request
     CompileBufferFuture = std::async(fnc);
 
     CompileReply reply;

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -46,11 +46,10 @@ class CompilerServiceImpl final : public Compiler::Service {
       reply.add_message()->CopyFrom(msg);
       while (true) {
         const LogMessage& nxt = ecb.GetNextLogMessage(end);
-        if (end) break;
+        if (end) { ecb.ClearLogMessages(); break; }
         reply.add_message()->CopyFrom(nxt);
       }
 
-      ecb.ClearLogMessages();
       writer->Write(reply);
     }
 

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -152,10 +152,9 @@ class CompilerServiceImpl final : public Compiler::Service {
     return Status::OK;
   }
 
-  Status SetCurrentConfig(ServerContext* /*context*/, const SetCurrentConfigRequest* request, Empty* reply) override {
+  Status SetCurrentConfig(ServerContext* /*context*/, const SetCurrentConfigRequest* request, Empty* /*reply*/) override {
     std::string yaml = this->options.APIyaml(&request->settings());
     syntax_error* err = plugin.SetDefinitions("", yaml.c_str());
-    reply = new Empty();
     return Status::OK;
   }
 

--- a/CommandLine/emake/Server.hpp
+++ b/CommandLine/emake/Server.hpp
@@ -3,4 +3,4 @@
 
 #include <string>
 
-int RunServer(const std::string& address, EnigmaPlugin& plugin, OptionsParser& options);
+int RunServer(const std::string& address, EnigmaPlugin& plugin, OptionsParser& options, CallBack &ecb);

--- a/CommandLine/protos/Makefile
+++ b/CommandLine/protos/Makefile
@@ -18,11 +18,9 @@ OBJ_DIR := .eobjs
 
 rwildcard=$(wildcard $1/$2) $(foreach d,$(wildcard $1/*),$(call rwildcard,$d,$2))
 PROTOS := $(call rwildcard,$(SRC_DIR),*.proto)
-PROTOS := $(filter-out ./server.proto, $(PROTOS))
 PROTO_OUT := $(patsubst $(SRC_DIR)/%, $(PROTO_DIR)/%, $(patsubst %.proto, %.pb.cc, $(PROTOS)))
 
 ifeq ($(CLI_ENABLE_SERVER), TRUE)
-	PROTOS += $(SRC_DIR)/server.proto
 	PROTO_OUT += $(PROTO_DIR)/server.grpc.pb.cc
 	PROTO_OBJECTS += $(OBJ_DIR)/codegen/server.o
 	LIBLDFLAGS := -lgrpc++

--- a/CommandLine/protos/server.proto
+++ b/CommandLine/protos/server.proto
@@ -8,7 +8,6 @@ service Compiler {
   rpc CompileBuffer (CompileRequest) returns (stream CompileReply);
   rpc GetResources (Empty) returns (stream Resource);
   rpc GetSystems (Empty) returns (stream SystemType);
-  rpc GetOutput(Empty) returns (stream OutputReply);
 
   rpc SyntaxCheck(SyntaxCheckRequest) returns (SyntaxError);
   rpc SetDefinitions(SetDefinitionsRequest) returns (SyntaxError);
@@ -32,24 +31,41 @@ message Resource {
   repeated string parameters = 9;
 }
 
-enum CompileMode {
-  RUN = 1;
-  DEBUG = 2;
-  DESIGN = 3;
-  COMPILE = 4;
-  REBUILD = 5;
-  INVALID = 6;
-}
-
 message CompileRequest {
+  enum CompileMode {
+    UNKNOWN = 0;
+    RUN = 1;
+    DEBUG = 2;
+    DESIGN = 3;
+    COMPILE = 4;
+    REBUILD = 5;
+  }
+
   optional Game game = 1;
   optional string name = 2;
   optional CompileMode mode = 3;
 }
 
+message LogMessage {
+  enum Severity {
+    UNKNOWN = 0;
+    FINE = 1;
+    INFO = 2;
+    WARNING = 3;
+    ERROR = 4;
+  }
+  optional Severity severity = 1; ///< The severity and nature of the message.
+  optional string message = 2; ///< The message to display to the user in the output.
+}
+
+message ProgressMessage {
+  optional float progress = 1; ///< In range 1-100 (you can use 0-1, but take a stance, here)
+  optional string message = 2; ///< The message to display inside of or after the progress bar.
+}
+
 message CompileReply {
-  optional string message = 1;
-  optional int32 progress = 2;
+  repeated LogMessage message = 1; ///< Compilation messages logged since the last update.
+  optional ProgressMessage progress = 2; ///< Current compilation progress.
 }
 
 message SyntaxError {
@@ -86,9 +102,4 @@ message SystemInfo {
   optional string description = 3; ///< A friendly description of the system and what it does.
   optional string author = 4; ///< Name of the system author or maintainer (e.g, "John Doe")
   optional string target = 5; ///< The target-platform of the system. Only used by compiler descriptions presently.
-}
-
-message OutputReply {
-  optional string out = 1; ///< All available output read from the standard output stream.
-  optional string err = 2; ///< All available output read from the standard error stream.
 }

--- a/CommandLine/protos/server.proto
+++ b/CommandLine/protos/server.proto
@@ -8,6 +8,7 @@ service Compiler {
   rpc CompileBuffer (CompileRequest) returns (stream CompileReply);
   rpc GetResources (Empty) returns (stream Resource);
   rpc GetSystems (Empty) returns (stream SystemType);
+  rpc GetOutput(Empty) returns (stream OutputReply);
 
   rpc SyntaxCheck(SyntaxCheckRequest) returns (SyntaxError);
   rpc SetDefinitions(SetDefinitionsRequest) returns (SyntaxError);
@@ -85,4 +86,9 @@ message SystemInfo {
   optional string description = 3; ///< A friendly description of the system and what it does.
   optional string author = 4; ///< Name of the system author or maintainer (e.g, "John Doe")
   optional string target = 5; ///< The target-platform of the system. Only used by compiler descriptions presently.
+}
+
+message OutputReply {
+  optional string out = 1; ///< All available output read from the standard output stream.
+  optional string err = 2; ///< All available output read from the standard error stream.
 }


### PR DESCRIPTION
Alright so the basic goal here was to get the emake server forwarding output to the client. This way it's possible to get the output when emake is running on a remote host. This has been accomplished by threading the game compile and sending a stream of log messages back to the client. For now the log messages are only taken from the IDE frame append callback and read from the IDE output redirect file.

### Summary of Changes
* Added an accessor to `CallBack` to get the current progress status of the compile.
* Added accessors to read the log message queue from `CallBack` which are synchronized using a semaphore. The design of the accessors is inherently thread-safe, as the user is expected to read the entire log queue and then clear the queue (which unlocks the queue) when they are done reading.
* Added a public `ProcessOutput` method to `CallBack` that is expected to be called asynchronously as it attempts to read a single log message at a time from the IDE output redirect file.
* Implemented the `AddFrame` IDE callback to `CallBack` that stores its text until the point a newline appears at the end of the current frame at which point it flushes a new log message to the queue.
* Implemented the progress/output redirect mutator IDE callbacks in `CallBack` to accomplish the above.
* Fixed warnings about incompatible function pointer cast in `EnigmaPlugin::Load` resulting from the fact that `GetProcAddress` returns `int*` by simply casting to the intermediate `void*` type. This looks like Windows is silly to me because `dlsym` on Unix/Linux/whatever returns `void*` so it doesn't have this warning.
* Changed `EnigmaPlugin::Init` to accept a `CallBack` instance to initialize with.
* Changed `RunServer` to accept a `CallBack` instance to read the log queue and such from.
* Changed the server's implementation of the `CompileBuffer` rpc to launch the game compile in an async thread. It then enters a blocking (for now) loop to forward all logged messages and the current progress to the client. Later this can be made into a FIFO queue so the server can compile multiple games at once. That may later require that `CallBack` be changed to synchronize log messages coming from those new threads.
* Fixed a warning about unused parameters in the `SetCurrentConfig` implementation by simply commenting the variable name. Also removed the reallocation which was wrong because GRPC actually allocates the reply for us.
* Fixed a warning about unused local variable `syntax_error* err` in the `SetCurrentConfig` implementation by simply commenting it out. The reason the reply for this RPC is empty is because we're still considering making definitions a resource instead of tying it to settings.
* Changed the protos makefile to always process the server proto. Building with the server mode disabled (the default) still works because we skip the grpc steps. Regardless, we want to use the same messages as the server in various places of the compiler now. In this particular case, I needed to use LogMessage over in `EnigmaCallbacks.hpp` which still needs to be built when the server is disabled.
* Moved the `CompileMode` enum into the `CompileRequest` message.
* Added the `LogMessage` and `ProgressMessage` proto messages Josh provided me to `server.proto` for structuring log messages.
* Changed the `CompileReply` message to return a series of log messages and the current progress during game compile.