### PR TITLE
Attempt To Fix Linux Compiled Games

### DIFF
--- a/Compilers/Linux/gcc.ey
+++ b/Compilers/Linux/gcc.ey
@@ -14,7 +14,7 @@ Make-Vars:
   cppflags:
   cxxflags: -std=c++11
   cflags:
-  ldflags:
+  ldflags: -no-pie
   links:
 
 Parser-Vars:


### PR DESCRIPTION
This should fix #1424 and make compile mode games launch when double clicked.