### PR TITLE
Update View Following Before Draw

### DIFF
--- a/CommandLine/testing/Tests/room_transition_test.gmx/objects/obj_0.object.gmx
+++ b/CommandLine/testing/Tests/room_transition_test.gmx/objects/obj_0.object.gmx
@@ -5,8 +5,8 @@
   <visible>-1</visible>
   <depth>0</depth>
   <persistent>-1</persistent>
-  <parentName>&lt;undefined&gt;</parentName>
   <maskName>&lt;undefined&gt;</maskName>
+  <parentName>&lt;undefined&gt;</parentName>
   <events>
     <event enumb="4" eventtype="7">
       <action>
@@ -14,8 +14,8 @@
         <id>603</id>
         <kind>7</kind>
         <userelative>0</userelative>
-        <isquestion>0</isquestion>
         <useapplyto>-1</useapplyto>
+        <isquestion>0</isquestion>
         <exetype>2</exetype>
         <functionname/>
         <codestring/>
@@ -25,20 +25,47 @@
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>if (room == rm_0) {
-    gtest_assert_eq(draw_get_color(), c_white);
-    gtest_assert_eq_eps(draw_get_alpha(), 1.0);
-
-    draw_set_color(c_red);
-    draw_set_alpha(0.2);
-    room_goto(rm_1);
-} else if (room == rm_1) {
-    // ensure that room transition did NOT reset color/alpha
-    // GM does not reset ANY render state when changing rooms
-    gtest_assert_eq(draw_get_color(), c_red);
-    gtest_assert_eq_eps(draw_get_alpha(), 0.2);
-}
-</string>
+            <string>if (room == rm_0) {&#13;
+    gtest_assert_eq(draw_get_color(), c_white);&#13;
+    gtest_assert_eq_eps(draw_get_alpha(), 1.0);&#13;
+&#13;
+    draw_set_color(c_red);&#13;
+    draw_set_alpha(0.2);&#13;
+} else if (room == rm_1) {&#13;
+    // ensure that room transition did NOT reset color/alpha&#13;
+    // GM does not reset ANY render state when changing rooms&#13;
+    gtest_assert_eq(draw_get_color(), c_red);&#13;
+    gtest_assert_eq_eps(draw_get_alpha(), 0.2);&#13;
+}</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event enumb="0" eventtype="8">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <useapplyto>-1</useapplyto>
+        <isquestion>0</isquestion>
+        <exetype>2</exetype>
+        <functionname/>
+        <codestring/>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>if (room == rm_0 &amp;&amp; view_current == 0) {&#13;
+	// ensure that the object following of&#13;
+	// all views is updated prior to draw events&#13;
+	gtest_assert_eq(view_yview[0], 7);&#13;
+	gtest_assert_eq(view_yview[1], 7);&#13;
+	&#13;
+	room_goto(rm_1);&#13;
+}</string>
           </argument>
         </arguments>
       </action>

--- a/CommandLine/testing/Tests/room_transition_test.gmx/rooms/rm_0.room.gmx
+++ b/CommandLine/testing/Tests/room_transition_test.gmx/rooms/rm_0.room.gmx
@@ -11,7 +11,7 @@
   <colour>16764006</colour>
   <showcolour>-1</showcolour>
   <code/>
-  <enableViews>0</enableViews>
+  <enableViews>-1</enableViews>
   <clearViewBackground>-1</clearViewBackground>
   <makerSettings>
     <isSet>-1</isSet>
@@ -40,8 +40,8 @@
     <background foreground="0" hspeed="0" htiled="-1" name="" stretch="0" visible="0" vspeed="0" vtiled="-1" x="0" y="0"/>
   </backgrounds>
   <views>
-    <view hborder="32" hport="480" hspeed="-1" hview="480" objName="&lt;undefined&gt;" vborder="32" visible="0" vspeed="-1" wport="640" wview="640" xport="0" xview="0" yport="0" yview="0"/>
-    <view hborder="32" hport="480" hspeed="-1" hview="480" objName="&lt;undefined&gt;" vborder="32" visible="0" vspeed="-1" wport="640" wview="640" xport="0" xview="0" yport="0" yview="0"/>
+    <view hborder="32" hport="480" hspeed="7" hview="100" objName="obj_0" vborder="32" visible="-1" vspeed="7" wport="640" wview="100" xport="0" xview="0" yport="0" yview="0"/>
+    <view hborder="32" hport="480" hspeed="7" hview="100" objName="obj_0" vborder="32" visible="-1" vspeed="7" wport="640" wview="100" xport="0" xview="0" yport="0" yview="0"/>
     <view hborder="32" hport="480" hspeed="-1" hview="480" objName="&lt;undefined&gt;" vborder="32" visible="0" vspeed="-1" wport="640" wview="640" xport="0" xview="0" yport="0" yview="0"/>
     <view hborder="32" hport="480" hspeed="-1" hview="480" objName="&lt;undefined&gt;" vborder="32" visible="0" vspeed="-1" wport="640" wview="640" xport="0" xview="0" yport="0" yview="0"/>
     <view hborder="32" hport="480" hspeed="-1" hview="480" objName="&lt;undefined&gt;" vborder="32" visible="0" vspeed="-1" wport="640" wview="640" xport="0" xview="0" yport="0" yview="0"/>
@@ -50,7 +50,7 @@
     <view hborder="32" hport="480" hspeed="-1" hview="480" objName="&lt;undefined&gt;" vborder="32" visible="0" vspeed="-1" wport="640" wview="640" xport="0" xview="0" yport="0" yview="0"/>
   </views>
   <instances>
-    <instance code="" colour="4294967295" id="100001" locked="0" name="inst_9886EF9A" objName="obj_0" rotation="0.0" scaleX="1.0" scaleY="1.0" x="0" y="0"/>
+    <instance code="" colour="4294967295" id="100001" locked="0" name="inst_9886EF9A" objName="obj_0" rotation="0.0" scaleX="1.0" scaleY="1.0" x="0" y="464"/>
   </instances>
   <tiles/>
   <PhysicsWorld>0</PhysicsWorld>

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -227,10 +227,8 @@ void screen_redraw()
   }
   else
   {
-    //TODO: Possibly implement view option from Stupido to control which view clears the background
-    // Only clear the background on the first visible view by checking if it hasn't been cleared yet
-    bool draw_backs = true;
-    bool background_allviews = true; // FIXME: Create a setting for this.
+    // update object following first in case the user accesses
+    // a view other than the current one in the draw event
     for (view_current = 0; view_current < 8; view_current++)
     {
       int vc = (int)view_current;
@@ -240,6 +238,17 @@ void screen_redraw()
       int vob = (int)view_object[vc];
       if (vob != -1)
         follow_object(vob, vc);
+    }
+
+    //TODO: Possibly implement view option from Stupido to control which view clears the background
+    // Only clear the background on the first visible view by checking if it hasn't been cleared yet
+    bool draw_backs = true;
+    bool background_allviews = true; // FIXME: Create a setting for this.
+    for (view_current = 0; view_current < 8; view_current++)
+    {
+      int vc = (int)view_current;
+      if (!view_visible[vc])
+        continue;
 
       screen_set_viewport(view_xport[vc], view_yport[vc], view_wport[vc], view_hport[vc]);
 


### PR DESCRIPTION
Sam has this bug in his game with respect to object following. In his draw event code he accesses variables of view 1 when the current view is view 0. View 1 also happens to be following an object. Brief flickering is caused when restarting because on the first frame we don't have view 1 fully initialized based on the object it follows when the current view is view 0 and he attempts to use its variables to draw a background which "jolts" from the view moving. This is just one of two ways to fix this minor glitch in his game.

This fix here adds a second loop to `screen_redraw` that updates all of the views and their object following before looping the views and firing instance draw events. This fixes the glitch in Sam's game because it means that both view 0 and view 1 are fully updated according to object following prior to firing the first draw event.