### PR TITLE
Switch Travis from Trusty to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ before_install:
       sudo add-apt-repository -y ppa:maarten-fonville/protobuf;
       sudo add-apt-repository -y ppa:mhier/libboost-latest;
       sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60";
-      sudo apt-get -y install build-essential zlib1g-dev libboost1.67-dev \
-        libprotobuf3.1-dev protobuf-compiler libglm-dev;
+      sudo apt-get -y install build-essential zlib1g-dev libboost1.67-dev libglm-dev;
 
       if [ "$COMPILER" == "gcc32" ] || [ "$COMPILER" == "clang32" ]; then
         sudo dpkg --add-architecture i386;
         sudo apt-get -y install libc6:i386 libc++-dev:i386 libstdc++6:i386\
           libncurses5:i386 lib32z1-dev libx11-6:i386 libglew-dev:i386\
-          libglu1-mesa-dev:i386 libgl1-mesa-dev:i386;
+          libglu1-mesa-dev:i386 libgl1-mesa-dev:i386 libprotobuf-dev:i386\
+          protobuf-compiler:i386;
 
         if [ "$COMPILER" == "gcc32" ]; then
           sudo apt-get -y install gcc-multilib g++-multilib;
@@ -37,7 +37,7 @@ before_install:
         unzip enigma-libs.zip -d ENIGMAsystem/;
         mv ENIGMAsystem/Install ENIGMAsystem/Additional;
       else
-        sudo apt-get -y install libc++-dev libglew-dev libglu1-mesa-dev;
+        sudo apt-get -y install libc++-dev libglew-dev libglu1-mesa-dev libprotobuf-dev protobuf-compiler;
       fi
 
       if [ "$AUDIO" == "OpenAL" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     set -eo pipefail
 
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      sudo add-apt-repository -y ppa:maarten-fonville/protobuf;
       sudo add-apt-repository -y ppa:mhier/libboost-latest;
       sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60";
       sudo apt-get -y install build-essential zlib1g-dev libboost1.67-dev \

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
       sudo add-apt-repository -y ppa:mhier/libboost-latest;
       sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60";
       sudo apt-get -y install build-essential zlib1g-dev libboost1.67-dev \
-        libprotobuf-dev protobuf-compiler libglm-dev;
+        libprotobuf3.1-dev protobuf-compiler libglm-dev;
 
       if [ "$COMPILER" == "gcc32" ] || [ "$COMPILER" == "clang32" ]; then
         sudo dpkg --add-architecture i386;

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ install:
 # by default most of our jobs will be run on a linux instance
 os: linux
 dist: xenial
-group: edge
 compiler: gcc
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
     set -eo pipefail
 
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      sudo add-apt-repository -y ppa:maarten-fonville/protobuf;
       sudo add-apt-repository -y ppa:mhier/libboost-latest;
       sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60";
       sudo apt-get -y install build-essential zlib1g-dev libboost1.67-dev \
@@ -31,7 +30,6 @@ before_install:
           sudo apt-get -y install gcc-multilib g++-multilib;
         fi
 
-        sudo ln -s /usr/include/x86_64-linux-gnu/zconf.h /usr/include;
       elif [ "$COMPILER" == "MinGW64" ] || [ "$COMPILER" == "MinGW32" ]; then
         sudo apt-get -y install mingw-w64 wine;
         curl -L https://github.com/enigma-dev/enigma-dev/files/2431000/enigma-libs.zip > enigma-libs.zip;
@@ -89,7 +87,8 @@ install:
 
 # by default most of our jobs will be run on a linux instance
 os: linux
-group: travis_latest
+dist: xenial
+group: edge
 compiler: gcc
 language: cpp
 

--- a/CommandLine/protos/Makefile
+++ b/CommandLine/protos/Makefile
@@ -11,7 +11,7 @@ else
 endif
 
 LIBRARY := ../../libProtocols$(EXT)
-PROTO_DIR := codegen/
+PROTO_DIR := codegen
 CXXFLAGS := -I$(PROTO_DIR) -std=c++11 -Wall -Wextra -Wpedantic -g -fPIC
 SRC_DIR := .
 OBJ_DIR := .eobjs

--- a/CommandLine/protos/Makefile
+++ b/CommandLine/protos/Makefile
@@ -11,7 +11,7 @@ else
 endif
 
 LIBRARY := ../../libProtocols$(EXT)
-PROTO_DIR := codegen
+PROTO_DIR := codegen/
 CXXFLAGS := -I$(PROTO_DIR) -std=c++11 -Wall -Wextra -Wpedantic -g -fPIC
 SRC_DIR := .
 OBJ_DIR := .eobjs


### PR DESCRIPTION
This is a recreation of #1328 which is itself a recreation of #1272 which keeps going stale.

Moving our Travis to Xenial was originally going to stop the build from randomly failing, but I haven't been getting this problem as badly lately. The other reason to do it was because the packages on Xenial are a lot newer, but now we need even newer packages. Most of the reasons for making this change don't matter to us now.