### PR TITLE
Stop Building libegm Outside The Test Harness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,9 @@ before_install:
 # build JDI and the CLI
 install:
   - |
-    if [ "$TEST_HARNESS" != true ]; then
-      make -j4
+    if [ "$TEST_HARNESS" == true ]; then
+      make -j4 emake
+    else
       CLI_ENABLE_EGM=FALSE make -j4 emake
     fi
 


### PR DESCRIPTION
Correct me if I am wrong, but I believe I made this mistake and intended for this to be an else in the Travis file. We want to make this change because we do not want to build libegm for every job since they don't all install the necessary dependencies for it.