### PR TITLE
Fix Event Iterator Leaks

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -72,7 +72,7 @@ namespace enigma
       case WM_CREATE:
         return 0;
       case WM_CLOSE:
-        instance_event_iterator = new inst_iter(NULL,NULL,NULL);
+        instance_event_iterator = &dummy_event_iterator;
         for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
         {
           it->myevent_closebutton();
@@ -114,7 +114,7 @@ namespace enigma
           if (WindowResizedCallback != NULL) {
             WindowResizedCallback();
           }
-          instance_event_iterator = new inst_iter(NULL,NULL,NULL);
+          instance_event_iterator = &dummy_event_iterator;
           for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
           {
             ((object_graphics*)*it)->myevent_drawresize();

--- a/ENIGMAsystem/SHELL/SHELLmain.cpp
+++ b/ENIGMAsystem/SHELL/SHELLmain.cpp
@@ -122,7 +122,7 @@ namespace enigma
   {
     // Fire Room End then Game End events in that order.
     // NOTE: This must be two loops because room/game end event for some object may try accessing another instance.
-    instance_event_iterator = new inst_iter(NULL,NULL,NULL);
+    instance_event_iterator = &dummy_event_iterator;
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
       it->myevent_roomend();
       it->myevent_gameend();

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -43,7 +43,7 @@ namespace enigma {
 namespace {
 
 static void fireAsyncDialogEvent() {
-  enigma::instance_event_iterator = new enigma::inst_iter(NULL,NULL,NULL);
+  enigma::instance_event_iterator = &enigma::dummy_event_iterator;
   for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
   {
     enigma::object_basic* const inst = ((enigma::object_basic*)*it);

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
@@ -212,7 +212,7 @@ namespace enigma
   set<object_basic*> cleanups; // We'll use set, to prevent stupidity
 
   // It's a good idea to centralize an event iterator so error reporting can tell where it is.
-  static inst_iter dummy_event_iterator(NULL,NULL,NULL); // For create events and such
+  inst_iter dummy_event_iterator(NULL,NULL,NULL); // For create events and such
   inst_iter *instance_event_iterator = &dummy_event_iterator; // Not bad for efficiency, either.
   object_basic *instance_other = NULL;
 

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system_base.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system_base.h
@@ -75,6 +75,7 @@ namespace enigma
   extern event_iter *events;
   extern objectid_base *objects;
   extern object_basic *ENIGMA_global_instance;
+  extern inst_iter dummy_event_iterator;
   extern inst_iter *instance_event_iterator;
   extern object_basic *instance_other;
 

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -157,7 +157,7 @@ namespace enigma
 
   void roomstruct::end() {
     // Fire the Room End event.
-    instance_event_iterator = new inst_iter(NULL,NULL,NULL);
+    instance_event_iterator = &dummy_event_iterator;
     for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
       it->myevent_roomend();
     }
@@ -266,7 +266,7 @@ namespace enigma
       }
     }
 
-    instance_event_iterator = new inst_iter(NULL,NULL,NULL);
+    instance_event_iterator = &dummy_event_iterator;
 
     // Fire the rooms preCreation code. This code includes instance sprite transformations added in the room editor.
     // (NOTE: This code uses instance_deactivated_list to look up instances by ID, in addition to the normal lookup approach).


### PR DESCRIPTION
This fixes memory leaks as a result of iterating events in various locations. The problem is that the allocated `inst_iter` everywhere are not being deallocated. The solution just uses the `dummy_event_iterator` which is global and has static storage duration that was intended solely for this purpose.