### PR TITLE
Add os_browser User Global Constant

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -1,7 +1,8 @@
 #include "PFmain.h"
 
+#include "PFwindow.h"
+#include "PFsystem.h"
 #include "Platforms/platforms_mandatory.h"
-#include "Platforms/General/PFwindow.h"
 #include "Universal_System/roomsystem.h"
 
 #include <unistd.h>  //getcwd, usleep
@@ -98,6 +99,7 @@ int enigma_main(int argc, char** argv) {
 
 namespace enigma_user {
 
+int os_browser = browser_not_a_browser;
 std::string working_directory = "";
 std::string program_directory = "";
 std::string keyboard_string = "";

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -99,7 +99,7 @@ int enigma_main(int argc, char** argv) {
 
 namespace enigma_user {
 
-int os_browser = browser_not_a_browser;
+const int os_browser = browser_not_a_browser;
 std::string working_directory = "";
 std::string program_directory = "";
 std::string keyboard_string = "";

--- a/ENIGMAsystem/SHELL/Platforms/General/PFsystem.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFsystem.h
@@ -24,19 +24,33 @@ using std::string;
 namespace enigma_user {
 
 enum {
-	os_unknown = -1,
-	os_windows = 0,
-	os_win32 = 0,
-	os_macosx = 1,
-	os_psp = 2,
-	os_ios = 3,
-	os_android = 4,
-	os_symbian = 5,
-	os_linux = 6,
-	os_winphone = 7,
-	os_tizen = 8,
-	os_win8native = 9,
+  os_unknown = -1,
+  os_windows = 0,
+  os_win32 = 0,
+  os_macosx = 1,
+  os_psp = 2,
+  os_ios = 3,
+  os_android = 4,
+  os_symbian = 5,
+  os_linux = 6,
+  os_winphone = 7,
+  os_tizen = 8,
+  os_win8native = 9,
 };
+
+enum {
+  browser_not_a_browser = -1,
+  browser_unknown = 0,
+  browser_ie = 1,
+  browser_firefox = 2,
+  browser_chrome = 3,
+  browser_safari = 4,
+  browser_opera = 5,
+  browser_safari_mobile = 6,
+  browser_windows_store = 7,
+};
+
+extern int os_browser;
 
 string os_get_config();
 int os_get_info();

--- a/ENIGMAsystem/SHELL/Platforms/General/PFsystem.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFsystem.h
@@ -50,7 +50,7 @@ enum {
   browser_windows_store = 7,
 };
 
-extern int os_browser;
+extern const int os_browser;
 
 string os_get_config();
 int os_get_info();


### PR DESCRIPTION
This adds the `os_browser` constant for checking if the game is being run in a browser. For now it obviously just defaults to `browser_not_a_browser` but it does resolve #1108.
https://docs.yoyogames.com/source/dadiospice/002_reference/operating%20system/os_browser.html