### PR TITLE
Include Pollution Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,7 +192,7 @@ script:
   - |
     if [ "$TEST_HARNESS" == true ]; then
       export ASAN_OPTIONS=detect_leaks=0;
-      ./ci-regression.sh "/tmp/enigma-master" 4
+      ./ci-regression.sh "/tmp/enigma-master" 4 || travis_terminate $?
     else
       ./ci-build.sh
     fi

--- a/CommandLine/testing/SimpleTests/math_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/math_test.sog/create.edl
@@ -231,6 +231,9 @@ y0 = 2;
 y1 = 3;
 yn = 4;
 
+// This one conflicts with the Win32 CreateFont macro
+CreateFont = 5;
+
 cons_show_message("Test end!");
 
 game_end();

--- a/ENIGMAsystem/SHELL/Platforms/General/PFthreads.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFthreads.cpp
@@ -1,3 +1,4 @@
+#include "PFthreads_impl.h"
 #include "PFthreads.h"
 
 #include "Universal_System/resource_data.h" //script_execute

--- a/ENIGMAsystem/SHELL/Platforms/General/PFthreads.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFthreads.h
@@ -20,8 +20,6 @@
 
 #include "Universal_System/var4.h"
 
-#include <deque>
-
 namespace enigma_user {
   int script_thread(int scr, variant arg0 = 0, variant arg1 = 0, variant arg2 = 0, variant arg3 = 0, variant arg4 = 0, variant arg5 = 0, variant arg6 = 0, variant arg7 = 0);
   int thread_create_script(int scr, variant arg0 = 0, variant arg1 = 0, variant arg2 = 0, variant arg3 = 0, variant arg4 = 0, variant arg5 = 0, variant arg6 = 0, variant arg7 = 0);

--- a/ENIGMAsystem/SHELL/Platforms/General/PFthreads.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFthreads.h
@@ -20,48 +20,7 @@
 
 #include "Universal_System/var4.h"
 
-#ifdef ENIGMA_PLATFORM_SDL
-  #include <SDL2/SDL.h>
-  using pltfrm_thread_t = SDL_Thread*;
-#elif ENIGMA_PLATFORM_WINDOWS 
-  #include <windows.h>
-  using pltfrm_thread_t = HANDLE;
-#else
-  #include <pthread.h> // use POSIX threads
-  using pltfrm_thread_t = pthread_t;
-#endif
-
 #include <deque>
-
-namespace enigma {
-
-struct ethread;
-
-struct scrtdata {
-  int scr;
-  variant args[8];
-  ethread* mt;
-  scrtdata(int s, variant nargs[8], ethread* mythread): scr(s), mt(mythread) { for (int i = 0; i < 8; i++) args[i] = nargs[i]; }
-};
-
-struct ethread {
-  pltfrm_thread_t handle;
-  scrtdata *sd;
-  bool active;
-  variant ret;
-  ethread(): handle(0), sd(NULL), active(false), ret(0) {};
-  ~ethread() {
-    if (sd != NULL) {
-      delete sd;
-    }
-  }
-};
-
-extern std::deque<ethread*> threads;
-
-void* thread_script_func(void* data);
-
-}
 
 namespace enigma_user {
   int script_thread(int scr, variant arg0 = 0, variant arg1 = 0, variant arg2 = 0, variant arg3 = 0, variant arg4 = 0, variant arg5 = 0, variant arg6 = 0, variant arg7 = 0);

--- a/ENIGMAsystem/SHELL/Platforms/General/PFthreads_impl.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFthreads_impl.h
@@ -1,0 +1,66 @@
+/** Copyright (C) 2008-2011 Josh Ventura
+*** Copyright (C) 2014 Robert B. Colton
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#ifndef ENIGMA_PLATFORM_THREADS_IMPL_H
+#define ENIGMA_PLATFORM_THREADS_IMPL_H
+
+#include "Universal_System/var4.h"
+
+#ifdef ENIGMA_PLATFORM_SDL
+  #include <SDL2/SDL.h>
+  using pltfrm_thread_t = SDL_Thread*;
+#elif ENIGMA_PLATFORM_WINDOWS
+  #include <windows.h>
+  using pltfrm_thread_t = HANDLE;
+#else
+  #include <pthread.h> // use POSIX threads
+  using pltfrm_thread_t = pthread_t;
+#endif
+
+#include <deque>
+
+namespace enigma {
+
+struct ethread;
+
+struct scrtdata {
+  int scr;
+  variant args[8];
+  ethread* mt;
+  scrtdata(int s, variant nargs[8], ethread* mythread): scr(s), mt(mythread) { for (int i = 0; i < 8; i++) args[i] = nargs[i]; }
+};
+
+struct ethread {
+  pltfrm_thread_t handle;
+  scrtdata *sd;
+  bool active;
+  variant ret;
+  ethread(): handle(0), sd(NULL), active(false), ret(0) {};
+  ~ethread() {
+    if (sd != NULL) {
+      delete sd;
+    }
+  }
+};
+
+extern std::deque<ethread*> threads;
+
+void* thread_script_func(void* data);
+
+} // namespace enigma
+
+#endif //ENIGMA_PLATFORM_THREADS_IMPL_H

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
@@ -204,6 +204,13 @@ bool display_set_all(int w, int h, int freq, int bitdepth);
 bool display_test_all(int w, int h, int freq, int bitdepth);
 void set_synchronization(bool enable);
 
+//NOTE: window_handle() should never be used by the engine, other systems, such as bridges, can make direct use of the HWND
+#if GM_COMPATIBILITY_VERSION <= 81
+unsigned long long window_handle();
+#else
+void* window_handle();
+#endif
+
 int window_get_x();
 int window_get_y();
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXthreads.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXthreads.cpp
@@ -17,16 +17,16 @@
 **/
 
 #include "Platforms/General/PFthreads.h"
+#include "Platforms/General/PFthreads_impl.h"
 
 using enigma::ethread;
 using enigma::threads;
-using enigma::thread_script_func;
 
 namespace enigma_user {
 
 int thread_start(int thread) {
   if (threads[thread]->active) { return -1; }
-  if (pthread_create(&threads[thread]->handle, NULL, thread_script_func, threads[thread]->sd)) {
+  if (pthread_create(&threads[thread]->handle, NULL, enigma::thread_script_func, threads[thread]->sd)) {
     return -2;
   }
   threads[thread]->active = true;

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Threads.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Threads.cpp
@@ -16,24 +16,24 @@
 **/
 
 #include "Platforms/General/PFthreads.h"
+#include "Platforms/General/PFthreads_impl.h"
 
 #include <functional>
 
 using enigma::ethread;
 using enigma::threads;
-using enigma::thread_script_func;
 
-namespace enigma_user {
-
-int _thread_script_func(void* data) {
-  thread_script_func(data);
+static int _thread_script_func(void* data) {
+  enigma::thread_script_func(data);
   return 0;
 }
+
+namespace enigma_user {
 
 int thread_start(int thread) {
   if (threads[thread]->active) return -1;
   threads[thread]->handle = SDL_CreateThread(_thread_script_func, NULL, (void *)threads[thread]->sd);
-  
+
   if (threads[thread]->handle == NULL)
     return -2;
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
@@ -22,7 +22,6 @@
 #include "Platforms/General/PFmain.h"
 
 #include <windows.h>
-#include <string>
 
 namespace enigma //TODO: Find where this belongs
 {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
@@ -22,12 +22,7 @@
 #include "Platforms/General/PFmain.h"
 
 #include <windows.h>
-#include <wchar.h>
 #include <string>
-
-typedef std::basic_string<WCHAR> tstring;
-tstring widen(const std::string &str);
-std::string shorten(tstring str);
 
 namespace enigma //TODO: Find where this belongs
 {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.h
@@ -31,22 +31,6 @@ namespace enigma //TODO: Find where this belongs
   extern HANDLE mainthread;
 }
 
-namespace enigma_user
-{
-
-//NOTE: window_handle() should never be used by the engine, other systems, such as bridges, can make direct use of the HWND
-#if GM_COMPATIBILITY_VERSION <= 81
-static inline unsigned long long window_handle() {
-  return (unsigned long long)enigma::hWnd;
-}
-#else
-static inline HWND window_handle() {
-  return enigma::hWnd;
-}
-#endif
-
-}
-
 void enigma_catchmouse_backend(bool x);
 #define enigmacatchmouse() enigma_catchmouse_backend(enigma::mousestatus[0]==1 && enigma::last_mousestatus[0]==1)
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSthreads.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSthreads.cpp
@@ -19,18 +19,18 @@
 #include "WINDOWSmain.h"
 
 #include "Platforms/General/PFthreads.h"
+#include "Platforms/General/PFthreads_impl.h"
 
 using enigma::ethread;
 using enigma::threads;
-using enigma::thread_script_func;
 
 namespace enigma_user {
 
 int thread_start(int thread) {
   if (threads[thread]->active) { return -1; }
-  
+
   DWORD dwThreadId;
-  threads[thread]->handle = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&thread_script_func, (LPVOID)threads[thread]->sd, 0, &dwThreadId);
+  threads[thread]->handle = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&enigma::thread_script_func, (LPVOID)threads[thread]->sd, 0, &dwThreadId);
   //TODO: May need to check if ret is -1L, and yes it is quite obvious the return value is
   //an unsigned integer, but Microsoft says to for some reason. See their documentation here.
   //http://msdn.microsoft.com/en-us/library/kdzttdcb.aspx
@@ -46,10 +46,10 @@ void thread_join(int thread) {
   if (GetCurrentThread() == enigma::mainthread) {
     while (WaitForSingleObject(threads[thread]->handle, 10) == WAIT_TIMEOUT) {
       MSG msg;
-      while (PeekMessage (&msg, NULL, 0, 0, PM_REMOVE)) { 
+      while (PeekMessage (&msg, NULL, 0, 0, PM_REMOVE)) {
         TranslateMessage (&msg);
         DispatchMessage (&msg);
-      } 
+      }
     }
   } else {
     WaitForSingleObject(threads[thread]->handle, INFINITE);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -17,22 +17,21 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <string>
-#include <windows.h>
-using namespace std;
+#include "Platforms/platforms_mandatory.h"
+#include "Platforms/General/PFmain.h" // For those damn vk_ constants.
+#include "Platforms/General/PFwindow.h"
+
+#include "Widget_Systems/widgets_mandatory.h"
 
 #include "Universal_System/estring.h" // For string_replace_all
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h" // room_caption
-#include "Platforms/General/PFmain.h" // For those damn vk_ constants.
-
-#include "Platforms/platforms_mandatory.h"
-#include "Widget_Systems/widgets_mandatory.h"
-#include "../General/PFwindow.h"
-
 #include "Universal_System/globalupdate.h"
 
+#include <windows.h>
 #include <stdio.h>
+#include <string>
+using namespace std;
 
 namespace enigma
 {
@@ -65,6 +64,16 @@ void configure_devmode(DEVMODE &devMode, int w, int h, int freq, int bitdepth) {
 }
 
 namespace enigma_user {
+
+#if GM_COMPATIBILITY_VERSION <= 81
+unsigned long long window_handle() {
+  return (unsigned long long)enigma::hWnd;
+}
+#else
+void* window_handle() {
+  return enigma::hWnd;
+}
+#endif
 
 // GM8.1 Used its own internal variables for these functions and reported the regular window dimensions when minimized,
 // Studio uses the native functions and will tell you the dimensions of the window are 0 when it is minimized,

--- a/ENIGMAsystem/SHELL/Platforms/Win32/include.h
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/include.h
@@ -1,5 +1,4 @@
-#include "WINDOWSmain.h"
-#include "../General/PFjoystick.h"  
+#include "../General/PFjoystick.h"
 #include "../General/PFthreads.h"
 #include "../General/PFini.h"
 #include "../General/PFfilemanip.h"

--- a/ENIGMAsystem/SHELL/Universal_System/GAME_GLOBALS.h
+++ b/ENIGMAsystem/SHELL/Universal_System/GAME_GLOBALS.h
@@ -33,6 +33,9 @@ GM Global variables
 #define ENIGMA_GAME_GLOBALS_H
 
 #include <string>
+#ifndef JUST_DEFINE_IT_RUN
+#include <deque>
+#endif
 
 namespace enigma_user {
 std::string caption_score = "Score:", caption_lives = "Lives:", caption_health = "Health:";
@@ -41,7 +44,6 @@ double health = 100;
 
 // TODO: MOVEME: Who put this here?
 #ifndef JUST_DEFINE_IT_RUN
-#include <deque>
 std::deque<int> instance_id;
 #else
 int *instance_id;

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -62,7 +62,7 @@ static const char ldgrs[256] = {
   1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0
 };
 
-static const std::string base64_chars =
+static const std::string base64_chars = 
              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
              "abcdefghijklmnopqrstuvwxyz"
              "0123456789+/";
@@ -81,7 +81,7 @@ string base64_encode(string const& str) {
   int in_ = 0;
   unsigned char char_array_3[3];
   unsigned char char_array_4[4];
-
+  
   while (in_len--) {
     char_array_3[i++] = str[in_]; in_++;
     if (i == 3) {
@@ -168,20 +168,20 @@ int ord(string str)  { return str[0]; }
 size_t string_length(string str) { return str.length(); }
 size_t string_length(const char* str) { return strlen(str); }
 
-size_t string_length_utf8(string str) {
-  size_t res = 0;
-  for (size_t i = 0; i < str.length(); ++i)
-    if ((str[i] & 0xC0) != 0x80)
-      ++res;
-  return res;
+size_t string_length_utf8(string str) { 
+  size_t res = 0; 
+  for (size_t i = 0; i < str.length(); ++i) 
+    if ((str[i] & 0xC0) != 0x80) 
+      ++res; 
+  return res; 
 }
 
-size_t string_length_utf8(const char* str) {
-  size_t res = 0;
-  for (size_t i = 0; str[i]; ++i)
-    if ((str[i] & 0xC0) != 0x80)
-      ++res;
-  return res;
+size_t string_length_utf8(const char* str) { 
+  size_t res = 0; 
+  for (size_t i = 0; str[i]; ++i) 
+    if ((str[i] & 0xC0) != 0x80) 
+      ++res; 
+  return res; 
 }
 
 size_t string_pos(string substr,string str) {

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -33,7 +33,6 @@ using std::string;
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
 
 #include <windows.h>
-#include <wchar.h>
 #include <vector>
 using std::vector;
 
@@ -63,7 +62,7 @@ static const char ldgrs[256] = {
   1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0
 };
 
-static const std::string base64_chars = 
+static const std::string base64_chars =
              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
              "abcdefghijklmnopqrstuvwxyz"
              "0123456789+/";
@@ -82,7 +81,7 @@ string base64_encode(string const& str) {
   int in_ = 0;
   unsigned char char_array_3[3];
   unsigned char char_array_4[4];
-  
+
   while (in_len--) {
     char_array_3[i++] = str[in_]; in_++;
     if (i == 3) {
@@ -169,20 +168,20 @@ int ord(string str)  { return str[0]; }
 size_t string_length(string str) { return str.length(); }
 size_t string_length(const char* str) { return strlen(str); }
 
-size_t string_length_utf8(string str) { 
-  size_t res = 0; 
-  for (size_t i = 0; i < str.length(); ++i) 
-    if ((str[i] & 0xC0) != 0x80) 
-      ++res; 
-  return res; 
+size_t string_length_utf8(string str) {
+  size_t res = 0;
+  for (size_t i = 0; i < str.length(); ++i)
+    if ((str[i] & 0xC0) != 0x80)
+      ++res;
+  return res;
 }
 
-size_t string_length_utf8(const char* str) { 
-  size_t res = 0; 
-  for (size_t i = 0; str[i]; ++i) 
-    if ((str[i] & 0xC0) != 0x80) 
-      ++res; 
-  return res; 
+size_t string_length_utf8(const char* str) {
+  size_t res = 0;
+  for (size_t i = 0; str[i]; ++i)
+    if ((str[i] & 0xC0) != 0x80)
+      ++res;
+  return res;
 }
 
 size_t string_pos(string substr,string str) {

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -26,10 +26,9 @@
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
 
-#include <windows.h>
-#include <wchar.h>
+#include <cwchar>
 
-typedef std::basic_string<WCHAR> tstring;
+typedef std::basic_string<wchar_t> tstring;
 tstring widen(const std::string &str);
 std::string shorten(tstring str);
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/DlgMod/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DlgMod/dialogs.cpp
@@ -16,7 +16,7 @@
 **/
 
 #include "Platforms/General/PFexternals.h"
-#include "Platforms/Win32/WINDOWSmain.h"
+#include "Platforms/General/PFwindow.h"
 #include <string>
 
 #ifdef DEBUG_MODE
@@ -61,11 +61,11 @@ namespace enigma_user
 {
   void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption)
   {
-    
+
   }
 
   int show_message(string str)
-  {    
+  {
     int DialogModule_result;
     external_call(external_define("DialogModule.dll", "window_get_caption", enigma_user::dll_cdecl, enigma_user::ty_string, 1, enigma_user::ty_string), window_handle());
     DialogModule_result = (int)external_call(external_define("DialogModule.dll", "show_message", enigma_user::dll_cdecl, enigma_user::ty_real, 1, enigma_user::ty_string), str);
@@ -74,7 +74,7 @@ namespace enigma_user
   }
 
   double show_question(string str)
-  {    
+  {
     double DialogModule_result;
     external_call(external_define("DialogModule.dll", "window_get_caption", enigma_user::dll_cdecl, enigma_user::ty_string, 1, enigma_user::ty_string), window_handle());
     DialogModule_result = external_call(external_define("DialogModule.dll", "show_question", enigma_user::dll_cdecl, enigma_user::ty_real, 1, enigma_user::ty_string), str);


### PR DESCRIPTION
Ok, so my goal here is to reduce the amount of pollution in our headers from including things like `windows.h` that result in identifier conflicts and also cause JDI to spontaneously combust. One outcome of these changes is that #1119 is effectively resolved and you can in fact safely assign a script the same name as any Win32 macro or identifier.

* Added a small assignment in the math test for a variable named "CreateFont" which errors without the changes in this pull request. This will prevent people from reintroducing these identifier conflicts again, just like the tests in there for the Bessel functions. However, this won't actually prevent anything until we set up the test harness to run on AppVeyor, since we only run it on Travis with Linux.
* Added a small change to `.travis.yml` to have it call `travis_terminate` when the `ci-regression.sh` script fails. I did this because it prevents the log from getting cut off when the script does exit. Prior to this the test harness job was failing but I couldn't see why. Oddly, after making this change the job miraculously passed.
* Separated out the implementation details of the threading functionality from `PFthreads.h` to `PFthreads_impl.h` so it doesn't get included in `SHELLmain.cpp`. This results in one less global `windows.h` include and less identifier conflicts.
* Moved the `_thread_script_func` wrapper for the SDL threads out of `namespace enigma_user` and made it static. The reason it exists is because SDL threads are typed to return an int, unlike Win32 and POSIX thread functions.
* Deleted the redundant declaration of `widen`/`shorten` from `WINDOWSmain.h` since it's already declared in `Universal_System/estring.h` so that other parts of the engine can use it (e.g, dialogs).
* Removed the include of `WINDOWSmain.h` from `Platforms/Win32/include.h` because it depends on `windows.h` and creates identifier conflicts.
* Moved the declaration of `window_handle` out of `WINDOWSmain.h` since it's no longer included by `Platforms/Win32/include.h` as a result of the fact that it includes `windows.h` and causes identifier conflicts. It is kept only to hold implementation state for the Win32 platform.
* Separated the declaration and definition of `window_handle()` so that it could be moved to `PFwindow.h` where it can be safely included by all platforms. Also changed the signature of the function to return `void*` so it can also be implemented on Mac/Xlib and doesn't require including `windows.h` to be declared or defined (an `HWND` happens to be a `void*` anyway). Honestly the function could later just be changed to return a `var` and still keep the compatibility setting since we made `var` overload pointer now.
* Reorganized the includes in `WINDOWSwindow.cpp` to put more common headers towards the bottom to decrease executable size.
* Moved the include of `deque` out of `namespace enigma_user` in `Universal_System/GAME_GLOBALS.h` because it was causing an assplosion when I removed the include of `deque` from `PFthreads.h` for some odd reason. The inclusion was added in f881c30fd931c7b2d4e2f1d409a7d04b5ace0327 to address the fact that it was missing in 883c176b228ed0d6af45fb25517a5d8c9afc4fd4. The namespace was later added "around" the include. Josh said the following:
    >you can't include within a namespace
you'll break the header and linker
* Changed the include of `wchar.h` to `cwchar` in `Universal_System/estring.h` because this is a C++ game engine.
* Changed the type of `tstring` to `wchar_t` instead of `WCHAR` so that it doesn't rely on Win32 and can be implemented on other platforms. This allowed me to remove yet another `windows.h` global include.