### PR TITLE
Stretched Sprite Origin Fix

### DIFF
--- a/CommandLine/testing/Tests/draw_test.sog/create.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/create.edl
@@ -1,0 +1,1 @@
+spr = sprite_add("CommandLine/testing/data/sprite.png", 4, false, false, 16, 10);

--- a/CommandLine/testing/Tests/draw_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/draw.edl
@@ -40,3 +40,7 @@ draw_set_color(c_white);
 // flush immediately to ensure that a 2D and 3D primitive
 // render correctly when flushed from the same batch
 draw_batch_flush();
+
+// stretched sprite should ignore origin
+draw_sprite_stretched(spr,0,0,0,25,25);
+draw_sprite_stretched_ext(spr,0,25,0,25,25,c_red,0.5);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
@@ -227,8 +227,8 @@ void draw_sprite_stretched(int spr, int subimg, gs_scalar x, gs_scalar y, gs_sca
 
   const gs_scalar tbx = spr2d->texturexarray[usi], tby = spr2d->textureyarray[usi],
               tbw = spr2d->texturewarray[usi], tbh = spr2d->textureharray[usi],
-              xvert1 = x-spr2d->xoffset, xvert2 = xvert1 + width,
-              yvert1 = y-spr2d->yoffset, yvert2 = yvert1 + height;
+              xvert1 = x, xvert2 = xvert1 + width,
+              yvert1 = y, yvert2 = yvert1 + height;
 
 	draw_primitive_begin_texture(pr_trianglestrip, spr2d->texturearray[usi]);
 	draw_vertex_texture_color(xvert1,yvert1,tbx,tby,color,alpha);


### PR DESCRIPTION
This is just a small fix to address #1099 which I have confirmed is in fact a bug. Mark Overmars is very explicit in the manual that `draw_sprite_stretched` "fills" the area as opposed to `draw_sprite` which places the origin at the position specified.

This simple fix just removes the offset of the primitive drawn by the sprite's origin. I've additionally added a test to the drawing test so we know if somebody tries to change it again. Although I do not actually change draw_sprite_stretched_ext here, it is still affected because it's just a wrapper that calls draw_sprite_stretched with its color and alpha.

In my opinion, GameMaker is correct about this behavior as the sprite origin is basically useless when drawing the sprite stretched over an area. I feel this is especially true considering the sprite origin is not scaled with the rest of the sprite, so it's better to just not use it both for compatibility and because it's saner.

### References
The GameMaker 6 through 8 manuals state the following:
>draw_sprite(sprite,subimg,x,y) Draws subimage subimg (-1 = current) of the sprite with its **origin at position** (x,y). (Without color blending and no alpha transparency.)
draw_sprite_stretched(sprite,subimg,x,y,w,h) Draws the sprite stretched so that it **fills the region** with top-left corner (x,y) and width w and height h.

The new GameMaker: Studio manual is even more explicit:

https://docs2.yoyogames.com/source/_build/3_scripting/4_gml_reference/drawing/sprites_and_tiles/draw_sprite_stretched.html
>NOTE: When drawing with this function, the sprite x offset and y offset are ignored and the sprite will be drawn with the top left corner at the specified x / y position in the room.

https://docs2.yoyogames.com/source/_build/3_scripting/4_gml_reference/drawing/sprites_and_tiles/draw_sprite_stretched_ext.html
>This function ignores the sprite's origin.

### ENIGMA Master
![master Stretched Sprite Origin](https://user-images.githubusercontent.com/3212801/48814491-f0300400-ed08-11e8-82b3-07550a373ddb.png)
### This pull request
![pr Stretched Sprite Origin](https://user-images.githubusercontent.com/3212801/48814502-fde58980-ed08-11e8-97ae-a1a978873acf.png)
### GameMaker 8
![GM8 Stretched Sprite Origin](https://user-images.githubusercontent.com/3212801/48814478-e27a7e80-ed08-11e8-9ff8-b2af621c0bc1.png)
### GameMaker: Studio
![GMS Stretched Sprite Origin](https://user-images.githubusercontent.com/3212801/48814457-cbd42780-ed08-11e8-9105-1f3861cb79d7.png)
