### PR TITLE
Render State Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,6 +186,7 @@ before_script:
       export DISPLAY=:1
       Xvfb :1 -screen 0 1024x768x24 &
       xfwm4 &
+      sleep 3
     fi
 
 script:

--- a/CommandLine/testing/Platform/TestHarness-X11.cpp
+++ b/CommandLine/testing/Platform/TestHarness-X11.cpp
@@ -131,7 +131,7 @@ class X11_TestHarness final: public TestHarness {
   }
 
   void wait() final {
-    usleep(250000);
+    usleep(1000000);
   }
   X11_TestHarness(Display *disp, pid_t game_pid, Window game_window,
                   const TestConfig &tc):

--- a/CommandLine/testing/Tests/draw_3d_shapes_test.gmx/objects/obj_0.object.gmx
+++ b/CommandLine/testing/Tests/draw_3d_shapes_test.gmx/objects/obj_0.object.gmx
@@ -51,23 +51,35 @@ size = 20;</string>
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>d3d_set_projection_ortho(0, 0, room_width, room_height, 0);&#13;
-&#13;
-for (var y = 0; y &lt; 6; y += 1) {&#13;
-	var yy = 25 + y * 45;&#13;
-&#13;
-	for (var i = 0; i &lt; 4; i += 1) {&#13;
-		// Show all sides around the x-axis&#13;
-		d3d_transform_set_rotation_x(i * 90);&#13;
-		d3d_transform_add_translation(25 + i * 45, yy, 0);&#13;
-		d3d_draw_shape(y, size, test_texture);&#13;
-		// Show all sides around the y-axis&#13;
-		d3d_transform_set_rotation_y(i * 90);&#13;
-		d3d_transform_add_translation(30 + (i + 4) * 45, yy, 0);&#13;
-		d3d_draw_shape(y, size, test_texture);&#13;
-	}&#13;
-}&#13;
-&#13;
+            <string>d3d_set_projection_ortho(0, 0, room_width, room_height, 0);
+
+for (var y = 0; y &lt; 6; y += 1) {
+	var yy = 25 + y * 45;
+
+	for (var i = 0; i &lt; 4; i += 1) {
+		// Show all sides around the x-axis
+		d3d_transform_set_rotation_x(i * 90);
+		d3d_transform_add_translation(25 + i * 45, yy, 0);
+		d3d_draw_shape(y, size, test_texture);
+		// Show all sides around the y-axis
+		d3d_transform_set_rotation_y(i * 90);
+		d3d_transform_add_translation(30 + (i + 4) * 45, yy, 0);
+		d3d_draw_shape(y, size, test_texture);
+	}
+}
+d3d_transform_set_identity();
+
+// test depth comparison function to ensure less than or equal
+d3d_transform_set_translation(0, room_height - 70, 0);
+draw_set_color(c_blue);
+d3d_draw_floor(10, 10, 1, 60, 60, 1, -1, 1, 1);
+draw_set_color(c_red);
+d3d_draw_floor(20, 20, 0, 50, 50, 0, -1, 1, 1);
+draw_set_color(c_green);
+d3d_draw_floor(30, 30, 0, 40, 40, 0, -1, 1, 1);
+draw_set_color(c_black);
+d3d_draw_floor(0, 0, 2, 70, 70, 2, -1, 1, 1);
+draw_set_color(c_white);
 d3d_transform_set_identity();</string>
           </argument>
         </arguments>

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
@@ -19,7 +19,6 @@
 #include "Platforms/Cocoa/CocoaMain.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GScolors.h"
-#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <iostream>
 #include <cstring>
@@ -45,6 +44,11 @@ namespace enigma {
   void SetResizeFptr() {
     WindowResizedCallback = &WindowResized;
   }
+
+  void ScreenRefresh() {
+    cocoa_screen_refresh();
+    cocoa_flush_opengl();
+  }
 }
 
 namespace enigma_user {
@@ -59,11 +63,4 @@ namespace enigma_user {
     set_synchronization(vsync);
     //TODO: Copy over from the Win32 bridge
   }
-
-  void screen_refresh() {
-    draw_batch_flush(batch_flush_deferred);
-    cocoa_screen_refresh();
-    cocoa_flush_opengl();
-  }
-
 }

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
@@ -19,6 +19,7 @@
 #include "Platforms/Cocoa/CocoaMain.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <iostream>
 #include <cstring>
@@ -60,6 +61,7 @@ namespace enigma_user {
   }
 
   void screen_refresh() {
+    draw_batch_flush(batch_flush_deferred);
     cocoa_screen_refresh();
     cocoa_flush_opengl();
   }

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
@@ -19,7 +19,6 @@
 #include "Platforms/Cocoa/CocoaMain.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GScolors.h"
-#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <iostream>
 #include <cstring>
@@ -45,6 +44,11 @@ namespace enigma {
   void SetResizeFptr() {
     WindowResizedCallback = &WindowResized;
   }
+
+  void ScreenRefresh() {
+    cocoa_screen_refresh();
+    cocoa_flush_opengl();
+  }
 }
 
 namespace enigma_user {
@@ -59,11 +63,4 @@ namespace enigma_user {
     set_synchronization(vsync);
     //TODO: Copy over from the Win32 bridge
   }
-
-  void screen_refresh() {
-    draw_batch_flush(batch_flush_deferred);
-    cocoa_screen_refresh();
-    cocoa_flush_opengl();
-  }
-
 }

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
@@ -19,6 +19,7 @@
 #include "Platforms/Cocoa/CocoaMain.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <iostream>
 #include <cstring>
@@ -60,6 +61,7 @@ namespace enigma_user {
   }
 
   void screen_refresh() {
+    draw_batch_flush(batch_flush_deferred);
     cocoa_screen_refresh();
     cocoa_flush_opengl();
   }

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -22,6 +22,7 @@
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Bridges/General/DX11Context.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <windows.h>
 #include <windowsx.h>
@@ -236,6 +237,7 @@ namespace enigma_user
   }
 
   void screen_refresh() {
+    draw_batch_flush(batch_flush_deferred);
     m_swapChain->Present(swap_interval, 0);
   }
 

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -22,7 +22,6 @@
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Bridges/General/DX11Context.h"
 #include "Graphics_Systems/General/GScolors.h"
-#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <windows.h>
 #include <windowsx.h>
@@ -226,6 +225,10 @@ namespace enigma
   }
 
   void DisableDrawing(void* handle) {}
+
+  void ScreenRefresh() {
+    m_swapChain->Present(swap_interval, 0);
+  }
 }
 
 namespace enigma_user
@@ -234,11 +237,6 @@ namespace enigma_user
 
   void display_reset(int samples, bool vsync) {
     swap_interval = vsync ? 1 : 0;
-  }
-
-  void screen_refresh() {
-    draw_batch_flush(batch_flush_deferred);
-    m_swapChain->Present(swap_interval, 0);
   }
 
   void set_synchronization(bool enable)

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -23,6 +23,7 @@
 #include "Graphics_Systems/Direct3D9/DX9SurfaceStruct.h"
 #include "Bridges/General/DX9Context.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <windows.h>
 #include <windowsx.h>
@@ -163,6 +164,7 @@ void display_reset(int samples, bool vsync) {
 }
 
 void screen_refresh() {
+  draw_batch_flush(batch_flush_deferred);
   d3dmgr->Present(NULL, NULL, NULL, NULL);
 }
 

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -23,7 +23,6 @@
 #include "Graphics_Systems/Direct3D9/DX9SurfaceStruct.h"
 #include "Bridges/General/DX9Context.h"
 #include "Graphics_Systems/General/GScolors.h"
-#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <windows.h>
 #include <windowsx.h>
@@ -132,6 +131,10 @@ namespace enigma
     d3dmgr->Release(); // close and release the 3D device
     d3dobj->Release(); // close and release Direct3D
   }
+
+  void ScreenRefresh() {
+    d3dmgr->Present(NULL, NULL, NULL, NULL);
+  }
 }
 
 namespace enigma_user
@@ -161,11 +164,6 @@ void display_reset(int samples, bool vsync) {
   enigma::OnDeviceLost();
   d3dmgr->Reset(&d3dpp);
   enigma::OnDeviceReset();
-}
-
-void screen_refresh() {
-  draw_batch_flush(batch_flush_deferred);
-  d3dmgr->Present(NULL, NULL, NULL, NULL);
 }
 
 void set_synchronization(bool enable)

--- a/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
@@ -21,12 +21,14 @@
 #include <cstring>
 #include <stdio.h>
 
+namespace enigma {
+  void ScreenRefresh(){}
+}
+
 namespace enigma_user {
   int display_aa = 14;
 
   void set_synchronization(bool enable){}
 
   void display_reset(int samples, bool vsync){}
-
-  void screen_refresh(){}
 }

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -15,7 +15,6 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "Graphics_Systems/General/GSprimitives.h"
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/SDL/Window.h"
 
@@ -53,6 +52,10 @@ void DisableDrawing(void*) {
   SDL_DestroyRenderer(renderer);
 }
 
+void ScreenRefresh() {
+  SDL_GL_SwapWindow(windowHandle);
+}
+
 }
 
 namespace enigma_user {
@@ -66,10 +69,4 @@ namespace enigma_user {
   void display_reset(int samples, bool vsync) {
     set_synchronization(vsync);
   }
-
-  void screen_refresh() {
-    draw_batch_flush(batch_flush_deferred);
-    SDL_GL_SwapWindow(enigma::windowHandle);
-  }
-
 }

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -15,6 +15,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "Graphics_Systems/General/GSprimitives.h"
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/SDL/Window.h"
 
@@ -67,6 +68,7 @@ namespace enigma_user {
   }
 
   void screen_refresh() {
+    draw_batch_flush(batch_flush_deferred);
     SDL_GL_SwapWindow(enigma::windowHandle);
   }
 

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
@@ -18,6 +18,7 @@
 
 #include "Platforms/Win32/WINDOWSmain.h"
 #include "Platforms/General/PFwindow.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <string>
 #include <GL/glew.h>
@@ -103,6 +104,7 @@ void display_reset(int samples, bool vsync) {
 }
 
 void screen_refresh() {
+  draw_batch_flush(batch_flush_deferred);
   SwapBuffers(enigma::window_hDC);
 }
 

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
@@ -18,7 +18,6 @@
 
 #include "Platforms/Win32/WINDOWSmain.h"
 #include "Platforms/General/PFwindow.h"
-#include "Graphics_Systems/General/GSprimitives.h"
 
 #include <string>
 #include <GL/glew.h>
@@ -54,6 +53,10 @@ namespace swaphandling {
 bool is_ext_swapcontrol_supported() {
   swaphandling::investigate_swapcontrol_support();
   return swaphandling::ext_swapcontrol_supported;
+}
+
+void ScreenRefresh() {
+  SwapBuffers(enigma::window_hDC);
 }
 
 }
@@ -101,11 +104,6 @@ void display_reset(int samples, bool vsync) {
   glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, ColorBufferID);
   glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, DepthBufferID);
 
-}
-
-void screen_refresh() {
-  draw_batch_flush(batch_flush_deferred);
-  SwapBuffers(enigma::window_hDC);
 }
 
 void set_synchronization(bool enable) {

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -16,7 +16,6 @@
 **/
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GScolors.h"
-#include "Graphics_Systems/General/GSprimitives.h"
 
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/xlib/XLIBwindow.h"
@@ -107,6 +106,10 @@ namespace enigma {
     swaphandling::investigate_swapcontrol_support();
     return swaphandling::mesa_swapcontrol_supported;
   }
+
+  void ScreenRefresh() {
+    glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
+  }
 }
 
 namespace enigma_user {
@@ -147,10 +150,4 @@ namespace enigma_user {
     set_synchronization(vsync);
     //TODO: Copy over from the Win32 bridge
   }
-
-  void screen_refresh() {
-    draw_batch_flush(batch_flush_deferred);
-    glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
-  }
-
 }

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -16,6 +16,7 @@
 **/
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/xlib/XLIBwindow.h"
@@ -148,6 +149,7 @@ namespace enigma_user {
   }
 
   void screen_refresh() {
+    draw_batch_flush(batch_flush_deferred);
     glXSwapBuffers(enigma::x11::disp, enigma::x11::win);
   }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -75,7 +75,7 @@ void screen_init()
   d3dmgr->SetRenderState(D3DRS_ZENABLE, FALSE);
   // make the same default as GL, keep in mind GM uses reverse depth ordering for ortho projections, where the higher the z value the further into the screen you are
   // but that is currently taken care of by using 32000/-32000 for znear/zfar respectively
-  d3dmgr->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESS);
+  d3dmgr->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
   d3dmgr->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
   d3dmgr->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
   d3dmgr->SetRenderState(D3DRS_ALPHAREF, (DWORD)0x00000001);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -169,8 +169,12 @@ void clear_view(float x, float y, float w, float h, float angle, bool showcolor)
 
 static inline void draw_gui()
 {
+  // turn some state off automatically for the user to draw the GUI
+  // this is exactly what GMSv1.4 does
   int culling = d3d_get_culling();
   bool hidden = d3d_get_hidden();
+  bool zwrite = enigma::d3dZWriteEnable;
+  d3d_set_zwriteenable(false);
   d3d_set_culling(rs_none);
   d3d_set_hidden(false);
 
@@ -192,12 +196,10 @@ static inline void draw_gui()
     if (stop_loop) break;
   }
 
-  // reset the culling
+  // reset the state to what the user had
   d3d_set_culling(culling);
-  // only restore hidden if the user didn't change it
-  if (!d3d_get_hidden()) {
-    d3d_set_hidden(hidden);
-  }
+  d3d_set_hidden(hidden);
+  d3d_set_zwriteenable(zwrite);
 }
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -214,8 +214,6 @@ void screen_redraw()
 {
   enigma::scene_begin();
 
-  // Clean up any textures that ENIGMA may still think are binded but actually are not
-  d3d_set_zwriteenable(true);
   if (!view_enabled)
   {
     screen_set_viewport(0, 0, window_get_region_width(), window_get_region_height());

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -210,6 +210,11 @@ unsigned int display_get_gui_height(){
   return enigma::gui_height;
 }
 
+void screen_refresh() {
+  draw_batch_flush(batch_flush_deferred);
+  enigma::ScreenRefresh();
+}
+
 void screen_redraw()
 {
   enigma::scene_begin();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.h
@@ -29,6 +29,8 @@ namespace enigma {
 
   void scene_begin();
   void scene_end();
+
+  void ScreenRefresh(); // implemented by bridges
 }
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -55,6 +55,7 @@ namespace enigma
     glEnable(GL_TEXTURE_2D);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glAlphaFunc(GL_ALWAYS,0);
+    glDepthFunc(GL_LEQUAL); // to match GM8's D3D8 default
 
     glColor4f(0,0,0,1);
     glBindTexture(GL_TEXTURE_2D,0);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
@@ -60,6 +60,7 @@ namespace enigma
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDepthFunc(GL_LEQUAL); // to match GM8's D3D8 default
 
     glBindTexture(GL_TEXTURE_2D,0);
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/graphics_mandatory.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/graphics_mandatory.h
@@ -74,4 +74,3 @@ namespace enigma_user
   void texture_set_interpolation_ext(int sampler, bool enable);
   #define texture_set_interpolation(enable) texture_set_interpolation_ext(0, enable)
 }
-


### PR DESCRIPTION
This pull request is me addressing some small render state issues all of which are found in the Wild Racing example.

### `screen_refresh` Should Trigger Batch Flush
This one is pretty obvious and I actually knew about it before merging the generic primitives changes I made. I was skeptical of how essential it would be though. But considering that `screen_refresh` is really the only guaranteed way in GM to get any drawing outside of the draw event to appear, we have to make this change so that stuff you draw is actually drawn before we present the backbuffer.

This fixes specifically the text on the startup screen of Wild Racing where the controls are drawn. The code is very simple, it just draws the text on the screen, refreshes the screen to present the backbuffer, and then waits for keyboard input.
![Wild Racing Controls Start Screen Fixed](https://user-images.githubusercontent.com/3212801/49900562-ea6f9f00-fe2c-11e8-8ad7-0981a0bb0bc0.png)

What I actually changed is very simple, I went through all of the bridges and moved `enigma_user::screen_refresh` to `enigma::ScreenRefresh`. I then created a new `enigma_user::screen_refresh` in `Graphics_System/General/GSscreen.cpp` that triggers a `draw_batch_flush(batch_flush_deferred)` before calling the internal `enigma::ScreenRefresh` implementation. This saves on the number of net added lines and also allows us to later make `screen_refresh` do additional things if we need it to without having to update every bridge.

### Default Depth Comparison Should Be Less Than or Equal To
This one is also very obvious and needs changed for GM8 compatibility. So GM8 used Direct3D8 which sets `D3DRS_ZFUNC` to `D3DCMP_LESSEQUAL` by default.
https://docs.microsoft.com/en-us/windows/desktop/direct3d9/d3drenderstatetype

OpenGL on the other hand defaults `glDepthFunc` to `GL_LESS` instead of `GL_LEQUAL`:
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthFunc.xhtml

This fixes specifically the text on the HUD of the Wild Racing game that displays the elapsed time. The code is very simple, a white filled rectangle is drawn, followed by a black rectangle outline, and finally the text is drawn last. Because 3D mode is on, depth testing is enabled and all of the above are trying to write with the same depth value. I should mention that this does in fact work in GM8 because it has the less than or equal comparison of depth. The fact that it works in GM though is a bit of a fluke, ideally the user should have turned off hidden surface removal to draw their hud, but regardless, this change is still important for compatibility.

![Wild Racing HUD Text Fixed](https://user-images.githubusercontent.com/3212801/49900961-06277500-fe2e-11e8-8afc-64b1b10fa731.png)

The way I fixed it is very simple, I just added a call to `glDepthFunc(GL_LEQUAL)` to `graphicssystem_initialize()` for OpenGL1 and OpenGL3. I discovered while updating the 3D shapes drawing test to cover depth comparison that I made a mistake too and apparently was forcing D3D9 to use GL's default of less when in fact its own default of less equal is obviously the correct one because that's what GM uses. So I just changed D3D9 back from just less to less equal.

I confirmed via a D3D8 API trace on GM8 and a D3D9 API trace on GMSv1.4 that GM does in fact use less than or equal by default for depth comparison.
![GMSv1.4 Default Depth Comparison Less Equal](https://user-images.githubusercontent.com/3212801/49905851-77baef80-fe3d-11e8-926d-060e99195721.png)

### Cleaned Up Screen Redraw Vestigials
I removed the comment: "// Clean up any textures that ENIGMA may still think are binded but actually are not"

That comment is left over from before I generalized the `screen_redraw` function. We used to explicitly unbind any bound textures from the previous frame. We don't do that now obviously, the comment is just leftover from that. We deal with this when the user goes to actually draw with a texture by binding the texture they want or unbinding the last texture if they don't want a texture. We can't do it the old way now anyway because of the user function `texture_set_stage` which allows the user to set the texture themselves, and if we were to unbind it they may not expect that leading to bugs.

I also moved an old call to `d3d_set_zwriteenable(true);` because it's only related to the Draw GUI event. GM8 and lower did not change any of your render state between draw events but YoYo does a couple of things to make the Draw GUI event easier. They turn off z writing and then turn it back on at the end of the event. I confirmed this with a D3D9 API trace:
![Z-writing Turned Off in GMS1.4 Before Draw GUI Event](https://user-images.githubusercontent.com/3212801/49905730-e186c980-fe3c-11e8-9508-7b8a54d280f0.png)

### Travis Test Harness Needs Longer Sleep
I got tired of restarting that job only for the very first test to keep drawing nothing. I seem to have got it after making Travis sleep for 3 seconds after starting XVFB and having the test harness wait 1 second (instead of 1/4th of a second) before taking a screenshot. As you can see in my comment below however, I then ran into another issue caused by Travis having an outdated GLM package. We need to address it eventually, but as far as this pr is concerned, I know everything here is correct.