### PR TITLE
Allow Drawing Outside Draw Event for Direct3D9

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -40,12 +40,14 @@ namespace enigma
   extern bool forceSoftwareVertexProcessing;
 
   void OnDeviceLost() {
+    d3dmgr->EndScene();
     for (vector<Surface*>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
       (*it)->OnDeviceLost();
     }
   }
 
   void OnDeviceReset() {
+    d3dmgr->BeginScene();
     for (vector<Surface*>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
       (*it)->OnDeviceReset();
     }
@@ -125,15 +127,20 @@ namespace enigma
         enigma_user::display_aa += i;
       }
     }
+
+    d3dmgr->BeginScene();
   }
 
   void DisableDrawing(void* handle) {
+    d3dmgr->EndScene();
     d3dmgr->Release(); // close and release the 3D device
     d3dobj->Release(); // close and release Direct3D
   }
 
   void ScreenRefresh() {
+    d3dmgr->EndScene();
     d3dmgr->Present(NULL, NULL, NULL, NULL);
+    d3dmgr->BeginScene();
   }
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -33,13 +33,9 @@ using namespace std;
 namespace enigma
 {
 
-void scene_begin() {
-  d3dmgr->BeginScene();
-}
+void scene_begin() {}
 
-void scene_end() {
-  d3dmgr->EndScene();
-}
+void scene_end() {}
 
 }
 


### PR DESCRIPTION
This one is pretty obvious and allows Direct3D9 to behave more like D3D11 and OGL. Instead of beginning and ending the scene with `screen_redraw` we simply begin the scene as soon as the device is created. We end the scene when we go to present with `screen_refresh` and immediately start a new scene. This allows the user to draw during step or create events, since they will be between `BeginScene`/`EndScene` calls.
https://docs.microsoft.com/en-us/windows/desktop/api/d3d9/nf-d3d9-idirect3ddevice9-beginscene

This does not have any noticeable performance concerns from my observations as my benchmarks continue to perform just fine. As I've said, OGL and D3D11 function this way out of the box anyway. This is why `BeginScene`/`EndScene` were dropped after D3D9, they just complicate the semantics unnecessarily.
https://docs.microsoft.com/en-us/windows/desktop/direct3d10/d3d10-graphics-programming-guide-d3d9-to-d3d10-considerations

I also made `DisableDrawing` end the scene as well so the last frame gets presented before closing. Our lost device and device reset handling also needs to end and begin a new scene when the device is reset.

This change basically fixes one aspect of running the Wild Racing game in Direct3D9. It makes the start screen actually appear (if I temporarily patch over the device reset issues too). This fixes the start screen because it draws the text, does a screen refresh, and then a keyboard wait all in the create event.
![Direct3D9 Wild Racing Start Screen](https://user-images.githubusercontent.com/3212801/50026047-7d3b4580-ffb5-11e8-8134-45d37a5a3110.png)
