### PR TITLE
Model Translation Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
@@ -198,14 +198,18 @@ void d3d_model_draw(int id) {
 }
 
 void d3d_model_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z) {
-  glm::mat4 backup = enigma::world;
+  // backup the current world matrix
+  d3d_transform_stack_push();
+
+  // we have to create a special translation here so that it occurs
+  // before any of the user's transformations took place
   enigma::world = glm::translate(enigma::world, glm::vec3(x, y, z));
   enigma::graphics_set_matrix(matrix_world);
 
   d3d_model_draw(id);
 
-  enigma::world = backup;
-  enigma::graphics_set_matrix(matrix_world);
+  // restore the world matrix the user had before this call
+  d3d_transform_stack_pop();
 }
 
 void d3d_model_draw(int id, int texId) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
@@ -21,10 +21,10 @@
 #include "GSmodel.h"
 #include "GSvertex.h"
 #include "GSvertex_impl.h"
-#include "GSmatrix_impl.h"
 #include "GSprimitives.h"
 #include "GScolors.h"
 #include "GSmatrix.h"
+#include "GSmatrix_impl.h"
 #include "GStextures.h"
 
 #include "Widget_Systems/widgets_mandatory.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
@@ -21,6 +21,7 @@
 #include "GSmodel.h"
 #include "GSvertex.h"
 #include "GSvertex_impl.h"
+#include "GSmatrix_impl.h"
 #include "GSprimitives.h"
 #include "GScolors.h"
 #include "GSmatrix.h"
@@ -28,6 +29,8 @@
 
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Universal_System/fileio.h"
+
+#include <glm/gtc/matrix_transform.hpp>
 
 #include <math.h>
 
@@ -195,9 +198,14 @@ void d3d_model_draw(int id) {
 }
 
 void d3d_model_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z) {
-  d3d_transform_add_translation(x, y, z);
+  glm::mat4 backup = enigma::world;
+  enigma::world = glm::translate(enigma::world, glm::vec3(x, y, z));
+  enigma::graphics_set_matrix(matrix_world);
+
   d3d_model_draw(id);
-  d3d_transform_add_translation(-x, -y, -z);
+
+  enigma::world = backup;
+  enigma::graphics_set_matrix(matrix_world);
 }
 
 void d3d_model_draw(int id, int texId) {
@@ -206,9 +214,8 @@ void d3d_model_draw(int id, int texId) {
 }
 
 void d3d_model_draw(int id, gs_scalar x, gs_scalar y, gs_scalar z, int texId) {
-  d3d_transform_add_translation(x, y, z);
-  d3d_model_draw(id, texId);
-  d3d_transform_add_translation(-x, -y, -z);
+  texture_set(texId);
+  d3d_model_draw(id, x, y, z);
 }
 
 void d3d_model_primitive_begin(int id, int kind, int format) {


### PR DESCRIPTION
This is a fix to address the model translation issues reported in #1456. As I discovered in that issue, through the use of [apitrace](https://github.com/apitrace/apitrace), GM uses a reverse multiplication order to translate the model to the position given. With this fix applied the body of the car is drawn in the correct location with respect to the car's chassis and the terrain height.

![Wild Racing Car Body Transform Fixed](https://user-images.githubusercontent.com/3212801/50047597-66185880-0086-11e9-9fe0-e6a31598e824.png)

### Summary of Changes
* Changed `d3d_model_draw(id,x,y,z)` to not use `d3d_transform_add_translation` because it uses the wrong multiplication order for internal use (it's correct when the user calls it though). Basically, the translation passed to `d3d_model_draw` needs to occur before the user's own transformations, not after.
* Used the transformation stack in `d3d_model_draw(id,x,y,z)` to save and restore the world matrix since we optimize those functions for that very task.
* Changed `d3d_model_draw(id,x,y,z,texId)` to call `d3d_model_draw(id,x,y,z)` so I wouldn't have to duplicate the translation fix for that function too.
