### PR TITLE
Direct3D9 Ex Support

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
+++ b/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
@@ -40,7 +40,8 @@ using std::vector;
 using std::map;
 
 namespace enigma {
-	extern HWND hWnd;
+  extern HWND hWnd;
+  extern bool Direct3D9Managed;
 }
 
 extern LPDIRECT3D9 d3dobj;    // the pointer to our Direct3D interface

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -38,9 +38,11 @@ ContextManager* d3dmgr; // the pointer to the device class
 namespace enigma
 {
   extern bool forceSoftwareVertexProcessing;
+  bool Direct3D9Managed = true;
 
   void OnDeviceLost() {
     d3dmgr->EndScene();
+    if (!Direct3D9Managed) return; // lost device only happens in managed d3d9
     for (vector<Surface*>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
       (*it)->OnDeviceLost();
     }
@@ -48,9 +50,16 @@ namespace enigma
 
   void OnDeviceReset() {
     d3dmgr->BeginScene();
+    if (!Direct3D9Managed) return; // lost device only happens in managed d3d9
     for (vector<Surface*>::iterator it = Surfaces.begin(); it != Surfaces.end(); it++) {
       (*it)->OnDeviceReset();
     }
+  }
+
+  void Reset(D3DPRESENT_PARAMETERS *d3dpp) {
+    OnDeviceLost();
+    d3dmgr->Reset(d3dpp);
+    OnDeviceReset();
   }
 
   extern void (*WindowResizedCallback)();
@@ -65,9 +74,7 @@ namespace enigma
     d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
     d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
     sc->Release();
-    OnDeviceLost();
-    d3dmgr->Reset(&d3dpp);
-    OnDeviceReset();
+    Reset(&d3dpp);
 
     // clear the window color, viewport does not need set because backbuffer was just recreated
     enigma_user::draw_clear(enigma_user::window_get_color());
@@ -80,7 +87,6 @@ namespace enigma
     HRESULT hr;
 
     D3DPRESENT_PARAMETERS d3dpp; // create a struct to hold various device information
-    d3dobj = Direct3DCreate9(D3D_SDK_VERSION); // create the Direct3D interface
     D3DFORMAT format = D3DFMT_A8R8G8B8;
 
     ZeroMemory(&d3dpp, sizeof(d3dpp)); // clear out the struct for use
@@ -105,18 +111,71 @@ namespace enigma
     if (forceSoftwareVertexProcessing) {
       behaviors = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
     }
-    hr = d3dobj->CreateDevice(D3DADAPTER_DEFAULT,
-                              D3DDEVTYPE_HAL,
-                              hWnd,
-                              behaviors,
-                              &d3dpp,
-                              &d3dmgr->device);
-    if (FAILED(hr)) {
-      MessageBox(hWnd,
-                 "Failed to create Direct3D 9.0 Device",
-                 DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
-                 MB_ICONERROR | MB_OK);
-      return; // should probably force the game closed
+
+    // Manually load the d3d9.dll library to check for D3D9Ex
+    HMODULE libHandle = NULL;
+    libHandle = LoadLibrary("d3d9.dll");
+
+    if (libHandle != NULL) {
+      // Define a function pointer to the Direct3DCreate9Ex function.
+      typedef HRESULT (WINAPI *LPDIRECT3DCREATE9EX)( UINT, void **);
+
+      // Obtain the address of the Direct3DCreate9Ex function.
+      LPDIRECT3DCREATE9EX Direct3DCreate9ExPtr = NULL;
+
+      Direct3DCreate9ExPtr = (LPDIRECT3DCREATE9EX)GetProcAddress(libHandle, "Direct3DCreate9Ex");
+
+      if (Direct3DCreate9ExPtr != NULL) {
+        // create Direct3D 9 Ex interface
+        IDirect3D9Ex* d3dexobj = NULL;
+        hr = Direct3DCreate9Ex(D3D_SDK_VERSION, &d3dexobj);
+
+        if (d3dexobj != NULL) {
+          IDirect3DDevice9Ex* d3dexdev = NULL;
+
+          hr = d3dexobj->CreateDeviceEx(D3DADAPTER_DEFAULT,
+                                        D3DDEVTYPE_HAL,
+                                        hWnd,
+                                        behaviors,
+                                        &d3dpp,
+                                        NULL,
+                                        &d3dexdev);
+
+          if (FAILED(hr)) {
+            // release the d3d9 ex object and fall through to
+            // try creating a regular d3d9 object instead
+            // (might be Windows Vista with non-WDDM drivers)
+            d3dexobj->Release();
+          } else {
+            d3dobj = d3dexobj;
+            d3dmgr->device = d3dexdev;
+            Direct3D9Managed = false;
+          }
+        }
+      }
+
+      // Free the library.
+      FreeLibrary(libHandle);
+    }
+
+    if (Direct3D9Managed) {
+      // try creating legacy Direct3D 9 interface
+      d3dobj = Direct3DCreate9(D3D_SDK_VERSION);
+
+      hr = d3dobj->CreateDevice(D3DADAPTER_DEFAULT,
+                                D3DDEVTYPE_HAL,
+                                hWnd,
+                                behaviors,
+                                &d3dpp,
+                                &d3dmgr->device);
+
+      if (FAILED(hr)) {
+        MessageBox(hWnd,
+                  "Failed to create Direct3D 9.0 Device",
+                  DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
+                  MB_ICONERROR | MB_OK);
+        return; // should probably force the game closed
+      }
     }
 
     d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE);
@@ -168,9 +227,7 @@ void display_reset(int samples, bool vsync) {
   }
   sc->Release();
 
-  enigma::OnDeviceLost();
-  d3dmgr->Reset(&d3dpp);
-  enigma::OnDeviceReset();
+  enigma::Reset(&d3dpp);
 }
 
 void set_synchronization(bool enable)
@@ -187,7 +244,7 @@ void set_synchronization(bool enable)
   }
   sc->Release();
 
-  d3dmgr->Reset(&d3dpp);
+  enigma::Reset(&d3dpp);
 }
 
 }

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -1,4 +1,4 @@
-/** Copyright (C) 2013 Robert B. Colton
+/** Copyright (C) 2013, 2018 Robert B. Colton
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -170,11 +170,7 @@ namespace enigma
                                 &d3dmgr->device);
 
       if (FAILED(hr)) {
-        MessageBox(hWnd,
-                  "Failed to create Direct3D 9.0 Device",
-                  DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
-                  MB_ICONERROR | MB_OK);
-        return; // should probably force the game closed
+        show_error("Failed to create Direct3D 9.0 Device", true);
       }
     }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -57,7 +57,13 @@ namespace enigma
     if (pxdata != nullptr) {
       D3DLOCKED_RECT rect;
       texture->LockRect(0, &rect, NULL, D3DLOCK_DISCARD);
-      memcpy(rect.pBits, pxdata, fullwidth * fullheight * 4);
+      // we have to respect the pitch returned by the lock because some GPU's
+      // have exhibited a minimum pitch size for small textures
+      // (e.g, 8x8 and 16x16 texture both have 64 pitch when created in the default pool)
+      // NOTE: sometime soon we must finally do texture paging...
+      for (size_t i = 0; i < height; ++i) {
+        memcpy(rect.pBits + i * rect.Pitch, pxdata + i * fullwidth * 4, width * 4);
+      }
       texture->UnlockRect(0);
     }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -62,7 +62,7 @@ namespace enigma
       // (e.g, 8x8 and 16x16 texture both have 64 pitch when created in the default pool)
       // NOTE: sometime soon we must finally do texture paging...
       for (size_t i = 0; i < height; ++i) {
-        memcpy(rect.pBits + i * rect.Pitch, pxdata + i * fullwidth * 4, width * 4);
+        memcpy((void*)((intptr_t)rect.pBits + i * rect.Pitch), (void*)((intptr_t)pxdata + i * fullwidth * 4), width * 4);
       }
       texture->UnlockRect(0);
     }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -53,10 +53,10 @@ namespace enigma
     DWORD usage = Direct3D9Managed ? 0 : D3DUSAGE_DYNAMIC;
     if (mipmap) usage |= D3DUSAGE_AUTOGENMIPMAP;
     d3dmgr->CreateTexture(fullwidth, fullheight, 1, usage, D3DFMT_A8R8G8B8, Direct3D9Managed ? D3DPOOL_MANAGED : D3DPOOL_DEFAULT, &texture, 0);
-    D3DLOCKED_RECT rect;
 
-    if (pxdata != nullptr){
-      texture->LockRect( 0, &rect, NULL, D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE);
+    if (pxdata != nullptr) {
+      D3DLOCKED_RECT rect;
+      texture->LockRect(0, &rect, NULL, D3DLOCK_DISCARD);
       memcpy(rect.pBits, pxdata, fullwidth * fullheight * 4);
       texture->UnlockRect(0);
     }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -46,16 +46,17 @@ inline unsigned int lgpp2(unsigned int x){//Trailing zero count. lg for perfect 
 
 namespace enigma
 {
-
   int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, void* pxdata, bool mipmap)
   {
     LPDIRECT3DTEXTURE9 texture = NULL;
 
-    d3dmgr->CreateTexture(fullwidth, fullheight, 1, mipmap ? D3DUSAGE_AUTOGENMIPMAP : 0, D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &texture, 0);
+    DWORD usage = Direct3D9Managed ? 0 : D3DUSAGE_DYNAMIC;
+    if (mipmap) usage |= D3DUSAGE_AUTOGENMIPMAP;
+    d3dmgr->CreateTexture(fullwidth, fullheight, 1, usage, D3DFMT_A8R8G8B8, Direct3D9Managed ? D3DPOOL_MANAGED : D3DPOOL_DEFAULT, &texture, 0);
     D3DLOCKED_RECT rect;
 
     if (pxdata != nullptr){
-      texture->LockRect( 0, &rect, NULL, D3DLOCK_DISCARD);
+      texture->LockRect( 0, &rect, NULL, D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE);
       memcpy(rect.pBits, pxdata, fullwidth * fullheight * 4);
       texture->UnlockRect(0);
     }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
@@ -75,11 +75,13 @@ void graphics_prepare_vertex_buffer(const int buffer) {
       }
     }
 
+    bool dynamic = (!vertexBuffer->frozen && !Direct3D9Managed);
+
     // create either a static or dynamic vbo peer depending on if the user called
     // vertex_freeze on the buffer
     if (!vertexBufferPeer) {
       DWORD usage = vertexBuffer->frozen ? D3DUSAGE_WRITEONLY : 0;
-      if (!vertexBuffer->frozen && !Direct3D9Managed) usage |= D3DUSAGE_DYNAMIC;
+      if (dynamic) usage |= D3DUSAGE_DYNAMIC;
       D3DPOOL managed_pool = vertexBuffer->frozen ? D3DPOOL_MANAGED : D3DPOOL_SYSTEMMEM;
 
       d3dmgr->CreateVertexBuffer(
@@ -90,7 +92,7 @@ void graphics_prepare_vertex_buffer(const int buffer) {
 
     // copy the vertex buffer contents over to the native peer vbo on the GPU
     VOID* pVoid;
-    vertexBufferPeer->Lock(0, 0, (VOID**)&pVoid, vertexBuffer->frozen ? 0 : D3DLOCK_DISCARD);
+    vertexBufferPeer->Lock(0, 0, (VOID**)&pVoid, dynamic ? D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE : 0);
     memcpy(pVoid, vertexBuffer->vertices.data(), size);
     vertexBufferPeer->Unlock();
 
@@ -123,11 +125,13 @@ void graphics_prepare_index_buffer(const int buffer) {
       }
     }
 
+    bool dynamic = (!indexBuffer->frozen && !Direct3D9Managed);
+
     // create either a static or dynamic ibo peer depending on if the user called
     // index_freeze on the buffer
     if (!indexBufferPeer) {
       DWORD usage = indexBuffer->frozen ? D3DUSAGE_WRITEONLY : 0;
-      if (!indexBuffer->frozen && !Direct3D9Managed) usage |= D3DUSAGE_DYNAMIC;
+      if (dynamic) usage |= D3DUSAGE_DYNAMIC;
       D3DPOOL managed_pool = indexBuffer->frozen ? D3DPOOL_MANAGED : D3DPOOL_SYSTEMMEM;
 
       d3dmgr->CreateIndexBuffer(
@@ -140,7 +144,7 @@ void graphics_prepare_index_buffer(const int buffer) {
 
     // copy the index buffer contents over to the native peer ibo on the GPU
     VOID* pVoid;
-    indexBufferPeer->Lock(0, 0, (VOID**)&pVoid, D3DLOCK_DISCARD);
+    indexBufferPeer->Lock(0, 0, (VOID**)&pVoid, dynamic ? D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE : 0);
     memcpy(pVoid, indexBuffer->indices.data(), size);
     indexBufferPeer->Unlock();
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
@@ -80,19 +80,18 @@ void graphics_prepare_vertex_buffer(const int buffer) {
     // create either a static or dynamic vbo peer depending on if the user called
     // vertex_freeze on the buffer
     if (!vertexBufferPeer) {
-      DWORD usage = vertexBuffer->frozen ? D3DUSAGE_WRITEONLY : 0;
+      DWORD usage = D3DUSAGE_WRITEONLY;
       if (dynamic) usage |= D3DUSAGE_DYNAMIC;
-      D3DPOOL managed_pool = vertexBuffer->frozen ? D3DPOOL_MANAGED : D3DPOOL_SYSTEMMEM;
 
       d3dmgr->CreateVertexBuffer(
-        size, usage, 0, Direct3D9Managed ? managed_pool : D3DPOOL_DEFAULT, &vertexBufferPeer, NULL
+        size, usage, 0, Direct3D9Managed ? D3DPOOL_MANAGED : D3DPOOL_DEFAULT, &vertexBufferPeer, NULL
       );
       vertexBufferPeers[buffer] = vertexBufferPeer;
     }
 
     // copy the vertex buffer contents over to the native peer vbo on the GPU
     VOID* pVoid;
-    vertexBufferPeer->Lock(0, 0, (VOID**)&pVoid, dynamic ? D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE : 0);
+    vertexBufferPeer->Lock(0, 0, (VOID**)&pVoid, dynamic ? D3DLOCK_DISCARD : 0);
     memcpy(pVoid, vertexBuffer->vertices.data(), size);
     vertexBufferPeer->Unlock();
 
@@ -130,21 +129,20 @@ void graphics_prepare_index_buffer(const int buffer) {
     // create either a static or dynamic ibo peer depending on if the user called
     // index_freeze on the buffer
     if (!indexBufferPeer) {
-      DWORD usage = indexBuffer->frozen ? D3DUSAGE_WRITEONLY : 0;
+      DWORD usage = D3DUSAGE_WRITEONLY;
       if (dynamic) usage |= D3DUSAGE_DYNAMIC;
-      D3DPOOL managed_pool = indexBuffer->frozen ? D3DPOOL_MANAGED : D3DPOOL_SYSTEMMEM;
 
       d3dmgr->CreateIndexBuffer(
         size, usage,
         (indexBuffer->type == index_type_uint) ? D3DFMT_INDEX32 : D3DFMT_INDEX16,
-        Direct3D9Managed ? managed_pool : D3DPOOL_DEFAULT, &indexBufferPeer, NULL
+        Direct3D9Managed ? D3DPOOL_MANAGED : D3DPOOL_DEFAULT, &indexBufferPeer, NULL
       );
       indexBufferPeers[buffer] = indexBufferPeer;
     }
 
     // copy the index buffer contents over to the native peer ibo on the GPU
     VOID* pVoid;
-    indexBufferPeer->Lock(0, 0, (VOID**)&pVoid, dynamic ? D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE : 0);
+    indexBufferPeer->Lock(0, 0, (VOID**)&pVoid, dynamic ? D3DLOCK_DISCARD : 0);
     memcpy(pVoid, indexBuffer->indices.data(), size);
     indexBufferPeer->Unlock();
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
@@ -78,9 +78,12 @@ void graphics_prepare_vertex_buffer(const int buffer) {
     // create either a static or dynamic vbo peer depending on if the user called
     // vertex_freeze on the buffer
     if (!vertexBufferPeer) {
+      DWORD usage = vertexBuffer->frozen ? D3DUSAGE_WRITEONLY : 0;
+      if (!vertexBuffer->frozen && !Direct3D9Managed) usage |= D3DUSAGE_DYNAMIC;
+      D3DPOOL managed_pool = vertexBuffer->frozen ? D3DPOOL_MANAGED : D3DPOOL_SYSTEMMEM;
+
       d3dmgr->CreateVertexBuffer(
-        size, vertexBuffer->frozen ? D3DUSAGE_WRITEONLY : (D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY),
-        0, D3DPOOL_DEFAULT, &vertexBufferPeer, NULL
+        size, usage, 0, Direct3D9Managed ? managed_pool : D3DPOOL_DEFAULT, &vertexBufferPeer, NULL
       );
       vertexBufferPeers[buffer] = vertexBufferPeer;
     }
@@ -123,9 +126,14 @@ void graphics_prepare_index_buffer(const int buffer) {
     // create either a static or dynamic ibo peer depending on if the user called
     // index_freeze on the buffer
     if (!indexBufferPeer) {
+      DWORD usage = indexBuffer->frozen ? D3DUSAGE_WRITEONLY : 0;
+      if (!indexBuffer->frozen && !Direct3D9Managed) usage |= D3DUSAGE_DYNAMIC;
+      D3DPOOL managed_pool = indexBuffer->frozen ? D3DPOOL_MANAGED : D3DPOOL_SYSTEMMEM;
+
       d3dmgr->CreateIndexBuffer(
-        size, indexBuffer->frozen ? D3DUSAGE_WRITEONLY : (D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY),
-        (indexBuffer->type == index_type_uint) ? D3DFMT_INDEX32 : D3DFMT_INDEX16, D3DPOOL_DEFAULT, &indexBufferPeer, NULL
+        size, usage,
+        (indexBuffer->type == index_type_uint) ? D3DFMT_INDEX32 : D3DFMT_INDEX16,
+        Direct3D9Managed ? managed_pool : D3DPOOL_DEFAULT, &indexBufferPeer, NULL
       );
       indexBufferPeers[buffer] = indexBufferPeer;
     }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/Info/About.ey
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/Info/About.ey
@@ -3,11 +3,11 @@
 
 Name: Direct3D 9.0
 Identifier: Direct3D9
-Description: Native hardware accelerated rendering on Windows platforms. Requires the DirectX 9.0 End User Runtime or later in the Windows Portable ZIP, DirectX which is included with our MinGW, being Microsoft technology is also exceptionally proprietary.
+Description: Native, hardware-accelerated rendering on Windows platforms. Requires the DirectX 9.0 End User Runtime or later. A Direct3D 9Ex device is used on supported platforms (Windows Vista or later), and a standard Direct3D 9 device is used otherwise. When a Direct3D 9Ex device is not supported (Windows XP), resources will be placed in a managed memory pool backed by system RAM, which may increase the game's memory consumption.
 Author: Robert Colton
 
 Depends:
 	Build-platforms: Windows, SDL
-  
+
 Represents:
 	Build-platforms: None


### PR DESCRIPTION
This pull request addresses the Direct3D9 reset issues mentioned in #1455 by using Direct3D 9Ex on supported platforms (Windows Vista or later) and regular Direct3D9 with resources placed in the managed memory pool everywhere else (Windows XP/non-WDDM drivers). GameMaker: Studio v1.4 also happens to be using Direct3D 9Ex on Windows, though I don't know if this was their decision or just built into ANGLE.

This solves the issue because Direct3D 9Ex does not lose textures, buffers, and surfaces as a result of a device reset.
https://docs.microsoft.com/en-us/windows/desktop/direct3d9/dx9lh
> Now with DirectX for Windows Vista, calling Reset after a mode change does not cause texture memory surfaces, textures and state information to be lost and these resources do not need to be recreated.

This also solves the issue for Windows XP users because resources placed in the `D3DPOOL_MANAGED` are backed by system memory and do not need to be recreated. It's worth mentioning that this pool is obsolete in Direct3D9 Ex, so this pull request uses one or the other. The only disadvantage to Windows XP users here is they will experience increased system RAM usage as a result of the resources being in the managed memory pool. I've inspected some games with Task Manager and there is a noticeable increase in RAM usage. But at this point, compatibility is probably more important, at least they can run ENIGMA where they can't run GMS2.
https://docs.microsoft.com/en-us/windows/desktop/direct3d9/d3dpool
>Managed resources are backed by system memory and do not need to be recreated when a device is lost.

### How The Fallback Works
I based the changes in this pull request on an example on MSDN that demonstrates how to dynamically check at runtime if Direct3D 9Ex is supported. We first try to load d3d9.dll and see if the function pointer Direct3DCreate9Ex exists. If it does, we attempt to create a Direct3D 9Ex device. If the dll is not found, the function pointer doesn't exist, or we otherwise fail to create the device, we then attempt to create a regular Direct3D 9 standard device and use the managed memory pool for resources.
https://docs.microsoft.com/en-us/windows/desktop/api/d3d9/nf-d3d9-direct3dcreate9ex#examples

### Texture Paging
I want to point out a discovery made in this pull request that when you create textures in the default pool, the GPU enforces a minimum texture size. Creating a 4x4, 8x8, or 16x16 texture all gave me a lock rect that had a pitch of 64 bytes. I assume that this happens to be my particular GPU's minimum texture page size. This tripped me up at first when moving the textures from managed until I just realized I needed to respect the pitch. Anyway, this is just a very good reason for us to finally do texture paging (mentioned in #653) soon.
![D3D9Ex CreateTexture Minimum Pitch](https://user-images.githubusercontent.com/3212801/50082176-4be19600-01be-11e9-9a87-b2011c919652.png)

### Practical Implications
The device reset failure I mentioned in #1455 that occurs in Wild Racing is no longer an issue. This means you can run the game in Direct3D9 without having to hack it to get it working.
![Direct3D9 Wild Racing](https://user-images.githubusercontent.com/3212801/50061938-11eaa280-0172-11e9-811e-89ea371fd2a4.png)
The device reset failure that used to occur in the High Polygonal Cubes Demo when either changing the MSAA level or toggling vertical synchronization does not occur now. The following screenshot is of the cubes demo with 8x MSAA and vertical synchronization.
![Direct3D9 High Polygonal Cubes Demo](https://user-images.githubusercontent.com/3212801/50061979-49594f00-0172-11e9-8168-ba8912d62446.png)

