### PR TITLE
Fix Direct3D Screen View Initialization

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -63,9 +63,8 @@ void screen_init()
       if (view_visible[(int)view_current]) {
         int vc = (int)view_current;
 
-        screen_set_viewport(view_xport[vc], view_yport[vc],
-          (window_get_region_width_scaled() - view_xport[vc]), (window_get_region_height_scaled() - view_yport[vc]));
-        d3d_set_projection_ortho(view_xview[vc], view_wview[vc] + view_xview[vc], view_yview[vc], view_hview[vc] + view_yview[vc], view_angle[vc]);
+        screen_set_viewport(view_xport[vc], view_yport[vc], view_wport[vc], view_hport[vc]);
+        d3d_set_projection_ortho(view_xview[vc], view_yview[vc], view_wview[vc], view_hview[vc], view_angle[vc]);
         break;
       }
     }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -59,9 +59,8 @@ void screen_init()
       if (view_visible[(int)view_current]) {
         int vc = (int)view_current;
 
-        screen_set_viewport(view_xport[vc], view_yport[vc],
-          (window_get_region_width_scaled() - view_xport[vc]), (window_get_region_height_scaled() - view_yport[vc]));
-        d3d_set_projection_ortho(view_xview[vc], view_wview[vc] + view_xview[vc], view_yview[vc], view_hview[vc] + view_yview[vc], view_angle[vc]);
+        screen_set_viewport(view_xport[vc], view_yport[vc], view_wport[vc], view_hport[vc]);
+        d3d_set_projection_ortho(view_xview[vc], view_yview[vc], view_wview[vc], view_hview[vc], view_angle[vc]);
         break;
       }
     }


### PR DESCRIPTION
I went digging for the last Wild Racing bug in Direct3D, I wanted to know why the heightmap was flat despite the fact I've already added `draw_getpixel` which it uses to read the heightmap. The issue turned out to be that I was subtracting the view port position from the window region size to obtain the viewport size, instead of just using the viewport size. This fix simply changes the viewport and projection initialization for views in Direct3D9 and Direct3D11 to be the same as OpenGL.

It seems that this mistake has existed ever since 5ae769fabc502730d2c477e2cf631c44f9d1786e where I first added views to Direct3D9. I would like to later move `screen_init` to general sources since the behavior is the same between the two systems. I've opened #1337 to cover that though, for now I just want to fix the projection for D3D only.

The heightmap is still slightly off because of half pixel differences between OpenGL and Direct3D that we will have to figure out later. For now, I am just glad that the projection is being initialized correctly.

### Direct3D9 Wild Racing
![D3D9 Wild Racing](https://user-images.githubusercontent.com/3212801/50119264-3d2bcb00-0220-11e9-90c4-09a7ad1f7bbd.png)

### OpenGL1 Wild Racing
![GL1 Wild Racing](https://user-images.githubusercontent.com/3212801/50119247-2dac8200-0220-11e9-9e04-a9fee8226e3e.png)

### OpenGL3 Wild Racing
![GL3 Wild Racing](https://user-images.githubusercontent.com/3212801/50119284-50d73180-0220-11e9-8af6-4ccfdfcbe63f.png)

