### PR TITLE
Fix Default Window Centering

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
@@ -271,9 +271,9 @@ void window_default(bool center_size) {
 
   enigma::windowWidth = enigma::regionWidth = xm;
   enigma::windowHeight = enigma::regionHeight = ym;
-  if (center) window_center();
 
   enigma::compute_window_size();
+  if (center) window_center();
 }
 
 void window_center() {


### PR DESCRIPTION
This has been pissing me off for months ever since we added SDL, I can't believe I let it go on so long. Anyway, long story short, when the game opens on master it's not centered properly. For SDL it's in the top-left corner of my monitor and for Win32 it's centered before the final size is determined, so it's still going offscreen. Simple fix here was to just move the centering after the determination of the window size which fixes it for SDL and Win32.

### Default Window Centering Fixed
![SDL High Polygonal Cubes Window Centered](https://user-images.githubusercontent.com/3212801/50201033-823a2500-0326-11e9-939f-80c9f589d8dd.png)
