### PR TITLE
SDL HINSTANCE/Widgets

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
@@ -22,17 +22,3 @@ HWND get_window_handle() {
 }
 
 } //namespace enigma
-
-namespace enigma_user {
-
-#if GM_COMPATIBILITY_VERSION <= 81
-unsigned long long window_handle() {
-  return (unsigned long long)enigma::hWnd;
-}
-#else
-void* window_handle() {
-  return enigma::hWnd;
-}
-#endif
-
-} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
@@ -7,6 +7,7 @@
 namespace enigma {
 
 HWND hWnd;
+HINSTANCE hInstance;
 
 HWND get_window_handle() {
   if (hWnd == NULL) { // dsound or d3d could init this first depending on systems used
@@ -14,9 +15,24 @@ HWND get_window_handle() {
     SDL_VERSION(&systemInfo.version);
     SDL_GetWindowWMInfo((SDL_Window*)windowHandle, &systemInfo);
     hWnd = systemInfo.info.win.window;
+    hInstance = systemInfo.info.win.hinstance;
   }
 
   return hWnd;
 }
 
 } //namespace enigma
+
+namespace enigma_user {
+
+#if GM_COMPATIBILITY_VERSION <= 81
+unsigned long long window_handle() {
+  return (unsigned long long)enigma::hWnd;
+}
+#else
+void* window_handle() {
+  return enigma::hWnd;
+}
+#endif
+
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/widgets.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/widgets.cpp
@@ -25,11 +25,14 @@
 **                                                                              **
 \********************************************************************************/
 
+#include "Widget_Systems/General/WSwidgets.h"
+#include "Widget_Systems/widgets_mandatory.h" // for show_error()
+#include "Bridges/Win32/WINDOWShandle.h" // for get_window_handle()
+
 // As is typical of Win32 code, this code is fuck-ugly. Refer to the GTK version for
 // porting to competent widget systems. Use this only for low-level APIs.
 #define WINVER 9001
 #include <windows.h>
-#include "Widget_Systems/General/WSwidgets.h"
 #include <commctrl.h>
 #include <windowsx.h>
 #include <stdio.h>
@@ -54,6 +57,10 @@ namespace enigma {
   extern HINSTANCE hInstance;
   bool widget_system_initialize()
   {
+    // make sure the hWnd and hInstance variables are initialized (e.g, SDL)
+    if (get_window_handle() == NULL) {
+      show_error("Cannot initialize Win32 widget system with NULL window handle.", true);
+    }
     INITCOMMONCONTROLSEX iccex;
     iccex.dwSize = sizeof(iccex);
     iccex.dwICC  = ICC_STANDARD_CLASSES | ICC_LISTVIEW_CLASSES;


### PR DESCRIPTION
The Win32 widget system relies on the HINSTANCE for some reason, so this pr provides it so that SDL will build with the Win32 widgets set.