### PR TITLE
Use Default HINSTANCE for Win32 Widgets

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
@@ -20,17 +20,3 @@ HWND get_window_handle() {
 }
 
 } //namespace enigma
-
-namespace enigma_user {
-
-#if GM_COMPATIBILITY_VERSION <= 81
-unsigned long long window_handle() {
-  return (unsigned long long)enigma::hWnd;
-}
-#else
-void* window_handle() {
-  return enigma::hWnd;
-}
-#endif
-
-} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
@@ -20,3 +20,17 @@ HWND get_window_handle() {
 }
 
 } //namespace enigma
+
+namespace enigma_user {
+
+#if GM_COMPATIBILITY_VERSION <= 81
+unsigned long long window_handle() {
+  return (unsigned long long)enigma::hWnd;
+}
+#else
+void* window_handle() {
+  return enigma::hWnd;
+}
+#endif
+
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -73,7 +73,6 @@ void show_error(string errortext, const bool fatal)
 }
 
 namespace enigma {
-  extern HINSTANCE hInstance;
   extern HWND hWnd;
   HWND infore;
 }
@@ -267,7 +266,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
   if (embedGameWindow) {
     parent = enigma::hWnd;
   } else {
-    WNDCLASS wc = {CS_VREDRAW|CS_HREDRAW,(WNDPROC)ShowInfoProc,0,0,enigma::hInstance,0,
+    WNDCLASS wc = {CS_VREDRAW|CS_HREDRAW,(WNDPROC)ShowInfoProc,0,0,NULL,0,
       0,GetSysColorBrush(COLOR_WINDOW),0,"infodialog"};
     RegisterClass(&wc);
 
@@ -283,11 +282,11 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
     }
 
     parent = CreateWindow("infodialog", TEXT(caption.c_str()),
-      flags, left, top, width, height, enigma::hWnd, 0, enigma::hInstance, 0);
+      flags, left, top, width, height, enigma::hWnd, 0, NULL, 0);
 
     if (showBorder) {
       // Set Window Information Icon
-      HICON hIcon = LoadIcon(enigma::hInstance, "infoicon");
+      HICON hIcon = LoadIcon(NULL, "infoicon");
       if (hIcon) {
         SendMessage(parent, WM_SETICON, ICON_SMALL,(LPARAM)hIcon);
         SendMessage(parent, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
@@ -297,7 +296,7 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
 
   enigma::infore=CreateWindowEx(WS_EX_TOPMOST,"RICHEDIT",TEXT("information text"),
     ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | ES_READONLY | WS_CHILD | WS_VISIBLE | WS_BORDER | WS_VSCROLL | WS_HSCROLL | WS_TABSTOP,
-    0, 0, width, height, parent, 0, enigma::hInstance, 0);
+    0, 0, width, height, parent, 0, NULL, 0);
 
   // Size the RTF Component to the Window
   RECT rectParent;
@@ -419,7 +418,7 @@ int show_message_ext(string msg, string but1, string but2, string but3)
   gs_message = msg;
   gs_but1 = but1; gs_but2 = but2; gs_but3 = but3;
 
-  return DialogBox(enigma::hInstance,"showmessageext",enigma::hWnd,ShowMessageExtProc);
+  return DialogBox(NULL,"showmessageext",enigma::hWnd,ShowMessageExtProc);
 }
 
 bool show_question(string str)
@@ -430,7 +429,7 @@ bool show_question(string str)
 string get_login(string username, string password, string cap)
 {
   gs_cap = cap; gs_username = username; gs_password = password;
-  DialogBox(enigma::hInstance,"getlogindialog",enigma::hWnd,GetLoginProc);
+  DialogBox(NULL,"getlogindialog",enigma::hWnd,GetLoginProc);
 
   return gs_str_submitted;
 }
@@ -438,7 +437,7 @@ string get_login(string username, string password, string cap)
 string get_string(string message,string def,string cap)
 {
   gs_cap = cap; gs_message = message; gs_def = def;
-  DialogBox(enigma::hInstance,"getstringdialog",enigma::hWnd,GetStrProc);
+  DialogBox(NULL,"getstringdialog",enigma::hWnd,GetStrProc);
 
   return gs_str_submitted;
 }
@@ -446,7 +445,7 @@ string get_string(string message,string def,string cap)
 int get_integer(string message,string def,string cap)
 {
   gs_cap = cap; gs_message = message; gs_def = def;
-  DialogBox(enigma::hInstance,"getstringdialog",enigma::hWnd,GetStrProc);
+  DialogBox(NULL,"getstringdialog",enigma::hWnd,GetStrProc);
   if (gs_str_submitted == "") return 0;
   puts(gs_str_submitted.c_str());
 
@@ -456,7 +455,7 @@ int get_integer(string message,string def,string cap)
 double get_number(string message,string def,string cap)
 {
   gs_cap = cap; gs_message = message; gs_def = def;
-  DialogBox(enigma::hInstance,"getstringdialog",enigma::hWnd,GetStrProc);
+  DialogBox(NULL,"getstringdialog",enigma::hWnd,GetStrProc);
   if (gs_str_submitted == "") return 0;
   puts(gs_str_submitted.c_str());
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/widgets.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/widgets.cpp
@@ -51,7 +51,6 @@ static INT_PTR widget_idmax = 0;
 
 namespace enigma {
   extern HWND hWnd;
-  extern HINSTANCE hInstance;
   bool widget_system_initialize()
   {
     INITCOMMONCONTROLSEX iccex;
@@ -143,7 +142,7 @@ struct Sgeneric_window
   Sgeneric_window()
   {
     /* The Window structure */
-    wincl.hInstance = enigma::hInstance;
+    wincl.hInstance = NULL;//enigma::hInstance;
     wincl.lpszClassName = enigma_window_generic_class;
     wincl.lpfnWndProc = GenWindowProcedure;      /* This function is called by windows */
     wincl.style = CS_DBLCLKS;                 /* Catch double-clicks */
@@ -169,7 +168,7 @@ struct Sgeneric_window
 
 int wgt_window_create(int w, int h)
 {
-  HWND win = CreateWindowEx(0, enigma_window_generic_class, "caption", WS_POPUP | WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, w, h, enigma::hWnd, (HMENU)(ptrdiff_t)widget_idmax, enigma::hInstance, (LPVOID)(ptrdiff_t)widget_idmax);
+  HWND win = CreateWindowEx(0, enigma_window_generic_class, "caption", WS_POPUP | WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, w, h, enigma::hWnd, (HMENU)(ptrdiff_t)widget_idmax, NULL/*enigma::hInstance*/, (LPVOID)(ptrdiff_t)widget_idmax);
   if (!win)
     return -1;
   setID(win,widget_idmax); fixFont(win);


### PR DESCRIPTION
This is an alternative approach to fixing what #1469 is trying to do. Instead of having SDL provide the HINSTANCE to other systems (such as the Win32 widgets) and extensions, we can also just remove references to it from the Win32 widget system altogether.

Passing a `NULL` HINSTANCE to many of the Win32 functions actually uses the instance of the current executable. So even after changing all of the `enigma::hInstance` usages with `NULL` in the Win32 widget system, the widgets still function normally because we are storing all of the dialog templates in the game exe anyway.
https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-dialogboxa
https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-createwindowexa