### PR TITLE
User Window Handle for SDL

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-Win32/handle.cpp
@@ -20,3 +20,17 @@ HWND get_window_handle() {
 }
 
 } //namespace enigma
+
+namespace enigma_user {
+
+#if GM_COMPATIBILITY_VERSION <= 81
+unsigned long long window_handle() {
+  return (unsigned long long)enigma::hWnd;
+}
+#else
+void* window_handle() {
+  return enigma::hWnd;
+}
+#endif
+
+} // namespace enigma_user


### PR DESCRIPTION
This adds the `window_handle` function to SDL. The compatibility macro is actually busted because of #1461, so this shouldn't be merged as-is.