### PR TITLE
Fix SDL Game Icon on Windows

### DIFF
--- a/Compilers/Windows/gcc.ey
+++ b/Compilers/Windows/gcc.ey
@@ -15,8 +15,9 @@ Make-Vars:
   cxxflags: -std=c++11 -I/mingw64/lib/libffi-3.2.1/include -I../Additional/i686-w64-mingw32/include
   cflags:
   ldflags: -L../Additional/i686-w64-mingw32/lib -static-libgcc -static-libstdc++ -static
-  rcflags: 
+  rcflags:
   links:
+  compile-target-platform: Win32
 
 Parser-Vars:
   defines: cpp -dM -x c++ --std=c++03 -E $blank

--- a/Compilers/Windows/gcc.ey
+++ b/Compilers/Windows/gcc.ey
@@ -15,9 +15,8 @@ Make-Vars:
   cxxflags: -std=c++11 -I/mingw64/lib/libffi-3.2.1/include -I../Additional/i686-w64-mingw32/include
   cflags:
   ldflags: -L../Additional/i686-w64-mingw32/lib -static-libgcc -static-libstdc++ -static
-  rcflags:
+  rcflags: 
   links:
-  compile-target-platform: Win32
 
 Parser-Vars:
   defines: cpp -dM -x c++ --std=c++03 -E $blank

--- a/ENIGMAsystem/SHELL/Makefile
+++ b/ENIGMAsystem/SHELL/Makefile
@@ -37,7 +37,7 @@ WIDGETS ?= None
 NETWORKING ?= None
 
 # RESOURCE FILE WITH ICON AND VERSION INFO
-ifeq ($(COMPILE-TARGET-PLATFORM), Win32)
+ifeq ($(TARGET-PLATFORM), Windows)
 RESOURCES += Preprocessor_Environment_Editable/Resources.rc
 endif
 

--- a/ENIGMAsystem/SHELL/Makefile
+++ b/ENIGMAsystem/SHELL/Makefile
@@ -37,7 +37,7 @@ WIDGETS ?= None
 NETWORKING ?= None
 
 # RESOURCE FILE WITH ICON AND VERSION INFO
-ifeq ($(PLATFORM), Win32)
+ifeq ($(COMPILE-TARGET-PLATFORM), Win32)
 RESOURCES += Preprocessor_Environment_Editable/Resources.rc
 endif
 


### PR DESCRIPTION
In master the game icon is not showing when using the SDL platform on Windows. The reason is because we don't link the rc file unless the platform is Win32. This fixes it by checking if the target platform is Windows.

This way seems to me to be the proper way for us to do this so that we can continue supporting cross-compilation correctly. Not only that, consider that we also use `target-platform` to determine whether to write the exe resource file or desktop entry anyway, so it only seems sensible to use the same value to determine when to link said rc file.
https://github.com/enigma-dev/enigma-dev/blob/25f11357ffc6fa184db338a586e6b96e7e64537c/CompilerSource/compiler/compile.cpp#L337