### PR TITLE
Fix Initial Window Visibility

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -69,7 +69,6 @@ int enigma_main(int argc, char** argv) {
 
   // Call ENIGMA system initializers; sprites, audio, and what have you
   initialize_everything();
-  showWindow();
 
   while (!game_isending) {
     if (!((std::string)enigma_user::room_caption).empty())

--- a/ENIGMAsystem/SHELL/Platforms/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/None/fillin.cpp
@@ -48,7 +48,6 @@ namespace enigma {
   void EnableDrawing(void* handle) {};
   void DisableDrawing(void* handle) {};
   int handleEvents() { return 0; }
-  void showWindow() {}
 }
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -65,8 +65,6 @@ void handleInput() {
   pushGamepads();
 }
 
-void showWindow() { SDL_ShowWindow(windowHandle); }
-
 void initCursors() {
   // cursors are negative ids 0 to -22
   cursors[-enigma_user::cr_arrow] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -73,14 +73,14 @@ namespace enigma_user {
         dname.erase(dname.size() - 1);
       }
     }
-    
+
     tstring tstr_dname = widen(dname);
     DWORD attr = GetFileAttributesW(tstr_dname.c_str());
 
     if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY)) {
       return (SetCurrentDirectoryW(tstr_dname.c_str()) != 0);
     }
-    
+
     return false;
   }
 } // enigma_user
@@ -309,8 +309,6 @@ void handleInput() { input_push(); }
 
 void destroyWindow() { DestroyWindow(enigma::hWnd); }
 
-void showWindow() { ShowWindow(enigma::hWnd, 1); }
-
 void initialize_directory_globals() {
   // Set the working_directory
   WCHAR buffer[MAX_PATH + 1];
@@ -323,7 +321,7 @@ void initialize_directory_globals() {
   enigma_user::program_directory = shorten(buffer);
   enigma_user::program_directory =
       enigma_user::program_directory.substr(0, enigma_user::program_directory.find_last_of("\\/"));
-  
+
   // Set the temp_directory
   buffer[0] = 0;
   GetTempPathW(MAX_PATH + 1, buffer);

--- a/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
+++ b/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
@@ -47,7 +47,6 @@ namespace enigma
 
   void EnableDrawing(void* handle = nullptr);
   void DisableDrawing(void* handle = nullptr);
-  void showWindow();
 
   // System / Window events
   int handleEvents();

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -128,10 +128,6 @@ bool initGameWindow()
   return true;
 }
 
-void showWindow() {
-  XMapRaised(disp, win);
-}
-
 void destroyWindow() {
   XCloseDisplay(enigma::x11::disp);
 }

--- a/ENIGMAsystem/SHELL/Universal_System/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/loading.cpp
@@ -24,6 +24,7 @@
 #include "libEGMstd.h"
 //#include "mathnc.h"
 
+#include "Platforms/General/PFwindow.h"
 #include "Platforms/platforms_mandatory.h"
 #include "Audio_Systems/audio_mandatory.h"
 #include "Widget_Systems/widgets_mandatory.h"
@@ -120,8 +121,10 @@ namespace enigma
     //Go to the first room
     if (enigma_user::room_count)
       enigma::game_start();
-    else
+    else {
       enigma_user::window_default();
+      enigma_user::window_set_visible(true);
+    }
 
     return 0;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -233,6 +233,8 @@ namespace enigma
     //NOTE: window_default() always centers the Window, GM8 only recenters the window when switching rooms
     //if the window size changes.
     enigma_user::window_default(true);
+    // window sized by first room, can make visible now
+    enigma_user::window_set_visible(true);
     enigma_user::io_clear();
     // we only initialize the screen and clear the window color during game start
     // NOTE: no version of GM has EVER reset the drawing color or alpha during room transition


### PR DESCRIPTION
Let me start off by explaining an issue that occurs on master since the last time we messed with this. If you show a message in the create event of an object, you will get the dialog but the game itself is not yet visible. This is unlike GameMaker, and actually can be quit annoying as a tiny dialog can be easily lost behind LGM's output window. What makes it even more uncomfortable is that the small dialog is modal, and because the game itself is not visible, there is no taskbar icon to restore the game. This has been a minor frustration I've faced for a couple of months now.

This pull request first dumps all of the `showWindow` crap fundies came up with since it's an obvious duplication of `window_set_visible`. Then I changed the room goto to set the window visible once it has called `window_default` (which handles setting the window to the room size etc). This way the window is made visible just before the create events are fired, fixing the annoyance for me.

Later, we should add the game settings splash screen and create the window initially visible from the very beginning. Then we paint the splash just before beginning the resource module load sequence. Then the splash remains visible during the duration of resource loading and finally we will fire a draw event once the room loads.
