### PR TITLE
Draw Before Step

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/loading.cpp
@@ -126,6 +126,9 @@ namespace enigma
       enigma_user::window_set_visible(true);
     }
 
+    // fire draw events before step (GM5/GM8)
+    enigma_user::screen_redraw();
+
     return 0;
   }
 } //namespace enigma


### PR DESCRIPTION
This actually does make a difference if a draw, instead of step, event is the first event after the create and start events. To avoid having to make complicated changes to the event system, my solution in this pull request simply adds a `screen_redraw` call to the end of the load sequence, which gives the same effect anyway. This pull request changes ENIGMA to be more like older GameMaker 5-8, instead of being like GMSv1.4 in this regard.

I made a test GMD project: [draw-step-order.zip](https://github.com/enigma-dev/enigma-dev/files/2700703/draw-step-order.zip)

* ENIGMA Master: create (black), step (black), draw (black), step (gray)
* This pull request: create (black), draw (black), step (gray), draw (gray)
* GameMaker 5: create (black), draw (black), step (gray), draw (gray)
* GameMaker 8: create (black), draw (black), step (gray), draw (gray)
* GMSv1.4: create (splash), step (splash), draw (splash), step (gray)

# Practical Implications
I've found one game alone that is directly affected by this and it's the Wild Racing game. Its start screen is drawn in an alarm that is set to `1` in the create event. In GameMaker 8, this means the control information is drawn like a HUD on *top* of the already drawn scene. In ENIGMA master and GMSv1.4, a step event occurred between create and the alarm, so the alarm event will draw on top of a black backbuffer. This does not entirely fix ENIGMA however because screen refresh differences between D3D and OGL mentioned in #1474 are also related to whether the backbuffer was discarded just prior to the alarm event.

### ENIGMA master (D3D and OGL)/Pull request (GL)/GMSv1.4
![Wild Racing Init Black](https://user-images.githubusercontent.com/3212801/50313525-9fcbd380-0479-11e9-867d-6788886d0855.png)

### Pull request (D3D)/GameMaker 8/GameMaker 5
![Wild Racing Init Scene](https://user-images.githubusercontent.com/3212801/50313599-ec171380-0479-11e9-8ad7-0559d4610f8a.png)

