### PR TITLE
Fix Copyright on Matrix Source

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
@@ -1,4 +1,7 @@
-/** Copyright (C) 2013-2014, 2018 Robert Colton
+/** Copyright (C) 2008-2012 Josh Ventura
+*** Copyright (C) 2013-2014 Robert Colton, Harijs Grinbergs
+*** Copyright (C) 2015 Harijs Grinbergs
+*** Copyright (C) 2018 Robert Colton
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***


### PR DESCRIPTION
It looks like I made a mistake in #1396 when I generalized the matrix functions. Although I started the source new, I did borrow function ideas as well as implementation specifics while writing the new source. I intended to keep everyone on the copyright headers, as I did in the literal header files, but forgot to in the source.