### PR TITLE
XTest Include & Link Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/XTEST/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/XTEST/Makefile
@@ -1,1 +1,2 @@
 SOURCES += Universal_System/Extensions/XTEST/xtest.cpp
+override LDLIBS += -lXtst

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/XTEST/xtest.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/XTEST/xtest.cpp
@@ -2,6 +2,8 @@
 
 #include "Platforms/xlib/XLIBwindow.h"
 
+#include <X11/extensions/XTest.h>
+
 namespace enigma {
   extern unsigned short keyrmap[256];
 }


### PR DESCRIPTION
The commit f7b04eba038b60507d57d1254c42cd22832e7f87 I made as a part of my original XTest pull request failed to move the include which was lost when @JoshDreamland recreated the pull request in #1463. So yeah, we just need to readd the include here in the XTest extension and I also forgot to link it and it should be good. With these changes, hugar over Discord tells me that it works.