### PR TITLE
Fix Model Copyright

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
@@ -1,5 +1,6 @@
 /** Copyright (C) 2013 Robert Colton, Adriano Tumminelli
-*** Copyright (C) 2014 Seth N. Hetu
+*** Copyright (C) 2014 Josh Ventura, Harijs Grinbergs, Seth N. Hetu
+*** Copyright (C) 2015 Harijs Grinbergs
 *** Copyright (C) 2017, 2018 Robert Colton
 ***
 *** This file is a part of the ENIGMA Development Environment.


### PR DESCRIPTION
Alright, because of #1478 I am also double checking a few other copyright changes. Harri's shape building logic was ultimately kept in 4bc76baf118cca0d4540d2aa449c41b46f6f5c36 because it was more efficient. Because he only ever added himself to the model struct header copyright, which was structured differently than what we have now, I missed moving his copyright to the actual model source where his logic appears. His work did contribute to this file, hence he should be kept on the copyright, plain and simple.