### PR TITLE
SDL Keyboard Simulation

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -298,4 +298,20 @@ bool keyboard_check_direct(int key) {
   return state[enigma::keyboard::inverse_keymap[key]];
 }
 
+void keyboard_key_press(int key) {
+  SDL_Event sdlevent = { };
+  sdlevent.type = SDL_KEYDOWN;
+  sdlevent.key.keysym.sym = enigma::keyboard::inverse_keymap[key];
+
+  SDL_PushEvent(&sdlevent);
+}
+
+void keyboard_key_release(int key) {
+  SDL_Event sdlevent = { };
+  sdlevent.type = SDL_KEYUP;
+  sdlevent.key.keysym.sym = enigma::keyboard::inverse_keymap[key];
+
+  SDL_PushEvent(&sdlevent);
+}
+
 }  // namespace enigma_user


### PR DESCRIPTION
This resolves #1480 and adds the requested functions to the SDL platform. There's currently two small caveats however. The first is that it is not operating system level like the Win32 or XTest extension variants. This means that other applications are not affected by the input simulation. The second caveat is that currently it only works with our keyboard check functions but not `keyboard_string` because the latter uses the text input API and events to know when text has been entered.
https://wiki.libsdl.org/Tutorials/TextInput

It's also possible that `keyboard_check_direct` may not be affected by key simulation of this kind. Finally, our Win32 platform is most consistent with GM8 and GMSv1.4 by having the `keyboard_string` be affected by the key simulation.
```gml
keyboard_key_press(ord('A'));
// this will show up because of the above
if (keyboard_check(ord('A')))
    draw_text(0,100,"'A' key is down");
// this is not affected by the fake pressing of the 'A' key
draw_text(0,0,keyboard_string);
```