### PR TITLE
Remove DXERR Usage From Direct3D

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
+++ b/ENIGMAsystem/SHELL/Bridges/General/DX9Context.h
@@ -25,7 +25,6 @@
 #include <windows.h>
 #include <windowsx.h>
 #include <d3d9.h>
-#include <dxerr9.h>
 
 #include <sstream>
 #include <string.h>
@@ -226,8 +225,7 @@ void Reset(D3DPRESENT_PARAMETERS *pPresentationParameters) {
 	if (FAILED(hr)) {
 		MessageBox(
 			enigma::hWnd,
-			"Failed to reset Direct3D 9.0 Device",
-			DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
+			TEXT("Device Reset Failed"), TEXT("Error"),
 			MB_ICONERROR | MB_OK
 		);
 		return;  // should probably force the game closed
@@ -259,7 +257,7 @@ HRESULT CreateIndexBuffer(UINT Length, DWORD Usage,  D3DFORMAT Format,  D3DPOOL 
 void CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture9 **ppTexture, HANDLE *pSharedHandle) {
 	HRESULT hr = device->CreateTexture(Width, Height, Levels, Usage, Format, Pool, ppTexture, pSharedHandle);
   	if (FAILED(hr)) {
-      MessageBox(NULL, DXGetErrorDescription9(hr), DXGetErrorString9(hr), MB_OK|MB_ICONEXCLAMATION);
+      MessageBox(NULL, TEXT("CreateTexture Failed"), TEXT("Error"), MB_OK|MB_ICONEXCLAMATION);
 	  return;
     }
 }
@@ -276,7 +274,7 @@ void CreateVertexDeclaration(const D3DVERTEXELEMENT9 *pVertexElements, IDirect3D
 void CreatePixelShader(const DWORD *pFunction, IDirect3DPixelShader9 **ppShader) {
 	HRESULT hr = device->CreatePixelShader(pFunction, ppShader);
 	if (FAILED(hr)) {
-      MessageBox(NULL, "CreatePixelShader failed", "CRendererDX9::Create", MB_OK|MB_ICONEXCLAMATION);
+      MessageBox(NULL, TEXT("CreatePixelShader Failed"), TEXT("Error"), MB_OK|MB_ICONEXCLAMATION);
       return;
     }
 }
@@ -284,7 +282,7 @@ void CreatePixelShader(const DWORD *pFunction, IDirect3DPixelShader9 **ppShader)
 void CreateVertexShader(const DWORD *pFunction, IDirect3DVertexShader9 **ppShader) {
 	HRESULT hr = device->CreateVertexShader(pFunction, ppShader);
 	if (FAILED(hr)) {
-      MessageBox(NULL, "CreateVertexShader failed", "CRendererDX9::Create", MB_OK|MB_ICONEXCLAMATION);
+      MessageBox(NULL, TEXT("CreateVertexShader Failed"), TEXT("Error"), MB_OK|MB_ICONEXCLAMATION);
 	  return;
     }
 }
@@ -293,8 +291,7 @@ void GetSwapChain(UINT  iSwapChain, IDirect3DSwapChain9 **ppSwapChain) {
 	HRESULT hr = device->GetSwapChain(iSwapChain, ppSwapChain);
 		if(FAILED(hr)){
 			MessageBox(enigma::hWnd,
-               "Failed to retrieve the Direct3D 9.0 Swap Chain",
-			   DXGetErrorDescription9(hr), //DXGetErrorString9(hr)
+			   TEXT("GetSwapChain Failed"), TEXT("Error"),
                MB_ICONERROR | MB_OK);
 			return;  // should probably force the game closed
 		}

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -27,7 +27,6 @@
 #include <windows.h>
 #include <windowsx.h>
 #include <d3d9.h>
-#include <dxerr9.h>
 #include <string>
 using namespace std;
 

--- a/ENIGMAsystem/SHELL/Bridges/SDL-Direct3D9/Makefile
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-Direct3D9/Makefile
@@ -1,2 +1,2 @@
 SOURCES += Bridges/General/Win32-Direct3D9.cpp $(wildcard Bridges/SDL-Direct3D/*.cpp)
-override LDLIBS += -ld3d9 -ldxerr9
+override LDLIBS += -ld3d9

--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/Makefile
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/Makefile
@@ -1,2 +1,2 @@
 SOURCES += Bridges/General/Win32-Direct3D9.cpp $(wildcard Bridges/Win32-Direct3D9/*.cpp)
-override LDLIBS += -ld3d9 -ldxerr9
+override LDLIBS += -ld3d9


### PR DESCRIPTION
This follows some of the changes in #1487 to bring D3D up to speed with the Windows SDK. DXERR9 was renamed to just DXERR before being totally deprecated and removed by Microsoft.
https://blogs.msdn.microsoft.com/chuckw/2012/04/24/wheres-dxerr-lib/

We were using it to provide i18n error messages to the user when certain operations would fail in the Direct3D9 system. There's a few problems with this. First, we were indiscriminately showing these error messages in run mode and not just debug mode like we do for everything else. Second, the error messages often weren't too descriptive except for ENIGMA developers as opposed to ENIGMA users.

Ideally, I want to remove `DX9Context.h` eventually, which is just adding function call overhead at this point, and bring it more inline with the other systems. This would mean that there wouldn't even be an opportunity to check these hr codes here anyway. At that time, we can switch to checking the `DEBUG_MODE` macro to display error messages to the user. Additionally, as explained in the MSDN blog post above, it will also be possible for us to retrieve i18n messages for the Direct3D errors using the `FormatMessage` API of Win32.

For now, this is just removing us of our reliance on DXERR to make progress on #1490.