### PR TITLE
Direct3D11 Depth Stencil State

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -34,7 +34,6 @@ ID3D11Device* m_device;
 ID3D11DeviceContext* m_deviceContext;
 ID3D11RenderTargetView* m_renderTargetView;
 ID3D11Texture2D* m_depthStencilBuffer;
-ID3D11DepthStencilState* m_depthStencilState;
 ID3D11DepthStencilView* m_depthStencilView;
 ID3D11RasterizerState* m_rasterState;
 
@@ -173,35 +172,6 @@ namespace enigma
     }
 
     initialize_render_targets();
-
-    // Set up the description of the stencil state.
-    D3D11_DEPTH_STENCIL_DESC depthStencilDesc = { };
-    depthStencilDesc.DepthEnable = false;
-    depthStencilDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
-    depthStencilDesc.DepthFunc = D3D11_COMPARISON_LESS;
-
-    depthStencilDesc.StencilEnable = false;
-    depthStencilDesc.StencilReadMask = 0xFF;
-    depthStencilDesc.StencilWriteMask = 0xFF;
-
-    // Stencil operations if pixel is front-facing.
-    depthStencilDesc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
-    depthStencilDesc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_INCR;
-    depthStencilDesc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
-    depthStencilDesc.FrontFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
-
-    // Stencil operations if pixel is back-facing.
-    depthStencilDesc.BackFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
-    depthStencilDesc.BackFace.StencilDepthFailOp = D3D11_STENCIL_OP_DECR;
-    depthStencilDesc.BackFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
-    depthStencilDesc.BackFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
-
-    result = m_device->CreateDepthStencilState(&depthStencilDesc, &m_depthStencilState);
-    if (FAILED(result)) {
-      show_error("Failed to create Direct3D11 depth stencil state.", true);
-    }
-
-    m_deviceContext->OMSetDepthStencilState(m_depthStencilState, 1);
 
     // Setup the raster description which will determine how and what polygons will be drawn.
     D3D11_RASTERIZER_DESC rasterDesc = { };

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.cpp
@@ -32,9 +32,11 @@ unsigned bound_texture=0;
 bool pbo_isgo;
 
 void init_blend_state();
+void init_depth_stencil_state();
 
 void graphicssystem_initialize() {
   init_blend_state();
+  init_depth_stencil_state();
 }
 
 } // namespace enigma


### PR DESCRIPTION
This is a simple change in the same category as #1494 where I am simply reorganizing the depth stencil state to allow toggling of hidden surface removal. Pretty straight-forward, but again I think it should be coming more clear why we would eventually benefit from having some sort of render state manager.

Another concern is performance, even though we are caching the descriptions of the state blocks. Direct3D11 can apparently create up to 4096 instances of the various state block types and will return the same pointer if a similar state is requested. I will need to do more research and benchmarking later though before I will have enough information for us to take advantage of that.

|             | Master | Pull Request |
|-------------|--------|----|
| 3D Cubes    |![3D Cubes Master](https://user-images.githubusercontent.com/3212801/50847307-41d73100-133f-11e9-9310-60a4ba758477.png)|![3D Cubes Pull Request](https://user-images.githubusercontent.com/3212801/50847456-a0041400-133f-11e9-87ce-ce65419ab732.png)|
| fps6        |![fps6 Master](https://user-images.githubusercontent.com/3212801/50847343-59161e80-133f-11e9-969b-b4e711d56436.png)|![fps6 Pull Request](https://user-images.githubusercontent.com/3212801/50847500-be6a0f80-133f-11e9-8e32-04c8e5e90040.png)|
| 3D Platform |![3D Platform Master](https://user-images.githubusercontent.com/3212801/50847365-6b905800-133f-11e9-90cf-7d87d3ef9233.png)|![3D Platform Pull Request](https://user-images.githubusercontent.com/3212801/50847523-d2157600-133f-11e9-864d-2dccb8c78b17.png)|