### PR TITLE
Direct3D11 Sampler State

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.cpp
@@ -33,10 +33,12 @@ bool pbo_isgo;
 
 void init_blend_state();
 void init_depth_stencil_state();
+void init_sampler_state();
 
 void graphicssystem_initialize() {
   init_blend_state();
   init_depth_stencil_state();
+  init_sampler_state();
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
@@ -51,90 +51,117 @@ ID3D11ShaderResourceView *getDefaultWhiteTexture() {
     return textureStructs[texid]->view;
 }
 
+D3D11_SAMPLER_DESC samplerDesc = { };
+
+void update_sampler_state() {
+  static ID3D11SamplerState *pSamplerState = NULL;
+  if (pSamplerState) { pSamplerState->Release(); pSamplerState = NULL; }
+  m_device->CreateSamplerState(&samplerDesc, &pSamplerState);
+  draw_batch_flush(batch_flush_deferred);
+  m_deviceContext->PSSetSamplers(0, 1, &pSamplerState);
+}
+
 } // namespace anonymous
 
-namespace enigma
+namespace enigma {
+
+int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, void* pxdata, bool mipmap)
 {
-  int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, void* pxdata, bool mipmap)
-  {
-    ID3D11Texture2D *tex;
-    D3D11_TEXTURE2D_DESC tdesc;
-    D3D11_SUBRESOURCE_DATA tbsd;
+  ID3D11Texture2D *tex;
+  D3D11_TEXTURE2D_DESC tdesc;
+  D3D11_SUBRESOURCE_DATA tbsd;
 
-    tbsd.pSysMem = pxdata;
-    tbsd.SysMemPitch = fullwidth*4;
-    // not needed since this is a 2d texture,
-    // but we can pass size info for debugging
-    tbsd.SysMemSlicePitch = fullwidth*fullheight*4;
+  tbsd.pSysMem = pxdata;
+  tbsd.SysMemPitch = fullwidth*4;
+  // not needed since this is a 2d texture,
+  // but we can pass size info for debugging
+  tbsd.SysMemSlicePitch = fullwidth*fullheight*4;
 
-    tdesc.Width = fullwidth;
-    tdesc.Height = fullheight;
-    tdesc.MipLevels = 1;
-    tdesc.ArraySize = 1;
+  tdesc.Width = fullwidth;
+  tdesc.Height = fullheight;
+  tdesc.MipLevels = 1;
+  tdesc.ArraySize = 1;
 
-    tdesc.SampleDesc.Count = 1;
-    tdesc.SampleDesc.Quality = 0;
-    tdesc.Usage = D3D11_USAGE_DEFAULT;
-    tdesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
-    tdesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+  tdesc.SampleDesc.Count = 1;
+  tdesc.SampleDesc.Quality = 0;
+  tdesc.Usage = D3D11_USAGE_DEFAULT;
+  tdesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  tdesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 
-    tdesc.CPUAccessFlags = 0;
-    tdesc.MiscFlags = 0;
+  tdesc.CPUAccessFlags = 0;
+  tdesc.MiscFlags = 0;
 
-    if (FAILED(m_device->CreateTexture2D(&tdesc,&tbsd,&tex)))
-      return 0;
+  if (FAILED(m_device->CreateTexture2D(&tdesc,&tbsd,&tex)))
+    return 0;
 
-    D3D11_SHADER_RESOURCE_VIEW_DESC vdesc;
-    vdesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
-    vdesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-    vdesc.Texture2D.MostDetailedMip = 0;
-    vdesc.Texture2D.MipLevels = 1;
+  D3D11_SHADER_RESOURCE_VIEW_DESC vdesc;
+  vdesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  vdesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+  vdesc.Texture2D.MostDetailedMip = 0;
+  vdesc.Texture2D.MipLevels = 1;
 
-    ID3D11ShaderResourceView *view;
-    m_device->CreateShaderResourceView(tex, &vdesc, &view);
+  ID3D11ShaderResourceView *view;
+  m_device->CreateShaderResourceView(tex, &vdesc, &view);
 
-    TextureStruct* textureStruct = new TextureStruct(tex, view);
-    textureStruct->width = width;
-    textureStruct->height = height;
-    textureStruct->fullwidth = fullwidth;
-    textureStruct->fullheight = fullheight;
-    textureStructs.push_back(textureStruct);
-    return textureStructs.size()-1;
-  }
+  TextureStruct* textureStruct = new TextureStruct(tex, view);
+  textureStruct->width = width;
+  textureStruct->height = height;
+  textureStruct->fullwidth = fullwidth;
+  textureStruct->fullheight = fullheight;
+  textureStructs.push_back(textureStruct);
+  return textureStructs.size()-1;
+}
 
-  int graphics_duplicate_texture(int tex, bool mipmap)
-  {
+int graphics_duplicate_texture(int tex, bool mipmap)
+{
 
-  }
+}
 
-  void graphics_copy_texture(int source, int destination, int x, int y)
-  {
+void graphics_copy_texture(int source, int destination, int x, int y)
+{
 
-  }
+}
 
-  void graphics_copy_texture_part(int source, int destination, int xoff, int yoff, int w, int h, int x, int y)
-  {
+void graphics_copy_texture_part(int source, int destination, int xoff, int yoff, int w, int h, int x, int y)
+{
 
-  }
+}
 
-  void graphics_replace_texture_alpha_from_texture(int tex, int copy_tex)
-  {
+void graphics_replace_texture_alpha_from_texture(int tex, int copy_tex)
+{
 
-  }
+}
 
-  void graphics_delete_texture(int tex)
-  {
+void graphics_delete_texture(int tex)
+{
 
-  }
+}
 
-  unsigned char* graphics_get_texture_pixeldata(unsigned texture, unsigned* fullwidth, unsigned* fullheight)
-  {
+unsigned char* graphics_get_texture_pixeldata(unsigned texture, unsigned* fullwidth, unsigned* fullheight)
+{
 
-  }
+}
+
+void init_sampler_state() {
+  samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+  samplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+  samplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+  samplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+  samplerDesc.MipLODBias = 0.0f;
+  samplerDesc.MaxAnisotropy = 1;
+  samplerDesc.ComparisonFunc = D3D11_COMPARISON_ALWAYS;
+  samplerDesc.BorderColor[0] = 0;
+  samplerDesc.BorderColor[1] = 0;
+  samplerDesc.BorderColor[2] = 0;
+  samplerDesc.BorderColor[3] = 0;
+  samplerDesc.MinLOD = 0;
+  samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
+  update_sampler_state();
+}
+
 } // namespace enigma
 
-namespace enigma_user
-{
+namespace enigma_user {
 
 int texture_add(string filename, bool mipmap) {
   unsigned int w, h, fullwidth, fullheight;
@@ -223,12 +250,17 @@ void texture_reset() {
 
 void texture_set_interpolation_ext(int sampler, bool enable)
 {
-
+  samplerDesc.Filter = enable ? D3D11_FILTER_MIN_MAG_MIP_LINEAR : D3D11_FILTER_MIN_MAG_MIP_POINT;
+  update_sampler_state();
 }
 
 void texture_set_repeat_ext(int sampler, bool repeat)
 {
-
+  D3D11_TEXTURE_ADDRESS_MODE addressMode = repeat ? D3D11_TEXTURE_ADDRESS_WRAP : D3D11_TEXTURE_ADDRESS_CLAMP;
+  samplerDesc.AddressU = addressMode;
+  samplerDesc.AddressV = addressMode;
+  samplerDesc.AddressW = addressMode;
+  update_sampler_state();
 }
 
 void texture_set_wrap_ext(int sampler, bool wrapu, bool wrapv, bool wrapw)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
@@ -308,28 +308,6 @@ void graphics_prepare_default_shader() {
     graphics_compile_shader(g_strPS, &pBlobPS, "PS", "PS", "ps_4_0");
     m_device->CreatePixelShader(pBlobPS->GetBufferPointer(), pBlobPS->GetBufferSize(),
                                 NULL, &g_pPixelShader);
-
-    D3D11_SAMPLER_DESC samplerDesc;
-    samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
-    samplerDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-    samplerDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-    samplerDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-    samplerDesc.MipLODBias = 0.0f;
-    samplerDesc.MaxAnisotropy = 1;
-    samplerDesc.ComparisonFunc = D3D11_COMPARISON_ALWAYS;
-    samplerDesc.BorderColor[0] = 0;
-    samplerDesc.BorderColor[1] = 0;
-    samplerDesc.BorderColor[2] = 0;
-    samplerDesc.BorderColor[3] = 0;
-    samplerDesc.MinLOD = 0;
-    samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
-
-    ID3D11SamplerState *samplerState;
-    m_device->CreateSamplerState(
-      &samplerDesc,
-      &samplerState
-    );
-    m_deviceContext->PSSetSamplers(0, 1, &samplerState);
   }
 
   D3D11_MAPPED_SUBRESOURCE mappedResource;


### PR DESCRIPTION
Following #1495 and #1494, I am just shifting around the sampler state to allow you to actually toggle the repetition and interpolation. There is more complicated changes to be made here before it becomes GM compatible. GM's internal rendering is apparently not affected by the user's texture address mode (clamp vs repeat), but is affected by the user's texture filter setting (interpolation; where the default is set in Game Settings).
https://docs.yoyogames.com/source/dadiospice/002_reference/drawing/texture_set_interpolation.html
https://docs.yoyogames.com/source/dadiospice/002_reference/drawing/texture_set_repeat.html

Regardless, for now, this at least improves the fps6 game in D3D11 by having interpolation properly enabled on the walls and billboards.

|      | Master | Pull Request |
|------|--------|--------------|
| fps6 |![fps6 Master](https://user-images.githubusercontent.com/3212801/50902732-af3f9c00-13e9-11e9-929b-3508ed2ce375.png)|![fps6 Pull Request](https://user-images.githubusercontent.com/3212801/50902692-90d9a080-13e9-11e9-9d3b-80f67bfe6fd1.png)|
