### PR TITLE
[TFD] stop doubles from going past 15 digits

### DIFF
--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -47,7 +47,7 @@ using enigma::tfd_DialogEngine;
 using std::string;
 
 static inline string remove_trailing_zeros(string strnumb) {
-  if (strnumb.find('.') != std::string::npos) {
+  if (strnumb.find('.') != string::npos) {
     while (!strnumb.empty() && (strnumb.back() == '0' || strnumb.back() == '.'))
       strnumb.pop_back();
   }

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -295,7 +295,7 @@ double get_integer(string str, double def) {
   else if (caption == "" && tfd_DialogEngine() == tfd_KDialog)
     caption = "KDialog";
 
-  if (def > std::numeric_limits<double>::max()) 
+  if (def > std::numeric_limits<double>::max())
     def = std::numeric_limits<double>::max();
 
   string integer = remove_trailing_zeros(std::to_string(def));
@@ -314,7 +314,7 @@ double get_integer(string str, double def) {
 
   if (input != NULL) {
     if (strtod(input, NULL) > std::numeric_limits<double>::max())
-      return std::numeric_limits<double>::max(); 
+      return std::numeric_limits<double>::max();
   }
 
   return input ? strtod(input, NULL) : 0;
@@ -328,7 +328,7 @@ double get_passcode(string str, double def) {
   else if (caption == "" && tfd_DialogEngine() == tfd_KDialog)
     caption = "KDialog";
 
-  if (def > std::numeric_limits<double>::max()) 
+  if (def > std::numeric_limits<double>::max())
     def = std::numeric_limits<double>::max();
 
   string integer = remove_trailing_zeros(std::to_string(def));

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -48,7 +48,7 @@ using std::string;
 
 static inline string remove_trailing_zeros(string strnumb) {
   if (strnumb.find('.') != string::npos) {
-    while (!strnumb.empty() && (strnumb.back() == '0' || strnumb.back() == '.'))
+    while (!strnumb.empty() && strnumb != '0' && (strnumb.back() == '0' || strnumb.back() == '.'))
       strnumb.pop_back();
   }
   return strnumb;

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <vector>
 #include <string>
+#include <limits>
 
 #ifdef DEBUG_MODE
 #include "Universal_System/var4.h"
@@ -294,8 +295,8 @@ double get_integer(string str, double def) {
   else if (caption == "" && tfd_DialogEngine() == tfd_KDialog)
     caption = "KDialog";
 
-  if (def > (2 << 56 - 1)) 
-    def = (2 << 56 - 1);
+  if (def > std::numeric_limits<double>::max()) 
+    def = std::numeric_limits<double>::max();
 
   string integer = remove_trailing_zeros(std::to_string(def));
 
@@ -312,8 +313,8 @@ double get_integer(string str, double def) {
   const char *input = tinyfd_inputBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
   if (input != NULL) {
-    if (strtod(input, NULL) > (2 << 56 - 1))
-      return (2 << 56 - 1);
+    if (strtod(input, NULL) > std::numeric_limits<double>::max())
+      return std::numeric_limits<double>::max();
   }
 
   return input ? strtod(input, NULL) : 0;
@@ -327,8 +328,8 @@ double get_passcode(string str, double def) {
   else if (caption == "" && tfd_DialogEngine() == tfd_KDialog)
     caption = "KDialog";
 
-  if (def > (2 << 56 - 1)) 
-    def = (2 << 56 - 1);
+  if (def > std::numeric_limits<double>::max()) 
+    def = std::numeric_limits<double>::max();
 
   string integer = remove_trailing_zeros(std::to_string(def));
 
@@ -345,8 +346,8 @@ double get_passcode(string str, double def) {
   const char *input = tinyfd_passwordBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
   if (input != NULL) {
-    if (strtod(input, NULL) > (2 << 56 - 1))
-      return (2 << 56 - 1);
+    if (strtod(input, NULL) > std::numeric_limits<double>::max())
+      return std::numeric_limits<double>::max();
   }
 
   return input ? strtod(input, NULL) : 0;

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -294,8 +294,8 @@ double get_integer(string str, double def) {
   else if (caption == "" && tfd_DialogEngine() == tfd_KDialog)
     caption = "KDialog";
 
-  if (def > 999999999999999) 
-    def = 999999999999999;
+  if (def > (2 << 56 - 1)) 
+    def = (2 << 56 - 1);
 
   string integer = remove_trailing_zeros(std::to_string(def));
 
@@ -312,8 +312,8 @@ double get_integer(string str, double def) {
   const char *input = tinyfd_inputBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
   if (input != NULL) {
-    if (strtod(input, NULL) > 999999999999999)
-      return 999999999999999;
+    if (strtod(input, NULL) > (2 << 56 - 1))
+      return (2 << 56 - 1);
   }
 
   return input ? strtod(input, NULL) : 0;
@@ -327,8 +327,8 @@ double get_passcode(string str, double def) {
   else if (caption == "" && tfd_DialogEngine() == tfd_KDialog)
     caption = "KDialog";
 
-  if (def > 999999999999999) 
-    def = 999999999999999;
+  if (def > (2 << 56 - 1)) 
+    def = (2 << 56 - 1);
 
   string integer = remove_trailing_zeros(std::to_string(def));
 
@@ -345,8 +345,8 @@ double get_passcode(string str, double def) {
   const char *input = tinyfd_passwordBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
   if (input != NULL) {
-    if (strtod(input, NULL) > 999999999999999)
-      return 999999999999999;
+    if (strtod(input, NULL) > (2 << 56 - 1))
+      return (2 << 56 - 1);
   }
 
   return input ? strtod(input, NULL) : 0;

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -287,9 +287,10 @@ double get_integer(string str, double def) {
   else if (caption == "" && tfd_DialogEngine() == tfd_KDialog)
     caption = "KDialog";
 
-  std::ostringstream def_integer;
-  def_integer << def;
-  string integer = def_integer.str();
+  if (def > 999999999999999) 
+    def = 999999999999999;
+
+  string integer = std::to_string(def);
 
   string msg;
 
@@ -303,6 +304,9 @@ double get_integer(string str, double def) {
 
   const char *input = tinyfd_inputBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
+  if (strtod(result, NULL) > 999999999999999)
+    return 999999999999999;
+
   return input ? strtod(input, NULL) : 0;
 }
 
@@ -314,9 +318,10 @@ double get_passcode(string str, double def) {
   else if (caption == "" && tfd_DialogEngine() == tfd_KDialog)
     caption = "KDialog";
 
-  std::ostringstream def_integer;
-  def_integer << def;
-  string integer = def_integer.str();
+  if (def > 999999999999999) 
+    def = 999999999999999;
+
+  string integer = std::to_string(def);
 
   string msg;
 
@@ -329,6 +334,9 @@ double get_passcode(string str, double def) {
   caption = tfd_add_escaping(caption);
 
   const char *input = tinyfd_passwordBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
+
+  if (strtod(result, NULL) > 999999999999999)
+    return 999999999999999;
 
   return input ? strtod(input, NULL) : 0;
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -314,7 +314,7 @@ double get_integer(string str, double def) {
 
   if (input != NULL) {
     if (strtod(input, NULL) > std::numeric_limits<double>::max())
-      return std::numeric_limits<double>::max();
+      return std::numeric_limits<double>::max(); 
   }
 
   return input ? strtod(input, NULL) : 0;

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -46,6 +46,14 @@ using enigma::tfd_DialogEngine;
 
 using std::string;
 
+static inline string remove_trailing_zeros(string strnumb) {
+  if (strnumb.find('.') != std::string::npos) {
+    while (!strnumb.empty() && (strnumb.back() == '0' || strnumb.back() == '.'))
+      strnumb.pop_back();
+  }
+  return strnumb;
+}
+
 namespace enigma {
   
 bool widget_system_initialize() {
@@ -290,7 +298,7 @@ double get_integer(string str, double def) {
   if (def > 999999999999999) 
     def = 999999999999999;
 
-  string integer = std::to_string(def);
+  string integer = remove_trailing_zeros(std::to_string(def));
 
   string msg;
 
@@ -304,7 +312,7 @@ double get_integer(string str, double def) {
 
   const char *input = tinyfd_inputBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
-  if (strtod(result, NULL) > 999999999999999)
+  if (strtod(input, NULL) > 999999999999999)
     return 999999999999999;
 
   return input ? strtod(input, NULL) : 0;
@@ -321,7 +329,7 @@ double get_passcode(string str, double def) {
   if (def > 999999999999999) 
     def = 999999999999999;
 
-  string integer = std::to_string(def);
+  string integer = remove_trailing_zeros(std::to_string(def));
 
   string msg;
 
@@ -335,7 +343,7 @@ double get_passcode(string str, double def) {
 
   const char *input = tinyfd_passwordBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
-  if (strtod(result, NULL) > 999999999999999)
+  if (strtod(input, NULL) > 999999999999999)
     return 999999999999999;
 
   return input ? strtod(input, NULL) : 0;

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <libgen.h>
 #include <string.h>
-#include <sstream>
 #include <vector>
 #include <string>
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -48,7 +48,7 @@ using std::string;
 
 static inline string remove_trailing_zeros(string strnumb) {
   if (strnumb.find('.') != string::npos) {
-    while (!strnumb.empty() && strnumb != '0' && (strnumb.back() == '0' || strnumb.back() == '.'))
+    while (!strnumb.empty() && strnumb != "0" && (strnumb.back() == '0' || strnumb.back() == '.'))
       strnumb.pop_back();
   }
   return strnumb;

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -311,8 +311,10 @@ double get_integer(string str, double def) {
 
   const char *input = tinyfd_inputBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
-  if (strtod(input, NULL) > 999999999999999)
-    return 999999999999999;
+  if (input != NULL) {
+    if (strtod(input, NULL) > 999999999999999)
+      return 999999999999999;
+  }
 
   return input ? strtod(input, NULL) : 0;
 }
@@ -342,8 +344,10 @@ double get_passcode(string str, double def) {
 
   const char *input = tinyfd_passwordBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
-  if (strtod(input, NULL) > 999999999999999)
-    return 999999999999999;
+  if (input != NULL) {
+    if (strtod(input, NULL) > 999999999999999)
+      return 999999999999999;
+  }
 
   return input ? strtod(input, NULL) : 0;
 }


### PR DESCRIPTION
I knew about this for quite some time but didn't feel like fixing it until just now, because people technically could fix this issue in their EDL/GML if they really wanted to. This auto-fixes an issue where get_integer() and get_passcode() would would have glitchy default or return value for the textbox if more than 999,999,999,999,999 used as default or returned.