### PR TITLE
Add game_save_id

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -65,7 +65,9 @@ void initialize_directory_globals() {
   uint32_t bufsize = sizeof(buffer);
   
   // we need to do this again because dirname modifies its argument
-  if (_NSGetExecutablePath(buffer, &bufsize) == 0 && env != NULL) {
+  bool exe = (_NSGetExecutablePath(buffer, &bufsize) == 0);
+  
+  if (exe && env != NULL) {
     enigma_user::game_save_id = add_slash(string(env)) + string(".config/");
     enigma_user::game_save_id += add_slash(basename(buffer));
   }

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -50,16 +50,24 @@ void initialize_directory_globals() {
   char buffer[PATH_MAX + 1];
   if (getcwd(buffer, PATH_MAX + 1) != NULL)
     enigma_user::working_directory = add_slash(buffer);
-  
-  // Set the game_save_id
-  enigma_user::game_save_id = enigma_user::working_directory;
 
   // Set the program_directory
   buffer[0] = 0;
-
   uint32_t bufsize = sizeof(buffer);
+  
   if (_NSGetExecutablePath(buffer, &bufsize) == 0) {
     enigma_user::program_directory = add_slash(dirname(buffer));
+  }
+  
+  // Set the game_save_id
+  buffer[0] = 0;
+  char *env = getenv("HOME");
+  uint32_t bufsize = sizeof(buffer);
+  
+  // we need to do this again because dirname modifies its argument
+  if (_NSGetExecutablePath(buffer, &bufsize) == 0 && env != NULL) {
+    enigma_user::game_save_id = add_slash(string(env)) + string(".config/");
+    enigma_user::game_save_id += add_slash(basename(buffer));
   }
 
   // Set the temp_directory

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -63,7 +63,6 @@ void initialize_directory_globals() {
   buffer[0] = 0;
   char *env = getenv("HOME");
   uint32_t bufsize = sizeof(buffer);
-  
   // we need to do this again because dirname modifies its argument
   bool exe = (_NSGetExecutablePath(buffer, &bufsize) == 0);
   

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -62,7 +62,7 @@ void initialize_directory_globals() {
   
   // Set the game_save_id
   buffer[0] = 0;
-  char *env = getenv("HOME");
+  env = getenv("HOME");
   uint32_t bufsize = sizeof(buffer);
   // we need to do this again because dirname modifies its argument
   bool exe = (_NSGetExecutablePath(buffer, &bufsize) == 0);

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -68,7 +68,9 @@ void initialize_directory_globals() {
   
   if (exe && env != NULL) {
     enigma_user::game_save_id = add_slash(string(env)) + string(".config/");
+    mkdir(enigma_user::game_save_id.c_str(), 777);
     enigma_user::game_save_id += add_slash(basename(buffer));
+    mkdir(enigma_user::game_save_id.c_str(), 777);
   }
 
   // Set the temp_directory

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -50,6 +50,9 @@ void initialize_directory_globals() {
   char buffer[PATH_MAX + 1];
   if (getcwd(buffer, PATH_MAX + 1) != NULL)
     enigma_user::working_directory = add_slash(buffer);
+  
+  // Set the game_save_id
+  enigma_user::game_save_id = enigma_user::working_directory;
 
   // Set the program_directory
   buffer[0] = 0;

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -62,8 +62,8 @@ void initialize_directory_globals() {
   
   // Set the game_save_id
   buffer[0] = 0;
-  env = getenv("HOME");
-  uint32_t bufsize = sizeof(buffer);
+  char *env = getenv("HOME");
+  bufsize = sizeof(buffer);
   // we need to do this again because dirname modifies its argument
   bool exe = (_NSGetExecutablePath(buffer, &bufsize) == 0);
   
@@ -75,7 +75,7 @@ void initialize_directory_globals() {
   }
 
   // Set the temp_directory
-  char *env = getenv("TMPDIR");
+  env = getenv("TMPDIR");
 
   if (env != NULL)
     enigma_user::temp_directory = add_slash(env);

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -21,6 +21,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include <mach-o/dyld.h>
 #include <limits.h>
 #include "CocoaMain.h"

--- a/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Cocoa/CocoaMain.cpp
@@ -62,8 +62,8 @@ void initialize_directory_globals() {
   
   // Set the game_save_id
   buffer[0] = 0;
-  char *env = getenv("HOME");
   bufsize = sizeof(buffer);
+  char *env = getenv("HOME");
   // we need to do this again because dirname modifies its argument
   bool exe = (_NSGetExecutablePath(buffer, &bufsize) == 0);
   

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -100,6 +100,7 @@ namespace enigma_user {
 
 const int os_browser = browser_not_a_browser;
 std::string working_directory = "";
+std::string game_save_id = "";
 std::string program_directory = "";
 std::string temp_directory = "";
 std::string keyboard_string = "";

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -100,9 +100,9 @@ namespace enigma_user {
 
 const int os_browser = browser_not_a_browser;
 std::string working_directory = "";
-std::string game_save_id = "";
 std::string program_directory = "";
 std::string temp_directory = "";
+std::string game_save_id = "";
 std::string keyboard_string = "";
 int keyboard_key = 0;
 double fps = 0;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -101,8 +101,8 @@ namespace enigma_user {
 const int os_browser = browser_not_a_browser;
 std::string working_directory = "";
 std::string program_directory = "";
-std::string temp_directory = "";
 std::string game_save_id = "";
+std::string temp_directory = "";
 std::string keyboard_string = "";
 int keyboard_key = 0;
 double fps = 0;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -48,9 +48,9 @@ namespace enigma {
 namespace enigma_user {
 
 extern std::string working_directory;
-extern std::string game_save_id;
 extern std::string program_directory;
 extern std::string temp_directory;
+extern std::string game_save_id;
 extern std::string keyboard_string;
 extern int keyboard_key;
 extern double fps;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -49,8 +49,8 @@ namespace enigma_user {
 
 extern std::string working_directory;
 extern std::string program_directory;
-extern std::string temp_directory;
 extern std::string game_save_id;
+extern std::string temp_directory;
 extern std::string keyboard_string;
 extern int keyboard_key;
 extern double fps;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -48,6 +48,7 @@ namespace enigma {
 namespace enigma_user {
 
 extern std::string working_directory;
+extern std::string game_save_id;
 extern std::string program_directory;
 extern std::string temp_directory;
 extern std::string keyboard_string;

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -18,7 +18,6 @@ bool set_working_directory(string dname) {
     char buffer[PATH_MAX + 1]; 
     if (getcwd(buffer, PATH_MAX + 1) != NULL) {
       working_directory = add_slash(buffer);
-      game_save_id = working_directory;
       return true;
     }
   }

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -18,6 +18,7 @@ bool set_working_directory(string dname) {
     char buffer[PATH_MAX + 1]; 
     if (getcwd(buffer, PATH_MAX + 1) != NULL) {
       working_directory = add_slash(buffer);
+      game_save_id = working_directory;
       return true;
     }
   }

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
@@ -29,10 +29,10 @@ void initialize_directory_globals() {
 
   // Set the game_save_id
   buffer[0] = 0;
+  char *env = getenv("HOME");
   // we need to do this again because dirname modifies its argument
   ssize_t count = readlink("/proc/self/exe", buffer, PATH_MAX + 1);
-  char *env = getenv("HOME");
-
+  
   if (count != -1 && env != NULL) {
     enigma_user::game_save_id = add_slash(string(env)) + string(".config/");
     enigma_user::game_save_id += add_slash(basename(buffer));

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
@@ -1,5 +1,6 @@
 #include "Platforms/General/PFmain.h"
 
+#include <sys/stat.h>
 #include <limits.h>
 #include <unistd.h>
 #include <libgen.h>

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
@@ -42,7 +42,7 @@ void initialize_directory_globals() {
   }
 
   // Set the temp_directory
-  char *env = getenv("TMPDIR");
+  env = getenv("TMPDIR");
 
   if (env != NULL)
     enigma_user::temp_directory = add_slash(env);

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
@@ -35,7 +35,9 @@ void initialize_directory_globals() {
   
   if (count != -1 && env != NULL) {
     enigma_user::game_save_id = add_slash(string(env)) + string(".config/");
+    mkdir(enigma_user::game_save_id.c_str(), 777);
     enigma_user::game_save_id += add_slash(basename(buffer));
+    mkdir(enigma_user::game_save_id.c_str(), 777);
   }
 
   // Set the temp_directory

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
@@ -20,6 +20,9 @@ void initialize_directory_globals() {
   char buffer[PATH_MAX + 1];
   if (getcwd(buffer, PATH_MAX + 1) != NULL)
     enigma_user::working_directory = add_slash(buffer);
+  
+  // Set the game_save_id
+  enigma_user::game_save_id = enigma_user::working_directory;
 
   // Set the program_directory
   buffer[0] = 0;

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
@@ -20,15 +20,23 @@ void initialize_directory_globals() {
   char buffer[PATH_MAX + 1];
   if (getcwd(buffer, PATH_MAX + 1) != NULL)
     enigma_user::working_directory = add_slash(buffer);
-  
-  // Set the game_save_id
-  enigma_user::game_save_id = enigma_user::working_directory;
 
   // Set the program_directory
   buffer[0] = 0;
   ssize_t count = readlink("/proc/self/exe", buffer, PATH_MAX + 1);
   if (count !=  -1)
     enigma_user::program_directory = add_slash(dirname(buffer));
+
+  // Set the game_save_id
+  buffer[0] = 0;
+  // we need to do this again because dirname modifies its argument
+  ssize_t count = readlink("/proc/self/exe", buffer, PATH_MAX + 1);
+  char *env = getenv("HOME");
+
+  if (count != -1 && env != NULL) {
+    enigma_user::game_save_id = add_slash(string(env)) + string(".config/");
+    enigma_user::game_save_id += add_slash(basename(buffer));
+  }
 
   // Set the temp_directory
   char *env = getenv("TMPDIR");

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/main.cpp
@@ -32,7 +32,7 @@ void initialize_directory_globals() {
   buffer[0] = 0;
   char *env = getenv("HOME");
   // we need to do this again because dirname modifies its argument
-  ssize_t count = readlink("/proc/self/exe", buffer, PATH_MAX + 1);
+  count = readlink("/proc/self/exe", buffer, PATH_MAX + 1);
   
   if (count != -1 && env != NULL) {
     enigma_user::game_save_id = add_slash(string(env)) + string(".config/");

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Main.cpp
@@ -4,7 +4,11 @@
 
 namespace enigma {
     void initialize_directory_globals() {
-      enigma_user::working_directory = SDL_GetBasePath(); 
+      // Set the working_directory
+      enigma_user::working_directory = SDL_GetBasePath();
+      
+      // Set the game_save_id
+      enigma_user::game_save_id = enigma_user::working_directory;
     }
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Main.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Main.cpp
@@ -6,9 +6,6 @@ namespace enigma {
     void initialize_directory_globals() {
       // Set the working_directory
       enigma_user::working_directory = SDL_GetBasePath();
-      
-      // Set the game_save_id
-      enigma_user::game_save_id = enigma_user::working_directory;
     }
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -326,14 +326,14 @@ void initialize_directory_globals() {
   
   // Set the game_save_id
   enigma_user::game_save_id = shorten(buffer);
-  size_t pos = enigma_user::game_save_id.find_last_of("\\/");
+  size_t pos = enigma_user::game_save_id.find_last_of("\\/") + 1;
   size_t len = enigma_user::game_save_id.find_last_of(".") - pos;
   enigma_user::game_save_id = enigma_user::game_save_id.substr(pos, len);
   
   buffer[0] = 0;
   tstring env = widen("LOCALAPPDATA");
   GetEnvironmentVariableW(env.c_str(), buffer, MAX_PATH + 1);
-  enigma_user::game_save_id = add_slash(shorten(buffer) + enigma_user::game_save_id);
+  enigma_user::game_save_id = add_slash(shorten(buffer)) + add_slash(enigma_user::game_save_id);
   tstring tstr_game_save_id =  widen(enigma_user::game_save_id);
   CreateDirectoryW(tstr_game_save_id.c_str(), NULL);
   

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -78,7 +78,6 @@ bool set_working_directory(string dname) {
     WCHAR wstr_buffer[MAX_PATH + 1];
     if (GetCurrentDirectoryW(MAX_PATH + 1, wstr_buffer) != 0) {
       working_directory = add_slash(shorten(wstr_buffer));
-      game_save_id = working_directory;
       return true;
     }
   }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -316,9 +316,6 @@ void initialize_directory_globals() {
   WCHAR buffer[MAX_PATH + 1];
   GetCurrentDirectoryW(MAX_PATH + 1, buffer);
   enigma_user::working_directory = add_slash(shorten(buffer));
-  
-  // Set the game_save_id
-  enigma_user::game_save_id = enigma_user::working_directory;
 
   // Set the program_directory
   buffer[0] = 0;
@@ -326,6 +323,17 @@ void initialize_directory_globals() {
   enigma_user::program_directory = shorten(buffer);
   enigma_user::program_directory =
     enigma_user::program_directory.substr(0, enigma_user::program_directory.find_last_of("\\/"));
+  
+  // Set the game_save_id
+  enigma_user::game_save_id = shorten(buffer);
+  size_t pos = enigma_user::game_save_id.find_last_of("\\/");
+  size_t len = enigma_user::game_save_id.find_last_of(".") - pos;
+  enigma_user::game_save_id = enigma_user::game_save_id.substr(pos, len);
+  
+  buffer[0] = 0;
+  tstring env = widen("LOCALAPPDATA");
+  GetEnvironmentVariableW(env.c_str(), buffer, MAX_PATH + 1);
+  enigma_user::game_save_id = add_slash(shorten(buffer) + enigma_user::game_save_id);
   
   // Set the temp_directory
   buffer[0] = 0;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -328,11 +328,7 @@ void initialize_directory_globals() {
   enigma_user::game_save_id = shorten(buffer);
   size_t pos = enigma_user::game_save_id.find_last_of("\\/");
   size_t len = enigma_user::game_save_id.find_last_of(".") - pos;
-  if (enigma_user::game_save_id.find(".tmp",
-    enigma_user::game_save_id.find_last_of(".")) != std::string::npos)
-    enigma_user::game_save_id = enigma_user::game_save_id.substr(pos);
-  else
-    enigma_user::game_save_id = enigma_user::game_save_id.substr(pos, len);
+  enigma_user::game_save_id = enigma_user::game_save_id.substr(pos, len);
   
   buffer[0] = 0;
   tstring env = widen("LOCALAPPDATA");

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -333,7 +333,7 @@ void initialize_directory_globals() {
   buffer[0] = 0;
   tstring env = widen("LOCALAPPDATA");
   GetEnvironmentVariableW(env.c_str(), buffer, MAX_PATH + 1);
-  enigma_user::game_save_id = add_slash(shorten(buffer) + enigma_user::game_save_id);
+  enigma_user::game_save_id = add_slash(shorten(buffer)) + add_slash(enigma_user::game_save_id);
   tstring tstr_game_save_id =  widen(enigma_user::game_save_id);
   CreateDirectoryW(tstr_game_save_id.c_str(), NULL);
   

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -328,11 +328,11 @@ void initialize_directory_globals() {
   enigma_user::game_save_id = shorten(buffer);
   size_t pos = enigma_user::game_save_id.find_last_of("\\/");
   size_t len = enigma_user::game_save_id.find_last_of(".") - pos;
-  if (enigma_user::game_save_id.find(".tmp", 
+  if (enigma_user::game_save_id.find(".tmp",
     enigma_user::game_save_id.find_last_of(".")) != std::string::npos)
-    enigma_user::game_save_id = enigma_user::game_save_id.substr(pos, len);
-  else
     enigma_user::game_save_id = enigma_user::game_save_id.substr(pos);
+  else
+    enigma_user::game_save_id = enigma_user::game_save_id.substr(pos, len);
   
   buffer[0] = 0;
   tstring env = widen("LOCALAPPDATA");

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -334,6 +334,8 @@ void initialize_directory_globals() {
   tstring env = widen("LOCALAPPDATA");
   GetEnvironmentVariableW(env.c_str(), buffer, MAX_PATH + 1);
   enigma_user::game_save_id = add_slash(shorten(buffer) + enigma_user::game_save_id);
+  tstring tstr_game_save_id =  widen(enigma_user::game_save_id);
+  CreateDirectoryW(tstr_game_save_id.c_str(), NULL);
   
   // Set the temp_directory
   buffer[0] = 0;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -78,6 +78,7 @@ bool set_working_directory(string dname) {
     WCHAR wstr_buffer[MAX_PATH + 1];
     if (GetCurrentDirectoryW(MAX_PATH + 1, wstr_buffer) != 0) {
       working_directory = add_slash(shorten(wstr_buffer));
+      game_save_id = working_directory;
       return true;
     }
   }
@@ -316,6 +317,9 @@ void initialize_directory_globals() {
   WCHAR buffer[MAX_PATH + 1];
   GetCurrentDirectoryW(MAX_PATH + 1, buffer);
   enigma_user::working_directory = add_slash(shorten(buffer));
+  
+  // Set the game_save_id
+  enigma_user::game_save_id = enigma_user::working_directory;
 
   // Set the program_directory
   buffer[0] = 0;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -328,7 +328,11 @@ void initialize_directory_globals() {
   enigma_user::game_save_id = shorten(buffer);
   size_t pos = enigma_user::game_save_id.find_last_of("\\/");
   size_t len = enigma_user::game_save_id.find_last_of(".") - pos;
-  enigma_user::game_save_id = enigma_user::game_save_id.substr(pos, len);
+  if (enigma_user::game_save_id.find(".tmp", 
+    enigma_user::game_save_id.find_last_of(".")) != std::string::npos)
+    enigma_user::game_save_id = enigma_user::game_save_id.substr(pos, len);
+  else
+    enigma_user::game_save_id = enigma_user::game_save_id.substr(pos);
   
   buffer[0] = 0;
   tstring env = widen("LOCALAPPDATA");

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -333,7 +333,7 @@ void initialize_directory_globals() {
   buffer[0] = 0;
   tstring env = widen("LOCALAPPDATA");
   GetEnvironmentVariableW(env.c_str(), buffer, MAX_PATH + 1);
-  enigma_user::game_save_id = add_slash(shorten(buffer)) + add_slash(enigma_user::game_save_id);
+  enigma_user::game_save_id = add_slash(shorten(buffer) + enigma_user::game_save_id);
   tstring tstr_game_save_id =  widen(enigma_user::game_save_id);
   CreateDirectoryW(tstr_game_save_id.c_str(), NULL);
   


### PR DESCRIPTION
This is almost exactly how GM does it, apart from the fact we do not build application bundles automatically yet, so I had to take a different approach on Mac that was more similar to the Linux method.

On Windows, this is what game_save_id returns in this PR:
`"C:\Users\[UserName]\AppData\Local\[GameName]\"`

On Mac, this is what game_save_id returns in this PR:
`"/Users/[UserName]/.config/[GameName]/"`

On Linux, this is what game_save_id returns in this PR:
`"/home/[UserName]/.config/[GameName]/"`

Demo Executable (Windows): [[GameName].zip](https://github.com/enigma-dev/enigma-dev/files/2760122/GameName.zip)

https://docs.yoyogames.com/source/dadiospice/002_reference/miscellaneous/game_save_id.html

