### PR TITLE
Switch OpenGL3 From RGBA to BGRA Vertex Color Format

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -136,7 +136,7 @@ void graphics_apply_vertex_format(int format, size_t offset) {
       case vertex_type_float2: elements = 2; size = 2; break;
       case vertex_type_float3: elements = 3; size = 3; break;
       case vertex_type_float4: elements = 4; size = 4; break;
-      case vertex_type_color: elements = 4; size = 1; type = GL_UNSIGNED_BYTE; break;
+      case vertex_type_color: elements = GL_BGRA; size = 1; type = GL_UNSIGNED_BYTE; break;
       case vertex_type_ubyte4: elements = 4; size = 1; type = GL_UNSIGNED_BYTE; break;
     }
 
@@ -195,12 +195,11 @@ void graphics_apply_vertex_format(int format, size_t offset) {
 namespace enigma_user {
 
 void vertex_argb(int buffer, unsigned argb) {
-  enigma::color_t finalcol = (COL_GET_A(argb) << 24) | (COL_GET_R(argb) << 16) | (COL_GET_G(argb) << 8) | COL_GET_B(argb);
-  enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
+  enigma::vertexBuffers[buffer]->vertices.push_back(argb);
 }
 
 void vertex_color(int buffer, int color, double alpha) {
-  enigma::color_t finalcol = color + (CLAMP_ALPHA(alpha) << 24);
+  enigma::color_t finalcol = (CLAMP_ALPHA(alpha) << 24) | (COL_GET_R(color) << 16) | (COL_GET_G(color) << 8) | COL_GET_B(color);
   enigma::vertexBuffers[buffer]->vertices.push_back(finalcol);
 }
 


### PR DESCRIPTION
This pull request is a companion of #1502 and switches the GL3 system to upload vertex color in the same format as our Direct3D systems. Essentially the `vertex_color` and `vertex_argb` functions in GL3 are changed to be the same as D3D11 and D3D9. This means the in-memory format of the vertex buffer data is now BGRA (notice it's ARGB backwards?) for color values instead of RGBA.

This change is accomplished by specifying `GL_BGRA` to `glVertexAttribPointer` for the size of color attributes. This feature was first introduced by the `EXT_vertex_array_bgra` extension written against GL2.1 (but may be available in GL1.1 and up). You'll notice the extension also mentions `DXGI_FORMAT_B8G8R8A8_UNORM` which I discussed in #1502 since I switched D3D11 to use that for the vertex color format to fix the color channel mixup.
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml
https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_vertex_array_bgra.txt

This pull request has no actual changes to the compatibility of any games, it just changes the vertex buffer in memory to be in the BGRA format instead of the RGBA format. The only thing this may improve is the compatibility of certain extensions to ENIGMA ported over from GM.