### PR TITLE
Switch Direct3D11 Swap Chain Format From RGBA to BGRA

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -146,7 +146,7 @@ namespace enigma
     swapChainDesc.BufferCount = 1;
     swapChainDesc.BufferDesc.Width = screenWidth;
     swapChainDesc.BufferDesc.Height = screenHeight;
-    swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    swapChainDesc.BufferDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
     swapChainDesc.BufferDesc.RefreshRate.Numerator = 0;
     swapChainDesc.BufferDesc.RefreshRate.Denominator = 1;
     swapChainDesc.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;


### PR DESCRIPTION
As far as I know, this change should make little fucking difference, but I did confirm, thanks to @rpjohnst, through an apitrace that GMS2 uses a BGRA swap chain format. This doesn't change any games, but we may as well use it for compatibility. This is important for extension compatibility in case people start messing with the device using `window_device` or something to that effect.

![GMS2 BGRA Swap Chain Format](https://user-images.githubusercontent.com/3212801/51421591-34574d80-1b6e-11e9-8780-70ad8a71baeb.png)
