### PR TITLE
Direct3D Blend State Cleanup

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
@@ -58,11 +58,9 @@ namespace enigma_user
 
 int draw_set_blend_mode(int mode) {
   const static D3D11_BLEND dest_modes[] = {D3D11_BLEND_INV_SRC_ALPHA,D3D11_BLEND_ONE,D3D11_BLEND_INV_SRC_COLOR,D3D11_BLEND_INV_SRC_COLOR};
-  const static D3D11_BLEND_OP blend_ops[] = {D3D11_BLEND_OP_ADD,D3D11_BLEND_OP_ADD,D3D11_BLEND_OP_SUBTRACT,D3D11_BLEND_OP_MAX};
 
   blendStateDesc.RenderTarget[0].SrcBlendAlpha = blendStateDesc.RenderTarget[0].SrcBlend = (mode == bm_subtract) ? D3D11_BLEND_ZERO : D3D11_BLEND_SRC_ALPHA;
   blendStateDesc.RenderTarget[0].DestBlendAlpha = blendStateDesc.RenderTarget[0].DestBlend = dest_modes[mode % 4];
-  blendStateDesc.RenderTarget[0].BlendOpAlpha = blendStateDesc.RenderTarget[0].BlendOp = blend_ops[mode % 4];
 
   update_blend_state();
   return 0;
@@ -77,7 +75,6 @@ int draw_set_blend_mode_ext(int src, int dest) {
 
   blendStateDesc.RenderTarget[0].SrcBlendAlpha = blendStateDesc.RenderTarget[0].SrcBlend = blend_equivs[(src-1)%11];
   blendStateDesc.RenderTarget[0].DestBlendAlpha = blendStateDesc.RenderTarget[0].DestBlend = blend_equivs[(src-1)%11];
-  blendStateDesc.RenderTarget[0].BlendOpAlpha = blendStateDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
 
   update_blend_state();
   return 0;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9blend.cpp
@@ -1,4 +1,4 @@
-/** Copyright (C) 2013 Robert B. Colton
+/** Copyright (C) 2013, 2019 Robert B. Colton
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***
@@ -29,63 +29,45 @@ namespace enigma
 namespace enigma_user
 {
 
-int draw_set_blend_mode(int mode){
-    if (enigma::currentblendmode[0] == mode && enigma::currentblendtype == 0) return 0;
-    draw_batch_flush(batch_flush_deferred);
-    enigma::currentblendmode[0] = mode;
-    enigma::currentblendtype = 0;
-	switch (mode)
-	{
-    case bm_add:
-		d3dmgr->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
-		d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
-		d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
-      return 0;
-    case bm_max:
-		d3dmgr->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_MAX);
-		d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
-		d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCCOLOR);
-      return 0;
-    case bm_subtract:
-		d3dmgr->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_SUBTRACT);
-		d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ZERO);
-		d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCCOLOR);
-      return 0;
-    default:
-		// bm_normal
-        d3dmgr->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
-		d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
-		d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
-      return 0;
-  }
+int draw_set_blend_mode(int mode) {
+  if (enigma::currentblendmode[0] == mode && enigma::currentblendtype == 0) return 0;
+  draw_batch_flush(batch_flush_deferred);
+  const static D3DBLEND dest_modes[] = {D3DBLEND_INVSRCALPHA,D3DBLEND_ONE,D3DBLEND_INVSRCCOLOR,D3DBLEND_INVSRCCOLOR};
+  enigma::currentblendmode[0] = mode;
+  enigma::currentblendtype = 0;
+  d3dmgr->SetRenderState(D3DRS_SRCBLEND, (mode == bm_subtract) ? D3DBLEND_ZERO : D3DBLEND_SRCALPHA);
+  d3dmgr->SetRenderState(D3DRS_DESTBLEND, dest_modes[mode % 4]);
+
+  return 0;
 }
 
 int draw_set_blend_mode_ext(int src, int dest){
   if (enigma::currentblendmode[0] == src && enigma::currentblendmode[1] == dest && enigma::currentblendtype == 1) return 0;
   draw_batch_flush(batch_flush_deferred);
-  const static D3DBLEND blendequivs[11] = {
-	  D3DBLEND_ZERO, D3DBLEND_ONE, D3DBLEND_SRCCOLOR, D3DBLEND_INVSRCCOLOR, D3DBLEND_SRCALPHA,
-	  D3DBLEND_INVSRCALPHA, D3DBLEND_DESTALPHA, D3DBLEND_INVDESTALPHA, D3DBLEND_DESTCOLOR,
-	  D3DBLEND_INVDESTCOLOR, D3DBLEND_SRCALPHASAT
+  const static D3DBLEND blendequivs[] = {
+    D3DBLEND_ZERO, D3DBLEND_ONE, D3DBLEND_SRCCOLOR, D3DBLEND_INVSRCCOLOR, D3DBLEND_SRCALPHA,
+    D3DBLEND_INVSRCALPHA, D3DBLEND_DESTALPHA, D3DBLEND_INVDESTALPHA, D3DBLEND_DESTCOLOR,
+    D3DBLEND_INVDESTCOLOR, D3DBLEND_SRCALPHASAT
   };
   enigma::currentblendtype = 1;
   enigma::currentblendmode[0] = src;
   enigma::currentblendmode[1] = dest;
-  d3dmgr->SetRenderState(D3DRS_SRCBLEND, blendequivs[(src-1)%10]);
-  d3dmgr->SetRenderState(D3DRS_DESTBLEND, blendequivs[(dest-1)%10]);
+  d3dmgr->SetRenderState(D3DRS_SRCBLEND, blendequivs[(src-1)%11]);
+  d3dmgr->SetRenderState(D3DRS_DESTBLEND, blendequivs[(dest-1)%11]);
+
   return 0;
 }
 
 int draw_get_blend_mode(){
-    return enigma::currentblendmode[0];
+  return enigma::currentblendmode[0];
 }
 
 int draw_get_blend_mode_ext(bool src){
-    return enigma::currentblendmode[(src==true?0:1)];
+  return enigma::currentblendmode[(src==true?0:1)];
 }
 
 int draw_get_blend_mode_type(){
-    return enigma::currentblendtype;
+  return enigma::currentblendtype;
 }
 
 }


### PR DESCRIPTION
This is going to seem trivial, but long story short, I am making this pull request because GM8 and GMS never change `D3DRS_BLENDOP`. They achieve it by using various combinations of `D3DBLEND` much like our OpenGL system does. The operation itself is always add by default and should remain that way. Later on I can make a blend mode comparison test to run on our CI to ensure this stuff never breaks.

Download Test Project for API Trace: [blend-api-trace-test.zip](https://github.com/enigma-dev/enigma-dev/files/2775237/blend-api-trace-test.zip)

* Remove changes to `D3DRS_BLENDOP` from D3D9
* Remove changes to `blendStateDesc.RenderTarget[0].BlendOp` from D3D11
* Use an array lookup modulo the size for `draw_set_blend_mode` in D3D9
* Fix modulo array size (which should be 11, not 10) for `draw_set_blend_mode_ext` in D3D9
* Fix formatting (tabs->2 spaces)

### GM8 API Trace
![GM8 Blend API Trace](https://user-images.githubusercontent.com/3212801/51422864-5eb40580-1b84-11e9-92fd-b074f4a9b5cc.png)

### GMSv1.4 API Trace
![GMS Blend API Trace](https://user-images.githubusercontent.com/3212801/51422890-219c4300-1b85-11e9-822d-086692d44e18.png)
