### PR TITLE
DirectSound Buffer Size Fixes

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -171,6 +171,8 @@ int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
 
   DSBUFFERDESC bufferDesc = {};
   bufferDesc.dwSize = sizeof(DSBUFFERDESC);
+  // DSBCAPS_CTRLFX causes all kinds of weird nasty shit, please read #1508 on GitHub
+  // before considering whether to readd it to the dwFlags below
   bufferDesc.dwFlags = DSBCAPS_CTRLDEFAULT;
   bufferDesc.dwBufferBytes = waveHeader->dataSize;
   bufferDesc.dwReserved = 0;

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -171,10 +171,8 @@ int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
 
   DSBUFFERDESC bufferDesc = {};
   bufferDesc.dwSize = sizeof(DSBUFFERDESC);
-  bufferDesc.dwFlags = DSBCAPS_CTRLDEFAULT | DSBCAPS_CTRLFX;
-  // DSBCAPS_CTRLFX requires sound buffers at least DSBSIZE_FX_MIN (150ms) in length
-  unsigned long minFXBufSize = DSBSIZE_FX_MIN * waveHeader->numChannels * (waveHeader->sampleRate + 1000 - 1) / 1000 * waveHeader->bitsPerSample / 8;
-  bufferDesc.dwBufferBytes = std::max(waveHeader->dataSize, minFXBufSize);
+  bufferDesc.dwFlags = DSBCAPS_CTRLDEFAULT;
+  bufferDesc.dwBufferBytes = waveHeader->dataSize;
   bufferDesc.dwReserved = 0;
   bufferDesc.lpwfxFormat = &waveFormat;
   bufferDesc.guid3DAlgorithm = GUID_NULL;
@@ -186,17 +184,14 @@ int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
   IDirectSoundBuffer* sndBuf = snd->soundBuffer;
 
   if (DS_OK == sndBuf->Lock(0,                     // Offset at which to start lock.
-                            0,                     // Size of lock; ignored because of flag.
+                            waveHeader->dataSize,  // Size of lock; ignored because of flag.
                             &lpvWrite,             // Gets address of first part of lock.
                             &dwLength,             // Gets size of first part of lock.
                             NULL,                  // Address of wraparound not needed.
                             NULL,                  // Size of wraparound not needed.
-                            DSBLOCK_ENTIREBUFFER)) // Flag.
+                            0))                    // Flag.
   {
     memcpy(lpvWrite, (char*)buffer + waveHeader->dataOffset, waveHeader->dataSize);
-    // fill with silence
-    if (waveHeader->dataSize < minFXBufSize)
-      memset(lpvWrite + waveHeader->dataSize, 1<<(waveHeader->bitsPerSample - 1), dwLength - waveHeader->dataSize);
     sndBuf->Unlock(lpvWrite,  // Address of lock start.
                    dwLength,  // Size of lock.
                    NULL,      // No wraparound portion.

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -172,7 +172,8 @@ int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
   DSBUFFERDESC bufferDesc = {};
   bufferDesc.dwSize = sizeof(DSBUFFERDESC);
   bufferDesc.dwFlags = DSBCAPS_CTRLDEFAULT | DSBCAPS_CTRLFX;
-  bufferDesc.dwBufferBytes = waveHeader->dataSize;
+  unsigned long minFXBufSize = DSBSIZE_FX_MIN * waveHeader->numChannels * (waveHeader->sampleRate + 1000 - 1) / 1000 * waveHeader->bitsPerSample / 8;
+  bufferDesc.dwBufferBytes = std::max(waveHeader->dataSize, minFXBufSize);
   bufferDesc.dwReserved = 0;
   bufferDesc.lpwfxFormat = &waveFormat;
   bufferDesc.guid3DAlgorithm = GUID_NULL;


### PR DESCRIPTION
This is a temporary fix for #1508. We are just removing the flag for now because due to an MSYS2 bug, it's currently impossible for us to implement sound effects.

