### PR TITLE
Default Render State Fixes

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
@@ -74,7 +74,7 @@ int draw_set_blend_mode_ext(int src, int dest) {
   };
 
   blendStateDesc.RenderTarget[0].SrcBlendAlpha = blendStateDesc.RenderTarget[0].SrcBlend = blend_equivs[(src-1)%11];
-  blendStateDesc.RenderTarget[0].DestBlendAlpha = blendStateDesc.RenderTarget[0].DestBlend = blend_equivs[(src-1)%11];
+  blendStateDesc.RenderTarget[0].DestBlendAlpha = blendStateDesc.RenderTarget[0].DestBlend = blend_equivs[(dest-1)%11];
 
   update_blend_state();
   return 0;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
@@ -59,8 +59,8 @@ namespace enigma_user
 int draw_set_blend_mode(int mode) {
   const static D3D11_BLEND dest_modes[] = {D3D11_BLEND_INV_SRC_ALPHA,D3D11_BLEND_ONE,D3D11_BLEND_INV_SRC_COLOR,D3D11_BLEND_INV_SRC_COLOR};
 
-  blendStateDesc.RenderTarget[0].SrcBlendAlpha = blendStateDesc.RenderTarget[0].SrcBlend = (mode == bm_subtract) ? D3D11_BLEND_ZERO : D3D11_BLEND_SRC_ALPHA;
-  blendStateDesc.RenderTarget[0].DestBlendAlpha = blendStateDesc.RenderTarget[0].DestBlend = dest_modes[mode % 4];
+  blendStateDesc.RenderTarget[0].SrcBlend = (mode == bm_subtract) ? D3D11_BLEND_ZERO : D3D11_BLEND_SRC_ALPHA;
+  blendStateDesc.RenderTarget[0].DestBlend = dest_modes[mode % 4];
 
   update_blend_state();
   return 0;
@@ -73,8 +73,8 @@ int draw_set_blend_mode_ext(int src, int dest) {
     D3D11_BLEND_INV_DEST_COLOR, D3D11_BLEND_SRC_ALPHA_SAT
   };
 
-  blendStateDesc.RenderTarget[0].SrcBlendAlpha = blendStateDesc.RenderTarget[0].SrcBlend = blend_equivs[(src-1)%11];
-  blendStateDesc.RenderTarget[0].DestBlendAlpha = blendStateDesc.RenderTarget[0].DestBlend = blend_equivs[(dest-1)%11];
+  blendStateDesc.RenderTarget[0].SrcBlend = blend_equivs[(src-1)%11];
+  blendStateDesc.RenderTarget[0].DestBlend = blend_equivs[(dest-1)%11];
 
   update_blend_state();
   return 0;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -96,6 +96,7 @@ void d3d_start()
   enigma::d3dPerspective = true;
   enigma::d3dCulling = rs_none;
   d3dmgr->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+  d3dmgr->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
   d3dmgr->SetRenderState(D3DRS_ZENABLE, enigma::d3dHidden = true);
 
   // Enable texture repetition by default

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -67,13 +67,11 @@ void screen_init()
   }
 
   d3dmgr->SetRenderState(D3DRS_LIGHTING, FALSE);
-  d3dmgr->SetRenderState(D3DRS_ZENABLE, FALSE);
   // make the same default as GL, keep in mind GM uses reverse depth ordering for ortho projections, where the higher the z value the further into the screen you are
   // but that is currently taken care of by using 32000/-32000 for znear/zfar respectively
   d3dmgr->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
   d3dmgr->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
   d3dmgr->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
-  d3dmgr->SetRenderState(D3DRS_ALPHAREF, (DWORD)0x00000001);
   d3dmgr->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATER);
   d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
   d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -74,7 +74,6 @@ void screen_init()
   d3dmgr->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
   d3dmgr->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
   d3dmgr->SetRenderState(D3DRS_ALPHAREF, (DWORD)0x00000001);
-  d3dmgr->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
   d3dmgr->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
   d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
   d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -74,7 +74,7 @@ void screen_init()
   d3dmgr->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
   d3dmgr->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
   d3dmgr->SetRenderState(D3DRS_ALPHAREF, (DWORD)0x00000001);
-  d3dmgr->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
+  d3dmgr->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATER);
   d3dmgr->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
   d3dmgr->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
   draw_set_color(c_white);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -123,7 +123,7 @@ void d3d_start()
   glDepthMask(true);
   glEnable(GL_DEPTH_TEST);
   glEnable(GL_ALPHA_TEST);
-  glAlphaFunc(GL_NOTEQUAL, 0);
+  glAlphaFunc(GL_GREATER, 0);
   glEnable(GL_NORMALIZE);
   glEnable(GL_COLOR_MATERIAL);
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -88,7 +88,6 @@ void screen_init()
   glDisable(GL_CULL_FACE);
   glEnable(GL_BLEND);
   glEnable(GL_SCISSOR_TEST);
-  glEnable(GL_ALPHA_TEST);
   glEnable(GL_TEXTURE_2D);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glAlphaFunc(GL_GREATER,0);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -91,7 +91,7 @@ void screen_init()
   glEnable(GL_ALPHA_TEST);
   glEnable(GL_TEXTURE_2D);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glAlphaFunc(GL_ALWAYS,0);
+  glAlphaFunc(GL_GREATER,0);
   texture_reset();
   draw_set_color(c_white);
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -54,7 +54,7 @@ namespace enigma
     glEnable(GL_ALPHA_TEST);
     glEnable(GL_TEXTURE_2D);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glAlphaFunc(GL_ALWAYS,0);
+    glAlphaFunc(GL_GREATER,0);
     glDepthFunc(GL_LEQUAL); // to match GM8's D3D8 default
 
     glColor4f(0,0,0,1);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -51,7 +51,6 @@ namespace enigma
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     glEnable(GL_BLEND);
-    glEnable(GL_ALPHA_TEST);
     glEnable(GL_TEXTURE_2D);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glAlphaFunc(GL_GREATER,0);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/OPENGLStd.cpp
@@ -67,7 +67,6 @@ namespace enigma
 #endif
 
       glEnable(GL_BLEND);
-      glEnable(GL_ALPHA_TEST);
       glEnable(GL_TEXTURE_2D);
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
       glAlphaFunc(GL_GREATER,0);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/OPENGLStd.cpp
@@ -33,7 +33,7 @@ namespace enigma
   unsigned char currentcolor[4] = {0,0,0,255};
   bool glew_isgo;
   bool pbo_isgo;
-  
+
   void graphicssystem_initialize()
   {
     #if GMSURFACE
@@ -49,29 +49,29 @@ namespace enigma
     glMatrixMode(GL_MODELVIEW);
       glLoadIdentity();
       glLoadIdentity();
-      
+
       glViewport(0,0,(int)room_width,(int)room_height);
 #if ENIGMA_WS_IPHONE !=0 || ENIGMA_WS_ANDROID !=0
 	  glOrthof(0,(int)room_width-1,(int)room_height-1,0,-1,1); //OPENGLES
 #else
 	  glOrtho(0,(int)room_width-1,(int)room_height-1,0,-1,1); //
-#endif 
+#endif
            glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-      
+
       glDisable(GL_DEPTH_TEST);
       glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 #if ENIGMA_WS_IPHONE !=0 || ENIGMA_WS_ANDROID !=0
 	  glClearDepthf(1.0); //OPENGLES put f back in
 #else
-	  glClearDepth(1.0); 
-#endif 
-      
+	  glClearDepth(1.0);
+#endif
+
       glEnable(GL_BLEND);
       glEnable(GL_ALPHA_TEST);
       glEnable(GL_TEXTURE_2D);
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-      glAlphaFunc(GL_ALWAYS,0);
-      
+      glAlphaFunc(GL_GREATER,0);
+
       glColor4f(0,0,0,1);
       glBindTexture(GL_TEXTURE_2D,0);
   }


### PR DESCRIPTION
This pull request is just me fixing a few more render states that I noticed are being initialized wrong. I specifically noticed some of these while examining a blend state test by Phantom 107 that I want to adapt for our CI. I am going to provide a modified version here that removes surfaces (because our DX systems have some issues with them).

Download Phantom107 Blend Example: [phantom107-blend-test.zip](https://github.com/enigma-dev/enigma-dev/files/2780157/phantom107-blend-test.zip)
Download Modified Blend Example: [phantom107-blend-test-nosurface.zip](https://github.com/enigma-dev/enigma-dev/files/2780164/phantom107-blend-test-nosurface.zip)

### Summary of Changes

* Moved the enabling of alpha testing to `d3d_start` because GM/GMSv1.4 has it disabled by default and so does D3D/GL. I used apitrace to confirm that `d3d_start` in GM8 will automatically turn on the alpha testing (affects specifically the fps6 example).
https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glAlphaFunc.xml
https://docs.microsoft.com/en-us/windows/desktop/direct3d9/d3drenderstatetype
https://docs.yoyogames.com/source/dadiospice/002_reference/drawing/colour%20and%20blending/draw_set_alpha_test.html
* Fixed a typo in D3D11's `draw_set_blend_mode_ext`  where we were accidentally using the source mode for the destination too.
* Removed the synchronization of the source and destination blend states with the alpha blend state. Apparently this was also contributing to the rendering difference in D3D11 master.
* Changed all systems to use a greater-than alpha comparison, which I confirmed with an apitrace. Both GM8 and GMS default to an alpha function of 5, which is `D3DCMP_GREATER`.
* Removed setting the initial alpha test ref value to 1 in D3D9 because GM just uses 0 by default as does GL/D3D.
* Removed initial setting of zwrite enable to false because GM actually leaves it on by default, even though hidden is disabled. To clarify, zwrite enable is a different setting than hidden which just toggles whether writing to the depth buffer is allowed. Toggling hidden changes whether hidden surface removal is performed at all.

### Change Comparison
|              | DX11 | DX9 | GL3 | GL1 |
|--------------|------|-----|-----|-----|
| Master       |![Blend Test DX11 Master](https://user-images.githubusercontent.com/3212801/51493698-1f540780-1d84-11e9-98c1-4399dc20f0fe.png)|![Blend Test DX9 Master](https://user-images.githubusercontent.com/3212801/51493662-08151a00-1d84-11e9-9bb0-38875f457246.png)|![Blend Test GL3 Master](https://user-images.githubusercontent.com/3212801/51493632-f3d11d00-1d83-11e9-883b-c3a08caa2244.png)|![Blend Test GL1 Master](https://user-images.githubusercontent.com/3212801/51493533-a654b000-1d83-11e9-8fd9-e29012b7b588.png)|
| Pull Request |![Blend Test DX11 Pr](https://user-images.githubusercontent.com/3212801/51497469-35b49000-1d91-11e9-8a52-557c4dd199b3.png)|![Blend Test DX9 Pr](https://user-images.githubusercontent.com/3212801/51493785-67732a00-1d84-11e9-9c87-d842e08d9a47.png)|![Blend Test GL3 Pr](https://user-images.githubusercontent.com/3212801/51493632-f3d11d00-1d83-11e9-883b-c3a08caa2244.png)|![Blend Test GL1 Pr](https://user-images.githubusercontent.com/3212801/51493533-a654b000-1d83-11e9-8fd9-e29012b7b588.png)|

### GameMaker Comparison
This is a comparison of the same blending test when run in GM. I should mention that for the two GMS versions, I had to check "Used for 3D" so the tree sprite would render correctly and the texture paging wouldn't interfere. For GMS2, I had to change some of the code because `draw_set_blend_mode` is renamed to `gpu_set_blendmode`.

| GM8 | GMSv1.4 | GMS2 |
|-----|---------|------|
|![Blend Test GM8](https://user-images.githubusercontent.com/3212801/51494409-8f638d00-1d86-11e9-9b66-539bc20adc20.png)|![Blend Test GMSv1.4](https://user-images.githubusercontent.com/3212801/51494484-ca65c080-1d86-11e9-836e-9f984ba32cb1.png)|![Blend Test GMS2](https://user-images.githubusercontent.com/3212801/51494734-c38b7d80-1d87-11e9-8895-86f2b8186720.png)|

