### PR TITLE
Fix Top Down Projection Angles

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
@@ -237,7 +237,7 @@ void d3d_set_projection_ext(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,
 void d3d_set_projection_ortho(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
   enigma::view = glm::ortho(x, x + width, y + height, y, -32000.0f, 32000.0f);
-  enigma::projection = glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 0.0f, 1.0f));
+  enigma::projection = glm::rotate(glm::mat4(1.0f), (float)gs_angle_to_radians(angle), glm::vec3(0.0f, 0.0f, 1.0f));
   enigma::graphics_set_matrix(matrix_view);
   enigma::graphics_set_matrix(matrix_projection);
 }
@@ -248,7 +248,7 @@ void d3d_set_projection_ortho_lookat(gs_scalar x, gs_scalar y, gs_scalar width, 
                                      gs_scalar xup, gs_scalar yup, gs_scalar zup) {
   enigma::view = glm::lookAt(glm::vec3(xfrom, yfrom, zfrom), glm::vec3(xto, yto, zto), glm::vec3(xup, yup, zup));
   enigma::projection = glm::ortho(x, x + width, y + height, y, -32000.0f, 32000.0f);
-  enigma::projection = glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::projection;
+  enigma::projection = glm::rotate(glm::mat4(1.0f), (float)gs_angle_to_radians(angle), glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::projection;
   enigma::graphics_set_matrix(matrix_view);
   enigma::graphics_set_matrix(matrix_projection);
 }
@@ -257,7 +257,7 @@ void d3d_set_projection_perspective(gs_scalar x, gs_scalar y, gs_scalar width, g
 {
   enigma::view = glm::ortho(x, x + width, y + height, y, 1.0f, 32000.0f);
   enigma::projection = glm::perspective((float)gs_angle_to_radians(40.0f), width/height, 1.0f, 32000.0f);
-  enigma::projection = glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::projection;
+  enigma::projection = glm::rotate(glm::mat4(1.0f), (float)gs_angle_to_radians(angle), glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::projection;
   enigma::graphics_set_matrix(matrix_view);
   enigma::graphics_set_matrix(matrix_projection);
 }


### PR DESCRIPTION
I don't know how I missed these functions, but in GM they take degrees and GLM wants radians. I caught this while testing some EDC games, specifically the fake 3D example.
https://enigma-dev.org/edc/games.php?game=66

This change leaves none of the matrix functions taking radians directly, so this should be near the last anomaly with the GM API that's fixed in these sources.

|        | DX11 | DX9 | GL1 | GL3 | GM8 |
|--------|------|-----|-----|-----|-----|
| Master |![Fake 3D DX11 Master](https://user-images.githubusercontent.com/3212801/51566306-3f59f880-1e62-11e9-8171-fee0792fa212.png)|![Fake 3D DX9 Master](https://user-images.githubusercontent.com/3212801/51566340-500a6e80-1e62-11e9-87c3-9d03bc4371ea.png)|![Fake 3D GL1 Master](https://user-images.githubusercontent.com/3212801/51566276-2cdfbf00-1e62-11e9-95fa-e553097e1505.png)|![Fake 3D GL3 Master](https://user-images.githubusercontent.com/3212801/51566377-60224e00-1e62-11e9-8f7c-be316ef78262.png)|![Fake 3D GM8](https://user-images.githubusercontent.com/3212801/51566527-be4f3100-1e62-11e9-868e-c3b89b328f07.png)|
| Pull Request |![Fake 3D DX11 Pr](https://user-images.githubusercontent.com/3212801/51566104-b642c180-1e61-11e9-9851-d43e9ce749a2.png)|![Fake 3D DX9 Pr](https://user-images.githubusercontent.com/3212801/51566137-cce91880-1e61-11e9-9baf-19034f2451b5.png)|![Fake 3D GL1 Pr](https://user-images.githubusercontent.com/3212801/51566060-a0cd9780-1e61-11e9-88dd-e7812ac62b80.png)|![Fake 3D GL3 Pr](https://user-images.githubusercontent.com/3212801/51566182-e7bb8d00-1e61-11e9-9ff3-2bf9989e5333.png)|![Fake 3D GM8](https://user-images.githubusercontent.com/3212801/51566527-be4f3100-1e62-11e9-868e-c3b89b328f07.png)|

