### PR TITLE
Fix Sprite Color Action

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/actions.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/actions.h
@@ -268,7 +268,7 @@ inline void action_sprite_transform(gs_scalar xscale, gs_scalar yscale, double a
     inst->image_angle = angle;
 }
 
-inline void action_sprite_color(int color, int alpha)
+inline void action_sprite_color(int color, double alpha)
 {
     enigma::object_collisions* const inst = ((enigma::object_collisions*)enigma::instance_event_iterator->inst);
     inst->image_blend = color;


### PR DESCRIPTION
This is a very simple change I caught while reviewing more EDC games. The alpha parameter on the sprite blend action is supposed to be floating point not integer. This effects specifically the Paper Mario battle engine from the EDC.
https://enigma-dev.org/edc/games.php?game=63

![GM8 Manual Color Sprite Action](https://user-images.githubusercontent.com/3212801/51573437-52c38e80-1e77-11e9-8cb4-c37a3af07c99.png)
![GMSv1.4 Manual Color Sprite Action](https://user-images.githubusercontent.com/3212801/51573490-8e5e5880-1e77-11e9-891c-a7550af0e892.png)

I've already corrected the wiki's article for this action too:
https://enigma-dev.org/docs/wiki/index.php?title=Action_sprite_color&action=historysubmit&diff=32045&oldid=26544

| Master GL1 | Pull GL1 | GM8 |
|------------|----------|-----|
|![Paper Mario Battle Engine GL1 Master](https://user-images.githubusercontent.com/3212801/51572926-39214780-1e75-11e9-88ae-5e26a96a45c1.png)|![Paper Mario Battle Engine GL1 Pull](https://user-images.githubusercontent.com/3212801/51572962-5f46e780-1e75-11e9-8185-fd9945b40879.png)|![Paper Mario Battle Engine GM8](https://user-images.githubusercontent.com/3212801/51573197-42f77a80-1e76-11e9-9ab7-7501120f98a5.png)|