### PR TITLE
Tile Leak Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStiles.cpp
@@ -91,6 +91,7 @@ namespace enigma
     {
         if (!tiles_are_dirty) return;
         tiles_are_dirty = false;
+        tile_layer_metadata.clear();
 
         static int vertexFormat = -1;
         if (!enigma_user::vertex_format_exists(vertexFormat)) {


### PR DESCRIPTION
I am breaking up some of my tile fixes into multiple requests to make them easier to explain. This one is the simplest and easiest to understand. So, one issue with the current tiles is that we are not clearing the metadata vector when switching rooms or when otherwise updating and reloading the tile layers. This leaks, big time, because it means that each room is not only drawing its own tiles but attempting to draw the tiles from all previous rooms. With this change applied, anomalies that were compounding the other issues with the tiles no longer occur and switching between rooms has deterministic tile rendering behavior.