### PR TITLE
Stable Sort for Tile Layer Depths

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStiles.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStiles.cpp
@@ -39,6 +39,11 @@ namespace {
 
 bool tiles_are_dirty = true;
 
+struct bkinxop
+{
+  bool operator() (const enigma::tile& a, const enigma::tile& b) {return (a.bckid < b.bckid);}
+} bkinxcomp;
+
 } // anonymous namespace
 
 namespace enigma
@@ -116,6 +121,7 @@ namespace enigma
             auto& dtiles = dit->second.tiles;
             if (dtiles.size())
             {
+                stable_sort(dtiles.begin(), dtiles.end(), bkinxcomp);
                 const auto layer_depth = dit->first;
                 for (std::vector<tile>::size_type i = 0; i != dtiles.size(); ++i)
                 {


### PR DESCRIPTION
I removed the unstable sort in #1516 because it was producing noticeable anomalies in ENIGMA's tile rendering for the Tile Collision Demo. I considered that a stable sort may be compatible, at least with GMSv1.4, and wouldn't affect too many people while still improving the efficiency of batching within a single tile layer depth. I found out it's true that when using a stable sort, no anomaly appears in the Tile Collision Demo. However, I improvised a test to intentionally break this and have shown below that, while the stable sort is more compatible, it is still less compatible than just sorting the layer by tile id.

Download Tile Stable Sort Test: [tile-stable-sort.zip](https://github.com/enigma-dev/enigma-dev/files/2814421/tile-stable-sort.zip)

|        | ENIGMA | GM |         |
|--------|--------|----|---------|
| Master |![Tile Stable Sort Test Master](https://user-images.githubusercontent.com/3212801/52012272-2a0b4c80-24a8-11e9-9460-d263a43f02f9.png)|![Tile Stable Sort Test GM8](https://user-images.githubusercontent.com/3212801/52012210-fcbe9e80-24a7-11e9-8552-0b186ee0fd8e.png)| GM8     |
| Pull   |![Tile Stable Sort Test Pull](https://user-images.githubusercontent.com/3212801/52012239-119b3200-24a8-11e9-8f15-42433d2244be.png)|![Tile Stable Sort Test GMSv1.4](https://user-images.githubusercontent.com/3212801/52012164-d8fb5880-24a7-11e9-9fcb-a8e62ad8dff8.png)| GMSv1.4 |