### PR TITLE
Make Mac dialogs use *.icns file set by Info.plist

### DIFF
--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -144,6 +144,17 @@ static inline string detect_all_files_filter(string filter) {
   return filter;
 }
 
+/* I know you guys don't like using platform macros; I'm ok with alternative ways to do this
+just let me know what you would rather me do and I'll change it accordingly. Thank you!!! */
+static inline void window_activate() {
+  #ifdef __APPLE__
+  if (tfd_DialogEngine == tfd_OsaScript) {
+    void cocoa_window_activate();
+    cocoa_window_activate();
+  }
+  #endif
+}
+
 static inline string get_open_filename_helper(string filter, string fname, string dir, string title, int const mselect) {
   string fname_or_dir;
 
@@ -218,13 +229,15 @@ void show_error(string errortext, const bool fatal) {
 
   msg = tfd_add_escaping(msg);
 
+  window_activate();
+
   if (fatal == 0) {
     msg = msg + "Do you want to abort the application?";
 
-  double input = tinyfd_messageBox("Error", msg.c_str(), "yesno", "error", 1, tfd_DialogEngine());
+    double input = tinyfd_messageBox("Error", msg.c_str(), "yesno", "error", 1, tfd_DialogEngine());
 
-  if (input == 1)
-    exit(0);
+    if (input == 1)
+      exit(0);
   } else {
     msg = msg + "Click 'OK' to abort the application.";
 
@@ -260,6 +273,8 @@ int show_message(const string &str) {
   msg = tfd_add_escaping(msg);
   caption = tfd_add_escaping(caption);
 
+  window_activate();
+
   tinyfd_messageBox(caption.c_str(), msg.c_str(), "ok", "info", 1, tfd_DialogEngine());
 
   return 1;
@@ -283,6 +298,8 @@ bool show_question(string str) {
   msg = tfd_add_escaping(msg);
   caption = tfd_add_escaping(caption);
 
+  window_activate();
+
   return tinyfd_messageBox(caption.c_str(), msg.c_str(), "yesno", "question", 1, tfd_DialogEngine());
 }
 
@@ -304,6 +321,8 @@ string get_string(string str, string def) {
   msg = tfd_add_escaping(msg);
   def = tfd_add_escaping(def);
   caption = tfd_add_escaping(caption);
+
+  window_activate();
 
   const char *input = tinyfd_inputBox(caption.c_str(), msg.c_str(), def.c_str(), tfd_DialogEngine());
 
@@ -328,6 +347,8 @@ string get_password(string str, string def) {
   msg = tfd_add_escaping(msg);
   def = tfd_add_escaping(def);
   caption = tfd_add_escaping(caption);
+
+  window_activate();
 
   const char *input = tinyfd_passwordBox(caption.c_str(), msg.c_str(), def.c_str(), tfd_DialogEngine());
 
@@ -356,6 +377,8 @@ double get_integer(string str, double def) {
   msg = tfd_add_escaping(msg);
   caption = tfd_add_escaping(caption);
 
+  window_activate();
+
   const char *input = tinyfd_inputBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 
   return input ? strtod(input, NULL) : 0;
@@ -382,6 +405,8 @@ double get_passcode(string str, double def) {
 
   msg = tfd_add_escaping(msg);
   caption = tfd_add_escaping(caption);
+
+  window_activate();
 
   const char *input = tinyfd_passwordBox(caption.c_str(), msg.c_str(), integer.c_str(), tfd_DialogEngine());
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.m
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.m
@@ -1,0 +1,7 @@
+#import <Cocoa/Cocoa.h>
+
+void cocoa_window_activate()
+{
+    [[NSApplication sharedApplication] activateIgnoringOtherApps : YES];
+}
+

--- a/ENIGMAsystem/SHELL/Widget_Systems/OsaScript/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/OsaScript/Makefile
@@ -1,4 +1,5 @@
 include $(SHARED_SRC_DIR)/tinyfiledialogs/Makefile
 
 SOURCES += Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+SOURCES += Widget_Systems/General/tinyfiledialogs/dialogs.m
 SOURCES += Widget_Systems/OsaScript/dialogs.cpp

--- a/shared/tinyfiledialogs/tinyfiledialogs.cpp
+++ b/shared/tinyfiledialogs/tinyfiledialogs.cpp
@@ -535,6 +535,71 @@ static int osx9orBetter( )
 }
 
 
+static void AddAppBundleIcon(char * lDialogString)
+{
+	std::string cmd1 = "";
+	cmd1 += "osascript -e \"tell application \\\"Finder\\\"\" ";
+	cmd1 += "-e \"set appPath to POSIX path of (path to frontmost application)\" ";
+	cmd1 += "-e \"set resourcesPath to appPath & \\\"Contents/Info.plist\\\"\" ";
+	cmd1 += "-e \"end tell\" ";
+                    
+	FILE *file1 = popen(cmd1.c_str(), "r");
+	char plist[260];
+	fgets(plist, 260, file1);
+	pclose(file1);
+                    
+	if (plist[strlen(plist) - 1] == '\n')
+		plist[strlen(plist) - 1] = '\0';
+                    
+	std::string cmd2 = "";
+	cmd2 += "defaults read \"";
+	cmd2 += plist;
+	cmd2 += "\" CFBundleIconFile";
+                    
+	FILE *file2 = popen(cmd2.c_str(), "r");
+	char icon[260];
+	fgets(icon, 260, file2);
+	pclose(file2);
+                    
+	if (icon[strlen(icon) - 1] == '\n')
+		icon[strlen(icon) - 1] = '\0';
+                    
+	std::string cmd3 = "";
+	cmd3 += "osascript -e \"tell application \\\"Finder\\\"\" ";
+	cmd3 += "-e \"set appPath to POSIX path of (path to frontmost application)\" ";
+	cmd3 += "-e \"set resourcesPath to appPath & \\\"Contents/Resources/\\\"\" ";
+	cmd3 += "-e \"end tell\" ";
+                    
+	FILE *file3 = popen(cmd3.c_str(), "r");
+	char path[260];
+	fgets(path, 260, file3);
+	pclose(file3);
+                    
+	if (path[strlen(path) - 1] == '\n')
+		path[strlen(path) - 1] = '\0';
+                    
+	std::string iconpath = "";
+	iconpath += path;
+	iconpath += icon;
+                    
+	std::string ext = ".icns";
+	if (iconpath.length() >= ext.length())
+	{
+		if (0 != iconpath.compare(iconpath.length() - ext.length(), ext.length(), ext))
+			iconpath += ext;
+	}
+                    
+	if ( !fileExists(iconpath.c_str()) )
+		strcat(lDialogString, "with icon note " ) ;
+	else
+	{
+		strcat(lDialogString, "with icon POSIX file \\\"");
+		strcat(lDialogString, iconpath.c_str());
+		strcat(lDialogString, "\\\" ");
+	}
+}
+
+
 int tinyfd_messageBox(
         char const * const aTitle , /* NULL or "" */
         char const * const aMessage , /* NULL or ""  may contain \n and \t */
@@ -577,18 +642,17 @@ int tinyfd_messageBox(
                         strcat(lDialogString, aTitle) ;
                         strcat(lDialogString, "\\\" ") ;
                 }
-                strcat(lDialogString, "with icon ") ;
                 if ( aIconType && ! strcmp( "error" , aIconType ) )
                 {
-                        strcat(lDialogString, "stop " ) ;
+                        strcat(lDialogString, "with icon stop " ) ;
                 }
                 else if ( aIconType && ! strcmp( "warning" , aIconType ) )
                 {
-                        strcat(lDialogString, "caution " ) ;
+                        strcat(lDialogString, "with icon caution " ) ;
                 }
                 else /* question or info */
                 {
-                        strcat(lDialogString, "note " ) ;
+			AddAppBundleIcon(lDialogString);
                 }
                 if ( aDialogType && ! strcmp( "okcancel" , aDialogType ) )
                 {
@@ -867,7 +931,8 @@ char const * tinyfd_inputBox(
                         strcat(lDialogString, aTitle) ;
                         strcat(lDialogString, "\\\" ") ;
                 }
-                strcat(lDialogString, "with icon note\" ") ;
+		AddAppBundleIcon(lDialogString);
+		strcat(lDialogString, "\" ");            
                 strcat(lDialogString, "-e \"\\\"1\\\" & text returned of result\" " );
                 strcat(lDialogString, "-e \"on error number -128\" " ) ;
                 strcat(lDialogString, "-e \"0\" " );
@@ -1045,16 +1110,15 @@ char const * tinyfd_passwordBox(
                         strcat(lDialogString, aDefaultInput) ;
                 }
                 strcat(lDialogString, "\\\" ") ;
-
                 strcat(lDialogString, "hidden answer true ") ;
-
                 if ( aTitle && strlen(aTitle) )
                 {
                         strcat(lDialogString, "with title \\\"") ;
                         strcat(lDialogString, aTitle) ;
                         strcat(lDialogString, "\\\" ") ;
                 }
-                strcat(lDialogString, "with icon note\" ") ;
+		AddAppBundleIcon(lDialogString);
+		strcat(lDialogString, "\" ");            
                 strcat(lDialogString, "-e \"\\\"1\\\" & text returned of result\" " );
                 strcat(lDialogString, "-e \"on error number -128\" " ) ;
                 strcat(lDialogString, "-e \"0\" " );
@@ -1194,69 +1258,76 @@ char const * tinyfd_passwordBox(
 }
 
 
-std::vector<std::string> SplitString(const std::string &str, char delimiter) {
-    std::vector<std::string> vec;
-    std::stringstream sstr(str);
-    std::string tmp;
-    while (std::getline(sstr, tmp, delimiter)) vec.push_back(tmp);
+std::vector<std::string> SplitString(const std::string &str, char delimiter)
+{
+	std::vector<std::string> vec;
+	std::stringstream sstr(str);
+	std::string tmp;
 
-    return vec;
+	while (std::getline(sstr, tmp, delimiter))
+		vec.push_back(tmp);
+
+	return vec;
 }
 
 
-std::string zenityFilter(std::string input) {
+std::string zenityFilter(std::string input)
+{
+	std::vector<std::string> stringVec = SplitString(input, '|');
 
-    std::vector<std::string> stringVec = SplitString(input, '|'); //split at delimeter
+	std::string outputString = "";
 
-    std::string outputString = "";
+	unsigned int index = 0;
+	for (const std::string &str : stringVec)
+	{
+		if (index % 2 == 0) 
+		{
+			outputString += " --file-filter='" + str + " | ";
+		} 
+		else 
+		{
+			outputString += str + "'";
+		}
 
-    unsigned int index = 0;
-    for (const std::string &str : stringVec) { //loops our array
+		index++;
+	}
 
-        if (index % 2 == 0) { //code for even |
-            outputString += " --file-filter='" + str + " | "; //concat string
-        } else { //code for odd |
-            outputString += str + "'"; //concat string
-        }
+	std::replace(outputString.begin(), outputString.end(), ';', ' ');
 
-        index++;
-    }
-
-    std::replace(outputString.begin(), outputString.end(), ';', ' ');
-
-    return outputString;
-
+	return outputString;
 }
 
 
-std::string kdialogFilter(std::string input) {
+std::string kdialogFilter(std::string input)
+{
+	input.resize(input.find("|", input.find("|") + 1));
+	std::vector<std::string> stringVec = SplitString(input, '|');
 
-    input.resize(input.find("|", input.find("|") + 1));
-    std::vector<std::string> stringVec = SplitString(input, '|'); //split at delimeter
+	std::string outputString = "";
 
-    std::string outputString = "";
+	unsigned int index = 0;
+	for (const std::string &str : stringVec)
+	{
+		if (index % 2 == 0)
+		{
+			outputString += str + "\"";
+        	}
+		else
+		{
+			outputString += " \"" + str + " | ";
+		}
 
-    unsigned int index = 0;
-    for (const std::string &str : stringVec) { //loops our array
+		index++;
+	}
 
-        if (index % 2 == 0) { //code for even |
-            outputString += str + "\""; //concat string
-        } else { //code for odd |
-            outputString += " \"" + str + " | "; //concat string
-        }
+	std::replace(outputString.begin(), outputString.end(), ';', ' ');
 
-        index++;
-    }
+	std::string part1 = outputString.substr(outputString.find("\"") + 1);
+	std::string part2 = outputString.substr(0, outputString.find("\"") + 1);
 
-    std::replace(outputString.begin(), outputString.end(), ';', ' ');
+	outputString = part1 + part2;
 
-    std::string part1 = outputString.substr(outputString.find("\"") + 1);
-    std::string part2 = outputString.substr(0, outputString.find("\"") + 1);
-
-    outputString = part1 + part2;
-
-    return outputString;
-
+	return outputString;
 }
 
 

--- a/shared/tinyfiledialogs/tinyfiledialogs.cpp
+++ b/shared/tinyfiledialogs/tinyfiledialogs.cpp
@@ -1258,7 +1258,7 @@ char const * tinyfd_passwordBox(
 }
 
 
-std::vector<std::string> SplitString(const std::string &str, char delimiter)
+static std::vector<std::string> SplitString(const std::string &str, char delimiter)
 {
 	std::vector<std::string> vec;
 	std::stringstream sstr(str);
@@ -1271,10 +1271,10 @@ std::vector<std::string> SplitString(const std::string &str, char delimiter)
 }
 
 
-std::string zenityFilter(std::string input)
+static std::string zenityFilter(std::string input)
 {
+	std::replace(input.begin(), input.end(), ';', ' ');
 	std::vector<std::string> stringVec = SplitString(input, '|');
-
 	std::string outputString = "";
 
 	unsigned int index = 0;
@@ -1282,7 +1282,7 @@ std::string zenityFilter(std::string input)
 	{
 		if (index % 2 == 0) 
 		{
-			outputString += " --file-filter='" + str + " | ";
+			outputString += " --file-filter='" + str + "|";
 		} 
 		else 
 		{
@@ -1292,41 +1292,40 @@ std::string zenityFilter(std::string input)
 		index++;
 	}
 
-	std::replace(outputString.begin(), outputString.end(), ';', ' ');
-
 	return outputString;
 }
 
 
-std::string kdialogFilter(std::string input)
+static std::string kdialogFilter(std::string input)
 {
-	input.resize(input.find("|", input.find("|") + 1));
+	std::replace(input.begin(), input.end(), ';', ' ');
 	std::vector<std::string> stringVec = SplitString(input, '|');
+	std::string outputString = " \"";
 
-	std::string outputString = "";
+	std::string even = "";
+	std::string odd = "";
 
 	unsigned int index = 0;
 	for (const std::string &str : stringVec)
 	{
-		if (index % 2 == 0)
+		if (index % 2 != 0) 
 		{
-			outputString += str + "\"";
-        	}
-		else
+			if (index == 1)
+				odd = str;
+			else
+				odd = "\n" + str;
+
+			outputString += odd + even;
+		}
+		else 
 		{
-			outputString += " \"" + str + " | ";
+			even = "|" + str;
 		}
 
 		index++;
 	}
 
-	std::replace(outputString.begin(), outputString.end(), ';', ' ');
-
-	std::string part1 = outputString.substr(outputString.find("\"") + 1);
-	std::string part2 = outputString.substr(0, outputString.find("\"") + 1);
-
-	outputString = part1 + part2;
-
+	outputString += "\"";
 	return outputString;
 }
 
@@ -1419,12 +1418,11 @@ char const * tinyfd_saveFileDialog(
                         strcat(lDialogString, " --attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2)"); /* contribution: Paul Rouget */
                 }
                 strcat( lDialogString , " --getsavefilename /" ) ;
-		/*
                 if ( aDefaultPathAndFile && strlen(aDefaultPathAndFile) )
                 {
                         if ( aDefaultPathAndFile[0] != '/' )
                         {
-                                strcat(lDialogString, "$PWD/") ;
+                                strcat(lDialogString, "\"$PWD/\"") ;
                         }
                         strcat(lDialogString, "\"") ;
                         strcat(lDialogString, aDefaultPathAndFile ) ;
@@ -1432,9 +1430,8 @@ char const * tinyfd_saveFileDialog(
                 }
                 else
                 {
-                        strcat(lDialogString, "$PWD/") ;
+                        strcat(lDialogString, "\"$PWD/\"") ;
                 }
-		*/
                 if ( aNumOfFilterPatterns > 0 )
                 {
                         strcat( lDialogString , (char *)kdialogFilter(aSingleFilterDescription).c_str() ) ;
@@ -1608,12 +1605,11 @@ char const * tinyfd_openFileDialog(
                         strcat(lDialogString, " --attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2)"); /* contribution: Paul Rouget */
                 }
                 strcat( lDialogString , " --getopenfilename /" ) ;
-		/*
                 if ( aDefaultPathAndFile && strlen(aDefaultPathAndFile) )
                 {
                         if ( aDefaultPathAndFile[0] != '/' )
                         {
-                                strcat(lDialogString, "$PWD/") ;
+                                strcat(lDialogString, "\"$PWD/\"") ;
                         }
                         strcat(lDialogString, "\"") ;
                         strcat(lDialogString, aDefaultPathAndFile ) ;
@@ -1621,9 +1617,8 @@ char const * tinyfd_openFileDialog(
                 }
                 else
                 {
-                        strcat(lDialogString, "$PWD/") ;
+                        strcat(lDialogString, "\"$PWD/\"") ;
                 }
-		*/
                 if ( aNumOfFilterPatterns > 0 )
                 {
                         strcat( lDialogString , (char *)kdialogFilter(aSingleFilterDescription).c_str() ) ;
@@ -1755,12 +1750,11 @@ char const * tinyfd_selectFolderDialog(
                         strcat(lDialogString, " --attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2)"); /* contribution: Paul Rouget */
                 }
                 strcat( lDialogString , " --getexistingdirectory /" ) ;
-		/*
                 if ( aDefaultPath && strlen(aDefaultPath) )
                 {
                         if ( aDefaultPath[0] != '/' )
                         {
-                                strcat(lDialogString, "$PWD/") ;
+                                strcat(lDialogString, "\"$PWD/\"") ;
                         }
                         strcat(lDialogString, "\"") ;
                         strcat(lDialogString, aDefaultPath ) ;
@@ -1768,9 +1762,8 @@ char const * tinyfd_selectFolderDialog(
                 }
                 else
                 {
-                        strcat(lDialogString, "$PWD/") ;
+                        strcat(lDialogString, "\"$PWD/\"") ;
                 }
-		*/
                 if ( aTitle && strlen(aTitle) )
                 {
                         strcat(lDialogString, " --title \"") ;


### PR DESCRIPTION
Before this pull request, the dialogs that display an icon would show the default icon for app bundles that have no icon set. This change makes sure the dialog recognizes and uses the icon set for the app bundle by the Info.plist if the file happens to exist, otherwise fall back on the previous behavior.

Applies to all of the following functions, except show_error() due to the limitations of applescript.

show_message():
![00](https://user-images.githubusercontent.com/4379204/52092731-83e24400-2586-11e9-89cc-399b59eee868.png)

show_question():
![01](https://user-images.githubusercontent.com/4379204/52092732-83e24400-2586-11e9-926d-fd9461ec8b41.png)

show_error():
![02](https://user-images.githubusercontent.com/4379204/52092733-83e24400-2586-11e9-96b3-7147f49f1382.png)

get_string():
![03](https://user-images.githubusercontent.com/4379204/52092734-83e24400-2586-11e9-9432-b16162b21b20.png)

get_password():
![04](https://user-images.githubusercontent.com/4379204/52092735-83e24400-2586-11e9-9644-16182c285474.png)

get_integer():
![05](https://user-images.githubusercontent.com/4379204/52092736-83e24400-2586-11e9-8245-5822b5cf7d83.png)

get_passcode():
![06](https://user-images.githubusercontent.com/4379204/52092737-847ada80-2586-11e9-9504-a82e8d571cb6.png)

Unlike the rest of the above functions, show_error() uses a stop sign icon, which in some versions of OS X, specifically the newer ones will show that default "no icon set" icon in the corner regardless, because applescript does not allow the user to change that icon when the stop sign is used. I'm keeping the use of the stop sign to make it easy to grasp visually without having to read the dialog that it is an error message.

In addition, KDialog now supports multiple file filters! KDialog is also now able to set the default directory and file name for the file and folder dialogs. The only bug remaining in KDialog is not being able to set the default text with get_password() and get_passcode(), (textbox is always initially empty).