### PR TITLE
Fix Perspective Projection Matrix

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
@@ -247,17 +247,17 @@ void d3d_set_projection_ortho_lookat(gs_scalar x, gs_scalar y, gs_scalar width, 
                                      gs_scalar xto, gs_scalar yto, gs_scalar zto,
                                      gs_scalar xup, gs_scalar yup, gs_scalar zup) {
   enigma::view = glm::lookAt(glm::vec3(xfrom, yfrom, zfrom), glm::vec3(xto, yto, zto), glm::vec3(xup, yup, zup));
+  enigma::view = glm::rotate(glm::mat4(1.0f), (float)gs_angle_to_radians(angle), glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::view;
   enigma::projection = glm::ortho(x, x + width, y + height, y, -32000.0f, 32000.0f);
-  enigma::projection = glm::rotate(glm::mat4(1.0f), (float)gs_angle_to_radians(angle), glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::projection;
   enigma::graphics_set_matrix(matrix_view);
   enigma::graphics_set_matrix(matrix_projection);
 }
 
 void d3d_set_projection_perspective(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-  enigma::view = glm::ortho(x, x + width, y + height, y, 1.0f, 32000.0f);
+  enigma::view = glm::translate(glm::mat4(1.0f), glm::vec3(-(x + width/2), -(y + height/2), width));
+  enigma::view = glm::rotate(glm::mat4(1.0f), (float)gs_angle_to_radians(angle), glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::view;
   enigma::projection = glm::perspective((float)gs_angle_to_radians(40.0f), width/height, 1.0f, 32000.0f);
-  enigma::projection = glm::rotate(glm::mat4(1.0f), (float)gs_angle_to_radians(angle), glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::projection;
   enigma::graphics_set_matrix(matrix_view);
   enigma::graphics_set_matrix(matrix_projection);
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
@@ -255,7 +255,7 @@ void d3d_set_projection_ortho_lookat(gs_scalar x, gs_scalar y, gs_scalar width, 
 
 void d3d_set_projection_perspective(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height, gs_scalar angle)
 {
-  enigma::view = glm::translate(glm::mat4(1.0f), glm::vec3(-(x + width/2), -(y + height/2), width));
+  enigma::view = glm::translate(glm::mat4(1.0f), glm::vec3(-(x + width/2), -(y + height/2), (width+height)/2));
   enigma::view = glm::rotate(glm::mat4(1.0f), (float)gs_angle_to_radians(angle), glm::vec3(0.0f, 0.0f, 1.0f)) * enigma::view;
   enigma::projection = glm::perspective((float)gs_angle_to_radians(40.0f), width/height, 1.0f, 32000.0f);
   enigma::graphics_set_matrix(matrix_view);


### PR DESCRIPTION
Josh helped me work through the issues with `d3d_set_projection_perspective` so that Project Mario's start screen works again. The issue is that its view matrix should have just been the rotation and translation, and the same is true for `d3d_set_projection_ortho` which we discovered via an apitrace.

With this change, Project Mario's start screen now draws correctly in the OpenGL systems. The Direct3D systems don't render correctly yet because of render state issues (I think z write enable is off, which I'll fix in a separate pull request). I also tested the fix in #1513 to make sure it is still working and saw no regression.

![Project Mario Perspective Logo](https://user-images.githubusercontent.com/3212801/52171729-f6425800-272f-11e9-9af1-a1268db33430.png)
![Project Mario Perspective Start Screen](https://user-images.githubusercontent.com/3212801/52171735-01958380-2730-11e9-9324-556b25ad14c5.png)
