### PR TITLE
Fix D3D9 Lighting Material

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -67,6 +67,13 @@ void screen_init()
   }
 
   d3dmgr->SetRenderState(D3DRS_LIGHTING, FALSE);
+  // just in case the user does turn on lighting, we need to set a material
+  // that works for lighting vertices that have no color data
+  D3DMATERIAL9 mtrl = {};
+  mtrl.Ambient.r = mtrl.Ambient.g = mtrl.Ambient.b = mtrl.Ambient.a = 1.0;
+  mtrl.Diffuse.r = mtrl.Diffuse.g = mtrl.Diffuse.b = mtrl.Diffuse.a = 1.0;
+  d3dmgr->SetMaterial(&mtrl);
+
   // make the same default as GL, keep in mind GM uses reverse depth ordering for ortho projections, where the higher the z value the further into the screen you are
   // but that is currently taken care of by using 32000/-32000 for znear/zfar respectively
   d3dmgr->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);


### PR DESCRIPTION
This pull request fixes some Direct3D9 rendering regressions for Project Mario. The specific problem is that vertices that do not have color data are not being rendered when lighting is enabled. Most of the models in Project Mario do not have color or alpha data, but do have texture and normal coordinates.

As is probably obvious, this is not the case with our OpenGL systems or classic GM where the vertices would be simply drawn black. The problem stems from the fact that Direct3D9 uses a default material that's black and transparent where the 0 alpha of the default material cancels out the color of the vertex. To help clarify, you can think of the material as D3D's analog to glColor from OpenGL.

https://docs.microsoft.com/en-us/windows/desktop/direct3d9/materials
>When you create a Direct3D device, the current material is automatically set to the default shown in the following table. Diffuse | (R:0, G:0, B:0, A:0)

https://docs.microsoft.com/en-us/windows/desktop/direct3d9/ambient-lighting
>The value for Cₐ is either: 
> * vertex color1, if AMBIENTMATERIALSOURCE = D3DMCS_COLOR1, and the first vertex color is supplied in the vertex declaration.
> * vertex color2, if AMBIENTMATERIALSOURCE = D3DMCS_COLOR2, and the second vertex color is supplied in vertex declaration.
> * material ambient color.

I likely introduced this regression in #1395 when I removed similar code originally added by me in c1b8ef19fe92c6dfb1bfb986a15bd5b34994c3e9 that was setting a custom material when defining point lights. That way still had a problem because it is actually more correct and cleaner to only set the material once at startup so it affects all types of lights and because there is no need to change it. The cause of the confusion is that apitrace does not show you what the current material state is anywhere I could see it.

| Master | Pull |
|--------|------|
|![Project Mario D3D9 Master](https://user-images.githubusercontent.com/3212801/52175577-cf0d7a00-2773-11e9-8886-9fd056c49e14.png)|![Project Mario D3D9 Pull Request](https://user-images.githubusercontent.com/3212801/52175565-aa190700-2773-11e9-9565-1b654bea791a.png)|
