### PR TITLE
Fix D3D9 Lighting Normalization

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -108,12 +108,12 @@ void d3d_start()
 
 void d3d_end()
 {
-    draw_batch_flush(batch_flush_deferred);
-	enigma::d3dMode = false;
-    enigma::d3dPerspective = false;
-	enigma::d3dCulling = rs_none;
-    d3dmgr->SetRenderState(D3DRS_NORMALIZENORMALS, FALSE);
-	d3d_set_hidden(false);
+  draw_batch_flush(batch_flush_deferred);
+  enigma::d3dMode = false;
+  enigma::d3dPerspective = false;
+  enigma::d3dCulling = rs_none;
+  d3dmgr->SetRenderState(D3DRS_NORMALIZENORMALS, FALSE);
+  d3d_set_hidden(false);
 }
 
 void d3d_set_software_vertex_processing(bool software) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -98,6 +98,7 @@ void d3d_start()
   d3dmgr->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
   d3dmgr->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
   d3dmgr->SetRenderState(D3DRS_ZENABLE, enigma::d3dHidden = true);
+  d3dmgr->SetRenderState(D3DRS_NORMALIZENORMALS, TRUE);
 
   // Enable texture repetition by default
   d3dmgr->SetSamplerState( 0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP );
@@ -111,6 +112,7 @@ void d3d_end()
 	enigma::d3dMode = false;
     enigma::d3dPerspective = false;
 	enigma::d3dCulling = rs_none;
+    d3dmgr->SetRenderState(D3DRS_NORMALIZENORMALS, FALSE);
 	d3d_set_hidden(false);
 }
 


### PR DESCRIPTION
Alright, so this is another lighting issue that needed to be addressed. GM does normalization of your vertex normals in its lighting computations. It apparently does this in the shader because GM8 and GMSv1.4 do not use the fixed-function lighting according to apitrace. Regardless, the problem here is that our OpenGL1 system is enabling GL_NORMALIZE, but our Direct3D9 system was not enabling the equivalent. There appears to be no alternative, such as normalizing during vertex upload, because we allow the user to transform the models freely using `d3d_transform_*` functions.

There is a noticeable hit for benchmarks, like the 3D Cubes Demo, that have lighting. However, the hit doesn't seem very big, only being about 20~/1700 fps in the 3D Cubes Demo specifically. Regardless, the change does fix rendering anomalies in Project Mario's start screen. The reason is because I draw Mario's head scaled way down from its imported size (which causes the need to normalize the normals).

#### Project Mario Start Screen
|        | DX9 | GL1 |
|--------|-----|-----|
| Master |![Project Mario Start DX9 Master](https://user-images.githubusercontent.com/3212801/52182444-4de1d180-27cb-11e9-92d9-c6b6270a0ffd.png)|![Project Mario Start GL1 Master](https://user-images.githubusercontent.com/3212801/52182432-2a1e8b80-27cb-11e9-9748-8c072e9781a4.png)|
| Pull   |![Project Mario Start DX9 Pull](https://user-images.githubusercontent.com/3212801/52182411-ed529480-27ca-11e9-8bd3-e419e01f41b4.png)|![Project Mario Start GL1 Pull](https://user-images.githubusercontent.com/3212801/52182407-de6be200-27ca-11e9-94a6-b6cfbd8948cb.png)|