### PR TITLE
Fix Typos in emake Makefile

### DIFF
--- a/CommandLine/emake/Makefile
+++ b/CommandLine/emake/Makefile
@@ -16,8 +16,8 @@ else
 	OS_LIBS=-lboost_system-mt -Wl,--no-as-needed -Wl,-rpath=./ -lboost_program_options-mt -lboost_iostreams-mt -lboost_filesystem-mt -lboost_system-mt -lpthread
 endif
 
-PROTO_DIR := ../../shared/protos
-CXXFLAGS  := -I$(SRC_DIR) -I../../CompilerSource -I../../shared -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -I$(SHARED_SRC_DIR)/lodepng -std=c++11 -Wall -Wextra -Wpedantic -g
+PROTO_DIR := $(SHARED_SRC_DIR)/protos
+CXXFLAGS  := -I$(SRC_DIR) -I../../CompilerSource -I$(SHARED_SRC_DIR) -I$(SHARED_SRC_DIR)/lodepng -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -std=c++11 -Wall -Wextra -Wpedantic -g
 LDFLAGS   := $(OS_LIBS) -L../../ -lz -L$(SHARED_SRC_DIR)/lodepng -llodepng -lProtocols -lprotobuf
 
 rwildcard=$(wildcard $1/$2) $(foreach d,$(wildcard $1/*),$(call rwildcard,$d,$2))


### PR DESCRIPTION
There was just a few typos in emake's makefile, we should have been using `$(SHARED_SRC_DIR)` in every place so it can be easily changed. Split out from #1533.