### PR TITLE
Clean Compiler Source Makefile

### DIFF
--- a/CompilerSource/Makefile
+++ b/CompilerSource/Makefile
@@ -1,7 +1,8 @@
 # "Shared" includes.
-include ../shared/Makefile
-include ../shared/eyaml/Makefile
-include ../shared/event_reader/Makefile
+SHARED_SRC_DIR := ../shared
+include $(SHARED_SRC_DIR)/Makefile
+include $(SHARED_SRC_DIR)/eyaml/Makefile
+include $(SHARED_SRC_DIR)/event_reader/Makefile
 
 #################
 # configuration #
@@ -39,9 +40,9 @@ rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 SOURCES := $(filter-out ./standalone_main.cpp, $(call rwildcard,./,*.cpp))
 OBJECTS := $(addprefix .eobjs/,$(SOURCES:.cpp=.o))
 DEPENDS := $(OBJECTS:.o=.d)
-PROTO_DIR := ../shared/protos
+PROTO_DIR := $(SHARED_SRC_DIR)/protos
 
-CXXFLAGS += -I../shared -I$(PROTO_DIR)/codegen $(addprefix -I../shared/, $(SHARED_INCLUDES))
+CXXFLAGS += -I$(SHARED_SRC_DIR) -I$(PROTO_DIR)/codegen $(addprefix -I$(SHARED_SRC_DIR)/, $(SHARED_INCLUDES))
 SOURCES += $(addprefix $(SHARED_SRC_DIR),$(SHARED_SOURCES))
 OBJECTS += $(addprefix .eobjs/shared/,$(SHARED_SOURCES:.cpp=.o))
 DEPENDS += $(addprefix .eobjs/shared/,$(SHARED_SOURCES:.cpp=.d))
@@ -69,7 +70,7 @@ $(TARGET): $(OBJECTS)
 # -MP gives phony rules for non-target files, avoiding problems with missing files
 .eobjs/%.o .eobjs/%.d: %.cpp | $(OBJDIRS)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -MMD -MP -c -o .eobjs/$*.o $<
-.eobjs/shared/%.o .eobjs/shared/%.d: ../shared/%.cpp | $(OBJDIRS)
+.eobjs/shared/%.o .eobjs/shared/%.d: $(SHARED_SRC_DIR)/%.cpp | $(OBJDIRS)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -MMD -MP -c -o .eobjs/shared/$*.o $<
 
 $(OBJDIRS):


### PR DESCRIPTION
I just wanted it to use `$(SHARED_SRC_DIR)` like the other makefiles so it's easier to move the directory later if needed. Split out from #1533.