### PR TITLE
Fix Remaining Healthbar Bugs

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
@@ -841,6 +841,16 @@ void draw_healthbar(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, float
     draw_vertex_color(x1,y2,backcol,alpha);
     draw_vertex_color(x2,y2,backcol,alpha);
     draw_primitive_end();
+
+    if (showborder) {
+      draw_primitive_begin(pr_linestrip);
+      draw_vertex_color(x1,y1,0,alpha);
+      draw_vertex_color(x2,y1,0,alpha);
+      draw_vertex_color(x2,y2,0,alpha);
+      draw_vertex_color(x1,y2,0,alpha);
+      draw_vertex_color(x1,y1,0,alpha);
+      draw_primitive_end();
+    }
   }
 
   switch (dir) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/actions.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/actions.h
@@ -147,9 +147,14 @@ inline void action_draw_sprite(const int sprite, const gs_scalar x, const gs_sca
         draw_sprite(sprite,subimage,x,y);
 }
 
-void action_draw_health(const gs_scalar x1, const gs_scalar y1, const gs_scalar x2, const gs_scalar y2, const double backColor, const int barColor);
-void action_draw_health(const gs_scalar x1, const gs_scalar y1, const gs_scalar x2, const gs_scalar y2, const double backColor, const int barColor) {
-  double realbar1, realbar2;
+void action_draw_health(const gs_scalar x1, const gs_scalar y1, const gs_scalar x2, const gs_scalar y2, const int backColor, const int barColor);
+void action_draw_health(const gs_scalar x1, const gs_scalar y1, const gs_scalar x2, const gs_scalar y2, const int backColor, const int barColor) {
+  static const int back_colors[] = {
+    c_black, c_black, c_gray, c_silver, c_white, c_maroon,
+    c_green, c_olive, c_navy, c_purple, c_teal, c_red,
+    c_lime, c_yellow, c_blue, c_fuchsia, c_aqua
+  };
+  int realbar1, realbar2;
   switch (barColor)
   {
       case 0: realbar1=c_green; realbar2=c_red; break;
@@ -174,10 +179,10 @@ void action_draw_health(const gs_scalar x1, const gs_scalar y1, const gs_scalar 
   }
 	if (argument_relative) {
         enigma::object_planar* const inst = ((enigma::object_planar*)enigma::instance_event_iterator->inst);
-        draw_healthbar(x1+inst->x, y1+inst->y, x2+inst->x, y2+inst->y, health, backColor, realbar2, realbar1, 0, 1, 1);
+        draw_healthbar(x1+inst->x, y1+inst->y, x2+inst->x, y2+inst->y, health, back_colors[backColor], realbar2, realbar1, 0, backColor, 1);
 	}
 	else
-        draw_healthbar(x1, y1, x2, y2, health, backColor, realbar2, realbar1, 0, 1, 1);
+        draw_healthbar(x1, y1, x2, y2, health, back_colors[backColor], realbar2, realbar1, 0, backColor, 1);
 }
 
 inline void action_draw_life(const gs_scalar x, const gs_scalar y, const string caption)


### PR DESCRIPTION
This pull request fixes some remaining issues with the healthbar action and function. The first issue is that the healthbar function was not drawing a border around the background color when the background is shown. The second issue is that the healthbar action function was not mapping the back color parameter to the color constants like the front color parameter. The none option for back color is handled specially by using its value as an argument to the show border parameter. Special thanks to @ProtoLink for helping me fix this, I ended up having to recreate the changes though since he lacks reliable internet to submit the changes himself.

| ENIGMA | GM8 |
|--------|-----|
|![ENIGMA Healthbar Back Color](https://user-images.githubusercontent.com/3212801/52430330-d6b28300-2ad3-11e9-872e-22432c60831e.png)|![GM8 Healthbar Back Color](https://user-images.githubusercontent.com/3212801/52430224-a23ec700-2ad3-11e9-8c09-437f55e3becc.png)|