### PR TITLE
Screen Copy Stopgaps

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
@@ -41,7 +41,7 @@ int background_create_from_screen(int x, int y, int w, int h, bool removeback, b
  	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 	int patchSize = full_width*full_height;
 	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
+	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, prevFbo);
 
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
@@ -74,7 +74,7 @@ int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool 
  	glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
 	int patchSize = full_width*full_height;
 	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
+	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
 
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
@@ -101,7 +101,7 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
  	glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
 	int patchSize = full_width*full_height;
 	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
+	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
 
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
@@ -40,7 +40,7 @@ int background_create_from_screen(int x, int y, int w, int h, bool removeback, b
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 	int patchSize = full_width*full_height;
 	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
+	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
 
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
@@ -74,7 +74,7 @@ int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool 
  	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 	int patchSize = full_width*full_height;
 	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
+	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
 
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
@@ -101,7 +101,7 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
  	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 	int patchSize = full_width*full_height;
 	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_RGBA, GL_UNSIGNED_BYTE, &rgbdata[0]);
+	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
 
 	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);


### PR DESCRIPTION
This is a recreation of #1522 that has stopgaps for the other sprite and background function and for OpenGL3. This pull request is basically a temporary stopgap for #1423 until I have more time to properly cleanup all of the screen copying. Special thanks to @ProtoLink for helping me fix this issue!

I made a small test for the functions that have been changed here.
Download Test GMK: [screen-copy-test.zip](https://github.com/enigma-dev/enigma-dev/files/2843301/screen-copy-test.zip)

|        | GL1 | GL3 |
|--------|-----|-----|
| Master |![Screen Copy GL1 Master](https://user-images.githubusercontent.com/3212801/52454423-bf968400-2b19-11e9-9c67-c2b416a403af.png)|![Screen Copy GL3 Master](https://user-images.githubusercontent.com/3212801/52454465-cae9af80-2b19-11e9-96c9-e7e26144d7d8.png)|
| Pull   |![Screen Copy GL1 Pull](https://user-images.githubusercontent.com/3212801/52454345-6fb7bd00-2b19-11e9-8af5-e71c452d0c32.png)|![Screen Copy GL3 Pull](https://user-images.githubusercontent.com/3212801/52454363-7f370600-2b19-11e9-8f88-de87069b5a57.png)|
