### PR TITLE
Fix Travis Regression Testing Concurrency

### DIFF
--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -8,7 +8,7 @@ if [ -z "$1" ]; then
 fi
 export TEST_HARNESS_MASTER_DIR="$1"
 
-if [ ! -z "$2" ]; then
+if [ -n "$2" ]; then
   MAKE_JOBS=-j$2
 fi
 

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -8,8 +8,8 @@ if [ -z "$1" ]; then
 fi
 export TEST_HARNESS_MASTER_DIR="$1"
 
-if [ -z "$2" ]; then
-  MAKE_JOBS=$2
+if [ ! -z "$2" ]; then
+  MAKE_JOBS=-j$2
 fi
 
 GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
@@ -33,7 +33,7 @@ cp -p -r "${PWD}" "${TEST_HARNESS_MASTER_DIR}"
 
 PREVIOUS_PWD=${PWD}
 pushd "${TEST_HARNESS_MASTER_DIR}"
-make all -j$MAKE_JOBS
+make all $MAKE_JOBS
 ./test-runner
 if [[ "$TRAVIS" -eq "true" ]]; then
   # upload coverage report before running regression tests
@@ -64,7 +64,7 @@ if [[ "${PWD}" == "${TEST_HARNESS_MASTER_DIR}" ]]; then
   git clean -f -d
 
   echo "Rebuilding plugin and harness from last commit..."
-  make all -j$MAKE_JOBS
+  make all $MAKE_JOBS
   echo "Generating regression comparison images..."
   mkdir -p "${PWD}/test-harness-out"
   ./test-runner --gtest_filter=Regression.*


### PR DESCRIPTION
I made some egregious Bash scripting booboos. Thanks to Josh for discovering this in #1541 for everybody. The problem is that we basically need to check if the job number parameter is **not** empty, and only when it's not, do we bother telling make the number of jobs. This should fix the test harness and get us back to normal again.