### PR TITLE
DX9 Surface Target Fixes

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -41,6 +41,8 @@ namespace enigma {
 vector<Surface*> Surfaces(0);
 D3DCOLOR get_currentcolor();
 
+//TODO Add caching of the surface's RAM copy to speed this shit up
+//Maybe also investigate the use of CreateRenderTarget
 void surface_copy_to_ram(IDirect3DSurface9 **src, IDirect3DSurface9 **dest) {
   D3DSURFACE_DESC desc;
   (*src)->GetDesc(&desc);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -41,6 +41,14 @@ namespace enigma {
 vector<Surface*> Surfaces(0);
 D3DCOLOR get_currentcolor();
 
+void surface_copy_to_systemmem(IDirect3DSurface9 **src, IDirect3DSurface9 **dest) {
+  D3DSURFACE_DESC desc;
+  (*src)->GetDesc(&desc);
+
+  d3dmgr->device->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, dest, NULL);
+  d3dmgr->device->GetRenderTargetData(*src, *dest);
+}
+
 } // namespace enigma
 
 namespace enigma_user {
@@ -143,11 +151,7 @@ int surface_getpixel(int id, int x, int y)
   draw_batch_flush(batch_flush_deferred);
 
   LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
-  D3DSURFACE_DESC desc;
-  pBuffer->GetDesc(&desc);
-
-  d3dmgr->device->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pSysBuffer, NULL);
-  d3dmgr->device->GetRenderTargetData(pBuffer, pSysBuffer);
+  enigma::surface_copy_to_systemmem(&pBuffer, &pSysBuffer);
 
   D3DLOCKED_RECT rect;
 
@@ -171,11 +175,7 @@ int surface_getpixel_ext(int id, int x, int y)
   draw_batch_flush(batch_flush_deferred);
 
   LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
-  D3DSURFACE_DESC desc;
-  pBuffer->GetDesc(&desc);
-
-  d3dmgr->device->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pSysBuffer, NULL);
-  d3dmgr->device->GetRenderTargetData(pBuffer, pSysBuffer);
+  enigma::surface_copy_to_systemmem(&pBuffer, &pSysBuffer);
 
   D3DLOCKED_RECT rect;
 
@@ -199,11 +199,7 @@ int surface_getpixel_alpha(int id, int x, int y)
   draw_batch_flush(batch_flush_deferred);
 
   LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
-  D3DSURFACE_DESC desc;
-  pBuffer->GetDesc(&desc);
-
-  d3dmgr->device->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pSysBuffer, NULL);
-  d3dmgr->device->GetRenderTargetData(pBuffer, pSysBuffer);
+  enigma::surface_copy_to_systemmem(&pBuffer, &pSysBuffer);
 
   D3DLOCKED_RECT rect;
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -142,15 +142,22 @@ int surface_getpixel(int id, int x, int y)
   if (x > surface->width || y > surface->height) return 0;
   draw_batch_flush(batch_flush_deferred);
 
-  LPDIRECT3DSURFACE9 pBuffer = surface->surf;
+  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
+  D3DSURFACE_DESC desc;
+  pBuffer->GetDesc(&desc);
+
+  d3dmgr->device->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pSysBuffer, NULL);
+  d3dmgr->device->GetRenderTargetData(pBuffer, pSysBuffer);
+
   D3DLOCKED_RECT rect;
 
-  pBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
+  pSysBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
   unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
   unsigned offset = y * rect.Pitch + x * 4;
-  int ret = bitmap[offset + 1] | (bitmap[offset + 2] << 8) | (bitmap[offset + 3] << 16);
-  pBuffer->UnlockRect();
-  delete[] bitmap;
+  int ret = bitmap[offset + 2] | (bitmap[offset + 1] << 8) | (bitmap[offset + 0] << 16);
+  pSysBuffer->UnlockRect();
+
+  pSysBuffer->Release();
 
   return ret;
 }
@@ -163,15 +170,22 @@ int surface_getpixel_ext(int id, int x, int y)
   if (x > surface->width || y > surface->height) return 0;
   draw_batch_flush(batch_flush_deferred);
 
-  LPDIRECT3DSURFACE9 pBuffer = surface->surf;
+  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
+  D3DSURFACE_DESC desc;
+  pBuffer->GetDesc(&desc);
+
+  d3dmgr->device->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pSysBuffer, NULL);
+  d3dmgr->device->GetRenderTargetData(pBuffer, pSysBuffer);
+
   D3DLOCKED_RECT rect;
 
-  pBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
+  pSysBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
   unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
   unsigned offset = y * rect.Pitch + x * 4;
-  int ret = bitmap[offset + 0] | (bitmap[offset + 1] << 8) | (bitmap[offset + 2] << 16) | (bitmap[offset + 3] << 24);
-  pBuffer->UnlockRect();
-  delete[] bitmap;
+  int ret = bitmap[offset + 2] | (bitmap[offset + 1] << 8) | (bitmap[offset + 0] << 16) | (bitmap[offset + 3] << 24);
+  pSysBuffer->UnlockRect();
+
+  pSysBuffer->Release();
 
   return ret;
 }
@@ -184,15 +198,22 @@ int surface_getpixel_alpha(int id, int x, int y)
   if (x > surface->width || y > surface->height) return 0;
   draw_batch_flush(batch_flush_deferred);
 
-  LPDIRECT3DSURFACE9 pBuffer = surface->surf;
+  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
+  D3DSURFACE_DESC desc;
+  pBuffer->GetDesc(&desc);
+
+  d3dmgr->device->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pSysBuffer, NULL);
+  d3dmgr->device->GetRenderTargetData(pBuffer, pSysBuffer);
+
   D3DLOCKED_RECT rect;
 
-  pBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
+  pSysBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
   unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
   unsigned offset = y * rect.Pitch + x * 4;
-  int ret = bitmap[offset];
-  pBuffer->UnlockRect();
-  delete[] bitmap;
+  int ret = bitmap[offset + 3];
+  pSysBuffer->UnlockRect();
+
+  pSysBuffer->Release();
 
   return ret;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -41,7 +41,7 @@ namespace enigma {
 vector<Surface*> Surfaces(0);
 D3DCOLOR get_currentcolor();
 
-void surface_copy_to_systemmem(IDirect3DSurface9 **src, IDirect3DSurface9 **dest) {
+void surface_copy_to_ram(IDirect3DSurface9 **src, IDirect3DSurface9 **dest) {
   D3DSURFACE_DESC desc;
   (*src)->GetDesc(&desc);
 
@@ -150,18 +150,18 @@ int surface_getpixel(int id, int x, int y)
   if (x > surface->width || y > surface->height) return 0;
   draw_batch_flush(batch_flush_deferred);
 
-  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
-  enigma::surface_copy_to_systemmem(&pBuffer, &pSysBuffer);
+  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pRamBuffer;
+  enigma::surface_copy_to_ram(&pBuffer, &pRamBuffer);
 
   D3DLOCKED_RECT rect;
 
-  pSysBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
+  pRamBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
   unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
   unsigned offset = y * rect.Pitch + x * 4;
   int ret = bitmap[offset + 2] | (bitmap[offset + 1] << 8) | (bitmap[offset + 0] << 16);
-  pSysBuffer->UnlockRect();
+  pRamBuffer->UnlockRect();
 
-  pSysBuffer->Release();
+  pRamBuffer->Release();
 
   return ret;
 }
@@ -174,18 +174,18 @@ int surface_getpixel_ext(int id, int x, int y)
   if (x > surface->width || y > surface->height) return 0;
   draw_batch_flush(batch_flush_deferred);
 
-  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
-  enigma::surface_copy_to_systemmem(&pBuffer, &pSysBuffer);
+  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pRamBuffer;
+  enigma::surface_copy_to_ram(&pBuffer, &pRamBuffer);
 
   D3DLOCKED_RECT rect;
 
-  pSysBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
+  pRamBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
   unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
   unsigned offset = y * rect.Pitch + x * 4;
   int ret = bitmap[offset + 2] | (bitmap[offset + 1] << 8) | (bitmap[offset + 0] << 16) | (bitmap[offset + 3] << 24);
-  pSysBuffer->UnlockRect();
+  pRamBuffer->UnlockRect();
 
-  pSysBuffer->Release();
+  pRamBuffer->Release();
 
   return ret;
 }
@@ -198,18 +198,18 @@ int surface_getpixel_alpha(int id, int x, int y)
   if (x > surface->width || y > surface->height) return 0;
   draw_batch_flush(batch_flush_deferred);
 
-  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pSysBuffer;
-  enigma::surface_copy_to_systemmem(&pBuffer, &pSysBuffer);
+  LPDIRECT3DSURFACE9 pBuffer = surface->surf, pRamBuffer;
+  enigma::surface_copy_to_ram(&pBuffer, &pRamBuffer);
 
   D3DLOCKED_RECT rect;
 
-  pSysBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
+  pRamBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
   unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
   unsigned offset = y * rect.Pitch + x * 4;
   int ret = bitmap[offset + 3];
-  pSysBuffer->UnlockRect();
+  pRamBuffer->UnlockRect();
 
-  pSysBuffer->Release();
+  pRamBuffer->Release();
 
   return ret;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -80,14 +80,11 @@ int surface_create_msaa(int width, int height, int levels)
   return enigma::Surfaces.size() - 1;
 }
 
-LPDIRECT3DSURFACE9 pBackBuffer;
-
 void surface_set_target(int id)
 {
   draw_batch_flush(batch_flush_deferred);
 
   get_surface(surface,id);
-  d3dmgr->device->GetRenderTarget(0, &pBackBuffer);
   d3dmgr->device->SetRenderTarget(0, surface->surf);
 
   d3d_set_projection_ortho(0, 0, surface->width, surface->height, 0);
@@ -97,10 +94,10 @@ void surface_reset_target()
 {
   draw_batch_flush(batch_flush_deferred);
 
-  //d3dmgr->ResetRenderTarget();
+  LPDIRECT3DSURFACE9 pBackBuffer;
+  d3dmgr->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
   d3dmgr->device->SetRenderTarget(0, pBackBuffer);
   pBackBuffer->Release();
-  pBackBuffer = NULL;
 }
 
 int surface_get_target()
@@ -146,10 +143,6 @@ int surface_getpixel(int id, int x, int y)
   draw_batch_flush(batch_flush_deferred);
 
   LPDIRECT3DSURFACE9 pBuffer = surface->surf;
-  d3dmgr->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
-  D3DSURFACE_DESC desc;
-  pBackBuffer->GetDesc(&desc);
-
   D3DLOCKED_RECT rect;
 
   pBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
@@ -171,10 +164,6 @@ int surface_getpixel_ext(int id, int x, int y)
   draw_batch_flush(batch_flush_deferred);
 
   LPDIRECT3DSURFACE9 pBuffer = surface->surf;
-  d3dmgr->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
-  D3DSURFACE_DESC desc;
-  pBackBuffer->GetDesc(&desc);
-
   D3DLOCKED_RECT rect;
 
   pBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
@@ -196,10 +185,6 @@ int surface_getpixel_alpha(int id, int x, int y)
   draw_batch_flush(batch_flush_deferred);
 
   LPDIRECT3DSURFACE9 pBuffer = surface->surf;
-  d3dmgr->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
-  D3DSURFACE_DESC desc;
-  pBackBuffer->GetDesc(&desc);
-
   D3DLOCKED_RECT rect;
 
   pBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);


### PR DESCRIPTION
A few games that use surfaces were having issues in Direct3D9. Basically, when the render target was being reset, I was setting it to the previously set render target instead of back to the normal backbuffer. Since we aren't using a stack, like GMSv1.4 started to do, we obviously end up losing the normal screen render target. I did not want to change us to using a stack yet because that is not backwards-compatible with GM8 and older versions. For now, I've just corrected my mistake in D3D9 and made it behave like GL1.

The following games will now actually render in Direct3D9, where on master they just appear black/blank.
* https://enigma-dev.org/edc/games.php?game=62
* https://enigma-dev.org/edc/games.php?game=67

While I was in here, I ended up fixing the surface pixel read functions too. The first thing was that I had some leftover junk code to obtain the swapchain backbuffer, which we don't even need. Next, we are using render target textures for the surfaces that are allocated in the default pool. This means we have to copy to an offscreen surface before we can lock them, just like the primary backbuffer. Finally, I was also doing a double delete because `D3DLOCKED_RECT` does not need its data explicitly deleted when it's stack-allocated.

https://docs.microsoft.com/en-us/windows/desktop/api/d3d9helper/nf-d3d9helper-idirect3dsurface9-lockrect
>This method cannot retrieve data from a surface that is is contained by a texture resource created with D3DUSAGE_RENDERTARGET because such a texture must be assigned to D3DPOOL_DEFAULT memory and is therefore not lockable. In this case, use instead IDirect3DDevice9::GetRenderTargetData to copy texture data from device memory to system memory.

I made a small test project to test the surface pixel reading. It works on this pull request but just crashes on master.
Download Surface Pixel Read GMK: [surface-pixel-read-test.zip](https://github.com/enigma-dev/enigma-dev/files/2847672/surface-pixel-read-test.zip)
