### PR TITLE
Resource Reference Proto Option

### DIFF
--- a/shared/protos/Object.proto
+++ b/shared/protos/Object.proto
@@ -7,9 +7,9 @@ import "Event.proto";
 message Object {
   optional int32 id = 2 [(gmx) = "GMX_DEPRECATED"];
 
-  optional string parent_name = 3 [(gmx) = "parentName", (yyp_id) = "parentObjectId"];
-  optional string sprite_name = 4 [(gmx) = "spriteName", (yyp_id) = "spriteId"];
-  optional string mask_name = 5 [(gmx) = "maskName", (yyp_id) = "maskSpriteId"];
+  optional string parent_name = 3 [(resource_ref)="object", (gmx) = "parentName", (yyp_id) = "parentObjectId"];
+  optional string sprite_name = 4 [(resource_ref)="sprite", (gmx) = "spriteName", (yyp_id) = "spriteId"];
+  optional string mask_name = 5 [(resource_ref)="sprite", (gmx) = "maskName", (yyp_id) = "maskSpriteId"];
 
   optional int32 depth = 6 [(yyp) = "YYP_DEPRECATED"];
   optional bool solid = 7;

--- a/shared/protos/Path.proto
+++ b/shared/protos/Path.proto
@@ -12,7 +12,7 @@ message Path {
 
   optional int32 id = 2 [(gmx) = "GMX_DEPRECATED"];
 
-  optional string background_room_name = 3 [(gmx_id) = "backroom"];
+  optional string background_room_name = 3 [(resource_ref)="room", (gmx_id) = "backroom"];
   optional int32 hsnap= 4;
   optional int32 vsnap = 5;
 

--- a/shared/protos/Room.proto
+++ b/shared/protos/Room.proto
@@ -24,7 +24,7 @@ message Room {
   message Background {
     optional bool visible = 1;
     optional bool foreground = 2;
-    optional string background_name = 3 [(gmx) = "name"];
+    optional string background_name = 3 [(resource_ref)="background", (gmx) = "name"];
     optional int32 x = 4;
     optional int32 y = 5;
     optional bool htiled = 6;
@@ -52,7 +52,7 @@ message Room {
     optional int32 vborder = 11;
     optional double hspeed = 12;
     optional double vspeed = 13;
-    optional string object_following = 14 [(gmx) = "objName"];
+    optional string object_following = 14 [(resource_ref)="object", (gmx) = "objName"];
   }
 
   repeated View views = 16 [(gmx) = "views/view", (yyp) = "views"];
@@ -60,7 +60,7 @@ message Room {
   message Instance {
     optional string name = 1;
     optional int32 id = 2 [(id_start) = 100000];
-    optional string object_type = 3 [(gmx) = "objName"];
+    optional string object_type = 3 [(resource_ref)="object", (gmx) = "objName"];
     optional double x = 4;
     optional double y = 5;
     optional double z = 6;
@@ -85,7 +85,7 @@ message Room {
   message Tile {
     optional string name = 1;
     optional int32 id = 2 [(id_start) = 10000000];
-    optional string background_name = 3 [(gmx) = "bgName"];
+    optional string background_name = 3 [(resource_ref)="background", (gmx) = "bgName"];
     optional double x = 4;
     optional double y = 5;
     optional int32 xoffset = 6 [(gmx) = "xo"];

--- a/shared/protos/options.proto
+++ b/shared/protos/options.proto
@@ -5,8 +5,9 @@ import "google/protobuf/descriptor.proto";
 extend google.protobuf.FieldOptions {
   optional int32 id_start = 50000;
   optional bool file_path = 50001;
-  optional string gmx = 50002;
-  optional string gmx_id = 50003;
-  optional string yyp = 50004;
-  optional string yyp_id = 50005;
+  optional string resource_ref = 50002;
+  optional string gmx = 50003;
+  optional string gmx_id = 50004;
+  optional string yyp = 50005;
+  optional string yyp_id = 50006;
 }


### PR DESCRIPTION
This change basically flags the fields in the protos that are references a resource has to another resource. This is useful for several reasons, but primarily it allows us to deal with `"<undefined>"` within the GMX reader itself by doing a simple comparison.