### PR TITLE
JDI Image Formats Crash Stopgap

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/libpng/libpng-ext.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/libpng/libpng-ext.cpp
@@ -19,6 +19,7 @@
 
 #include "libpng-ext.h"
 #include "Universal_System/image_formats.h"
+#include "Universal_System/image_formats_exts.h"
 #include "Universal_System/nlpo2.h"
 
 #include "libpng-util.h"

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -18,6 +18,7 @@
 **/
 
 #include "image_formats.h"
+#include "image_formats_exts.h"
 #include "Universal_System/estring.h"
 
 #include "gif_format.h"

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -19,7 +19,6 @@
 #ifndef ENIGMA_IMAGEFORMATS_H
 #define ENIGMA_IMAGEFORMATS_H
 
-#include <functional>
 #include <string>
 
 /// NOTE: These image formats expect the data to be un-aligned and always reads and writes with BGRA full color
@@ -34,12 +33,6 @@ enum {
   color_fmt_bgra,
   color_fmt_bgr
 };
-
-using ImageLoadFunction = std::function<unsigned char*(std::string, unsigned int*, unsigned int*, unsigned int*, unsigned int*, bool)>;
-using ImageSaveFunction = std::function<int(std::string, const unsigned char*, unsigned, unsigned, unsigned, unsigned, bool)>;
-
-void image_add_loader(std::string format, ImageLoadFunction fnc);
-void image_add_saver(std::string format, ImageSaveFunction fnc);
 
 /// Gets the image format, eg. ".bmp", ".png", etc.
 std::string image_get_format(std::string filename);

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats_exts.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats_exts.h
@@ -1,0 +1,35 @@
+/** Copyright (C) 2019 Robert B. Colton
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#ifndef ENIGMA_IMAGEFORMATS_EXTS_H
+#define ENIGMA_IMAGEFORMATS_EXTS_H
+
+#include <functional>
+#include <string>
+
+namespace enigma
+{
+
+using ImageLoadFunction = std::function<unsigned char*(std::string, unsigned int*, unsigned int*, unsigned int*, unsigned int*, bool)>;
+using ImageSaveFunction = std::function<int(std::string, const unsigned char*, unsigned, unsigned, unsigned, unsigned, bool)>;
+
+void image_add_loader(std::string format, ImageLoadFunction fnc);
+void image_add_saver(std::string format, ImageSaveFunction fnc);
+
+} //namespace enigma
+
+#endif //ENIGMA_IMAGEFORMATS_EXTS_H


### PR DESCRIPTION
So I am guessing that my include of `<functional>` is what is including `<cstdlib>` and appears to be crashing @time-killer-games pull request #1546.