### PR TITLE
New Code Model

### DIFF
--- a/CommandLine/Util.h
+++ b/CommandLine/Util.h
@@ -1,0 +1,12 @@
+#include <string>
+
+inline std::string string_replace_all(std::string str, std::string substr, std::string nstr)
+{
+  size_t pos = 0;
+  while ((pos = str.find(substr, pos)) != std::string::npos)
+  {
+    str.replace(pos, substr.length(), nstr);
+    pos += nstr.length();
+  }
+  return str;
+}

--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -14,7 +14,7 @@ PROTO_DIR := ../../shared/protos
 SRC_DIR   := .
 OBJ_DIR   := .eobjs
 
-CXXFLAGS  := -I$(SRC_DIR) $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -I$(SHARED_SOURCES)/libpng-util -Wall -Wextra -Wpedantic -g -fPIC
+CXXFLAGS  := -I$(SRC_DIR) -I../ $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -I$(SHARED_SOURCES)/libpng-util -Wall -Wextra -Wpedantic -g -fPIC
 LDFLAGS   := -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -lstdc++fs -L$(SHARED_SOURCES)/libpng-util -lpng-util -lpng
 
 #if gcc >= 8 use std::filesystem instead of boost

--- a/CommandLine/libEGM/action.cpp
+++ b/CommandLine/libEGM/action.cpp
@@ -1,17 +1,24 @@
-#include "Event.pb.h"
+/** Copyright (C) 2018 Robert B. Colton
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
 
-static inline std::string string_replace_all(std::string str, std::string substr, std::string nstr)
-{
-  size_t pos = 0;
-  while ((pos = str.find(substr, pos)) != std::string::npos)
-  {
-    str.replace(pos, substr.length(), nstr);
-    pos += nstr.length();
-  }
-  return str;
-}
+#include "action.h"
+#include "Util.h"
 
-static std::string Argument2Code(const buffers::resources::Argument& arg) {
+std::string Argument2Code(const buffers::resources::Argument& arg) {
   using buffers::resources::ArgumentKind;
   std::string val = arg.string();
 
@@ -57,7 +64,7 @@ static std::string Argument2Code(const buffers::resources::Argument& arg) {
   return val;
 }
 
-static std::string Actions2Code(const ::google::protobuf::RepeatedPtrField< buffers::resources::Action >& actions) {
+std::string Actions2Code(const std::vector< buffers::resources::Action >& actions) {
   using buffers::resources::ActionKind;
   using buffers::resources::ActionExecution;
   std::string code = "";

--- a/CommandLine/libEGM/action.h
+++ b/CommandLine/libEGM/action.h
@@ -1,0 +1,23 @@
+/** Copyright (C) 2018 Robert B. Colton
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include "Event.pb.h"
+
+#include <vector>
+
+std::string Argument2Code(const buffers::resources::Argument& arg);
+std::string Actions2Code(const std::vector< buffers::resources::Action >& actions);

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -17,6 +17,7 @@
 
 #include "gmk.h"
 #include "filesystem.h"
+#include "action.h"
 
 #include "libpng-util.h"
 
@@ -799,38 +800,29 @@ std::unique_ptr<Font> LoadFont(Decoder &dec, int /*ver*/) {
   return font;
 }
 
-// TODO: Look up event name by type integer
-string Describe(const Event &ev) {
-  string res = "Event " + to_string(ev.type()) + ":";
-  if (ev.has_name()) return res + ev.name();
-  return res + to_string(ev.number());
-}
-
-string Describe(const Timeline_Moment &m) {
-  return "Timeline moment " + to_string(m.step());
-}
-
-template<class Event> int LoadActions(Decoder &dec, Event *event) {
+int LoadActions(Decoder &dec, std::string* code, std::string eventName) {
   int ver = dec.read4();
   if (ver != 400) {
-    err << "Unsupported GMK actions version '" << ver << "' for "
-        << Describe(*event) << "'" << std::endl;
+    err << "Unsupported GMK actions version '" << ver <<
+      "' for event '" << eventName << "'" << std::endl;
     return 0;
   }
 
   int noacts = dec.read4();
+  std::vector<Action> actions;
+  actions.reserve(noacts);
   for (int k = 0; k < noacts; k++) {
-    auto action = event->add_actions();
+    Action action;
     dec.skip(4);
-    action->set_libid(dec.read4());
-    action->set_id(dec.read4());
-    action->set_kind(static_cast<ActionKind>(dec.read4()));
-    action->set_use_relative(dec.readBool());
-    action->set_is_question(dec.readBool());
-    action->set_use_apply_to(dec.readBool());
-    action->set_exe_type(static_cast<ActionExecution>(dec.read4()));
-    action->set_function_name(dec.readStr());
-    action->set_code_string(dec.readStr());
+    action.set_libid(dec.read4());
+    action.set_id(dec.read4());
+    action.set_kind(static_cast<ActionKind>(dec.read4()));
+    action.set_use_relative(dec.readBool());
+    action.set_is_question(dec.readBool());
+    action.set_use_apply_to(dec.readBool());
+    action.set_exe_type(static_cast<ActionExecution>(dec.read4()));
+    action.set_function_name(dec.readStr());
+    action.set_code_string(dec.readStr());
 
     int numofargs = dec.read4(); // number of library action's arguments
     int numofargkinds = dec.read4(); // number of library action's argument kinds
@@ -841,15 +833,15 @@ template<class Event> int LoadActions(Decoder &dec, Event *event) {
     int applies_to = dec.read4();
     switch (applies_to) {
       case -1:
-        action->set_who_name("self");
+        action.set_who_name("self");
         break;
       case -2:
-        action->set_who_name("other");
+        action.set_who_name("other");
         break;
       default:
-        dec.postponeName(action->mutable_who_name(), applies_to, TypeCase::kObject);
+        action.set_who_name(std::to_string(applies_to));
     }
-    action->set_relative(dec.readBool());
+    action.set_relative(dec.readBool());
 
     int actualnoargs = dec.read4();
     for (int l = 0; l < actualnoargs; l++) {
@@ -857,7 +849,7 @@ template<class Event> int LoadActions(Decoder &dec, Event *event) {
         dec.skip(dec.read4());
         continue;
       }
-      auto argument = action->add_arguments();
+      auto argument = action.add_arguments();
       argument->set_kind(static_cast<ArgumentKind>(argkinds[l]));
       std::string strval = dec.readStr();
 
@@ -884,8 +876,11 @@ template<class Event> int LoadActions(Decoder &dec, Event *event) {
       }
     }
 
-    action->set_is_not(dec.readBool());
+    action.set_is_not(dec.readBool());
+    actions.emplace_back(action);
   }
+
+  code->append(Actions2Code(actions));
 
   return 1;
 }
@@ -897,7 +892,7 @@ std::unique_ptr<Timeline> LoadTimeline(Decoder &dec, int /*ver*/) {
   for (int i = 0; i < nomoms; i++) {
     auto moment = timeline->add_moments();
     moment->set_step(dec.read4());
-    if (!LoadActions(dec, moment)) return nullptr;
+    if (!LoadActions(dec, moment->mutable_code(), "step_" + std::to_string(moment->step()))) return nullptr;
   }
 
   return timeline;
@@ -924,7 +919,7 @@ std::unique_ptr<Object> LoadObject(Decoder &dec, int /*ver*/) {
       event->set_type(i);
       event->set_number(second);
 
-      if (!LoadActions(dec, event)) return nullptr;
+      if (!LoadActions(dec, event->mutable_code(), event->name())) return nullptr;
     }
   }
 

--- a/CompilerSource/backend/GameData.cpp
+++ b/CompilerSource/backend/GameData.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "GameData.h"
-#include "Actions2Code.h"
 
 #include "libpng-util.h"
 
@@ -266,12 +265,7 @@ ShaderData::ShaderData(const ::Shader &shader):
 }
 
 TimelineData::TimelineData(const buffers::resources::Timeline &q, const std::string& name):
-  buffers::resources::Timeline(q), name(name) {
-  for (int i = 0; i < moments_size(); ++i) {
-    auto* mmt = mutable_moments(i);
-    mmt->set_code(Actions2Code(mmt->actions()));
-  }
-}
+  buffers::resources::Timeline(q), name(name) {}
 TimelineData::TimelineData(const ::Timeline &timeline):
   name(timeline.name) {
   set_id(timeline.id);
@@ -284,12 +278,7 @@ TimelineData::TimelineData(const ::Timeline &timeline):
 }
 
 ObjectData::ObjectData(const buffers::resources::Object &q, const std::string& name):
-  buffers::resources::Object(q), name(name) {
-  for (int i = 0; i < events_size(); ++i) {
-    auto* evt = mutable_events(i);
-    evt->set_code(Actions2Code(evt->actions()));
-  }
-}
+  buffers::resources::Object(q), name(name) {}
 ObjectData::ObjectData(const ::GmObject &object, const ESLookup &lookup):
   name(object.name) {
   set_id(object.id);

--- a/shared/protos/Event.proto
+++ b/shared/protos/Event.proto
@@ -80,6 +80,5 @@ message Event {
     int32 number = 2 [(gmx) = "enumb"];
     string name = 3 [(gmx) = "ename", (yyp_id) = "collisionObjectId"];
   }
-  repeated Action actions = 4 [(gmx) = "action"];
-  optional string code = 5 [(gmx) = "GMX_DEPRECATED"];
+  optional string code = 4 [(gmx) = "action"];
 }

--- a/shared/protos/Timeline.proto
+++ b/shared/protos/Timeline.proto
@@ -7,8 +7,7 @@ import "Event.proto";
 message Timeline {
   message Moment {
     optional int32 step = 1;
-    repeated Action actions = 2 [(gmx) = "action"];
-    optional string code = 3;
+    optional string code = 2 [(gmx) = "action"];
   }
 
   optional int32 id = 1 [(gmx) = "GMX_DEPRECATED"];


### PR DESCRIPTION
I have split these changes out from #1479 to make them easier to digest and integrate. The goal of this pull request is to deprecate the old drag and drop actions by having libEGM convert them to code immediately when a GMK or GMX is loaded instead of having GameData do it at the compile stage. RadialGM has no plans to provide a user interface for the old drag and drop feature. This pull request will allow old games to be run by still providing the actions converted to code for the user.

* GameData does **_NOT_** do the actions->gml conversion now
* GMK/GMX converts the actions->gml with some special handling (they are emplaced at the back of a vector that is passed to `Actions2Code`)
* `Actions2Code` logic was moved from `CompilerSource/backend/Actions2Code.h` to its own source in `libEGM/action.cpp` and `libEGM/action.h`
* A header `CommandLine/Util.h` was created so that we don't keep copying and pasting `string_replace_all` everywhere

The new action format, if we get around to doing it, will use JDI to parse the GML and comments into a UI like GMS2.