### PR TITLE
Fix OpenGL1 Vertex Array Fallback Query

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -23,12 +23,6 @@
 #include <map>
 using std::map;
 
-namespace enigma {
-
-bool vbo_is_supported = false;
-
-} // namespace enigma
-
 namespace {
 
 GLenum primitive_types[] = { 0, GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_TRIANGLES, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN };
@@ -109,6 +103,8 @@ void graphics_prepare_buffer_peer(const int buffer, const bool isIndex) {
 } // anonymous namespace
 
 namespace enigma {
+
+bool vbo_is_supported = false;
 
 void graphics_delete_vertex_buffer_peer(int buffer) {
   if (vbo_is_supported) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -23,11 +23,15 @@
 #include <map>
 using std::map;
 
+namespace enigma {
+
+bool vbo_is_supported = false;
+
+} // namespace enigma
+
 namespace {
 
 GLenum primitive_types[] = { 0, GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_TRIANGLES, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN };
-
-bool vbo_is_supported = GL_ARB_vertex_buffer_object;
 
 // for OpenGL1.1
 map<int, std::vector<enigma::VertexElement> > vertexBufferArrays;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -33,8 +33,13 @@ namespace enigma
   bool glew_isgo;
   bool pbo_isgo;
 
+  extern bool vbo_is_supported;
+
   void graphicssystem_initialize()
   {
+    // we don't check for extensions until GLEW has been initialized
+    vbo_is_supported = GLEW_ARB_vertex_buffer_object;
+
     //enigma::pbo_isgo=GL_ARB_pixel_buffer_object;
     glMatrixMode(GL_PROJECTION);
     glClearColor(0,0,0,0);


### PR DESCRIPTION
From what I discovered looking at #1557, I apparently used the wrong global for checking if the vertex buffer object extension is available. I also discovered that these globals can only be checked after glew has been initialized. So, I had to change it to check for vbo support during graphics system initialize.

http://glew.sourceforge.net/basic.html
>Starting from GLEW 1.1.0, you can find out if a particular extension is available on your platform by querying globally defined variables of the form GLEW_{extension_name}