### PR TITLE
Fix GL1 Fallback for Index Buffers

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -246,7 +246,7 @@ void vertex_submit_offset(int buffer, int primitive, unsigned offset, unsigned s
   void* base_pointer = enigma::graphics_prepare_buffer(buffer, false);
   enigma::ClientState state = enigma::graphics_apply_vertex_format(vertexBuffer->format, (GLvoid*)((intptr_t)base_pointer + offset));
 
-	glDrawArrays(primitive_types[primitive], start, count);
+  glDrawArrays(primitive_types[primitive], start, count);
 
   enigma::graphics_reset_client_state(state);
 }
@@ -272,7 +272,8 @@ void index_submit_range(int buffer, int vertex, int primitive, unsigned start, u
   glDrawElements(primitive_types[primitive], count, indexType, (GLvoid*)((intptr_t)base_index_pointer + start));
 
   enigma::graphics_reset_client_state(state);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  if (enigma::vbo_is_supported)
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 } // namespace enigma_user


### PR DESCRIPTION
I noticed after merging #1558 that I had also previously placed a `glBindBuffer` call at the end of the index buffer submit function to unbind an index buffer. This call was being executed even when arrays were being used. This caused @rcobraone further issues in #1557 since his graphics card is failing to provide support for buffer objects and the related functions.