### PR TITLE
Fix GL1 VBO Fallback Aliasing

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -15,6 +15,10 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+//NOTE: If this source is changed to utilize additional features of the GL_ARB_vertex_buffer_object
+//extension, then please be sure to update the graphics_init_vbo_method() helper below to ensure any
+//functions are properly aliased and will continue working on affected graphics cards.
+
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSvertex_impl.h"
 #include "Graphics_Systems/General/GSprimitives.h"
@@ -105,6 +109,19 @@ void graphics_prepare_buffer_peer(const int buffer, const bool isIndex) {
 namespace enigma {
 
 bool vbo_is_supported = false;
+
+void graphics_init_vbo_method() {
+  // we don't check for extensions until GLEW has been initialized
+  vbo_is_supported = GLEW_ARB_vertex_buffer_object;
+  // if the vbo extension is supported, but the GL version is old,
+  // we need to alias the buffer functions to the extension ones
+  if (GLEW_ARB_vertex_buffer_object == true && GLEW_VERSION_1_5 == false) {
+    glGenBuffers = glGenBuffersARB;
+    glBindBuffer = glBindBufferARB;
+    glBufferData = glBufferDataARB;
+    glDeleteBuffers = glDeleteBuffersARB;
+  }
+}
 
 void graphics_delete_vertex_buffer_peer(int buffer) {
   if (vbo_is_supported) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -39,6 +39,14 @@ namespace enigma
   {
     // we don't check for extensions until GLEW has been initialized
     vbo_is_supported = GLEW_ARB_vertex_buffer_object;
+    // if the vbo extension is supported, but the GL version is old,
+    // we need to alias the buffer functions to the extension ones
+    if (GLEW_ARB_vertex_buffer_object == true && GLEW_VERSION_1_5 == false) {
+      glGenBuffers = glGenBuffersARB;
+      glBindBuffer = glBindBufferARB;
+      glBufferData = glBufferDataARB;
+      glDeleteBuffers = glDeleteBuffersARB;
+    }
 
     //enigma::pbo_isgo=GL_ARB_pixel_buffer_object;
     glMatrixMode(GL_PROJECTION);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -33,20 +33,11 @@ namespace enigma
   bool glew_isgo;
   bool pbo_isgo;
 
-  extern bool vbo_is_supported;
+  void graphics_init_vbo_method();
 
   void graphicssystem_initialize()
   {
-    // we don't check for extensions until GLEW has been initialized
-    vbo_is_supported = GLEW_ARB_vertex_buffer_object;
-    // if the vbo extension is supported, but the GL version is old,
-    // we need to alias the buffer functions to the extension ones
-    if (GLEW_ARB_vertex_buffer_object == true && GLEW_VERSION_1_5 == false) {
-      glGenBuffers = glGenBuffersARB;
-      glBindBuffer = glBindBufferARB;
-      glBufferData = glBufferDataARB;
-      glDeleteBuffers = glDeleteBuffersARB;
-    }
+    graphics_init_vbo_method();
 
     //enigma::pbo_isgo=GL_ARB_pixel_buffer_object;
     glMatrixMode(GL_PROJECTION);


### PR DESCRIPTION
Ok, #1557 led to us discovering one more final change that needs to be made for the fallback to work. If you have an OpenGL version less than 1.5, but the VBO extension is supported, then you must use the special `ARB` postfixed alias of the buffer functions. Special thanks to @rcobraone for figuring this out and providing a reference from Khronos.

I can confirm that, according to the GLEW maintainers themselves, the workaround I am proposing here is completely acceptable and recommended.
https://sourceforge.net/p/glew/bugs/208/

>I think the short answer to this is that your workaround is the recommended way.