### PR TITLE
Cleanup OpenGL1 Warnings

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -30,8 +30,6 @@ using namespace std;
 #include "Graphics_Systems/graphics_mandatory.h" // Room dimensions.
 namespace enigma
 {
-  bool glew_isgo;
-  bool pbo_isgo;
 
   void graphics_init_vbo_method();
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.h
@@ -29,8 +29,6 @@ namespace enigma
   extern unsigned char currentcolor[4];
   extern int currentblendmode[2];
   extern int currentblendtype;
-  extern bool glew_isgo;
-  extern bool pbo_isgo;
 }
 
 #include "../General/GScolors.h"
@@ -40,4 +38,3 @@ namespace enigma
 #include "../General/GSblend.h"
 #include "../General/GSsurface.h"
 #include "../General/GSscreen.h"
-


### PR DESCRIPTION
This pull request is part of a family of proposed changes aimed at reducing the compilation warnings in the various graphics systems.
* #1567, #1566, #1565, #1564

For this specific graphics system, OpenGL1, there wasn't actually any warnings to address. However, I did decide to remove two unused variables I noticed lingering around.