### PR TITLE
Cleanup Direct3D9 Warnings

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.cpp
@@ -15,28 +15,30 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <iostream>
-#include <string>
-
 #include "Direct3D9Headers.h"
-using namespace std;
+
 #include "DIRECTX9Std.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h" // Room dimensions.
 #include "Graphics_Systems/graphics_mandatory.h" // Room dimensions.
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+
 namespace enigma
 {
-  bool pbo_isgo;
 
-  void graphicssystem_initialize()
-  {
-  }
-}
+void graphicssystem_initialize() {}
+
+} // namespace enigma
 
 namespace enigma_user {
-// Stolen entirely from the documentation and thrown into a switch() structure.
+
 string draw_get_graphics_error()
 {
+  return ""; //TODO: implement
+}
 
-}
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.h
@@ -20,7 +20,6 @@ namespace enigma
   extern unsigned char currentcolor[4];
   extern int currentblendmode[2];
   extern int currentblendtype;
-  extern bool pbo_isgo;
 }
 
 #include "../General/GScolors.h"
@@ -30,4 +29,3 @@ namespace enigma
 #include "../General/GSblend.h"
 #include "../General/GSsurface.h"
 #include "../General/GSscreen.h"
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9SurfaceStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9SurfaceStruct.h
@@ -67,7 +67,7 @@ namespace enigma
   #include "libEGMstd.h"
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_surface(surf,id)\
-    if (id < 0 or id >= enigma::Surfaces.size() or !enigma::Surfaces[id]) {\
+    if (id < 0 or size_t(id) >= enigma::Surfaces.size() or !enigma::Surfaces[id]) {\
       show_error("Attempting to use non-existing surface " + toString(id), false);\
       return;\
     }\

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
@@ -15,61 +15,25 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <cstddef>
-
-#include <math.h>
 #include "Direct3D9Headers.h"
+#include "DX9TextureStruct.h"
+
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GSbackground.h"
 #include "Graphics_Systems/General/GStextures.h"
+
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/background_internal.h"
 #include "Universal_System/sprites_internal.h"
 
-#ifdef DEBUG_MODE
-  #include <string>
-  #include "libEGMstd.h"
-  #include "Widget_Systems/widgets_mandatory.h"
-  #define get_background(bck2d,back)\
-    if (back < 0 or size_t(back) >= enigma::background_idmax or !enigma::backgroundstructarray[back]) {\
-      show_error("Attempting to draw non-existing background " + toString(back), false);\
-      return;\
-    }\
-    const enigma::background *const bck2d = enigma::backgroundstructarray[back];
-  #define get_backgroundnv(bck2d,back,r)\
-    if (back < 0 or size_t(back) >= enigma::background_idmax or !enigma::backgroundstructarray[back]) {\
-      show_error("Attempting to draw non-existing background " + toString(back), false);\
-      return r;\
-    }\
-    const enigma::background *const bck2d = enigma::backgroundstructarray[back];
-#else
-  #define get_background(bck2d,back)\
-    const enigma::background *const bck2d = enigma::backgroundstructarray[back];
-  #define get_backgroundnv(bck2d,back,r)\
-    const enigma::background *const bck2d = enigma::backgroundstructarray[back];
-#endif
-
-#include "Graphics_Systems/General/GScolor_macros.h"
+#include <cstddef>
+#include <math.h>
 
 namespace enigma_user {
-  extern int room_width, room_height;
-}
-namespace enigma {
-  extern size_t background_idmax;
-  D3DCOLOR get_currentcolor();
-}
-
-
-#include <string.h> // needed for querying ARB extensions
-
-#include "DX9TextureStruct.h"
-
-namespace enigma_user
-{
 
 int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
 {
-
+  return -1; //TODO: implement
 }
 
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
@@ -76,7 +76,7 @@ void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blu
 void draw_set_color_write_enable(bool red, bool green, bool blue, bool alpha)
 {
 	draw_batch_flush(batch_flush_deferred);
-	DWORD flags = NULL;
+	DWORD flags = 0;
 	if (red) { flags |= D3DCOLORWRITEENABLE_RED; }
 	if (green) { flags |= D3DCOLORWRITEENABLE_GREEN; }
 	if (blue) { flags |= D3DCOLORWRITEENABLE_BLUE; }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -33,20 +33,10 @@ using namespace enigma::dx9;
 namespace {
 
 template<typename T, typename F>
-struct alias_cast_t
-{
-  union
-  {
-    F raw;
-    T data;
-  };
-};
-
-template<typename T, typename F>
 T alias_cast(F raw_data) {
-  alias_cast_t<T, F> ac;
-  ac.raw = raw_data;
-  return ac.data;
+  T value;
+  memcpy(&value, &raw_data, sizeof(value));
+  return value;
 }
 
 D3DCULL cullingstates[3] = {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -319,7 +319,7 @@ class d3d_lights
             ms = light_ind.size();
             D3DCAPS9 caps;
 			d3dmgr->device->GetDeviceCaps(&caps);
-            if (ms >= caps.MaxActiveLights)
+            if (DWORD(ms) >= caps.MaxActiveLights)
                 return false;
 
             light_ind.insert(pair<int,int>(id, ms));
@@ -355,7 +355,7 @@ class d3d_lights
             ms = light_ind.size();
             D3DCAPS9 caps;
 			d3dmgr->device->GetDeviceCaps(&caps);
-            if (ms >= caps.MaxActiveLights)
+            if (DWORD(ms) >= caps.MaxActiveLights)
                 return false;
 
             light_ind.insert(pair<int,int>(id, ms));
@@ -390,7 +390,7 @@ class d3d_lights
             ms = light_ind.size();
             D3DCAPS9 caps;
 			d3dmgr->device->GetDeviceCaps(&caps);
-            if (ms >= caps.MaxActiveLights)
+            if (DWORD(ms) >= caps.MaxActiveLights)
                 return false;
         }
 
@@ -404,7 +404,7 @@ class d3d_lights
             const int ms = light_ind.size();
 			D3DCAPS9 caps;
 			d3dmgr->device->GetDeviceCaps(&caps);
-            if (ms >= caps.MaxActiveLights)
+            if (DWORD(ms) >= caps.MaxActiveLights)
                 return false;
             light_ind.insert(pair<int,int>(id, ms));
 			d3dmgr->LightEnable(ms, TRUE);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -451,7 +451,6 @@ bool d3d_light_define_specularity(int id, int r, int g, int b, double a)
 void d3d_light_specularity(int facemode, int r, int g, int b, double a)
 {
     draw_batch_flush(batch_flush_deferred);
-    float specular[4] = {r, g, b, a};
 }
 
 void d3d_light_shininess(int facemode, int shine)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -41,12 +41,12 @@ namespace enigma_user
 
 int draw_get_msaa_maxlevel()
 {
-
+  return 0; //TODO: implement
 }
 
 bool draw_get_msaa_supported()
 {
-
+  return false; //TODO: implement
 }
 
 void draw_set_msaa_enabled(bool enable)
@@ -60,16 +60,16 @@ void draw_enable_alphablend(bool enable) {
 }
 
 bool draw_get_alpha_test() {
-	DWORD* enabled;
-	d3dmgr->device->GetRenderState(D3DRS_ALPHATESTENABLE, enabled);
-	return *enabled;
+	DWORD enabled = 0;
+	d3dmgr->device->GetRenderState(D3DRS_ALPHATESTENABLE, &enabled);
+	return enabled;
 }
 
 unsigned draw_get_alpha_test_ref_value()
 {
-	DWORD* val;
-	d3dmgr->device->GetRenderState(D3DRS_ALPHAREF, val);
-	return *val;
+	DWORD val = 0;
+	d3dmgr->device->GetRenderState(D3DRS_ALPHAREF, &val);
+	return val;
 }
 
 void draw_set_alpha_test(bool enable)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -154,7 +154,7 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   gs_scalar sx, sy;
   sx = (window_get_width() - window_get_region_width_scaled()) / 2;
   sy = (window_get_height() - window_get_region_height_scaled()) / 2;
-	D3DVIEWPORT9 pViewport = { sx + x, sy + y, width, height, 0, 1.0f };
+	D3DVIEWPORT9 pViewport = { (DWORD)(sx + x), (DWORD)(sy + y), (DWORD)width, (DWORD)height, 0, 1.0f };
 	d3dmgr->device->SetViewport(&pViewport);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
@@ -68,7 +68,7 @@ namespace enigma_user
 {
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
-
+  return -1; //TODO: implement
 }
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9surface.cpp
@@ -111,7 +111,7 @@ void surface_reset_target()
 
 int surface_get_target()
 {
-
+  return 0; //TODO: implement
 }
 
 void surface_free(int id)
@@ -122,7 +122,7 @@ void surface_free(int id)
 
 bool surface_exists(int id)
 {
-  return !((id < 0) or (id > enigma::Surfaces.size()) or (enigma::Surfaces[id] == NULL));
+  return !((id < 0) or (size_t(id) > enigma::Surfaces.size()) or (enigma::Surfaces[id] == NULL));
 }
 
 int surface_get_texture(int id)
@@ -258,17 +258,17 @@ int surface_save(int id, string filename)
 
 int surface_save_part(int id, string filename, unsigned x, unsigned y, unsigned w, unsigned h)
 {
-
+  return 0; //TODO: implement
 }
 
 int background_create_from_surface(int id, int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
 {
-
+  return 0; //TODO: implement
 }
 
 int sprite_create_from_surface(int id, int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig)
 {
-
+  return 0; //TODO: implement
 }
 
 int sprite_create_from_surface(int id, int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig)


### PR DESCRIPTION
This pull request is part of a family of proposed changes aimed at reducing the compilation warnings in the various graphics systems.
* #1567, #1566, #1565, #1564

This system, Direct3D9, was by far the hardest to cleanup for various reasons.
* Many warnings stemmed from missing return statements like #1567. I attempted to use reasonable default return values and placed `//TODO` comments on these functions.
* Some macros like `get_surface` needed to cast the surface id to size type in order to compare it safely with a vector size.
* The `get_background` macro was redundant because we had moved it to `Universal_System` some time ago and it was already being included.
* I had to create an `alias_cast` helper method, with assistance from Rusky, to address type-punned warnings with the fog states. The Direct3D `SetRenderState` method takes the fog states as a DWORD but expects floating-point values. So, a memcpy is needed to interpret the bits of the floats as a DWORD.
https://docs.microsoft.com/en-us/windows/desktop/direct3d9/d3drenderstatetype
* I moved several state array maps into an anonymous namespace in `DX9d3d.cpp` even though there was no warnings just to prevent potential future linking conflicts.
* Several lighting functions needed to cast the light ids to DWORD in order to safely compare them to the max number of active lights.
* There were a couple of functions in `DX9draw.cpp` where I was using uninitialized pointers to return state to the user.
* The `D3DVIEWPORT9` struct of DX9 requires us to cast the floating point viewport bounds to DWORD.