### PR TITLE
Cleanup OpenGL3 Warnings

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.cpp
@@ -70,7 +70,7 @@
 
     #define get_program(ptiter,program,err)\
     if (program < 0) { printf("Program id [%i] < 0 given!\n", program); return err; }\
-    if (program >= enigma::shaderprograms.size()) { printf("Program id [%i] > size() [%i] given!\n", program, enigma::shaderprograms.size()); return err; }\
+    if (size_t(program) >= enigma::shaderprograms.size()) { printf("Program id [%i] > size() [%llu] given!\n", program, enigma::shaderprograms.size()); return err; }\
     if (enigma::shaderprograms[program] == nullptr) { printf("Program with id [%i] is deleted!\n", program); return err; }\
     enigma::ShaderProgram* ptiter = enigma::shaderprograms[program];
 #else

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.cpp
@@ -90,12 +90,12 @@
 
     #define get_program(ptiter,program,err)\
     if (program < 0) { return err; }\
-    if (program >= enigma::shaderprograms.size()) { return err; }\
+    if (size_t(program) >= enigma::shaderprograms.size()) { return err; }\
     if (enigma::shaderprograms[program] == nullptr) { return err; }\
     enigma::ShaderProgram* ptiter = enigma::shaderprograms[program];
 #endif
 
-extern GLenum shadertypes[5] = {
+GLenum shadertypes[5] = {
   GL_VERTEX_SHADER, GL_FRAGMENT_SHADER, GL_TESS_CONTROL_SHADER, GL_TESS_EVALUATION_SHADER, GL_GEOMETRY_SHADER
 };
 
@@ -640,7 +640,7 @@ void glsl_program_detach(int id, int sid)
 
 void glsl_program_set(int id)
 {
-  if (enigma::bound_shader != id) {
+  if (enigma::bound_shader != unsigned(id)) {
     enigma_user::draw_batch_flush(enigma_user::batch_flush_deferred);
     enigma::bound_shader = id;
     glUseProgram(enigma::shaderprograms[id]->shaderprogram);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
@@ -47,10 +47,10 @@ vector<TextureStruct*> textureStructs(0);
       show_error("Attempting to access non-existing texture " + toString(texid), false);\
       return v;\
     }\
-    const unsigned tex = (texid==-1?-1:textureStructs[texid]->gltex);
+    const unsigned tex = (texid==-1?0:textureStructs[texid]->gltex);
 #else
   #define get_texture(tex,texid,v)\
-    const unsigned tex = (texid==-1?-1:textureStructs[texid]->gltex);
+    const unsigned tex = (texid==-1?0:textureStructs[texid]->gltex);
 #endif
 
 /*enum {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
@@ -47,10 +47,10 @@ vector<TextureStruct*> textureStructs(0);
       show_error("Attempting to access non-existing texture " + toString(texid), false);\
       return v;\
     }\
-    const int tex = (texid==-1?-1:textureStructs[texid]->gltex);
+    const unsigned tex = (texid==-1?-1:textureStructs[texid]->gltex);
 #else
   #define get_texture(tex,texid,v)\
-    const int tex = (texid==-1?-1:textureStructs[texid]->gltex);
+    const unsigned tex = (texid==-1?-1:textureStructs[texid]->gltex);
 #endif
 
 /*enum {
@@ -401,7 +401,7 @@ void texture_set_stage(int stage, int texid) {
   //TODO(harijs): Check if stage <0
   get_texture(gt,texid,);
   if (enigma::samplerstates[stage].bound_texture != gt) {
-    if ((unsigned int)enigma::bound_texture_stage != GL_TEXTURE0 + stage) { glActiveTexture(enigma::bound_texture_stage = (GL_TEXTURE0 + stage)); }
+    if (enigma::bound_texture_stage != GL_TEXTURE0 + stage) { glActiveTexture(enigma::bound_texture_stage = (GL_TEXTURE0 + stage)); }
     glBindTexture(GL_TEXTURE_2D, enigma::samplerstates[stage].bound_texture = (unsigned)(gt >= 0? gt : 0));
   }
 }


### PR DESCRIPTION
This pull request is part of a family of proposed changes aimed at reducing the compilation warnings in the various graphics systems.
* #1567, #1566, #1565, #1564

This system, OpenGL3, was the easiest to clean up the warnings for second to OpenGL1.
* The `get_program` shader macro needed to cast the program id to size type to safely compare it with the shader program vector size.
* The `get_program` shader macro needed to format the shader program vector size as a long long unsigned int rather than signed int in the debug print statement.
* The shader types array map had an extraneous `extern` qualification.
* A comparison of the bound shader needed to cast the user shader id to unsigned.
* The `get_texture` macro needed to be of type unsigned (since GL texture ids are unsigned) and return 0 (the default incomplete texture in OpenGL) as the GL texture id when the user wants to draw untextured.
* A comparison of the bound texture stage did not need an extraneous cast to unsigned.