### PR TITLE
Cleanup Direct3D11 Warnings

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.cpp
@@ -15,21 +15,20 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "DIRECTX11Std.h"
+#include "Direct3D11Headers.h"
+
+#include "Graphics_Systems/graphics_mandatory.h" // Room dimensions.
+
+#include "Universal_System/var4.h"
+#include "Universal_System/roomsystem.h" // Room dimensions.
+
 #include <iostream>
 #include <string>
 
-#include "Direct3D11Headers.h"
 using namespace std;
-#include "DIRECTX11Std.h"
-#include "Universal_System/var4.h"
-#include "Universal_System/roomsystem.h" // Room dimensions.
-#include "Graphics_Systems/graphics_mandatory.h" // Room dimensions.
 
-namespace enigma
-{
-
-unsigned bound_texture=0;
-bool pbo_isgo;
+namespace enigma {
 
 void init_blend_state();
 void init_depth_stencil_state();
@@ -45,9 +44,8 @@ void graphicssystem_initialize() {
 
 namespace enigma_user {
 
-// Stolen entirely from the documentation and thrown into a switch() structure.
 string draw_get_graphics_error() {
-
+  return ""; //TODO: implement
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.h
@@ -15,14 +15,13 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-namespace enigma
-{
-  extern unsigned bound_texture;
-  extern unsigned char currentcolor[4];
-  extern int currentblendmode[2];
-  extern int currentblendtype;
-  extern bool pbo_isgo;
-}
+namespace enigma {
+
+extern unsigned char currentcolor[4];
+extern int currentblendmode[2];
+extern int currentblendtype;
+
+} // namespace enigma
 
 #include "../General/GScolors.h"
 #include "../General/GSprimitives.h"
@@ -31,4 +30,3 @@ namespace enigma
 #include "../General/GSblend.h"
 #include "../General/GSsurface.h"
 #include "../General/GSscreen.h"
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11SurfaceStruct.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11SurfaceStruct.h
@@ -52,7 +52,7 @@ namespace enigma
   #include "libEGMstd.h"
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_surface(surf,id)\
-    if (id < 0 or id >= enigma::Surfaces.size() or !enigma::Surfaces[id]) {\
+    if (id < 0 or size_t(id) >= enigma::Surfaces.size() or !enigma::Surfaces[id]) {\
       show_error("Attempting to use non-existing surface " + toString(id), false);\
       return;\
     }\

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11background.cpp
@@ -15,59 +15,24 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <cstddef>
-
-#include <math.h>
 #include "Direct3D11Headers.h"
-#include "Graphics_Systems/General/GSprimitives.h"
+#include "DX11TextureStruct.h"
 #include "Graphics_Systems/General/GSbackground.h"
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
+
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/background_internal.h"
-#include "Universal_System/sprites_internal.h"
 
-#ifdef DEBUG_MODE
-  #include <string>
-  #include "libEGMstd.h"
-  #include "Widget_Systems/widgets_mandatory.h"
-  #define get_background(bck2d,back)\
-    if (back < 0 or size_t(back) >= enigma::background_idmax or !enigma::backgroundstructarray[back]) {\
-      show_error("Attempting to draw non-existing background " + toString(back), false);\
-      return;\
-    }\
-    const enigma::background *const bck2d = enigma::backgroundstructarray[back];
-  #define get_backgroundnv(bck2d,back,r)\
-    if (back < 0 or size_t(back) >= enigma::background_idmax or !enigma::backgroundstructarray[back]) {\
-      show_error("Attempting to draw non-existing background " + toString(back), false);\
-      return r;\
-    }\
-    const enigma::background *const bck2d = enigma::backgroundstructarray[back];
-#else
-  #define get_background(bck2d,back)\
-    const enigma::background *const bck2d = enigma::backgroundstructarray[back];
-  #define get_backgroundnv(bck2d,back,r)\
-    const enigma::background *const bck2d = enigma::backgroundstructarray[back];
-#endif
+#include <cstddef>
+
+#include <math.h>
 
 namespace enigma_user {
-  extern int room_width, room_height;
-}
-namespace enigma {
-  extern size_t background_idmax;
-}
-
-
-#include <string.h> // needed for querying ARB extensions
-
-#include "DX11TextureStruct.h"
-
-namespace enigma_user
-{
 
 int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
 {
-
+  return -1; //TODO: implement
 }
 
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -243,27 +243,27 @@ class d3d_lights
 
     bool light_define_direction(int id, gs_scalar dx, gs_scalar dy, gs_scalar dz, int col)
     {
-
+      return false; //TODO: implement
     }
 
     bool light_define_point(int id, gs_scalar x, gs_scalar y, gs_scalar z, double range, int col)
     {
-
+      return false; //TODO: implement
     }
 
     bool light_define_specularity(int id, int r, int g, int b, double a)
     {
-
+      return false; //TODO: implement
     }
 
     bool light_enable(int id)
     {
-
+      return false; //TODO: implement
     }
 
     bool light_disable(int id)
     {
-
+      return false; //TODO: implement
     }
 } d3d_lighting;
 
@@ -287,7 +287,6 @@ bool d3d_light_define_specularity(int id, int r, int g, int b, double a)
 
 void d3d_light_specularity(int facemode, int r, int g, int b, double a)
 {
-  float specular[4] = {r, g, b, a};
 
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
@@ -38,12 +38,12 @@ namespace enigma_user
 
 int draw_get_msaa_maxlevel()
 {
-
+  return 0; //TODO: implement
 }
 
 bool draw_get_msaa_supported()
 {
-
+  return false; //TODO: implement
 }
 
 void draw_set_msaa_enabled(bool enable)
@@ -58,12 +58,12 @@ void draw_enable_alphablend(bool enable)
 
 bool draw_get_alpha_test()
 {
-
+  return false; //TODO: implement
 }
 
 unsigned draw_get_alpha_test_ref_value()
 {
-
+  return 0; //TODO: implement
 }
 
 void draw_set_alpha_test(bool enable)
@@ -94,11 +94,13 @@ namespace enigma_user
 int draw_getpixel(int x, int y)
 {
   draw_batch_flush(batch_flush_deferred);
+  return 0; //TODO: implement
 }
 
 int draw_getpixel_ext(int x, int y)
 {
   draw_batch_flush(batch_flush_deferred);
+  return 0; //TODO: implement
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -71,14 +71,16 @@ void screen_init()
   }
 }
 
-int screen_save(string filename) //Assumes native integers are little endian
+int screen_save(string filename)
 {
   draw_batch_flush(batch_flush_deferred);
+  return -1; //TODO: implement
 }
 
-int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h) //Assumes native integers are little endian
+int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h)
 {
   draw_batch_flush(batch_flush_deferred);
+  return -1; //TODO: implement
 }
 
 void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11sprite.cpp
@@ -17,22 +17,15 @@
 
 #include "Direct3D11Headers.h"
 #include "DX11TextureStruct.h"
-#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
 #include "Graphics_Systems/General/GSsprite.h"
 #include "Graphics_Systems/General/GStextures.h"
-#include "Graphics_Systems/General/GSprimitives.h"
 
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
-#include "Universal_System/instance_system.h"
-#include "Universal_System/graphics_object.h"
 
 #include <cmath>
 #include <cstdlib>
-#include <string>
-
-using std::string;
 
 #ifdef DEBUG_MODE
   #include "libEGMstd.h"
@@ -61,11 +54,10 @@ using std::string;
     const enigma::sprite *const spr = enigma::spritestructarray[id];
 #endif
 
-namespace enigma_user
-{
+namespace enigma_user {
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
-
+  return -1; //TODO: implement
 }
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
@@ -76,4 +68,4 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 
 }
 
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11surface.cpp
@@ -118,7 +118,7 @@ int surface_create(int width, int height, bool depthbuffer, bool, bool)
 
 int surface_create_msaa(int width, int height, int levels)
 {
-
+  return -1; //TODO: implement
 }
 
 void surface_set_target(int id)
@@ -138,7 +138,7 @@ void surface_reset_target()
 
 int surface_get_target()
 {
-
+  return -1; //TODO: implement
 }
 
 void surface_free(int id)
@@ -149,7 +149,7 @@ void surface_free(int id)
 
 bool surface_exists(int id)
 {
-  return !((id < 0) or (id > enigma::Surfaces.size()) or (enigma::Surfaces[id] == NULL));
+  return !((id < 0) or (size_t(id) > enigma::Surfaces.size()) or (enigma::Surfaces[id] == NULL));
 }
 
 int surface_get_texture(int id)
@@ -172,17 +172,17 @@ int surface_get_height(int id)
 
 int surface_getpixel(int id, int x, int y)
 {
-
+  return 0; //TODO: implement
 }
 
 int surface_getpixel_ext(int id, int x, int y)
 {
-
+  return 0; //TODO: implement
 }
 
 int surface_getpixel_alpha(int id, int x, int y)
 {
-
+  return 0; //TODO: implement
 }
 
 }
@@ -200,22 +200,22 @@ namespace enigma_user
 
 int surface_save(int id, string filename)
 {
-
+  return -1; //TODO: implement
 }
 
 int surface_save_part(int id, string filename, unsigned x, unsigned y, unsigned w, unsigned h)
 {
-
+  return -1; //TODO: implement
 }
 
 int background_create_from_surface(int id, int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
 {
-
+  return -1; //TODO: implement
 }
 
 int sprite_create_from_surface(int id, int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig)
 {
-
+  return -1; //TODO: implement
 }
 
 int sprite_create_from_surface(int id, int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
@@ -115,7 +115,7 @@ int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth,
 
 int graphics_duplicate_texture(int tex, bool mipmap)
 {
-
+  return -1; //TODO: implement
 }
 
 void graphics_copy_texture(int source, int destination, int x, int y)
@@ -140,7 +140,7 @@ void graphics_delete_texture(int tex)
 
 unsigned char* graphics_get_texture_pixeldata(unsigned texture, unsigned* fullwidth, unsigned* fullheight)
 {
-
+  return NULL; //TODO: implement
 }
 
 void init_sampler_state() {
@@ -177,7 +177,7 @@ int texture_add(string filename, bool mipmap) {
 }
 
 void texture_save(int texid, string fname) {
-	unsigned w, h;
+	unsigned w = 0, h = 0;
 	unsigned char* rgbdata = enigma::graphics_get_texture_pixeldata(texid, &w, &h);
 
   string ext = enigma::image_get_format(fname);
@@ -286,17 +286,17 @@ void texture_set_lod_ext(int sampler, double minlod, double maxlod, int maxlevel
 
 bool texture_mipmapping_supported()
 {
-
+  return false; //TODO: implement
 }
 
 bool texture_anisotropy_supported()
 {
-
+  return false; //TODO: implement
 }
 
 float texture_anisotropy_maxlevel()
 {
-
+  return 0.0f; //TODO: implement
 }
 
 void texture_anisotropy_filter(int sampler, gs_scalar levels)


### PR DESCRIPTION
This pull request is part of a family of proposed changes aimed at reducing the compilation warnings in the various graphics systems.
* #1567, #1566, #1565, #1564

This system, Direct3D11, primarily had the most warnings from missing return statements. I tried to use sensible return values for unimplemented functions and `//TODO` comments on these functions. Other than that it just had a few integer comparison warnings and redefinition of the `get_background` macro (which has been moved to Universal_System) just like Direct3D9 did in #1565.