### PR TITLE
cross-platform abort/retry/ignore show_error()

### DIFF
--- a/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
@@ -38,15 +38,15 @@ bool widget_system_initialize() {
   
 } // namespave enigma
 
-extern "C" int cocoa_show_message(const char *title, const char *str, bool error);
-extern "C" int cocoa_show_question(const char *title, const char *str, bool error);
+extern "C" int cocoa_show_message(const char *str, bool error);
+extern "C" int cocoa_show_question(const char *str, bool error);
 extern "C" int cocoa_show_error(const char *str, bool abort);
-extern "C" const char *cocoa_input_box(const char *title, const char *str, const char *def);
-extern "C" const char *cocoa_password_box(const char *title, const char *str, const char *def);
-extern "C" const char *cocoa_get_open_filename(const char *title, const char *filter, const char *fname, const char *dir, const bool mselect);
-extern "C" const char *cocoa_get_save_filename(const char *title, const char *filter, const char *fname, const char *dir);
-extern "C" const char *cocoa_get_directory(const char *title, const char *dname);
-extern "C" int cocoa_get_color(const char *title, int defcol);
+extern "C" const char *cocoa_input_box(const char *str, const char *def);
+extern "C" const char *cocoa_password_box(const char *str, const char *def);
+extern "C" const char *cocoa_get_open_filename(const char *filter, const char *fname, const char *dir, const char *title, const bool mselect);
+extern "C" const char *cocoa_get_save_filename(const char *filter, const char *fname, const char *dir, const char *title);
+extern "C" const char *cocoa_get_directory(const char *capt, const char *root);
+extern "C" int cocoa_get_color(int defcol, const char *title);
 
 static inline string remove_trailing_zeros(double numb) {
   string strnumb = std::to_string(numb);
@@ -76,65 +76,59 @@ void show_info(string text, int bgcolor, int left, int top, int width, int heigh
 }
 
 int show_message(const string &str) {
-  string title = window_get_caption();
-  cocoa_show_message(title.c_str(), str.c_str(), false);
+  cocoa_show_message(str.c_str());
   return 1;
 }
 
 bool show_question(string str) {
-  string title = window_get_caption();
-  bool result = (bool)cocoa_show_question(title.c_str(), str.c_str(), false);
+  bool result = (bool)cocoa_show_question(str.c_str());
   return result;
 }
 
 string get_string(string str, string def) {
-  string title = window_get_caption();
-  string result = cocoa_input_box(title.c_str(), str.c_str(), def.c_str());
+  string result = cocoa_input_box(str.c_str(), def.c_str());
   return result;
 }
 
 string get_password(string str, string def) {
-  string title = window_get_caption();
-  string result = cocoa_password_box(title.c_str(), str.c_str(), def.c_str());
+  string result = cocoa_password_box(str.c_str(), def.c_str());
   return result;
 }
 
 double get_integer(string str, double def) {
-  string title = window_get_caption();
   string integer = remove_trailing_zeros(def);
-  string result = cocoa_input_box(title.c_str(), str.c_str(), integer.c_str());
+  string result = cocoa_input_box(str.c_str(), integer.c_str());
   return result ? strtod(input, NULL) : 0;
 }
 
 double get_passcode(string str, double def) {
-  string title = window_get_caption();
   string integer = remove_trailing_zeros(def);
-  string result = cocoa_password_box(title.c_str(), str.c_str(), integer.c_str());
+  string result = cocoa_password_box(str.c_str(), integer.c_str());
   return result ? strtod(input, NULL) : 0;
 }
 
 string get_open_filename(string filter, string fname) {
-  return cocoa_get_open_filename("", filter.c_str(), fname.c_str(), "", false);
+  return cocoa_get_open_filename(filter.c_str(), fname.c_str(), "", "", false);
 }
 
 string get_open_filenames(string filter, string fname) {
-  return cocoa_get_open_filename("", filter.c_str(), fname.c_str(), "", true);
+  return cocoa_get_open_filename(filter.c_str(), fname.c_str(), "", "", true);
 }
 
 string get_save_filename(string filter, string fname) {
-  return cocoa_get_save_filename("", filter.c_str(), fname.c_str(), "");
+  return cocoa_get_save_filename(filter.c_str(), fname.c_str(), "", "");
 }
 
 string get_open_filename_ext(string filter, string fname, string dir, string title) {
-  return cocoa_get_open_filename(title.c_str(), filter.c_str(), fname.c_str(), dir.c_str(), false);
+  return cocoa_get_open_filename(filter.c_str(), fname.c_str(), dir.c_str(), title.c_str(), false);
 }
 
 string get_open_filenames_ext(string filter, string fname, string dir, string title) {
-  return cocoa_get_open_filename(title.c_str(), filter.c_str(), fname.c_str(), dir.c_str(), true);
+  return cocoa_get_open_filename(filter.c_str(), fname.c_str(), dir.c_str(), title.c_str(), true);
 }
 
 string get_save_filename_ext(string filter, string fname, string dir, string title) {
-  return cocoa_get_save_filename(title.c_str(), filter.c_str(), fname.c_str(), dir.c_str());
+  return cocoa_get_save_filename(filter.c_str(), fname.c_str(), dir.c_str(), title.c_str());
 }
 
 string get_directory(string dname) {
@@ -146,11 +140,11 @@ string get_directory_alt(string capt, string root) {
 }
 
 int get_color(int defcol) {
-  return cocoa_get_color("", defcol);
+  return cocoa_get_color(defcol, "");
 }
 
 int get_color_ext(int defcol, string title) {
-  return cocoa_get_color(title.c_str(), defcol);
+  return cocoa_get_color(defcol, title.c_str());
 } 
 
 } // enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
@@ -38,8 +38,8 @@ bool widget_system_initialize() {
   
 } // namespave enigma
 
-extern "C" int cocoa_show_message(const char *str, bool error);
-extern "C" int cocoa_show_question(const char *str, bool error);
+extern "C" int cocoa_show_message(const char *str);
+extern "C" int cocoa_show_question(const char *str);
 extern "C" int cocoa_show_error(const char *str, bool abort);
 extern "C" const char *cocoa_input_box(const char *str, const char *def);
 extern "C" const char *cocoa_password_box(const char *str, const char *def);

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/tinyfiledialogs/dialogs.cpp
@@ -191,28 +191,15 @@ void show_error(string errortext, const bool fatal) {
   #else
   errortext = "Error in some event or another for some object: \r\n\r\n" + errortext;
   #endif
-  
-  string msg;
 
-  if (errortext == "")
-    msg = " ";
-  else
-    msg = errortext;
+  if (errortext == "") errortext = " ";
+  int input = 0;
 
-  if (msg != " ")
-    msg = msg + "\n\n";
-
-  msg = tfd_add_escaping(msg);
-
-  if (fatal == 0) {
-    msg = msg + "Do you want to abort the application?";
-    double input = tinyfd_messageBox("Error", msg.c_str(), "yesno", "error", 1, tfd_DialogEngine());
-
-    if (input == 1)
-      exit(0);
+  if (!fatal) {
+    input = tinyfd_errorMessageBox("Error", errortext.c_str(), 0, tfd_DialogEngine());
+    if (input == 2) exit(0);
   } else {
-    msg = msg + "Click 'OK' to abort the application.";
-    tinyfd_messageBox("Error", msg.c_str(), "ok", "error", 1, tfd_DialogEngine());
+    tinyfd_errorMessageBox("Error", errortext.c_str(), 1, tfd_DialogEngine());
     exit(0);
   }
 }
@@ -231,7 +218,7 @@ int show_message(const string &str) {
   caption = tfd_add_escaping(caption);
   if (str == "") msg = " "; else msg = str;
   caption = caption_helper(caption);
-  tinyfd_messageBox(caption.c_str(), msg.c_str(), "ok", "info", 1, tfd_DialogEngine());
+  tinyfd_messageBox(caption.c_str(), msg.c_str(), "ok", "info", tfd_DialogEngine());
   return 1;
 }
 
@@ -239,7 +226,7 @@ bool show_question(string str) {
   caption = window_get_caption();
   str = message_helper(str);
   caption = caption_helper(caption);
-  return tinyfd_messageBox(caption.c_str(), msg.c_str(), "yesno", "question", 1, tfd_DialogEngine());
+  return tinyfd_messageBox(caption.c_str(), msg.c_str(), "yesno", "question", tfd_DialogEngine());
 }
 
 string get_string(string str, string def) {

--- a/shared/tinyfiledialogs/tinyfiledialogs.h
+++ b/shared/tinyfiledialogs/tinyfiledialogs.h
@@ -106,26 +106,32 @@ extern "C" {
 
 int tinyfd_messageBox(
 	char const * const aTitle , /* NULL or "" */
-	char const * const aMessage , /* NULL or "" may contain \n \t */
+	char const * const aMessage , /* NULL or "" */
 	char const * const aDialogType , /* "ok" "okcancel" "yesno" "yesnocancel" */
 	char const * const aIconType , /* "info" "warning" "error" "question" */
-	int const aDefaultButton , /* 0 for cancel/no , 1 for ok/yes , 2 for no in yesnocancel */
 	int const aDialogEngine ) ; /* 0 for Zenity, 1 for KDialog */
 	/* 0 for cancel/no , 1 for ok/yes , 2 for no in yesnocancel */
 
+int tinyfd_errorMessageBox(
+	char const * const aTitle , /* NULL or "" */
+	char const * const aMessage , /* NULL or "" */
+	int const aFatalError , /* 0 for abort/retry/ignore , 1 for abort */
+	int const aDialogEngine ) ; /* 0 for Zenity, 1 for KDialog */
+	/* 0 for ignore , 1 for retry , 2 for abort */
+
 char const * tinyfd_inputBox(
 	char const * const aTitle , /* NULL or "" */
-	char const * const aMessage , /* NULL or "" may NOT contain \n \t on windows */
+	char const * const aMessage , /* NULL or "" */
 	char const * const aDefaultInput ,  /* NULL or "" */
 	int const aDialogEngine ) ; /* 0 for Zenity, 1 for KDialog */
 	/* returns NULL on cancel */
 
 char const * tinyfd_passwordBox(
 	char const * const aTitle , /* NULL or "" */
-	char const * const aMessage , /* NULL or "" may NOT contain \n nor \t */
+	char const * const aMessage , /* NULL or "" */
 	char const * const aDefaultInput , /* NULL or "" */
 	int const aDialogEngine ) ; /* 0 for Zenity, 1 for KDialog */
-        /* returns NULL on cancel */
+	/* returns NULL on cancel */
 
 char const * tinyfd_saveFileDialog(
 	char const * const aTitle , /* NULL or "" */


### PR DESCRIPTION
Adds the M$ standard abort/retry/ignore error message buttons to show_error() but doing so on all platforms and widget systems. when fatal is true all the buttons abort the game where as only the abort button does that during non-fatal. I'm planning to get rid of the retry/ignore buttons for fatal and retry for non-fatal as they serve no purpose in these contexts, I'm just waiting for KDialog authors to add the --ok-label command line option so that this stuff will be possible for all of our widget systems. It is in their plans to do it, confirmed on their GitHub repository notes. This will allow me to change the single "OK" button to "Abort" for KDialog's fatal error message box, then I'll update all the widgets.

Also reordered the Objective-C function arguments to match the C++ ones in Cocoa Widgets.