### PR TITLE
Fix Hidden & Depth Writing Render State

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -104,16 +104,18 @@ void d3d_end()
 
 void d3d_set_hidden(bool enable)
 {
-    draw_batch_flush(batch_flush_deferred);
-    enigma::d3dHidden = enable;
-    depthStencilDesc.DepthEnable = enable;
-    update_depth_stencil_state();
+  draw_batch_flush(batch_flush_deferred);
+  enigma::d3dHidden = enable;
+  depthStencilDesc.DepthEnable = enable;
+  update_depth_stencil_state();
 }
 
 void d3d_set_zwriteenable(bool enable)
 {
-    draw_batch_flush(batch_flush_deferred);
-	enigma::d3dZWriteEnable = enable;
+  draw_batch_flush(batch_flush_deferred);
+  enigma::d3dZWriteEnable = enable;
+  depthStencilDesc.DepthWriteMask = enable ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
+  update_depth_stencil_state();
 }
 
 void d3d_set_lighting(bool enable)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -165,7 +165,6 @@ void d3d_set_hidden(bool enable)
   draw_batch_flush(batch_flush_deferred);
   (enable?glEnable:glDisable)(GL_DEPTH_TEST);
   enigma::d3dHidden = enable;
-  //d3d_set_zwriteenable(enable);
 }
 
 // disabling zwriting can let you turn off testing for a single model, for instance

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -167,7 +167,6 @@ void d3d_set_hidden(bool enable)
   draw_batch_flush(batch_flush_deferred);
   (enable?glEnable:glDisable)(GL_DEPTH_TEST);
   enigma::d3dHidden = enable;
-	d3d_set_zwriteenable(enable);
 }
 
 // disabling zwriting can let you turn off testing for a single model, for instance


### PR DESCRIPTION
The main issue here is that GL3's `d3d_set_hidden` was also toggling `d3d_set_zwriteenable` which it's not supposed to do. This was causing rendering anomalies when I ran Project Mario in GL3. Git blame says I did it in aa45de8915bcfc0d7b40c0629119e07f08211142 and I really don't know why. While I was in here, I decided to also implement `d3d_set_zwriteenable` for D3D11 using the depth stencil description's `DepthWriteMask` which seems to be the DX11 analog to DX9's `D3DRS_ZWRITEENABLE`.

|     | Master | Pull |
|-----|--------|------|
| GL3 |![Project Mario GL3 Master](https://user-images.githubusercontent.com/3212801/53819995-fc974000-3f38-11e9-8575-a33b32d5ad05.png)|![Project Mario GL3 Pull](https://user-images.githubusercontent.com/3212801/53819891-d2de1900-3f38-11e9-9f3b-3ba356ded802.png)|

I made a little test for GMSv1.4 so I could [apitrace](https://github.com/apitrace/apitrace) it and confirm that GM does not toggle zwriteenable when hidden is toggled. It's worth mentioning that I had to add a call to `draw_line` before the changes to the hidden surface removal state would actually show and I also had to call `d3d_start` in the create event. They must have started caching states internally. Regardless, we can see from the API Trace below that `d3d_set_hidden` should have no effect on the zwriteenable (glDepthMask) only on the zenable (GL_DEPTH_TEST).
```gml
var i;
i=0;
repeat (1000) {
    i+=1;
    d3d_set_hidden((i mod 2) == 0);
    draw_line(0, i, 50, i);
}
```
Before starting d3d mode, GM would not toggle the hidden state, and it batched all of my draw line calls together:
```
3167 @0 IDirect3DDevice9Ex::DrawPrimitive(this = 0x96fb880, PrimitiveType = D3DPT_LINELIST, StartVertex = 0, PrimitiveCount = 1000) = D3D_OK
```
![GMSv1.4 Hidden Surface Removal API Trace](https://user-images.githubusercontent.com/3212801/53821202-4b45d980-3f3b-11e9-92a1-8fb8a48b38ac.png)
