### PR TITLE
Cleanup Vestigial Sprite/Background Garbage

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11background.cpp
@@ -16,17 +16,13 @@
 **/
 
 #include "Direct3D11Headers.h"
-#include "DX11TextureStruct.h"
-#include "Graphics_Systems/General/GSbackground.h"
-#include "Graphics_Systems/General/GStextures.h"
-#include "Graphics_Systems/General/GScolor_macros.h"
 
+#include "Graphics_Systems/General/GSbackground.h"
+#include "Graphics_Systems/General/GSprimitives.h"
+
+#include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/background_internal.h"
-
-#include <cstddef>
-
-#include <math.h>
 
 namespace enigma_user {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11sprite.cpp
@@ -31,7 +31,7 @@ int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool 
 }
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
-	return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
+  return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
 }
 
 void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11sprite.cpp
@@ -16,43 +16,13 @@
 **/
 
 #include "Direct3D11Headers.h"
-#include "DX11TextureStruct.h"
-#include "Graphics_Systems/General/GScolor_macros.h"
-#include "Graphics_Systems/General/GSsprite.h"
-#include "Graphics_Systems/General/GStextures.h"
 
+#include "Graphics_Systems/General/GSsprite.h"
+#include "Graphics_Systems/General/GSprimitives.h"
+
+#include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
-
-#include <cmath>
-#include <cstdlib>
-
-#ifdef DEBUG_MODE
-  #include "libEGMstd.h"
-  #include "Widget_Systems/widgets_mandatory.h"
-  #define get_sprite(spr,id,r) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return r; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_spritev(spr,id) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_sprite_null(spr,id,r) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return r; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-#else
-  #define get_sprite(spr,id,r) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_spritev(spr,id) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_sprite_null(spr,id,r) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-#endif
 
 namespace enigma_user {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9background.cpp
@@ -16,18 +16,13 @@
 **/
 
 #include "Direct3D9Headers.h"
-#include "DX9TextureStruct.h"
 
-#include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GSbackground.h"
-#include "Graphics_Systems/General/GStextures.h"
+#include "Graphics_Systems/General/GSprimitives.h"
 
+#include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/background_internal.h"
-#include "Universal_System/sprites_internal.h"
-
-#include <cstddef>
-#include <math.h>
 
 namespace enigma_user {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
@@ -15,54 +15,14 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <cmath>
-#include <cstdlib>
-#include <string>
-using std::string;
-
 #include "Direct3D9Headers.h"
-#include "../General/GScolors.h"
-#include "../General/GSsprite.h"
-#include "../General/GStextures.h"
-#include "../General/GSprimitives.h"
 
+#include "Graphics_Systems/General/GSsprite.h"
+#include "Graphics_Systems/General/GSprimitives.h"
+
+#include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
-#include "Universal_System/instance_system.h"
-#include "Universal_System/graphics_object.h"
-
-#include "Graphics_Systems/General/GScolor_macros.h"
-
-
-#ifdef DEBUG_MODE
-  #include "libEGMstd.h"
-  #include "Widget_Systems/widgets_mandatory.h"
-  #define get_sprite(spr,id,r) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return r; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_spritev(spr,id) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_sprite_null(spr,id,r) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return r; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-#else
-  #define get_sprite(spr,id,r) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_spritev(spr,id) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_sprite_null(spr,id,r) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-#endif
-
-#include "Direct3D9Headers.h"
-#include "DX9TextureStruct.h"
 
 namespace enigma_user
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9sprite.cpp
@@ -24,19 +24,18 @@
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
 
-namespace enigma_user
-{
+namespace enigma_user {
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
   return -1; //TODO: implement
 }
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
-	return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
+  return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
 }
 
 void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth) {
 
 }
 
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
@@ -25,9 +25,6 @@
 
 #include "Platforms/General/PFwindow.h"
 
-#include <cstddef>
-#include <math.h>
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLbackground.cpp
@@ -25,8 +25,7 @@
 
 #include "Platforms/General/PFwindow.h"
 
-namespace enigma_user
-{
+namespace enigma_user {
 
 int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
 {
@@ -52,4 +51,4 @@ int background_create_from_screen(int x, int y, int w, int h, bool removeback, b
   return bckid;
 }
 
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
@@ -22,42 +22,8 @@
 #include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
-#include "Universal_System/instance_system.h"
-#include "Universal_System/graphics_object.h"
 
 #include "Platforms/General/PFwindow.h"
-
-#include <cmath>
-#include <cstdlib>
-#include <string>
-using std::string;
-
-#ifdef DEBUG_MODE
-  #include "libEGMstd.h"
-  #include "Widget_Systems/widgets_mandatory.h"
-  #define get_sprite(spr,id,r) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return r; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_spritev(spr,id) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_sprite_null(spr,id,r) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return r; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-#else
-  #define get_sprite(spr,id,r) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_spritev(spr,id) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_sprite_null(spr,id,r) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-#endif
 
 // These two leave a bad taste in my mouth because they depend on views, which should be removable.
 // However, for now, they stay.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsprite.cpp
@@ -28,8 +28,7 @@
 // These two leave a bad taste in my mouth because they depend on views, which should be removable.
 // However, for now, they stay.
 
-namespace enigma_user
-{
+namespace enigma_user {
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
   draw_batch_flush(batch_flush_deferred);
@@ -77,4 +76,4 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 	rgbdata.clear();
 }
 
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
@@ -25,8 +25,7 @@
 
 #include "Platforms/General/PFwindow.h"
 
-namespace enigma_user
-{
+namespace enigma_user {
 
 int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload) {
 	draw_batch_flush(batch_flush_deferred);
@@ -51,4 +50,4 @@ int background_create_from_screen(int x, int y, int w, int h, bool removeback, b
   return bckid;
 }
 
-}
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3background.cpp
@@ -25,9 +25,6 @@
 
 #include "Platforms/General/PFwindow.h"
 
-#include <cstddef>
-#include <math.h>
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
@@ -22,42 +22,8 @@
 #include "Universal_System/image_formats.h"
 #include "Universal_System/nlpo2.h"
 #include "Universal_System/sprites_internal.h"
-#include "Universal_System/instance_system.h"
-#include "Universal_System/graphics_object.h"
 
 #include "Platforms/General/PFwindow.h"
-
-#include <cmath>
-#include <cstdlib>
-#include <string>
-using std::string;
-
-#ifdef DEBUG_MODE
-  #include "libEGMstd.h"
-  #include "Widget_Systems/widgets_mandatory.h"
-  #define get_sprite(spr,id,r) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return r; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_spritev(spr,id) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_sprite_null(spr,id,r) \
-    if (id < -1 or size_t(id) > enigma::sprite_idmax) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
-      return r; \
-    } const enigma::sprite *const spr = enigma::spritestructarray[id];
-#else
-  #define get_sprite(spr,id,r) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_spritev(spr,id) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-  #define get_sprite_null(spr,id,r) \
-    const enigma::sprite *const spr = enigma::spritestructarray[id];
-#endif
 
 // These two leave a bad taste in my mouth because they depend on views, which should be removable.
 // However, for now, they stay.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3sprite.cpp
@@ -28,8 +28,7 @@
 // These two leave a bad taste in my mouth because they depend on views, which should be removable.
 // However, for now, they stay.
 
-namespace enigma_user
-{
+namespace enigma_user {
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
   draw_batch_flush(batch_flush_deferred);
@@ -77,4 +76,4 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
 	rgbdata.clear();
 }
 
-}
+} // namespace enigma_user


### PR DESCRIPTION
I had been planning to do this for a while because I continued running into the vestigial. First, there was no need for each graphics system to duplicate the `get_sprite` macro which, in fact, wasn't even being used anyway. The `get_sprite` macro belongs in `Universal_System` like the `get_background` macro. However, since there's already another non-macro version of `get_sprite` in `Universal_System`, and because this macro wasn't needed, I simply deleted it. I also removed other unused includes that are from the old ENIGMA and have been lingering in these sources for a while.