### PR TITLE
Cleanup DirectSound Warnings

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -78,7 +78,6 @@ void sound_stop_all() {
 }
 
 void sound_delete(int sound) {
-  get_soundv(snd, sound);
   sound_stop(sound);
   sound_resources.erase(sound_resources.begin() + sound);
 }
@@ -137,8 +136,8 @@ float sound_get_volume(int sound) {
 
 float sound_get_length(int sound) {  // Not for Streams
   get_sound(snd, sound, -1);
-  //snd->soundBuffer->GetLength();
-  return 0;
+
+  return snd->length;
 }
 
 float sound_get_position(int sound) {  // Not for Streams
@@ -190,7 +189,7 @@ int sound_add(string fname, int kind, bool preload)  //At the moment, the latter
 }
 
 bool sound_replace(int sound, string fname, int kind, bool preload) {
-  if (sound >= 0 && sound < sound_resources.size() && sound_resources[sound]) {
+  if (sound >= 0 && size_t(sound) < sound_resources.size() && sound_resources[sound]) {
     get_sound(snd, sound, false);
     delete snd;
   }

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -154,8 +154,8 @@ WaveHeaderType* buffer_get_wave_header(char* buffer, size_t bufsize) {
 
 int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
   SoundResource* snd = new SoundResource();
-  if (id >= sound_resources.size()) {
-    sound_resources.resize(id + 1);
+  if (size_t(id) >= sound_resources.size()) {
+    sound_resources.resize(size_t(id) + 1);
   }
   sound_resources[id] = snd;
 
@@ -201,6 +201,13 @@ int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
   } else {
     //ErrorHandler();  // Add error-handling here.
   }
+
+  float channels = waveHeader->numChannels,
+        freq = waveHeader->sampleRate,
+        bits = waveHeader->bitsPerSample,
+        size = waveHeader->dataSize;
+
+  snd->length = size / channels / (bits / 8) / freq;
 
   delete waveHeader;
 

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
@@ -33,8 +33,9 @@ struct SoundResource {
   void (*cleanup)(void *userdata);               // optional cleanup callback for streams
   void *userdata;                                // optional userdata for streams
   void (*seek)(void *userdata, float position);  // optional seeking
-  int type;                                      //0 for sound, 1 for music, -1 for error
+  int type;                                      // 0 for sound, 1 for music, -1 for error
   int kind;                                      //
+  float length;                                  // length of the sound buffer
 
   load_state loaded;  // Degree to which this sound has been loaded successfully
   bool idle;          // True if this sound is not being used, false if playing or paused.


### PR DESCRIPTION
I figured I'd carry on and knock out some more warnings in other systems besides graphics now. DirectSound wasn't too bad honestly, though I see some stuff that will maybe need looked at again later in the context of #1125.
* There were some `get_sound` calls that were declaring unused variables in functions that didn't need them.
* I decided to just add `sound_get_length` here by computing it when a sound is loaded and storing it as a member of the sound resource structure. I just used the same calculation as the OpenAL system, which I hope is correct, but don't really care to test.
* I needed to cast the sound id passed to `sound_replace` to size_t in order to safely compare it with the resources vector size. I also had to do similar for `sound_add_from_buffer` in order to resize the sound resources vector when necessary.