### PR TITLE
Cleanup OpenAL Warnings

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
@@ -153,7 +153,6 @@ int audio_play_sound_at(int sound, as_scalar x, as_scalar y, as_scalar z, as_sca
 }
 
 int audio_play_sound_on(int emitter, int sound, bool loop, double priority) {
-  get_sound(snd, sound, 0);
   SoundEmitter *emit = sound_emitters[emitter];
   int src = audio_play_sound_at(sound, emit->emitPos[0], emit->emitPos[1], emit->emitPos[2], emit->falloff[0],
                                 emit->falloff[1], emit->falloff[2], loop, priority) -


### PR DESCRIPTION
This pull request is a friend of #1573 with the same goal of reducing warnings in the audio systems. Easily enough, OpenAL had only a single warning about an unused variable produced by a call to the `get_sound` macro in `audio_play_sound_on` which was unused because that function simply calls `audio_play_sound_at` using the emitter's location as an argument.