### PR TITLE
Add Direct3D11 Support for MSAA

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -53,6 +53,13 @@ using namespace enigma::dx11;
 
 int swap_interval = 0;
 
+void release_render_targets() {
+  m_deviceContext->OMSetRenderTargets(0, 0, 0);
+  m_renderTargetView->Release();
+  m_depthStencilBuffer->Release();
+  m_depthStencilView->Release();
+}
+
 void initialize_render_targets(UINT samples=1) {
   HRESULT result;
 
@@ -127,10 +134,7 @@ namespace enigma {
 extern void (*WindowResizedCallback)();
 void WindowResized() {
   // release all the old references first
-  m_deviceContext->OMSetRenderTargets(0, 0, 0);
-  m_renderTargetView->Release();
-  m_depthStencilBuffer->Release();
-  m_depthStencilView->Release();
+  release_render_targets();
 
   // resize the buffers to match the screen
   m_swapChain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
@@ -230,18 +234,15 @@ void display_reset(int samples, bool vsync) {
   // when disabling msaa, we still need at least 1 samples
   if (samples < 1) samples = 1;
 
-  // get the old swap chain description and turn on msaa
+  // get the old swap chain description to reconfigure
   DXGI_SWAP_CHAIN_DESC swapChainDesc;
   m_swapChain->GetDesc(&swapChainDesc);
 
   // short-circuit if we already have a swap chain with this many samples
-  if (swapChainDesc.SampleDesc.Count == samples) return;
+  if (swapChainDesc.SampleDesc.Count == UINT(samples)) return;
 
   // release all the old references first
-  m_deviceContext->OMSetRenderTargets(0, 0, 0);
-  m_renderTargetView->Release();
-  m_depthStencilBuffer->Release();
-  m_depthStencilView->Release();
+  release_render_targets();
   m_swapChain->Release();
 
   // set the swap chain samples

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -53,7 +53,7 @@ using namespace enigma::dx11;
 
 int swap_interval = 0;
 
-void initialize_render_targets() {
+void initialize_render_targets(UINT samples=1) {
   HRESULT result;
 
   // Get the pointer to the back buffer.
@@ -83,8 +83,8 @@ void initialize_render_targets() {
   depthBufferDesc.MipLevels = 1;
   depthBufferDesc.ArraySize = 1;
   depthBufferDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
-  depthBufferDesc.SampleDesc.Count = 1;
-  depthBufferDesc.SampleDesc.Quality = 0;
+  depthBufferDesc.SampleDesc.Count = samples;
+  depthBufferDesc.SampleDesc.Quality = D3D11_STANDARD_MULTISAMPLE_PATTERN;
   depthBufferDesc.Usage = D3D11_USAGE_DEFAULT;
   depthBufferDesc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
   depthBufferDesc.CPUAccessFlags = 0;
@@ -98,7 +98,7 @@ void initialize_render_targets() {
   // Set up the depth stencil view description.
   D3D11_DEPTH_STENCIL_VIEW_DESC depthStencilViewDesc = { };
   depthStencilViewDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
-  depthStencilViewDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
+  depthStencilViewDesc.ViewDimension = samples > 1 ? D3D11_DSV_DIMENSION_TEXTURE2DMS : D3D11_DSV_DIMENSION_TEXTURE2D;
   depthStencilViewDesc.Texture2D.MipSlice = 0;
 
   result = m_device->CreateDepthStencilView(m_depthStencilBuffer, &depthStencilViewDesc, &m_depthStencilView);
@@ -122,105 +122,156 @@ void initialize_render_targets() {
 
 } // namespace anonymous
 
-namespace enigma
-{
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
+namespace enigma {
 
-    // release all the old references first
-    m_deviceContext->OMSetRenderTargets(0, 0, 0);
-    m_renderTargetView->Release();
-    m_depthStencilBuffer->Release();
-    m_depthStencilView->Release();
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  // release all the old references first
+  m_deviceContext->OMSetRenderTargets(0, 0, 0);
+  m_renderTargetView->Release();
+  m_depthStencilBuffer->Release();
+  m_depthStencilView->Release();
 
-    m_swapChain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
+  // resize the buffers to match the screen
+  m_swapChain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
 
-    // recreate the render target and depth stencil buffers
-    // and their related views with the new window size
-    initialize_render_targets();
+  // recreate the render target and depth stencil buffers
+  // and their related views with the new window size
+  initialize_render_targets();
 
-    // clear the window color, viewport does not need set because backbuffer was just recreated
-    enigma_user::draw_clear(enigma_user::window_get_color());
+  // clear the window color, viewport does not need set because backbuffer was just recreated
+  enigma_user::draw_clear(enigma_user::window_get_color());
+}
+
+void EnableDrawing(void* handle) {
+  WindowResizedCallback = &WindowResized;
+
+  int screenWidth = enigma_user::window_get_width(),
+      screenHeight = enigma_user::window_get_height();
+
+  HRESULT result;
+
+  DXGI_SWAP_CHAIN_DESC swapChainDesc = { };
+  swapChainDesc.BufferCount = 1;
+  swapChainDesc.BufferDesc.Width = screenWidth;
+  swapChainDesc.BufferDesc.Height = screenHeight;
+  swapChainDesc.BufferDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  swapChainDesc.BufferDesc.RefreshRate.Numerator = 0;
+  swapChainDesc.BufferDesc.RefreshRate.Denominator = 1;
+  swapChainDesc.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
+  swapChainDesc.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
+  swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+  swapChainDesc.SampleDesc.Count = 1;
+  swapChainDesc.SampleDesc.Quality = D3D11_STANDARD_MULTISAMPLE_PATTERN;
+  swapChainDesc.OutputWindow = enigma::hWnd;
+  swapChainDesc.Windowed = true; // initially windowed and not fullscreen
+  swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+  swapChainDesc.Flags = 0;
+
+  D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_0;
+
+  UINT flags = 0;
+  #ifdef DEBUG_MODE
+  flags |= D3D11_CREATE_DEVICE_DEBUG;
+  #endif
+  result = D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, flags, &featureLevel, 1,
+                                          D3D11_SDK_VERSION, &swapChainDesc, &m_swapChain, &m_device, NULL, &m_deviceContext);
+  if (FAILED(result)) {
+    show_error("Failed to create Direct3D11 device and swap chain.", true);
   }
 
-  void EnableDrawing(void* handle) {
-    WindowResizedCallback = &WindowResized;
+  initialize_render_targets();
 
-    int screenWidth = enigma_user::window_get_width(),
-        screenHeight = enigma_user::window_get_height();
+  // Setup the raster description which will determine how and what polygons will be drawn.
+  D3D11_RASTERIZER_DESC rasterDesc = { };
+  rasterDesc.AntialiasedLineEnable = false;
+  rasterDesc.CullMode = D3D11_CULL_NONE;
+  rasterDesc.DepthBias = 0;
+  rasterDesc.DepthBiasClamp = 0.0f;
+  rasterDesc.DepthClipEnable = false;
+  rasterDesc.FillMode = D3D11_FILL_SOLID;
+  rasterDesc.FrontCounterClockwise = false;
+  rasterDesc.MultisampleEnable = false;
+  rasterDesc.ScissorEnable = false;
+  rasterDesc.SlopeScaledDepthBias = 0.0f;
 
-    HRESULT result;
-
-    DXGI_SWAP_CHAIN_DESC swapChainDesc = { };
-    swapChainDesc.BufferCount = 1;
-    swapChainDesc.BufferDesc.Width = screenWidth;
-    swapChainDesc.BufferDesc.Height = screenHeight;
-    swapChainDesc.BufferDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
-    swapChainDesc.BufferDesc.RefreshRate.Numerator = 0;
-    swapChainDesc.BufferDesc.RefreshRate.Denominator = 1;
-    swapChainDesc.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
-    swapChainDesc.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
-    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    swapChainDesc.SampleDesc.Count = 1;
-    swapChainDesc.SampleDesc.Quality = 0;
-    swapChainDesc.OutputWindow = enigma::hWnd;
-    swapChainDesc.Windowed = true; // initially windowed and not fullscreen
-    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
-    swapChainDesc.Flags = 0;
-
-    D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_0;
-
-    UINT flags = 0;
-    #ifdef DEBUG_MODE
-    flags |= D3D11_CREATE_DEVICE_DEBUG;
-    #endif
-    result = D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, flags, &featureLevel, 1,
-                                           D3D11_SDK_VERSION, &swapChainDesc, &m_swapChain, &m_device, NULL, &m_deviceContext);
-    if (FAILED(result)) {
-      show_error("Failed to create Direct3D11 device and swap chain.", true);
-    }
-
-    initialize_render_targets();
-
-    // Setup the raster description which will determine how and what polygons will be drawn.
-    D3D11_RASTERIZER_DESC rasterDesc = { };
-    rasterDesc.AntialiasedLineEnable = false;
-    rasterDesc.CullMode = D3D11_CULL_NONE;
-    rasterDesc.DepthBias = 0;
-    rasterDesc.DepthBiasClamp = 0.0f;
-    rasterDesc.DepthClipEnable = false;
-    rasterDesc.FillMode = D3D11_FILL_SOLID;
-    rasterDesc.FrontCounterClockwise = false;
-    rasterDesc.MultisampleEnable = false;
-    rasterDesc.ScissorEnable = false;
-    rasterDesc.SlopeScaledDepthBias = 0.0f;
-
-    result = m_device->CreateRasterizerState(&rasterDesc, &m_rasterState);
-    if (FAILED(result)) {
-      show_error("Failed to create Direct3D11 rasterizer state.", true);
-    }
-
-    m_deviceContext->RSSetState(m_rasterState);
+  result = m_device->CreateRasterizerState(&rasterDesc, &m_rasterState);
+  if (FAILED(result)) {
+    show_error("Failed to create Direct3D11 rasterizer state.", true);
   }
 
-  void DisableDrawing(void* handle) {}
+  m_deviceContext->RSSetState(m_rasterState);
 
-  void ScreenRefresh() {
-    m_swapChain->Present(swap_interval, 0);
+  enigma_user::display_aa = 0;
+  UINT quality_levels = 0;
+  for (int i = 16; i > 1; i--) {
+    if (SUCCEEDED(m_device->CheckMultisampleQualityLevels(swapChainDesc.BufferDesc.Format, i, &quality_levels))) {
+      if (quality_levels > 0)
+        enigma_user::display_aa += i;
+    }
   }
 }
 
-namespace enigma_user
-{
-  int display_aa = 0;
+void DisableDrawing(void* handle) {}
 
-  void display_reset(int samples, bool vsync) {
-    swap_interval = vsync ? 1 : 0;
-  }
-
-  void set_synchronization(bool enable)
-  {
-    swap_interval = enable ? 1 : 0;
-  }
-
+void ScreenRefresh() {
+  m_swapChain->Present(swap_interval, 0);
 }
+
+} // namespace enigma
+
+namespace enigma_user {
+
+int display_aa = 0;
+
+void display_reset(int samples, bool vsync) {
+  swap_interval = vsync ? 1 : 0;
+
+  // when disabling msaa, we still need at least 1 samples
+  if (samples < 1) samples = 1;
+
+  // get the old swap chain description and turn on msaa
+  DXGI_SWAP_CHAIN_DESC swapChainDesc;
+  m_swapChain->GetDesc(&swapChainDesc);
+
+  // short-circuit if we already have a swap chain with this many samples
+  if (swapChainDesc.SampleDesc.Count == samples) return;
+
+  // release all the old references first
+  m_deviceContext->OMSetRenderTargets(0, 0, 0);
+  m_renderTargetView->Release();
+  m_depthStencilBuffer->Release();
+  m_depthStencilView->Release();
+  m_swapChain->Release();
+
+  // set the swap chain samples
+  swapChainDesc.SampleDesc.Count = samples;
+  swapChainDesc.SampleDesc.Quality = D3D11_STANDARD_MULTISAMPLE_PATTERN;
+
+  // obtain the dxgi factory we created the device with
+  IDXGIDevice* dxgiDevice = 0;
+  m_device->QueryInterface(__uuidof(IDXGIDevice), (void **)&dxgiDevice);
+  IDXGIAdapter* dxgiAdapter = 0;
+  dxgiDevice->GetParent(__uuidof(IDXGIAdapter), (void **)&dxgiAdapter);
+  IDXGIFactory* dxgiFactory = 0;
+  dxgiAdapter->GetParent(__uuidof(IDXGIFactory), (void **)&dxgiFactory);
+
+  // create the new swap chain
+  dxgiFactory->CreateSwapChain(m_device, &swapChainDesc, &m_swapChain);
+
+  // release the dxgi factory COM pointers
+  dxgiFactory->Release();
+  dxgiAdapter->Release();
+  dxgiDevice->Release();
+
+  // recreate the render target and depth stencil buffers
+  // and their related views with the new swap chain
+  initialize_render_targets(samples);
+}
+
+void set_synchronization(bool enable)
+{
+  swap_interval = enable ? 1 : 0;
+}
+
+} // namespace enigma_user


### PR DESCRIPTION
This feature was sort of easy to do since I have done it already for D3D9 and I just felt like getting it in here. The function `display_reset(samples,vsync)` just has to release the swap chain, default render target, and the depth buffer and then recreate them with the sample count. We also have to query for the `enigma_user::display_aa` levels in `EnableDrawing` so the user knows what MSAA levels are supported. While I was at it, I decided to change the indentation level to 2 spaces, consistent with the rest of the engine, because I have a hard time reading the code with the extra indentation.

|      | Master | Pull |
|------|--------|------|
| DX11 |![3D Cubes Demo on Master Direct3D11 with 0xMSAA](https://user-images.githubusercontent.com/3212801/54075386-c0cbe580-426c-11e9-97ff-af71fd717f56.png)|![3D Cubes Demo on Pull Request Direct3D11 with 8xMSAA](https://user-images.githubusercontent.com/3212801/54075412-0092cd00-426d-11e9-914d-90b31210758e.png)|
