### PR TITLE
Cleanup Redundant MSAA State Definitions

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL1/graphics_bridge.cpp
@@ -52,9 +52,6 @@ namespace enigma {
 }
 
 namespace enigma_user {
-  // Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
-  int display_aa = 14;
-
   void set_synchronization(bool enable) {
 
   }

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL3/graphics_bridge.cpp
@@ -52,9 +52,6 @@ namespace enigma {
 }
 
 namespace enigma_user {
-  // Don't know where to query this on Cocoa, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
-  int display_aa = 14;
-
   void set_synchronization(bool enable) {
 
   }

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -226,8 +226,6 @@ void ScreenRefresh() {
 
 namespace enigma_user {
 
-int display_aa = 0;
-
 void display_reset(int samples, bool vsync) {
   swap_interval = vsync ? 1 : 0;
 

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -219,8 +219,6 @@ ContextManager* d3dmgr; // the pointer to the device class
 
 namespace enigma_user {
 
-int display_aa = 0;
-
 void display_reset(int samples, bool vsync) {
   if (d3dmgr == NULL) { return; }
   IDirect3DSwapChain9 *sc;

--- a/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/None-None/graphics_bridge.cpp
@@ -26,8 +26,6 @@ namespace enigma {
 }
 
 namespace enigma_user {
-  int display_aa = 14;
-
   void set_synchronization(bool enable){}
 
   void display_reset(int samples, bool vsync){}

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -59,9 +59,6 @@ void ScreenRefresh() {
 }
 
 namespace enigma_user {
-  // Don't know where to query this on XLIB, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
-  int display_aa = 14;
-
   void set_synchronization(bool enable) {
     SDL_GL_SetSwapInterval(enable);
   }

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
@@ -63,8 +63,6 @@ void ScreenRefresh() {
 
 namespace enigma_user {
 
-int display_aa = 0;
-
 void display_reset(int samples, bool vsync) {
   int interval = vsync ? 1 : 0;
 

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -113,9 +113,6 @@ namespace enigma {
 }
 
 namespace enigma_user {
-  // Don't know where to query this on XLIB, just defaulting it to 2,4,and 8 samples all supported, Windows puts it in EnableDrawing
-  int display_aa = 14;
-
   void set_synchronization(bool enable) {
     // General notes:
     // Setting swapping on and off is platform-dependent and requires platform-specific extensions.

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
@@ -84,6 +84,7 @@ int keyboard_lastkey = 0;
 
 double mouse_x, mouse_y;
 int mouse_button, mouse_lastbutton;
+int display_aa = 0;
 short mouse_hscrolls = 0;
 short mouse_vscrolls = 0;
 


### PR DESCRIPTION
This is pretty obvious, we clearly don't need the definition of the global readonly variable `display_aa` spread out across all the bridges. We can define it in one place, since the user may want to read it even when the target device doesn't support MSAA. I have tested and confirm this does not cause any regressions in the MSAA features, and doesn't seem to cause any compile errors where MSAA is not supported.