### PR TITLE
Cleanup & Fix SDL's OpenGL Bridge Context

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -27,10 +27,11 @@ int msaa_fbo = 0;
 
 SDL_GLContext context;
 
+void set_sdl_gl_context_version();
+
 bool initGameWindow() {
   SDL_Init(SDL_INIT_VIDEO);
-  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, ENIGMA_GL_MAJOR_VERSION);
-  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, ENIGMA_GL_MINOR_VERSION);
+  set_sdl_gl_context_version();
   SDL_GL_SetSwapInterval(0);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -29,16 +29,16 @@ SDL_GLContext context;
 
 bool initGameWindow() {
   SDL_Init(SDL_INIT_VIDEO);
-  windowHandle = SDL_CreateWindow("SDL", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
-  return (windowHandle != nullptr);
-}
-
-void EnableDrawing(void*) {
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, ENIGMA_GL_MAJOR_VERSION);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, ENIGMA_GL_MINOR_VERSION);
   SDL_GL_SetSwapInterval(0);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+  windowHandle = SDL_CreateWindow("SDL", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+  return (windowHandle != nullptr);
+}
+
+void EnableDrawing(void*) {
   context = SDL_GL_CreateContext(windowHandle);
 
   GLenum err = glewInit();

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -26,7 +26,6 @@ namespace enigma {
 int msaa_fbo = 0;
 
 SDL_GLContext context;
-SDL_Renderer *renderer;
 
 bool initGameWindow() {
   SDL_Init(SDL_INIT_VIDEO);
@@ -41,7 +40,6 @@ void EnableDrawing(void*) {
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
   context = SDL_GL_CreateContext(windowHandle);
-  renderer = SDL_CreateRenderer(windowHandle, -1, SDL_RENDERER_ACCELERATED);
 
   GLenum err = glewInit();
   if (GLEW_OK != err)
@@ -49,7 +47,7 @@ void EnableDrawing(void*) {
 }
 
 void DisableDrawing(void*) {
-  SDL_DestroyRenderer(renderer);
+  SDL_GL_DeleteContext(context);
 }
 
 void ScreenRefresh() {

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL1/Makefile
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL1/Makefile
@@ -1,2 +1,1 @@
-override CXXFLAGS += -DENIGMA_GL_MAJOR_VERSION=1 -DENIGMA_GL_MINOR_VERSION=1
-SOURCES += $(wildcard Bridges/SDL-OpenGL/*.cpp)
+SOURCES += Bridges/SDL-OpenGL1/graphics_bridge.cpp $(wildcard Bridges/SDL-OpenGL/*.cpp)

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL1/graphics_bridge.cpp
@@ -1,0 +1,12 @@
+
+#include <SDL2/SDL.h>
+
+namespace enigma {
+
+void set_sdl_gl_context_version() {
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
+}
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL3/Makefile
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL3/Makefile
@@ -1,2 +1,1 @@
-override CXXFLAGS += -DENIGMA_GL_MAJOR_VERSION=3 -DENIGMA_GL_MINOR_VERSION=3
-SOURCES += $(wildcard Bridges/SDL-OpenGL/*.cpp)
+SOURCES += Bridges/SDL-OpenGL3/graphics_bridge.cpp $(wildcard Bridges/SDL-OpenGL/*.cpp)

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL3/graphics_bridge.cpp
@@ -1,0 +1,12 @@
+
+#include <SDL2/SDL.h>
+
+namespace enigma {
+
+void set_sdl_gl_context_version() {
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+}
+
+} // namespace enigma


### PR DESCRIPTION
This has been bugging me for a couple of months why OpenGL had intense z-fighting when using the SDL platform. I finally figured it out and also managed to remove some garbage while I was in here.

### SDL GL Attributes Must Be Set Prior To Window Creation
This is the one that kept alluding me and is why there was intense z-fighting in 3D games. Apparently, SDL requires you to set the GL attributes before you create a window. Because we were setting them after creating the window, in `EnableDrawing`, we were getting the default 16 bit depth buffer instead of the 24 bit one we requested.
https://wiki.libsdl.org/SDL_GL_SetAttribute

|     | Master | Pull |
|-----|--------|------|
| GL1 |![SDL Master GL1 Zfighting](https://user-images.githubusercontent.com/3212801/54081390-3322e100-42d2-11e9-9dce-8751d189601e.png)|![SDL Pull GL1 No Zfighting](https://user-images.githubusercontent.com/3212801/54081409-8c8b1000-42d2-11e9-8a4a-c93f60afb3b2.png)|
| GL3 |![SDL Master GL3 Zfighting](https://user-images.githubusercontent.com/3212801/54081395-4fbf1900-42d2-11e9-8ef3-d8edd9e997dc.png)|![SDL Pull GL3 No Zfighting](https://user-images.githubusercontent.com/3212801/54081415-a7f61b00-42d2-11e9-996e-90921efafce2.png)|

### We Don't Need SDL_Renderer
This is pretty obvious, since we have built our own rendering engine, we don't need any of SDL's abstractions here. Creating an `SDL_Renderer` is not a requirement to using OpenGL with SDL. While removing it, I also made sure to add the missing call to delete the SDL GL context when we are finished drawing.
https://wiki.libsdl.org/SDL_GL_CreateContext

### OpenGL3 Needs A Core Context
Fundies is clearly a dipshit and the defines he put in the makefile (cedb6e20984c1df1ae7eb416740452dd03c49a96) clearly don't relink when switching graphics systems. I had to remove that garbage and create a `set_sdl_gl_context_version` helper in both SDL-OpenGL bridges. The helper sets the OpenGL major and minor version and the context type (compatibility for 1.1 and core for 3.3).  This fixes the 3D Animation Platform Example sent to me previously by DarkAceZ in both graphics systems under SDL. On master, this game does not draw the 3D cubes that the player walks on in OpenGL3 (probably because Harris's core 3.3 shader handles the lighting on them). I seem to have discovered also that similar behavior is exhibited with the Wild Racing game where on master SDL+GL3 the terrain doesn't render, but on this pull request it does.

