### PR TITLE
add function execute_shell_eval()

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -20,6 +20,7 @@
 #define ENIGMA_PLATFORM_MAIN
 
 #include <string>
+#include "Universal_System/var4.h"
 
 namespace enigma {
   extern bool game_isending;
@@ -77,7 +78,7 @@ unsigned long long disk_free(std::string drive);
 void set_program_priority(int value);
 void execute_shell(std::string fname, std::string args);
 void execute_shell(std::string operation, std::string fname, std::string args);
-std::string execute_shell_eval(std::string command);
+var execute_shell_eval(std::string command);
 void execute_program(std::string fname, std::string args, bool wait);
 void execute_program(std::string operation, std::string fname, std::string args, bool wait);
 

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -77,6 +77,7 @@ unsigned long long disk_free(std::string drive);
 void set_program_priority(int value);
 void execute_shell(std::string fname, std::string args);
 void execute_shell(std::string operation, std::string fname, std::string args);
+std::string execute_shell_eval(std::string command);
 void execute_program(std::string fname, std::string args, bool wait);
 void execute_program(std::string operation, std::string fname, std::string args, bool wait);
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -10,7 +10,7 @@
 #include <errno.h>
 #include <stdint.h>
 
-ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+static inline ssssize_t getline(char **lineptr, size_t *n, FILE *stream) {
   size_t pos;
   int c;
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -162,7 +162,7 @@ unsigned long get_timer() {  // microseconds since the start of the game
 std::string shellscript_evaluate(std::string command) {
   char *buffer = NULL;
   size_t buffer_size = 0;
-  std::string result = "";
+  std::string result;
 
   FILE *file = popen(command.c_str(), "r");
   while (getline(&buffer, &buffer_size, file) != -1)

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -7,56 +7,55 @@
 #include <cstdlib>         //free,malloc,realloc
 
 #ifdef _WIN32
-static inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
-  char *bufptr = NULL;
-  char *p = bufptr;
-  ssize_t size;
+#include <errno.h>
+#include <stdint.h>
+
+ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+  size_t pos;
   int c;
 
-  if (lineptr == NULL && n == 0) {
+  if (lineptr == NULL || stream == NULL || n == NULL) {
+    errno = EINVAL;
     return -1;
   }
-  if (stream == NULL) {
-    return -1;
-  }
-  if (n == NULL) {
-    return -1;
-  }
-  bufptr = *lineptr;
-  size = *n;
 
   c = fgetc(stream);
   if (c == EOF) {
     return -1;
   }
-  if (bufptr == NULL) {
-    bufptr = malloc(128);
-    if (bufptr == NULL) {
+
+  if (*lineptr == NULL) {
+    *lineptr = malloc(128);
+    if (*lineptr == NULL) {
       return -1;
     }
-    size = 128;
+    *n = 128;
   }
-  p = bufptr;
+
+  pos = 0;
   while(c != EOF) {
-    if ((p - bufptr) > (size - 1)) {
-      size = size + 128;
-      bufptr = realloc((void *)bufptr, size);
-      if (bufptr == NULL) {
+    if (pos + 1 >= *n) {
+      size_t new_size = *n + (*n >> 2);
+      if (new_size < 128) {
+        new_size = 128;
+      }
+      char *new_ptr = realloc(*lineptr, new_size);
+      if (new_ptr == NULL) {
         return -1;
       }
+      *n = new_size;
+      *lineptr = new_ptr;
     }
-    *p++ = c;
+
+    ((unsigned char *)(*lineptr))[pos ++] = c;
     if (c == '\n') {
       break;
     }
     c = fgetc(stream);
   }
 
-  *p++ = '\0';
-  *lineptr = bufptr;
-  *n = size;
-
-  return p - bufptr - 1;
+  (*lineptr)[pos] = '\0';
+  return pos;
 }
 #endif
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -159,7 +159,7 @@ unsigned long get_timer() {  // microseconds since the start of the game
   return (enigma::time_current.tv_sec) * 1000000 + (enigma::time_current.tv_nsec / 1000);
 }
 
-std::string shellscript_evaluate(std::string command) {
+std::string execute_shell_eval(std::string command) {
   char *buffer = NULL;
   size_t buffer_size = 0;
   std::string result;

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -10,7 +10,7 @@
 #include <errno.h>
 #include <stdint.h>
 
-static inline ssssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+static inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
   size_t pos;
   int c;
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -3,7 +3,8 @@
 #include <time.h> //CLOCK_MONOTONIC
 #include <sys/types.h>     //getpid
 #include <unistd.h>        //usleep
-#include <cstdio>          //popen, getline
+#include <cstdio>          //popen,getline
+#include <cstdlib>         //free
 
 namespace enigma {
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -40,7 +40,7 @@ static inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
   while(c != EOF) {
     if ((p - bufptr) > (size - 1)) {
       size = size + 128;
-      bufptr = realloc(bufptr, size);
+      bufptr = realloc((void *)bufptr, size);
       if (bufptr == NULL) {
         return -1;
       }

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -182,9 +182,6 @@ std::string execute_shell_eval(std::string command) {
   free(buffer);
   pclose(file);
 
-  if (result.back() == '\n')
-    result.pop_back();
-
   return result;
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -3,7 +3,7 @@
 #include <time.h> //CLOCK_MONOTONIC
 #include <sys/types.h>     //getpid
 #include <unistd.h>        //usleep
-#include <cstdio>          //popen,getline
+#include <cstdio>          //popen,getline,pclose
 #include <cstdlib>         //free
 
 namespace enigma {

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -3,8 +3,8 @@
 #include <time.h> //CLOCK_MONOTONIC
 #include <sys/types.h>     //getpid
 #include <unistd.h>        //usleep
-#include <cstdio>          //popen,getline,pclose
-#include <cstdlib>         //free
+#include <cstdio>          //popen,getline,fgetc,pclose
+#include <cstdlib>         //free,malloc,realloc
 
 #ifdef _WIN32
 static inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
@@ -170,10 +170,10 @@ void execute_shell(std::string operation, std::string fname, std::string args) {
 
 void execute_shell(std::string fname, std::string args) { execute_shell("", fname, args); }
 
-std::string execute_shell_eval(std::string command) {
+var execute_shell_eval(std::string command) {
   char *buffer = NULL;
   size_t buffer_size = 0;
-  std::string result;
+  var result;
 
   FILE *file = popen(command.c_str(), "r");
   while (getline(&buffer, &buffer_size, file) != -1)

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -103,6 +103,24 @@ unsigned long get_timer() {  // microseconds since the start of the game
   return (enigma::time_current.tv_sec) * 1000000 + (enigma::time_current.tv_nsec / 1000);
 }
 
+std::string shellscript_evaluate(std::string command) {
+  char *buffer = NULL;
+  size_t buffer_size = 0;
+  std::string result = "";
+
+  FILE *file = popen(command.c_str(), "r");
+  while (getline(&buffer, &buffer_size, file) != -1)
+    result += buffer;
+
+  free(buffer);
+  pclose(file);
+
+  if (result.back() == '\n')
+    result.pop_back();
+
+  return result;
+}
+
 void execute_shell(std::string operation, std::string fname, std::string args) {
   if (system(NULL)) {
     system((fname + args + " &").c_str());
@@ -124,6 +142,7 @@ void execute_program(std::string operation, std::string fname, std::string args,
 }
 
 void execute_program(std::string fname, std::string args, bool wait) { execute_program("", fname, args, wait); }
+
 
 void url_open(std::string url, std::string target, std::string options) {
   execute_program("xdg-open", url, false);

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -159,6 +159,17 @@ unsigned long get_timer() {  // microseconds since the start of the game
   return (enigma::time_current.tv_sec) * 1000000 + (enigma::time_current.tv_nsec / 1000);
 }
 
+void execute_shell(std::string operation, std::string fname, std::string args) {
+  if (system(NULL)) {
+    system((fname + args + " &").c_str());
+  } else {
+    printf("execute_shell cannot be used as there is no command processor!");
+    return;
+  }
+}
+
+void execute_shell(std::string fname, std::string args) { execute_shell("", fname, args); }
+
 std::string execute_shell_eval(std::string command) {
   char *buffer = NULL;
   size_t buffer_size = 0;
@@ -176,17 +187,6 @@ std::string execute_shell_eval(std::string command) {
 
   return result;
 }
-
-void execute_shell(std::string operation, std::string fname, std::string args) {
-  if (system(NULL)) {
-    system((fname + args + " &").c_str());
-  } else {
-    printf("execute_shell cannot be used as there is no command processor!");
-    return;
-  }
-}
-
-void execute_shell(std::string fname, std::string args) { execute_shell("", fname, args); }
 
 void execute_program(std::string operation, std::string fname, std::string args, bool wait) {
   if (system(NULL)) {

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -6,6 +6,60 @@
 #include <cstdio>          //popen,getline,pclose
 #include <cstdlib>         //free
 
+#ifdef _WIN32
+static inline size_t getline(char **lineptr, size_t *n, FILE *stream) {
+  char *bufptr = NULL;
+  char *p = bufptr;
+  size_t size;
+  int c;
+
+  if (lineptr == NULL && n == 0) {
+    return -1;
+  }
+  if (stream == NULL) {
+    return -1;
+  }
+  if (n == NULL) {
+    return -1;
+  }
+  bufptr = *lineptr;
+  size = *n;
+
+  c = fgetc(stream);
+  if (c == EOF) {
+    return -1;
+  }
+  if (bufptr == NULL) {
+    bufptr = malloc(128);
+    if (bufptr == NULL) {
+      return -1;
+    }
+    size = 128;
+  }
+  p = bufptr;
+  while(c != EOF) {
+    if ((p - bufptr) > (size - 1)) {
+      size = size + 128;
+      bufptr = realloc(bufptr, size);
+      if (bufptr == NULL) {
+        return -1;
+      }
+    }
+    *p++ = c;
+    if (c == '\n') {
+      break;
+    }
+    c = fgetc(stream);
+  }
+
+  *p++ = '\0';
+  *lineptr = bufptr;
+  *n = size;
+
+  return p - bufptr - 1;
+}
+#endif
+
 namespace enigma {
 
 static struct timespec time_offset;

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -10,7 +10,7 @@
 static inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
   char *bufptr = NULL;
   char *p = bufptr;
-  size_t size;
+  ssize_t size;
   int c;
 
   if (lineptr == NULL && n == 0) {

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -7,7 +7,7 @@
 #include <cstdlib>         //free
 
 #ifdef _WIN32
-static inline size_t getline(char **lineptr, size_t *n, FILE *stream) {
+static inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
   char *bufptr = NULL;
   char *p = bufptr;
   size_t size;

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -7,8 +7,8 @@
 #include <cstdlib>         //free,malloc,realloc
 
 #ifdef _WIN32
-#include <errno.h>
-#include <stdint.h>
+#include <cerrno>
+#include <cstdint>
 
 static inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
   size_t pos;

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -3,6 +3,7 @@
 #include <time.h> //CLOCK_MONOTONIC
 #include <sys/types.h>     //getpid
 #include <unistd.h>        //usleep
+#include <cstdio>          //popen, getline
 
 namespace enigma {
 


### PR DESCRIPTION
to make matters easier this replaces my previous pr.

two things I need to know from Josh:

- do you want me to cout the error info or would you prefer it to go as a second return value, which i don't know how to do? In debug mode, I could even make it show in a graphic error message.

- does this work for multiple lines in the command argument? or do i need to std::replace each new line and carriage return with a whitespace? I'm still not 100% sure whether even that would work tbh.

thanks babe!