### PR TITLE
Patch for breaking protoc change.

### DIFF
--- a/CompilerSource/backend/GameData.cpp
+++ b/CompilerSource/backend/GameData.cpp
@@ -115,38 +115,38 @@ struct ESLookup {
 };
 
 SpriteData::SpriteData(const buffers::resources::Sprite &q, const std::string& name, const std::vector<ImageData>& subimages):
-  buffers::resources::Sprite(q), name(name), image_data(subimages) {}
+  BaseProtoWrapper(q), name(name), image_data(subimages) {}
 SpriteData::SpriteData(const ::Sprite &sprite):
   name(sprite.name) {
-  set_id(sprite.id);
+  data.set_id(sprite.id);
 
   // Discarded: sprite.transparent
   // Discarded: sprite.maskShapes
 
-  set_shape((buffers::resources::Sprite_Shape) sprite.shape);  // Enum correspondence guaranteed
-  set_alpha_tolerance(sprite.alphaTolerance);
-  set_separate_mask(sprite.separateMask);
-  set_smooth_edges(sprite.smoothEdges);
-  set_preload(sprite.preload);
-  set_origin_x(sprite.originX);
-  set_origin_y(sprite.originY);
+  data.set_shape((buffers::resources::Sprite_Shape) sprite.shape);  // Enum correspondence guaranteed
+  data.set_alpha_tolerance(sprite.alphaTolerance);
+  data.set_separate_mask(sprite.separateMask);
+  data.set_smooth_edges(sprite.smoothEdges);
+  data.set_preload(sprite.preload);
+  data.set_origin_x(sprite.originX);
+  data.set_origin_y(sprite.originY);
 
-  set_bbox_mode((buffers::resources::Sprite_BoundingBox) sprite.bbMode);  // Enum correspondence guaranteed
-  set_bbox_left(sprite.bbLeft);
-  set_bbox_right(sprite.bbRight);
-  set_bbox_top(sprite.bbTop);
-  set_bbox_bottom(sprite.bbBottom);
+  data.set_bbox_mode((buffers::resources::Sprite_BoundingBox) sprite.bbMode);  // Enum correspondence guaranteed
+  data.set_bbox_left(sprite.bbLeft);
+  data.set_bbox_right(sprite.bbRight);
+  data.set_bbox_top(sprite.bbTop);
+  data.set_bbox_bottom(sprite.bbBottom);
 
   for (int i = 0; i < sprite.subImageCount; ++i)
     image_data.emplace_back(sprite.subImages[i].image);
 }
 
 SoundData::SoundData(const buffers::resources::Sound &q, const std::string& name, const BinaryData& data):
-  buffers::resources::Sound(q), name(name), audio(data) {}
+  BaseProtoWrapper(q), name(name), audio(data) {}
 SoundData::SoundData(const ::Sound &sound):
   name(sound.name),
   audio(sound.data, sound.data + sound.size) {
-  set_id(sound.id);
+  data.set_id(sound.id);
 
   // Discarded: sound.chorus
   // Discarded: sound.echo
@@ -154,50 +154,50 @@ SoundData::SoundData(const ::Sound &sound):
   // Discarded: sound.gargle
   // Discarded: sound.reverb
 
-  set_kind((buffers::resources::Sound_Kind) sound.kind);
-  set_file_extension(sound.fileType);
-  set_file_name(sound.fileName);
-  set_volume(sound.volume);
-  set_pan(sound.pan);
-  set_preload(sound.preload);
+  data.set_kind((buffers::resources::Sound_Kind) sound.kind);
+  data.set_file_extension(sound.fileType);
+  data.set_file_name(sound.fileName);
+  data.set_volume(sound.volume);
+  data.set_pan(sound.pan);
+  data.set_preload(sound.preload);
 }
 
 BackgroundData::BackgroundData(const buffers::resources::Background &q, const std::string& name, const ImageData& image):
-  buffers::resources::Background(q), name(name), image_data(image) {}
+  BaseProtoWrapper(q), name(name), image_data(image) {}
 BackgroundData::BackgroundData(const ::Background &background):
   name(background.name),
   image_data(background.backgroundImage) {
-  set_id(background.id);
+  data.set_id(background.id);
 
   legacy_transparency = background.transparent;
 
   // Discarded: background.smoothEdges
 
-  set_preload(background.preload);
-  set_use_as_tileset(background.useAsTileset);
-  set_tile_width(background.tileWidth);
-  set_tile_height(background.tileHeight);
-  set_horizontal_offset(background.hOffset);
-  set_vertical_offset(background.vOffset);
-  set_horizontal_spacing(background.hSep);
-  set_vertical_spacing(background.vSep);
+  data.set_preload(background.preload);
+  data.set_use_as_tileset(background.useAsTileset);
+  data.set_tile_width(background.tileWidth);
+  data.set_tile_height(background.tileHeight);
+  data.set_horizontal_offset(background.hOffset);
+  data.set_vertical_offset(background.vOffset);
+  data.set_horizontal_spacing(background.hSep);
+  data.set_vertical_spacing(background.vSep);
 }
 
 FontData::FontData(const buffers::resources::Font &q, const std::string& name):
-  buffers::resources::Font(q), name(name) {}
+  BaseProtoWrapper(q), name(name) {}
 FontData::FontData(const ::Font &font):
   name(font.name) {
-  set_id(font.id);
+  data.set_id(font.id);
 
-  set_font_name(font.fontName);
-  set_size(font.size);
-  set_bold(font.bold);
-  set_italic(font.italic);
+  data.set_font_name(font.fontName);
+  data.set_size(font.size);
+  data.set_bold(font.bold);
+  data.set_italic(font.italic);
 
   for (int i = 0; i < font.glyphRangeCount; ++i) {
     normalized_ranges.emplace_back(font.glyphRanges[i]);
     for (const auto &glyph : normalized_ranges.back().glyphs) {
-      *add_glyphs() = glyph.metrics;
+      *data.add_glyphs() = glyph.metrics;
     }
   }
 }
@@ -222,21 +222,21 @@ FontData::GlyphData::GlyphData(const ::Glyph &glyph):
 }
 
 PathData::PathData(const buffers::resources::Path &q, const std::string& name):
-  buffers::resources::Path(q), name(name) {}
+  BaseProtoWrapper(q), name(name) {}
 PathData::PathData(const ::Path &path):
   name(path.name) {
-  set_id(path.id);
+  data.set_id(path.id);
 
-  set_smooth(path.smooth);
-  set_closed(path.closed);
-  set_precision(path.precision);
+  data.set_smooth(path.smooth);
+  data.set_closed(path.closed);
+  data.set_precision(path.precision);
 
 	// Discarded: backgroundRoomId;
-  set_hsnap(path.snapX);
-  set_vsnap(path.snapY);
+  data.set_hsnap(path.snapX);
+  data.set_vsnap(path.snapY);
 
   for (int i = 0; i < path.pointCount; ++i) {
-    auto *p = add_points();
+    auto *p = data.add_points();
     p->set_x(path.points[i].x);
     p->set_y(path.points[i].y);
     p->set_speed(path.points[i].speed);
@@ -244,59 +244,59 @@ PathData::PathData(const ::Path &path):
 }
 
 ScriptData::ScriptData(const buffers::resources::Script &q, const std::string& name):
-  buffers::resources::Script(q), name(name) {}
+  BaseProtoWrapper(q), name(name) {}
 ScriptData::ScriptData(const ::Script &script):
   name(script.name) {
-  set_id(script.id);
-  set_code(script.code);
+  data.set_id(script.id);
+  data.set_code(script.code);
 }
 
 ShaderData::ShaderData(const buffers::resources::Shader &q, const std::string& name):
-  buffers::resources::Shader(q), name(name) {}
+  BaseProtoWrapper(q), name(name) {}
 ShaderData::ShaderData(const ::Shader &shader):
   name(shader.name) {
-  set_id(shader.id);
+  data.set_id(shader.id);
 
-  set_vertex_code(shader.vertex);
-  set_fragment_code(shader.fragment);
-  set_type(shader.type);
-  set_precompile(shader.precompile);
+  data.set_vertex_code(shader.vertex);
+  data.set_fragment_code(shader.fragment);
+  data.set_type(shader.type);
+  data.set_precompile(shader.precompile);
 
 }
 
 TimelineData::TimelineData(const buffers::resources::Timeline &q, const std::string& name):
-  buffers::resources::Timeline(q), name(name) {}
+  BaseProtoWrapper(q), name(name) {}
 TimelineData::TimelineData(const ::Timeline &timeline):
   name(timeline.name) {
-  set_id(timeline.id);
+  data.set_id(timeline.id);
 
   for (int i = 0; i < timeline.momentCount; ++i) {
-    auto *moment = add_moments();
+    auto *moment = data.add_moments();
     moment->set_step(timeline.moments[i].stepNo);
     moment->set_code(timeline.moments[i].code);
   }
 }
 
 ObjectData::ObjectData(const buffers::resources::Object &q, const std::string& name):
-  buffers::resources::Object(q), name(name) {}
+  BaseProtoWrapper(q), name(name) {}
 ObjectData::ObjectData(const ::GmObject &object, const ESLookup &lookup):
   name(object.name) {
-  set_id(object.id);
+  data.set_id(object.id);
 
   if (object.spriteId >= 0)
-    set_sprite_name(lookup.sprite[object.spriteId]);
-  set_solid(object.solid);
-  set_visible(object.visible);
-  set_depth(object.depth);
-  set_persistent(object.persistent);
+    data.set_sprite_name(lookup.sprite[object.spriteId]);
+  data.set_solid(object.solid);
+  data.set_visible(object.visible);
+  data.set_depth(object.depth);
+  data.set_persistent(object.persistent);
   if (object.parentId >= 0)
-    set_parent_name(lookup.object[object.parentId]);
+    data.set_parent_name(lookup.object[object.parentId]);
   if (object.maskId >= 0)
-    set_mask_name(lookup.sprite[object.maskId]);
+    data.set_mask_name(lookup.sprite[object.maskId]);
 
   for (int i = 0; i < object.mainEventCount; ++i) {
     for (int j = 0; j < object.mainEvents[i].eventCount; ++j) {
-      auto *event = add_events();
+      auto *event = data.add_events();
       event->set_type(object.mainEvents[i].id);
       event->set_number(object.mainEvents[i].events[j].id);
       event->set_code(object.mainEvents[i].events[j].code);
@@ -305,32 +305,32 @@ ObjectData::ObjectData(const ::GmObject &object, const ESLookup &lookup):
 }
 
 RoomData::RoomData(const buffers::resources::Room &q, const std::string& name):
-  buffers::resources::Room(q), name(name) {}
+  BaseProtoWrapper(q), name(name) {}
 RoomData::RoomData(const ::Room &room, const ESLookup &lookup):
   name(room.name) {
   cout << "Import room." << endl;
-  set_id(room.id);
+  data.set_id(room.id);
 
   if (room.caption)
-    set_caption(room.caption);
-  set_width(room.width);
-  set_height(room.height);
+    data.set_caption(room.caption);
+  data.set_width(room.width);
+  data.set_height(room.height);
 
-  set_hsnap(room.snapX);
-  set_vsnap(room.snapY);
-  set_isometric(room.isometric);
+  data.set_hsnap(room.snapX);
+  data.set_vsnap(room.snapY);
+  data.set_isometric(room.isometric);
 
-  set_speed(room.speed);
-  set_persistent(room.persistent);
-  set_color(javaColor(room.backgroundColor));  // RGBA
-  set_show_color(room.drawBackgroundColor);
+  data.set_speed(room.speed);
+  data.set_persistent(room.persistent);
+  data.set_color(javaColor(room.backgroundColor));  // RGBA
+  data.set_show_color(room.drawBackgroundColor);
   if (room.creationCode)
-    set_creation_code(room.creationCode);
+    data.set_creation_code(room.creationCode);
 
-  set_enable_views(room.enableViews);
+  data.set_enable_views(room.enableViews);
 
   for (int i = 0; i < room.backgroundDefCount; ++i) {
-    auto *background = add_backgrounds();
+    auto *background = data.add_backgrounds();
     const auto &es_background = room.backgroundDefs[i];
 
     background->set_visible(es_background.visible);
@@ -347,7 +347,7 @@ RoomData::RoomData(const ::Room &room, const ESLookup &lookup):
   }
 
   for (int i = 0; i < room.viewCount; ++i) {
-    auto *view = add_views();
+    auto *view = data.add_views();
     const auto &es_view = room.views[i];
 
     view->set_visible(es_view.visible);
@@ -368,7 +368,7 @@ RoomData::RoomData(const ::Room &room, const ESLookup &lookup):
   }
 
   for (int i = 0; i < room.instanceCount; ++i) {
-    auto *instance = add_instances();
+    auto *instance = data.add_instances();
     const auto &es_instance = room.instances[i];
     // Discarded: es_instance.locked
 
@@ -383,7 +383,7 @@ RoomData::RoomData(const ::Room &room, const ESLookup &lookup):
   }
 
   for (int i = 0; i < room.tileCount; ++i) {
-    auto *tile = add_tiles();
+    auto *tile = data.add_tiles();
     const auto &es_tile = room.tiles[i];
 
     tile->set_id(es_tile.id);

--- a/CompilerSource/backend/GameData.h
+++ b/CompilerSource/backend/GameData.h
@@ -20,6 +20,26 @@
 
 struct ESLookup;
 
+template<class Proto> struct ProtoMessageInheritor {
+  Proto data;
+  typedef Proto BaseProtoClass;
+  typedef ProtoMessageInheritor<Proto> BaseProtoWrapper;
+
+  decltype(((Proto*)nullptr)->id()) id() const {
+    return data.id();
+  }
+
+  Proto *operator->() {
+    return &data;
+  }
+  const Proto *operator->() const {
+    return &data;
+  }
+
+  ProtoMessageInheritor() {}
+  ProtoMessageInheritor(const Proto &p): data(p) {}
+};
+
 typedef std::vector<uint8_t> BinaryData;
 struct ImageData {
   int width, height;
@@ -30,32 +50,35 @@ struct ImageData {
   ImageData(int w, int h, const uint8_t *data, size_t size);
 };
 
-struct SpriteData : buffers::resources::Sprite {
+struct SpriteData : ProtoMessageInheritor<buffers::resources::Sprite> {
   std::string name;
   std::vector<ImageData> image_data;
 
-  SpriteData(const buffers::resources::Sprite &sprite, const std::string& name, const std::vector<ImageData>& subimages);
+  SpriteData(const BaseProtoClass &sprite,
+             const std::string& name, const std::vector<ImageData>& subimages);
   SpriteData(const ::Sprite &sprite);
 };
 
-struct SoundData : buffers::resources::Sound {
+struct SoundData : ProtoMessageInheritor<buffers::resources::Sound> {
   std::string name;
   BinaryData audio;
 
-  SoundData(const buffers::resources::Sound &sound, const std::string& name, const BinaryData& data);
+  SoundData(const BaseProtoClass &sound,
+            const std::string& name, const BinaryData& data);
   SoundData(const ::Sound &sound);
 };
 
-struct BackgroundData : buffers::resources::Background {
+struct BackgroundData : ProtoMessageInheritor<buffers::resources::Background> {
   std::string name;
   ImageData image_data;
   bool legacy_transparency;
 
-  BackgroundData(const buffers::resources::Background &background, const std::string& name, const ImageData& image);
+  BackgroundData(const BaseProtoClass &background,
+                 const std::string& name, const ImageData& image);
   BackgroundData(const ::Background &background);
 };
 
-struct FontData : buffers::resources::Font {
+struct FontData : ProtoMessageInheritor<buffers::resources::Font> {
   std::string name;
   struct GlyphData : ImageData {
     buffers::resources::Font::Glyph metrics;
@@ -74,38 +97,38 @@ struct FontData : buffers::resources::Font {
   };
   std::vector<NormalizedRange> normalized_ranges;
 
-  FontData(const buffers::resources::Font &font, const std::string& name);
+  FontData(const BaseProtoClass &font, const std::string& name);
   FontData(const ::Font &font);
 };
 
-struct PathData : buffers::resources::Path {
+struct PathData : ProtoMessageInheritor<buffers::resources::Path> {
   std::string name;
-  PathData(const buffers::resources::Path &q, const std::string& name);
+  PathData(const BaseProtoClass &q, const std::string& name);
   PathData(const ::Path &path);
 };
-struct ScriptData : buffers::resources::Script {
+struct ScriptData : ProtoMessageInheritor<buffers::resources::Script> {
   std::string name;
-  ScriptData(const buffers::resources::Script &q, const std::string& name);
+  ScriptData(const BaseProtoClass &q, const std::string& name);
   ScriptData(const ::Script &script);
 };
-struct ShaderData : buffers::resources::Shader {
+struct ShaderData : ProtoMessageInheritor<buffers::resources::Shader> {
   std::string name;
-  ShaderData(const buffers::resources::Shader &q, const std::string& name);
+  ShaderData(const BaseProtoClass &q, const std::string& name);
   ShaderData(const ::Shader &shader);
 };
-struct TimelineData : buffers::resources::Timeline {
+struct TimelineData : ProtoMessageInheritor<buffers::resources::Timeline> {
   std::string name;
-  TimelineData(const buffers::resources::Timeline &q, const std::string& name);
+  TimelineData(const BaseProtoClass &q, const std::string& name);
   TimelineData(const ::Timeline &timeline);
 };
-struct ObjectData : buffers::resources::Object {
+struct ObjectData : ProtoMessageInheritor<buffers::resources::Object> {
   std::string name;
-  ObjectData(const buffers::resources::Object &q, const std::string& name);
+  ObjectData(const BaseProtoClass &q, const std::string& name);
   ObjectData(const ::GmObject &object, const ESLookup &lookup);
 };
-struct RoomData : buffers::resources::Room {
+struct RoomData : ProtoMessageInheritor<buffers::resources::Room> {
   std::string name;
-  RoomData(const buffers::resources::Room &q, const std::string& name);
+  RoomData(const BaseProtoClass &q, const std::string& name);
   RoomData(const ::Room &room, const ESLookup &lookup);
 };
 

--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -436,8 +436,8 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
     wto <<"  std::map<int, int> curr;\n\n";
     for (size_t i=0; i<game.timelines.size(); i++) {
       wto <<"  curr.clear();\n";
-      for (int j = 0; j < game.timelines[i].moments().size(); j++) {
-        wto << "  curr[" << game.timelines[i].moments()[j].step()
+      for (int j = 0; j < game.timelines[i]->moments().size(); j++) {
+        wto << "  curr[" << game.timelines[i]->moments()[j].step()
                          << "] = " << j <<";\n";
       }
       wto <<"  res.push_back(curr);\n\n";

--- a/CompilerSource/compiler/components/module_write_backgrounds.cpp
+++ b/CompilerSource/compiler/components/module_write_backgrounds.cpp
@@ -65,19 +65,19 @@ int lang_CPP::module_write_backgrounds(const GameData &game, FILE *gameModule)
   for (int i = 0; i < back_count; i++)
   {
     writei(game.backgrounds[i].id(), gameModule);  // id
-    writei(game.backgrounds[i].image_data.width, gameModule);   // width
+    writei(game.backgrounds[i].image_data.width,  gameModule);  // width
     writei(game.backgrounds[i].image_data.height, gameModule);  // height
 
-    writei(game.backgrounds[i].legacy_transparency, gameModule);
-    writei(game.backgrounds[i].smooth_edges(), gameModule);
-    writei(game.backgrounds[i].preload(), gameModule);
-    writei(game.backgrounds[i].use_as_tileset(), gameModule);
-    writei(game.backgrounds[i].tile_width(), gameModule);
-    writei(game.backgrounds[i].tile_height(), gameModule);
-    writei(game.backgrounds[i].horizontal_offset(), gameModule);
-    writei(game.backgrounds[i].vertical_offset(), gameModule);
-    writei(game.backgrounds[i].horizontal_spacing(), gameModule);
-    writei(game.backgrounds[i].vertical_spacing(), gameModule);
+    writei(game.backgrounds[i].legacy_transparency,   gameModule);
+    writei(game.backgrounds[i]->smooth_edges(),       gameModule);
+    writei(game.backgrounds[i]->preload(),            gameModule);
+    writei(game.backgrounds[i]->use_as_tileset(),     gameModule);
+    writei(game.backgrounds[i]->tile_width(),         gameModule);
+    writei(game.backgrounds[i]->tile_height(),        gameModule);
+    writei(game.backgrounds[i]->horizontal_offset(),  gameModule);
+    writei(game.backgrounds[i]->vertical_offset(),    gameModule);
+    writei(game.backgrounds[i]->horizontal_spacing(), gameModule);
+    writei(game.backgrounds[i]->vertical_spacing(),   gameModule);
 
     const int sz = game.backgrounds[i].image_data.pixels.size();
     writei(sz, gameModule); // size

--- a/CompilerSource/compiler/components/module_write_fonts.cpp
+++ b/CompilerSource/compiler/components/module_write_fonts.cpp
@@ -98,7 +98,7 @@ int lang_CPP::module_write_fonts(const GameData &game, FILE *gameModule)
   for (const auto &font : game.fonts) {
     cout << "Iterating included fonts..." << endl;
     // Simple allocations and initializations
-    int gc = font.glyphs().size();
+    int gc = font->glyphs().size();
 
     pvrect* boxes = new pvrect[gc];
 
@@ -108,7 +108,7 @@ int lang_CPP::module_write_fonts(const GameData &game, FILE *gameModule)
 
     // Copy our glyph metrics into it
     size_t ib = 0;
-    for (const auto &glyph : font.glyphs()) {
+    for (const auto &glyph : font->glyphs()) {
       boxes[ib].w = glyph.width(),
       boxes[ib].h = glyph.height();
       ib++;
@@ -117,7 +117,7 @@ int lang_CPP::module_write_fonts(const GameData &game, FILE *gameModule)
 
     // Sort our boxes from largest to smallest in area.
     size_t glyphno = 0;
-    for (const auto &glyph : font.glyphs()) {
+    for (const auto &glyph : font->glyphs()) {
       box_order.push_back(sizepair(glyph.width() * glyph.height(), glyphno++));
     }
     box_order.sort();

--- a/CompilerSource/compiler/components/module_write_paths.cpp
+++ b/CompilerSource/compiler/components/module_write_paths.cpp
@@ -70,20 +70,20 @@ int lang_CPP::module_write_paths(const GameData &game, FILE *gameModule)
   {
     writei(game.paths[i].id(), gameModule); //id
 
-    writei(game.paths[i].smooth(), gameModule);
-    writei(game.paths[i].closed(), gameModule);
-    writei(game.paths[i].precision(), gameModule);
+    writei(game.paths[i]->smooth(), gameModule);
+    writei(game.paths[i]->closed(), gameModule);
+    writei(game.paths[i]->precision(), gameModule);
     // possibly snapX/Y?
 
     // Track how many path points we're copying
-    int pointCount = game.paths[i].points().size();
+    int pointCount = game.paths[i]->points().size();
     writei(pointCount,gameModule);
 
     for (int ii = 0; ii < pointCount; ii++)
     {
-      writei(game.paths[i].points(ii).x(), gameModule);
-      writei(game.paths[i].points(ii).y(), gameModule);
-      writei(game.paths[i].points(ii).speed(), gameModule);
+      writei(game.paths[i]->points(ii).x(), gameModule);
+      writei(game.paths[i]->points(ii).y(), gameModule);
+      writei(game.paths[i]->points(ii).speed(), gameModule);
     }
   }
 

--- a/CompilerSource/compiler/components/module_write_sprites.cpp
+++ b/CompilerSource/compiler/components/module_write_sprites.cpp
@@ -91,14 +91,14 @@ int lang_CPP::module_write_sprites(const GameData &game, FILE *gameModule)
 
     writei(swidth, gameModule); //width
     writei(sheight,gameModule); //height
-    writei(game.sprites[i].origin_x(),  gameModule); // xorig
-    writei(game.sprites[i].origin_y(),  gameModule); // yorig
-    writei(game.sprites[i].bbox_top(),    gameModule); // BBox Top
-    writei(game.sprites[i].bbox_bottom(), gameModule); // BBox Bottom
-    writei(game.sprites[i].bbox_left(),   gameModule); // BBox Left
-    writei(game.sprites[i].bbox_right(),  gameModule); // BBox Right
-    writei(game.sprites[i].bbox_mode(),   gameModule); // BBox Mode
-    writei(game.sprites[i].shape(),    gameModule); // Mask shape
+    writei(game.sprites[i]->origin_x(),  gameModule); // xorig
+    writei(game.sprites[i]->origin_y(),  gameModule); // yorig
+    writei(game.sprites[i]->bbox_top(),    gameModule); // BBox Top
+    writei(game.sprites[i]->bbox_bottom(), gameModule); // BBox Bottom
+    writei(game.sprites[i]->bbox_left(),   gameModule); // BBox Left
+    writei(game.sprites[i]->bbox_right(),  gameModule); // BBox Right
+    writei(game.sprites[i]->bbox_mode(),   gameModule); // BBox Mode
+    writei(game.sprites[i]->shape(),    gameModule); // Mask shape
 
     writei(subCount,gameModule); //subimages
 

--- a/CompilerSource/compiler/components/parse_and_link.cpp
+++ b/CompilerSource/compiler/components/parse_and_link.cpp
@@ -64,10 +64,10 @@ int lang_CPP::compile_parseAndLink(const GameData &game, CompileState &state) {
   scripts.resize(game.scripts.size());
   for (size_t i = 0; i < game.scripts.size(); i++) {
     std::string newcode;
-    int a = syncheck::syntaxcheck(game.scripts[i].code(), newcode);
+    int a = syncheck::syntaxcheck(game.scripts[i]->code(), newcode);
     if (a != -1) {
       user << "Syntax error in script `" << game.scripts[i].name << "'\n"
-           << format_error(game.scripts[i].code(), syncheck::syerr, a) << flushl;
+           << format_error(game.scripts[i]->code(), syncheck::syerr, a) << flushl;
       return E_ERROR_SYNTAX;
     }
     // Keep a parsed record of this script
@@ -89,7 +89,7 @@ int lang_CPP::compile_parseAndLink(const GameData &game, CompileState &state) {
   for (const auto &timeline : game.timelines)
   {
     tline_lookup[timeline.name].id = timeline.id();
-    for (const auto &moment : timeline.moments())
+    for (const auto &moment : timeline->moments())
     {
       std::string newcode;
       int a = syncheck::syntaxcheck(moment.code(), newcode);
@@ -203,7 +203,7 @@ int lang_CPP::compile_parseAndLink(const GameData &game, CompileState &state) {
   //TODO: Linking timelines might not be strictly necessary, because scripts can now find their children through the timelines they call.
   int lookup_id = 0;
   for (const auto &timeline : game.timelines) {
-    for (const auto &moment : timeline.moments()) {
+    for (const auto &moment : timeline->moments()) {
       string curscrname = timeline.name;
       parsed_script* curscript = tlines[lookup_id++]; //At this point, what we have is this:     for each script as curscript
       edbg << "Linking `" << curscrname << " moment: " <<moment.step() << "':\n";
@@ -236,16 +236,20 @@ int lang_CPP::compile_parseAndLink(const GameData &game, CompileState &state) {
     unsigned ev_count = 0;
     state.parsed_objects.push_back(
       new parsed_object(
-        object.name, object.id(), object.sprite_name(), object.mask_name(),
-        object.parent_name(),
-        object.visible(), object.solid(),
-        object.depth(), object.persistent()
+        object.name, object.id(),
+        object->sprite_name(),
+        object->mask_name(),
+        object->parent_name(),
+        object->visible(),
+        object->solid(),
+        object->depth(),
+        object->persistent()
       ));
     parsed_object* pob = state.parsed_objects.back();
 
-    edbg << " " << object.name << ": " << object.events().size() << " events: " << flushl;
+    edbg << " " << object.name << ": " << object->events().size() << " events: " << flushl;
 
-    for (const auto& event : object.events()) {
+    for (const auto& event : object->events()) {
       int ev_id;
         if (event.has_name()) {
           edbg << "  Event[" << event.type() << ", " << event.name() << "] ";
@@ -300,16 +304,16 @@ int lang_CPP::compile_parseAndLink(const GameData &game, CompileState &state) {
     pev.mainId = 0, pev.id = 0, pev.myObj = pr;
 
     std::string newcode;
-    int sc = syncheck::syntaxcheck(room.creation_code(), newcode);
+    int sc = syncheck::syntaxcheck(room->creation_code(), newcode);
     if (sc != -1) {
       user << "Syntax error in room creation code for room " << room.id()
            << " (`" << room.name << "'):\n"
-           << format_error(room.creation_code(),syncheck::syerr,sc) << flushl;
+           << format_error(room->creation_code(),syncheck::syerr,sc) << flushl;
       return E_ERROR_SYNTAX;
     }
     parser_main(newcode,&pev,script_names);
 
-    for (const auto &instance : room.instances()) {
+    for (const auto &instance : room->instances()) {
       if (!instance.creation_code().empty()) {
         newcode = "";
         int a = syncheck::syntaxcheck(instance.creation_code(), newcode);
@@ -327,7 +331,7 @@ int lang_CPP::compile_parseAndLink(const GameData &game, CompileState &state) {
     }
 
     //PreCreate code
-    for (const auto &instance : room.instances()) {
+    for (const auto &instance : room->instances()) {
       if (!instance.initialization_code().empty()) {
         std::string newcode;
         int a = syncheck::syntaxcheck(instance.initialization_code(), newcode);

--- a/CompilerSource/compiler/components/write_defragged_events.cpp
+++ b/CompilerSource/compiler/components/write_defragged_events.cpp
@@ -63,9 +63,9 @@ int lang_CPP::compile_writeDefraggedEvents(const GameData &game, const ParsedObj
   // Defragged events must be written before object data, or object data cannot determine which events were used.
   used_events.clear();
   for (size_t i = 0; i < game.objects.size(); i++) {
-    for (int ii = 0; ii < game.objects[i].events().size(); ii++) {
-      const int mid = game.objects[i].events(ii).type();
-      const int  id = event_get_number(game.objects[i].events(ii));
+    for (int ii = 0; ii < game.objects[i]->events().size(); ii++) {
+      const int mid = game.objects[i]->events(ii).type();
+      const int  id = event_get_number(game.objects[i]->events(ii));
       if (event_is_instance(mid, id)) {
         used_events[event_stacked_get_root_name(mid)].inc(mid,id);
       } else {
@@ -79,9 +79,9 @@ int lang_CPP::compile_writeDefraggedEvents(const GameData &game, const ParsedObj
 
   //Write timeline/moment names. Timelines are like scripts, but we don't have to worry about arguments or return types.
   for (size_t i = 0; i < game.timelines.size(); i++) {
-    for (int j = 0; j < game.timelines[i].moments().size(); j++) {
+    for (int j = 0; j < game.timelines[i]->moments().size(); j++) {
       wto << "void TLINE_" << game.timelines[i].name << "_MOMENT_"
-          << game.timelines[i].moments(j).step() <<"();\n";
+          << game.timelines[i]->moments(j).step() <<"();\n";
     }
   }
   wto <<"\n";
@@ -132,10 +132,10 @@ int lang_CPP::compile_writeDefraggedEvents(const GameData &game, const ParsedObj
   for (size_t i = 0; i < game.timelines.size(); i++) {
     wto << "        case " << game.timelines[i].id() <<": {\n";
     wto << "          switch (moment_index) {\n";
-    for (int j = 0; j < game.timelines[i].moments().size(); j++) {
+    for (int j = 0; j < game.timelines[i]->moments().size(); j++) {
       wto << "            case " <<j <<": {\n";
       wto << "              ::TLINE_" << game.timelines[i].name << "_MOMENT_"
-                                      << game.timelines[i].moments(j).step() << "();\n";
+                                      << game.timelines[i]->moments(j).step() << "();\n";
       wto << "              break;\n";
       wto << "            }\n";
     }

--- a/CompilerSource/compiler/components/write_font_info.cpp
+++ b/CompilerSource/compiler/components/write_font_info.cpp
@@ -47,11 +47,11 @@ int lang_CPP::compile_writeFontInfo(const GameData &game)
   for (const auto &font : game.fonts) {
     wto << "    {\""
         << font.name        << "\", "     // string name;
-        << font.id()        << ", \""     // int id;
-        << font.font_name() << "\", "     // string fontName;
-        << font.size()      << ", "       // int size;
-        << font.bold()      << ", "       // bool bold;
-        << font.italic()    << ", "       // bool italic;
+        << font->id()        << ", \""    // int id;
+        << font->font_name() << "\", "    // string fontName;
+        << font->size()      << ", "      // int size;
+        << font->bold()      << ", "      // bool bold;
+        << font->italic()    << ", "      // bool italic;
         << font.normalized_ranges.size()  // int glyphRangeCount;
         << "}," << endl;
 

--- a/CompilerSource/compiler/components/write_room_data.cpp
+++ b/CompilerSource/compiler/components/write_room_data.cpp
@@ -69,24 +69,25 @@ int lang_CPP::compile_writeRoomData(const GameData &game, const ParsedRoomVec &p
 
   for (const auto &room : game.rooms) {
     wto << "  tile tiles_" << room.id() << "[] = {\n";
-    for (int ii = 0, modme = 0; ii < room->tiles().size(); ii++) {
+    int modme = 0;
+    for (const auto &tile : room->tiles()) {
       wto << "{"
-          << room->tiles(ii).id()      << ","
-          << resname(room->tiles(ii).background_name()) << ","
-          << room->tiles(ii).xoffset() << ","
-          << room->tiles(ii).yoffset() << ","
-          << room->tiles(ii).depth()   << ","
-          << room->tiles(ii).height()  << ","
-          << room->tiles(ii).width()   << ","
-          << room->tiles(ii).x()       << ","
-          << room->tiles(ii).y()       << ","
-          << room->tiles(ii).xscale()  << ","
-          << room->tiles(ii).yscale()  << ","
-          << room->tiles(ii).alpha()   << ","
-          << room->tiles(ii).color()   << "},";
+          << tile.id()      << ","
+          << resname(tile.background_name()) << ","
+          << tile.xoffset() << ","
+          << tile.yoffset() << ","
+          << tile.depth()   << ","
+          << tile.height()  << ","
+          << tile.width()   << ","
+          << tile.x()       << ","
+          << tile.y()       << ","
+          << tile.xscale()  << ","
+          << tile.yscale()  << ","
+          << tile.alpha()   << ","
+          << tile.color()   << "},";
         if (++modme % 16 == 0) wto << "\n        ";
-      if (room->tiles(ii).id() > room_hightileid)
-        room_hightileid = room->tiles(ii).id();
+      if (tile.id() > room_hightileid)
+        room_hightileid = tile.id();
     }
     wto << "  };\n";
   }

--- a/CompilerSource/compiler/components/write_room_data.cpp
+++ b/CompilerSource/compiler/components/write_room_data.cpp
@@ -69,24 +69,24 @@ int lang_CPP::compile_writeRoomData(const GameData &game, const ParsedRoomVec &p
 
   for (const auto &room : game.rooms) {
     wto << "  tile tiles_" << room.id() << "[] = {\n";
-    for (int ii = 0, modme = 0; ii < room.tiles().size(); ii++) {
+    for (int ii = 0, modme = 0; ii < room->tiles().size(); ii++) {
       wto << "{"
-          << room.tiles(ii).id()      << ","
-          << resname(room.tiles(ii).background_name()) << ","
-          << room.tiles(ii).xoffset() << ","
-          << room.tiles(ii).yoffset() << ","
-          << room.tiles(ii).depth()   << ","
-          << room.tiles(ii).height()  << ","
-          << room.tiles(ii).width()   << ","
-          << room.tiles(ii).x()       << ","
-          << room.tiles(ii).y()       << ","
-          << room.tiles(ii).xscale()  << ","
-          << room.tiles(ii).yscale()  << ","
-          << room.tiles(ii).alpha()   << ","
-          << room.tiles(ii).color()   << "},";
+          << room->tiles(ii).id()      << ","
+          << resname(room->tiles(ii).background_name()) << ","
+          << room->tiles(ii).xoffset() << ","
+          << room->tiles(ii).yoffset() << ","
+          << room->tiles(ii).depth()   << ","
+          << room->tiles(ii).height()  << ","
+          << room->tiles(ii).width()   << ","
+          << room->tiles(ii).x()       << ","
+          << room->tiles(ii).y()       << ","
+          << room->tiles(ii).xscale()  << ","
+          << room->tiles(ii).yscale()  << ","
+          << room->tiles(ii).alpha()   << ","
+          << room->tiles(ii).color()   << "},";
         if (++modme % 16 == 0) wto << "\n        ";
-      if (room.tiles(ii).id() > room_hightileid)
-        room_hightileid = room.tiles(ii).id();
+      if (room->tiles(ii).id() > room_hightileid)
+        room_hightileid = room->tiles(ii).id();
     }
     wto << "  };\n";
   }
@@ -94,7 +94,7 @@ int lang_CPP::compile_writeRoomData(const GameData &game, const ParsedRoomVec &p
   for (const auto &room : game.rooms) {
     wto << "  inst insts_" << room.id() << "[] = {\n";
     int modme = 0;
-    for (const auto &instance : room.instances()) {
+    for (const auto &instance : room->instances()) {
       wto << "{" <<
         instance.id() << "," <<
         instance.object_type() << "," <<
@@ -115,20 +115,20 @@ int lang_CPP::compile_writeRoomData(const GameData &game, const ParsedRoomVec &p
     << room.id() << ", "  // The ID of this room
     << room_index << ", \""  // The tree order index of this room
     << room.name << "\",  \""  // The name of this room
-    << room.caption() << "\",\n      "  // The caption of this room
+    << room->caption() << "\",\n      "  // The caption of this room
 
-    << format_color(room.color()) << ", "  // Background color
-    << (room.show_color() ? "true" : "false")  // Draw background color
+    << format_color(room->color()) << ", "  // Background color
+    << (room->show_color() ? "true" : "false")  // Draw background color
     << ", roomcreate" << room.id() << ",\n      "  // Creation code
     << "roomprecreate" << room.id() << ",\n      "  // PreCreation code
 
-    << room.width() << ", " << room.height() << ", " // Width and Height
-    << room.speed() << ",  "  // Speed
-    << (room.persistent() ? "true" : "false") << ",  "  // Persistent
+    <<  room->width() << ", " << room->height() << ", "  // Width and Height
+    <<  room->speed() << ",  "  // Speed
+    << (room->persistent() ? "true" : "false")  << ",  "  // Persistent
 
-    << (room.enable_views() ? "true" : "false") << ", {\n"; // Views Enabled
+    << (room->enable_views() ? "true" : "false") << ", {\n";  // Views Enabled
 
-    for (const auto &view : room.views()) {
+    for (const auto &view : room->views()) {
       wto << "        { "
           << (view.visible() ? "true" : "false") << ",   " // Visible
 
@@ -149,25 +149,25 @@ int lang_CPP::compile_writeRoomData(const GameData &game, const ParsedRoomVec &p
     }
     //Start of Backgrounds
     wto << "      }, {\n      ";
-     for (const auto &background : room.backgrounds()) {
+     for (const auto &background : room->backgrounds()) {
         wto << "  { "
         << (background.visible() ? "true" : "false")    << ", "    // Visible
         << (background.foreground() ? "true" : "false") << ", "    // Foreground
-        << resname(background.background_name())        << ",  "   // Background
-        << background.x()                               << ", "    // X
-        << background.y()                               << ",   "  // Y
-        << background.hspeed()                          << ", "    // HSpeed
-        << background.vspeed()                          << ",   "  // VSpeed
+        <<  resname(background.background_name())       << ",  "   // Background
+        <<  background.x()                              << ", "    // X
+        <<  background.y()                              << ",   "  // Y
+        <<  background.hspeed()                         << ", "    // HSpeed
+        <<  background.vspeed()                         << ",   "  // VSpeed
         << (background.htiled()  ? "true" : "false")    << ", "    // tileHor
         << (background.vtiled()  ? "true" : "false")    << ",   "  // tileVert
         << (background.stretch() ? "true" : "false")    << ",   "  // Stretch
-        << background.alpha() << ",   "    // Alpha
-        << background.color() << " },\n      ";  // Color
+        <<  background.alpha()                          << ",   "  // Alpha
+        <<  background.color()  << " },\n      ";                  // Color
      }
     wto <<
     " },\n" //End of Backgrounds
-    "      " << room.instances().size() << ", insts_" << room.id() << ",\n"
-    "      " << room.tiles().size() << ", tiles_" << room.id() << "\n"
+    "      " << room->instances().size() << ", insts_" << room.id() << ",\n"
+    "      " << room->tiles().size() << ", tiles_" << room.id() << "\n"
     "    },\n";
 
     if (room.id() > room_highid)

--- a/CompilerSource/compiler/components/write_shader_data.cpp
+++ b/CompilerSource/compiler/components/write_shader_data.cpp
@@ -69,14 +69,14 @@ int lang_CPP::compile_writeShaderData(const GameData &game, parsed_object *EGMgl
     while (idmax < shader.id()) {
       ++idmax, wto << "ShaderStruct(),\n";
     }
-    string vertexcode  =  shader.vertex_code();
-    string fragmentcode = shader.fragment_code();
+    string vertexcode  =  shader->vertex_code();
+    string fragmentcode = shader->fragment_code();
     //TODO: Replace quotations with escape sequences.
     wto << "    { "
         << '"' << esc(vertexcode)   << "\", "
         << '"' << esc(fragmentcode) << "\", "
-        << '"' << shader.type() << "\", "
-        << (shader.precompile()? "true" : "false")
+        << '"' << shader->type() << "\", "
+        << (shader->precompile()? "true" : "false")
         << " },\n";
     idmax += 1;
   }


### PR DESCRIPTION
The Protocol Buffer compiler, protoc, has started appending `final` to generated class definitions as of 3.7. Because of this, our extension classes will no longer build. This removes our dependency on the ability to inherit proto classes, at the cost of using `->` instead of `.` to refer to proto fields from the Data classes.

I've filed a bug about the breaking change as protocolbuffers/protobuf#5869, but do not plan to wait for the resolution, since users are having problems now.