### PR TITLE
Fix libegm Protos Include Directory

### DIFF
--- a/CommandLine/libEGM/CMakeLists.txt
+++ b/CommandLine/libEGM/CMakeLists.txt
@@ -53,7 +53,7 @@ endif(MSVC)
 find_package(yaml-cpp CONFIG REQUIRED)
 target_link_libraries(${LIB} PRIVATE yaml-cpp)
 
-include_directories(. "${ENIGMA_DIR}/shared/protos/" "${ENIGMA_DIR}/shared/libpng-util")
+include_directories(. "${ENIGMA_DIR}/shared/protos/codegen" "${ENIGMA_DIR}/shared/libpng-util")
 
 include(FindProtobuf)
 target_link_libraries(${LIB} PRIVATE ${Protobuf_LIBRARY})

--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -14,7 +14,7 @@ PROTO_DIR := ../../shared/protos
 SRC_DIR   := .
 OBJ_DIR   := .eobjs
 
-CXXFLAGS  := -I$(SRC_DIR) -I../ $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -I$(SHARED_SOURCES)/libpng-util -Wall -Wextra -Wpedantic -g -fPIC
+CXXFLAGS  := -I$(SRC_DIR) -I../ $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR)/codegen -I$(SHARED_SOURCES)/libpng-util -Wall -Wextra -Wpedantic -g -fPIC
 LDFLAGS   := -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -lstdc++fs -L$(SHARED_SOURCES)/libpng-util -lpng-util -lpng
 
 #if gcc >= 8 use std::filesystem instead of boost

--- a/CommandLine/libEGM/egm-rooms.h
+++ b/CommandLine/libEGM/egm-rooms.h
@@ -1,7 +1,7 @@
 #ifndef EGM_ROOMS_UTIL_h
 #define EGM_ROOMS_UTIL_h
 
-#include "codegen/project.pb.h"
+#include "project.pb.h"
 
 #include <map>
 #include <vector>
@@ -18,7 +18,7 @@ struct InstanceLayers {
   std::vector<Layer> layers;
   // Any instances with noncompactable attributes.
   std::vector<buffers::resources::Room::Instance> snowflakes;
-  
+
 };
 
 struct TileLayers {
@@ -30,7 +30,7 @@ struct TileLayers {
   std::vector<Layer> layers;
   // Any tiles with noncompactable attributes.
   std::vector<buffers::resources::Room::Tile> snowflakes;
-  
+
 };
 
 InstanceLayers BuildInstanceLayers(const buffers::resources::Room &room);

--- a/CommandLine/libEGM/egm.h
+++ b/CommandLine/libEGM/egm.h
@@ -15,7 +15,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "codegen/project.pb.h"
+#include "project.pb.h"
 
 #include <string>
 

--- a/CommandLine/libEGM/gmk.h
+++ b/CommandLine/libEGM/gmk.h
@@ -15,7 +15,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "codegen/project.pb.h"
+#include "project.pb.h"
 
 #include <iostream>
 #include <streambuf>

--- a/CommandLine/libEGM/gmx.h
+++ b/CommandLine/libEGM/gmx.h
@@ -15,7 +15,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "codegen/project.pb.h"
+#include "project.pb.h"
 
 #include <iostream>
 #include <streambuf>

--- a/CommandLine/libEGM/yyp.h
+++ b/CommandLine/libEGM/yyp.h
@@ -15,7 +15,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "codegen/project.pb.h"
+#include "project.pb.h"
 
 #include <iostream>
 #include <streambuf>


### PR DESCRIPTION
I ran into build issues trying to update the ENIGMA submodule for RadialGM.
https://github.com/enigma-dev/RadialGM/pull/57

When I did the recent change to convert actions to code immediately (3dd0326edadee06e2895fe3245c338be62da0c57), I made a mistake with one of the includes in `action.h`. I included just the `Event.pb.h` header without its `codegen/` path.

Instead of fixing that mistake, this pull request is proposing that we simply add `shared/protos/codegen/` to the Make and CMake include directories. For one, we don't ever actually include the `.proto` files, so having `shared/protos/` in the include directories doesn't make sense. The codegen includes have a unique file extension of `.pb.h` which distinguishes them from other headers, so there's no chance of getting mixed up. It just makes it simpler to change the include directory like I am proposing here. 