### PR TITLE
Implement `execute_shell_for_output` and `string_split`.

### DIFF
--- a/CommandLine/testing/SimpleTests/string_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/string_test.sog/create.edl
@@ -1,0 +1,119 @@
+gtest_assert_eq(base64_encode("The cake is a lie."), "VGhlIGNha2UgaXMgYSBsaWUu");
+gtest_assert_eq(base64_decode("VGhlIGNha2UgaXMgYSBsaWUu"), "The cake is a lie.");
+
+gtest_assert_true(is_base64("a"[0]));
+gtest_assert_true(is_base64("z"[0]));
+gtest_assert_true(is_base64("A"[0]));
+gtest_assert_true(is_base64("Z"[0]));
+gtest_assert_true(is_base64("0"[0]));
+gtest_assert_true(is_base64("1"[0]));
+gtest_assert_true(is_base64("9"[0]));
+gtest_assert_true(is_base64("/"[0]));
+gtest_assert_true(is_base64("+"[0]));
+
+// False, even though this can occur at the end of a base64 string as padding.s
+gtest_assert_false(is_base64("="[0]));
+
+gtest_assert_false(is_base64("."[0]));
+gtest_assert_false(is_base64("-"[0]));
+gtest_assert_false(is_base64("*"[0]));
+gtest_assert_false(is_base64("("[0]));
+gtest_assert_false(is_base64(")"[0]));
+gtest_assert_false(is_base64("["[0]));
+gtest_assert_false(is_base64("]"[0]));
+gtest_assert_false(is_base64("{"[0]));
+gtest_assert_false(is_base64("}"[0]));
+
+// TODO: These are completely busted.
+// std::string ansi_char(char byte);
+// std::string chr(char val);
+// int ord(std::string str);
+
+gtest_assert_eq(real(15.5), 15.5);
+gtest_assert_eq(real((float) 15.5), 15.5);
+gtest_assert_eq(real("3.125"), 3.125);
+// Without making guarantees about the behavior of big numbers,
+// assert that they're covered.
+//gtest_assert_gt(real("1234567890123"), 1234567890000.);
+
+variant my_str = "hello, world";
+gtest_assert_eq(string_length("hello, world"), 12);
+gtest_assert_eq(string_length(my_str), 12);
+
+// String length operations use bytes unless otherwise directed.
+my_str = "hello, 🌎! 😀";
+gtest_assert_eq(string_length("hello, 🌎! 😀"), 17);
+gtest_assert_eq(string_length(my_str), 17);
+gtest_assert_eq(string_length_utf8("hello, 🌎! 😀"), 11);
+gtest_assert_eq(string_length_utf8(my_str), 11);
+
+
+// TODO: This may be inconsistent with the GM version.
+gtest_assert_eq(string_format(pi, 0, 2), "3.14");
+gtest_assert_eq(string_format(pi, 5, 2), "03.14");
+gtest_assert_eq(string_format(pi, 7, 2), "0003.14");
+gtest_assert_eq(string_format(pi, 7, 5), "3.14159");
+
+// String functions are one-based... it's sad.
+// Something we might consider doing in the future is changing the string_
+// spec to evaluate unicode characters, since we're already doing weird
+// arithmetic to translate these indices to bytes (namely, subtraction).
+gtest_assert_eq(string_copy("hello, world", 4, 6), "lo, wo");
+gtest_assert_eq(string_set_byte_at("hello", 2, "u"[0]), "hullo");
+gtest_assert_eq(string_byte_at("[✓] Same", 1), (char) 0x5B);
+gtest_assert_eq(string_byte_at("[✓] Same", 2), (char) 0xE2);
+gtest_assert_eq(string_char_at("pina colada", 3), "n");
+// TODO: This doesn't work right now because ñ is multi-byte.
+// gtest_assert_eq(string_char_at("piña colada", 3), "ñ");
+gtest_assert_eq(string_delete("fire truck", 2, 6), "fuck");
+gtest_assert_eq(string_insert("penis", "themightierthanthesword", 4),
+                "thepenismightierthanthesword");
+
+// Naive search is always safe in unicode.
+// We use byte offsets rather than char offsets here, too.
+gtest_assert_eq(string_pos("wood", "how much wood would a woodchuck chuck"), 10);
+
+
+// Back into the realm of sanity.
+gtest_assert_eq(string_replace_all("a::b::c::d", "::", "."), "a.b.c.d");
+gtest_assert_eq(string_replace_all("a::b::c::d", "::", "::::"), "a::::b::::c::::d");
+gtest_assert_eq(string_replace_all("poopoopoopoopoop", "poop", "boob"), "boobooboobooboob");
+gtest_assert_eq(string_replace("a::b::c::d", "::", "."), "a.b::c::d");
+gtest_assert_eq(string_replace("a::b::c::d", "::", "::::"), "a::::b::c::d");
+gtest_assert_eq(string_replace("poopoopoopoopoop", "poop", "boob"), "booboopoopoopoop");
+
+gtest_assert_eq(string_count("foo", "foo bar foo foo bar"), 3);
+gtest_assert_eq(string_count("bar", "foo bar foo foo bar"), 2);
+gtest_assert_eq(string_count("baz", "foo bar foo foo bar"), 0);
+gtest_assert_eq(string_count("poop", "poopoopoopoopoop"), 3);
+
+gtest_assert_eq(string_lower("hElLo, wOrLd"), "hello, world");
+gtest_assert_eq(string_upper("hElLo, wOrLd"), "HELLO, WORLD");
+
+gtest_assert_eq(string_repeat("poop", 3), "pooppooppoop");
+
+gtest_assert_eq(string_letters("F0r o1ste2 d0 B0ut5 t0! :s"), "FrostedButts");
+gtest_assert_eq(string_digits("d0 1 need 2? :3"), "0123");
+gtest_assert_eq(string_lettersdigits("~* (W33b L0rd) *~"), "W33bL0rd");
+
+gtest_assert_true(string_isletters("HelloWorld"));
+gtest_assert_false(string_isletters("Hello, world!"));
+gtest_assert_false(string_isletters("hello_world"));
+gtest_assert_true(string_isdigits("12345"));
+gtest_assert_false(string_isdigits("1,234,567"));
+gtest_assert_false(string_isdigits("1.234"));
+gtest_assert_false(string_isdigits("sum1"));
+gtest_assert_true(string_islettersdigits("sum1"));
+gtest_assert_false(string_islettersdigits("sum1 do it"));
+
+var array = string_split("zero,one,two,three", ",");
+gtest_assert_eq(array[0], "zero");
+gtest_assert_eq(array[1], "one");
+gtest_assert_eq(array[2], "two");
+gtest_assert_eq(array[3], "three");
+
+gtest_assert_eq(array_length_1d(string_split("zero,one,two,three", ",")), 4);
+gtest_assert_eq(array_length_1d(string_split("zero,one,two,three,", ",")), 5);
+gtest_assert_eq(array_length_1d(string_split("zero,,one,two,,,three,", ",", true)), 4);
+
+game_end();

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -77,6 +77,7 @@ unsigned long long disk_free(std::string drive);
 void set_program_priority(int value);
 void execute_shell(std::string fname, std::string args);
 void execute_shell(std::string operation, std::string fname, std::string args);
+std::string execute_shell_for_output(const std::string &command);
 void execute_program(std::string fname, std::string args, bool wait);
 void execute_program(std::string operation, std::string fname, std::string args, bool wait);
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -123,6 +123,17 @@ void execute_program(std::string operation, std::string fname, std::string args,
   }
 }
 
+std::string execute_shell_for_output(const std::string &command) {
+  std::string res;
+  char buffer[BUFSIZ];
+  FILE *pf = popen(command.c_str(), "r");
+  while (!feof(pf)) {
+    res.append(buffer, fread(&buffer, sizeof(char), BUFSIZ, pf));
+  }
+  pclose(pf);
+  return res;
+}
+
 void execute_program(std::string fname, std::string args, bool wait) { execute_program("", fname, args, wait); }
 
 void url_open(std::string url, std::string target, std::string options) {

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <cstdlib>
+#include <vector>
 #include "var4.h"
 #include "estring.h"
 
@@ -33,7 +34,6 @@ using std::string;
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
 
 #include <windows.h>
-#include <vector>
 using std::vector;
 
 tstring widen(const string &str) {
@@ -189,12 +189,11 @@ size_t string_pos(string substr,string str) {
   return res == string::npos ? 0 : (int)res;
 }
 
-string string_format(double val, unsigned tot, unsigned dec)
-{
-  char sbuf[19]; sbuf[0] = 0;
-  sprintf(sbuf,"%0*.*f",tot,dec,val);
-  const string fstr = sbuf;
-  return fstr.c_str();
+string string_format(double val, unsigned tot, unsigned dec) {
+  std::vector<char> sbuf(19 + tot + dec);
+  sbuf[0] = 0;
+  sprintf(sbuf.data(), "%0*.*f", tot, dec, val);
+  return sbuf.data();
 }
 
 string string_copy(string str, int index, int count) {

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -380,7 +380,7 @@ var string_split(const std::string &str, const std::string &delim,
       res[found++] = str.substr(last, next - last);
     last = next + delim.length();
   }
-  if (!skip_empty || last + 1 < str.length())
+  if (!skip_empty || last < str.length())
     res[found++] = str.substr(last);
   return res;
 }

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -367,4 +367,22 @@ string filename_change_ext(string fname, string newext)
   return fname.replace(fp,fname.length(),newext);
 }
 
+var string_split(const std::string &str, const std::string &delim,
+                 bool skip_empty) {
+  var res;
+  if (delim.empty()) {
+    res[0] = str;
+    return res;
+  }
+  size_t last = 0, next, found = 0;
+  while ((next = str.find(delim, last)) != std::string::npos) {
+    if (!skip_empty || next > last)
+      res[found++] = str.substr(last, next - last);
+    last = next + delim.length();
+  }
+  if (!skip_empty || last + 1 < str.length())
+    res[found++] = str.substr(last);
+  return res;
+}
+
 }

--- a/ENIGMAsystem/SHELL/Universal_System/estring.h
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.h
@@ -85,6 +85,9 @@ std::string filename_drive(std::string fname);
 std::string filename_ext(std::string fname);
 std::string filename_change_ext(std::string fname, std::string newext);
 
+var string_split(const std::string &str, const std::string &delim,
+                 bool skip_empty = false);
+
 }  //namespace enigma_user
 
 #endif  //ENIGMA_ESTRING_H


### PR DESCRIPTION
These two methods are useful in tandem. The former runs a shell function and returns all data it printed as a string. The latter splits a string on a given delimiter (common to many languages).

An example usage is performing an ls, as follows (note that no sane program should do this instead of using the `file_find` API):

```cpp
files = string_split(execute_shell_for_output("ls"), "#", true);
for (int i = 0; i < array_length_1d(files); ++i) {
  show_message(">> " + files[i]);
}
```