### PR TITLE
Fix libegm Util Include

### DIFF
--- a/CommandLine/libEGM/CMakeLists.txt
+++ b/CommandLine/libEGM/CMakeLists.txt
@@ -53,7 +53,7 @@ endif(MSVC)
 find_package(yaml-cpp CONFIG REQUIRED)
 target_link_libraries(${LIB} PRIVATE yaml-cpp)
 
-include_directories(. "${ENIGMA_DIR}/shared/protos/codegen" "${ENIGMA_DIR}/shared/libpng-util")
+include_directories(. ../ "${ENIGMA_DIR}/shared/protos/codegen" "${ENIGMA_DIR}/shared/libpng-util")
 
 include(FindProtobuf)
 target_link_libraries(${LIB} PRIVATE ${Protobuf_LIBRARY})


### PR DESCRIPTION
Ran into another issue while building RGM with the updated submodule.
https://github.com/enigma-dev/RadialGM/pull/57

The CMake does not include the directory containing `Util.h` like the Make does. Pretty obvious fix here.