### PR TITLE
Cleanup SDL Window Init & Add Game Settings

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -22,6 +22,7 @@
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/Direct3D11/Direct3D11Headers.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Bridges/Win32/WINDOWShandle.h" // for get_window_handle()
 
 #include <windows.h>
 #include <windowsx.h>
@@ -148,6 +149,7 @@ void WindowResized() {
 }
 
 void EnableDrawing(void* handle) {
+  get_window_handle();
   WindowResizedCallback = &WindowResized;
 
   int screenWidth = enigma_user::window_get_width(),

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -23,6 +23,7 @@
 #include "Graphics_Systems/Direct3D9/DX9SurfaceStruct.h"
 #include "Graphics_Systems/Direct3D9/Direct3D9Headers.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Bridges/Win32/WINDOWShandle.h" // for get_window_handle()
 
 #include <windows.h>
 #include <windowsx.h>
@@ -99,6 +100,7 @@ ContextManager* d3dmgr; // the pointer to the device class
   }
 
   void EnableDrawing(void* handle) {
+    get_window_handle();
     WindowResizedCallback = &WindowResized;
 
     d3dmgr = new ContextManager();

--- a/ENIGMAsystem/SHELL/Bridges/SDL-Direct3D/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-Direct3D/graphics_bridge.cpp
@@ -1,5 +1,5 @@
 namespace enigma {
 
-void init_sdl_window_attributes() {}
+void init_sdl_window_bridge_attributes() {}
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Bridges/SDL-Direct3D/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-Direct3D/graphics_bridge.cpp
@@ -1,13 +1,5 @@
-#include "Platforms/SDL/Window.h"
-#include "Bridges/Win32/WINDOWShandle.h"
-
-#include <SDL2/SDL.h>
-
 namespace enigma {
-bool initGameWindow() {
-  SDL_Init(SDL_INIT_VIDEO);
-  windowHandle = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE);
-  get_window_handle();
-  return (windowHandle != nullptr);
-}
-}
+
+void init_sdl_window_attributes() {}
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -23,20 +23,20 @@
 
 namespace enigma {
 
+extern unsigned sdl_window_flags;
+
 int msaa_fbo = 0;
 
 SDL_GLContext context;
 
 void set_sdl_gl_context_version();
 
-bool initGameWindow() {
-  SDL_Init(SDL_INIT_VIDEO);
+void init_sdl_window_attributes() {
   set_sdl_gl_context_version();
   SDL_GL_SetSwapInterval(0);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
-  windowHandle = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
-  return (windowHandle != nullptr);
+  sdl_window_flags |= SDL_WINDOW_OPENGL;
 }
 
 void EnableDrawing(void*) {
@@ -55,14 +55,16 @@ void ScreenRefresh() {
   SDL_GL_SwapWindow(windowHandle);
 }
 
-}
+} // namespace enigma
 
 namespace enigma_user {
-  void set_synchronization(bool enable) {
-    SDL_GL_SetSwapInterval(enable);
-  }
 
-  void display_reset(int samples, bool vsync) {
-    set_synchronization(vsync);
-  }
+void set_synchronization(bool enable) {
+  SDL_GL_SetSwapInterval(enable);
 }
+
+void display_reset(int samples, bool vsync) {
+  set_synchronization(vsync);
+}
+
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -31,7 +31,7 @@ SDL_GLContext context;
 
 void set_sdl_gl_context_version();
 
-void init_sdl_window_attributes() {
+void init_sdl_window_bridge_attributes() {
   set_sdl_gl_context_version();
   SDL_GL_SetSwapInterval(0);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -9,8 +9,6 @@
 #include "Universal_System/estring.h" // ord
 #include "Universal_System/roomsystem.h" // room_caption, update_mouse_variables
 
-#include "Bridges/Win32/WINDOWShandle.h" // for get_window_handle()
-
 #include <array>
 #include <string>
 #include <algorithm>
@@ -44,7 +42,6 @@ bool initGameWindow() {
   if (isFullScreen) sdl_window_flags |= SDL_WINDOW_FULLSCREEN;
   init_sdl_window_attributes();
   windowHandle = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, sdl_window_flags);
-  get_window_handle();
   return (windowHandle != nullptr);
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -33,14 +33,18 @@ void (*WindowResizedCallback)();
 SDL_Window* windowHandle = nullptr;
 unsigned sdl_window_flags = SDL_WINDOW_HIDDEN;
 
-void init_sdl_window_attributes();
+// this is to be implemented by an SDL bridge
+// it is for setting any attributes on the
+// window before it is created
+// (e.g, SDL's OpenGL context attributes)
+void init_sdl_window_bridge_attributes();
 
 bool initGameWindow() {
   SDL_Init(SDL_INIT_VIDEO);
   if (isSizeable) sdl_window_flags |= SDL_WINDOW_RESIZABLE;
   if (!showBorder) sdl_window_flags |= SDL_WINDOW_BORDERLESS;
   if (isFullScreen) sdl_window_flags |= SDL_WINDOW_FULLSCREEN;
-  init_sdl_window_attributes();
+  init_sdl_window_bridge_attributes();
   windowHandle = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, sdl_window_flags);
   return (windowHandle != nullptr);
 }

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -9,6 +9,7 @@
 #include "Universal_System/estring.h" // ord
 #include "Universal_System/roomsystem.h" // room_caption, update_mouse_variables
 
+#include "Bridges/Win32/WINDOWShandle.h" // for get_window_handle()
 
 #include <array>
 #include <string>
@@ -32,6 +33,20 @@ namespace enigma {
 void (*WindowResizedCallback)();
 
 SDL_Window* windowHandle = nullptr;
+unsigned sdl_window_flags = SDL_WINDOW_HIDDEN;
+
+void init_sdl_window_attributes();
+
+bool initGameWindow() {
+  SDL_Init(SDL_INIT_VIDEO);
+  if (isSizeable) sdl_window_flags |= SDL_WINDOW_RESIZABLE;
+  if (!showBorder) sdl_window_flags |= SDL_WINDOW_BORDERLESS;
+  if (isFullScreen) sdl_window_flags |= SDL_WINDOW_FULLSCREEN;
+  init_sdl_window_attributes();
+  windowHandle = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, sdl_window_flags);
+  get_window_handle();
+  return (windowHandle != nullptr);
+}
 
 namespace keyboard {
   using namespace enigma_user;


### PR DESCRIPTION
I started noticing that if we are ever going to add the game settings to SDL we should probably cleanup its window creation. What I did here is very simple. First, I moved the `bool initGameWindow()` definition back to `Platforms/SDL/Window.cpp` so it's in the same place as the other platforms. I left any of the bridge-specific attribute setting in a new helper `init_sdl_window_attributes` specifically for OpenGL. I added a global `unsigned enigma::sdl_window_attributes` so the SDL-OpenGL bridge could specify `SDL_WINDOW_OPENGL`. Finally, I actually added the game settings in `initGameWindow` by appending the SDL window flags for the settings.