### PR TITLE
Fix Byte Definition Conflict in emake Callbacks

### DIFF
--- a/CommandLine/emake/EnigmaCallbacks.hpp
+++ b/CommandLine/emake/EnigmaCallbacks.hpp
@@ -1,12 +1,12 @@
 #ifndef EMAKE_ENIGMACALLBACKS_HPP
 #define EMAKE_ENIGMACALLBACKS_HPP
 
+#include "codegen/server.pb.h"
+
 //This
 #include "backend/JavaCallbacks.h"
 //Should be:
 //#include "backend/EnigmaCallbacks.h"
-
-#include "codegen/server.pb.h"
 
 #include <fstream>
 #include <string>


### PR DESCRIPTION
According to #1593 this fixes a compile error when building the frontend. Apparently the GRPC server's codegen defines a byte data type that conflicts with the one defined by our own backend's Java callbacks. I haven't seen the error myself, I am just going by what the user is reporting. I see that changing it the way they suggest doesn't cause any new issues.