### PR TITLE
Cleanup Universal System Warnings

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/motion_planning_struct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/MotionPlanning/motion_planning_struct.cpp
@@ -92,7 +92,8 @@ namespace enigma
     {
         enigma::grid** gridold = gridstructarray;
         gridstructarray = new grid*[enigma::grid_idmax+2];
-        for (size_t i = 0; i < enigma::grid_idmax; i++) gridstructarray[i] = gridold[i]; delete[] gridold;
+        for (size_t i = 0; i < enigma::grid_idmax; i++) gridstructarray[i] = gridold[i];
+        delete[] gridold;
     }
 
     //Helper functions

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/pathstruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Paths/pathstruct.cpp
@@ -157,7 +157,8 @@ namespace enigma
     {
         enigma::path** pathold = pathstructarray;
         pathstructarray = new path*[enigma::path_idmax+2];
-        for (size_t i = 0; i < enigma::path_idmax; i++) pathstructarray[i] = pathold[i]; delete[] pathold;
+        for (size_t i = 0; i < enigma::path_idmax; i++) pathstructarray[i] = pathold[i];
+        delete[] pathold;
     }
 
     /// Returns an iterator to the point in @param path whose segment covers @param position.
@@ -214,7 +215,7 @@ namespace enigma
         y = y1 + (y2-y1) * t;
       }
     }
-    
+
     void path_getXY_scaled(path *pth, cs_scalar &x, cs_scalar &y, cs_scalar position, cs_scalar scale)
     {
       path_getXY(pth, x, y, position);

--- a/ENIGMAsystem/SHELL/Universal_System/resource_data.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/resource_data.cpp
@@ -79,8 +79,7 @@ variant script_execute(int scr, variant arg0, variant arg1, variant arg2, varian
 
 bool script_exists(int script)
 {
-    return (script >= 0 && script < enigma::script_idmax && bool(enigma::callable_scripts[script].base));
+    return (script >= 0 && size_t(script) < enigma::script_idmax && bool(enigma::callable_scripts[script].base));
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -82,20 +82,20 @@ namespace enigma
   {
     using namespace enigma_user;
     object_basic *instanceexists = fetch_instance_by_int(vob);
-  
+
     if (instanceexists)
     {
       object_planar* vobr = (object_planar*)instanceexists;
-  
+
       double vobx = vobr->x, voby = vobr->y;
-  
+
       //int bbl=*vobr.x+*vobr.bbox_left,bbr=*vobr.x+*vobr.bbox_right,bbt=*vobr.y+*vobr.bbox_top,bbb=*vobr.y+*vobr.bbox_bottom;
       //if (bbl<view_xview[vc]+view_hbor[vc]) view_xview[vc]=bbl-view_hbor[vc];
-  
+
       double vbc_h, vbc_v;
       (view_hborder[vc] > view_wview[vc]/2) ? vbc_h = view_wview[vc]/2 : vbc_h = view_hborder[vc];
       (view_vborder[vc] > view_hview[vc]/2) ? vbc_v = view_hview[vc]/2 : vbc_v = view_vborder[vc];
-  
+
       if (view_hspeed[vc] == -1)
       {
         if (vobx < view_xview[vc] + vbc_h)
@@ -118,7 +118,7 @@ namespace enigma
             view_xview[vc] = vobx + vbc_h - view_wview[vc];
         }
       }
-  
+
       if (view_vspeed[vc] == -1)
       {
         if (voby < view_yview[vc] + vbc_v)
@@ -141,19 +141,19 @@ namespace enigma
             view_yview[vc] = voby + vbc_v - view_hview[vc];
         }
       }
-  
+
       if (view_xview[vc] < 0)
         view_xview[vc] = 0;
       else if (view_xview[vc] > room_width - view_wview[vc])
         view_xview[vc] = room_width - view_wview[vc];
-  
+
       if (view_yview[vc] < 0)
         view_yview[vc] = 0;
       else if (view_yview[vc] > room_height - view_hview[vc])
         view_yview[vc] = room_height - view_hview[vc];
     }
   }
-  
+
 
   void roomstruct::end() {
     // Fire the Room End event.
@@ -431,7 +431,7 @@ int room_goto_previous()
 
 int room_next(int num)
 {
-  if (num < 0 or num >= enigma::room_idmax)
+  if (num < 0 or size_t(num) >= enigma::room_idmax)
     return -1;
   enigma::roomstruct *rit = enigma::roomdata[num];
   if (!rit or rit->order+1 >= enigma::room_loadtimecount)
@@ -440,7 +440,7 @@ int room_next(int num)
 }
 int room_previous(int num)
 {
-  if (num < 0 or num >= enigma::room_idmax)
+  if (num < 0 or size_t(num) >= enigma::room_idmax)
     return -1;
   enigma::roomstruct *rit = enigma::roomdata[num];
   if (!rit or rit->order-1 < 0)
@@ -450,7 +450,7 @@ int room_previous(int num)
 
 bool room_exists(int roomid)
 {
-  return roomid >= 0 and roomid < enigma::room_idmax and enigma::roomdata[roomid];
+  return roomid >= 0 and size_t(roomid) < enigma::room_idmax and enigma::roomdata[roomid];
 }
 
 int room_set_width(int indx, int wid)

--- a/ENIGMAsystem/SHELL/Universal_System/var_array.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var_array.cpp
@@ -34,7 +34,7 @@ var array_create(size_t size, variant value) { return var(value, size); }
 var array_create_2d(size_t length, size_t height, variant value) { return var(value, length, height); }
 bool array_equals(const var& arr1, const var& arr2) {
   if (arr1.array_len() != arr2.array_len()) return false;
-  for (size_t i = 0; i < arr1.array_len(); i++) {
+  for (int i = 0; i < arr1.array_len(); i++) {
     if (arr1[i] != arr2[i]) return false;
   }
   return true;

--- a/ENIGMAsystem/SHELL/Universal_System/zlib.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/zlib.cpp
@@ -22,11 +22,6 @@
 #include <string>
 #include <zlib.h>
 
-namespace {
-  int zlib_compressed_size=0;
-  int zlib_decompressed_size=0;
-}
-
 namespace enigma {
 
 unsigned char* zlib_compress(unsigned char* inbuffer,int actualsize)
@@ -46,7 +41,6 @@ unsigned char* zlib_compress(unsigned char* inbuffer,int actualsize)
      #endif
     }
 
-    zlib_compressed_size=outsize;
     return (unsigned char*)outbytef;
 }
 


### PR DESCRIPTION
Continuing on with the cleanup of warnings until we get rid of them all, here's Universal System.
* The motion planning and path extensions had misleading indentation on a for loop that reallocates their data structure. In both cases, the outer array is being copied to a new outer array, but with the same internal pointers. So I figured out that the delete was intended to go on a new line, outside the for loop, because, again, we're only deleting the outer array not the inner rows. I ran the A* motion planning example by TheExDeus from the EDC to make sure nothing regressed.
https://enigma-dev.org/edc/games.php?game=61
* Fixed warning in `script_exists` by casting the script id to size_t so it can be safely compared with `enigma::script_idmax`.
* Fixed warnings in `room_next`, `room_previous`, and `room_exists` by casting the room id to size_t so it can be safely compared with `enigma::room_idmax`.
* Changed the control variable in `array_equals` from size_t to int so that it can be safely compared to the `array_len()` member of Josh's VLAs.
* Removed two of Josh's unused variables in the zlib sources that I could not find any other reference to.