### PR TITLE
Cleanup Win32 Warnings

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSjoystick.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSjoystick.cpp
@@ -33,7 +33,6 @@ bool joystick_load(int id)
 {
 	JOYINFO joyinfo;
 	UINT wNumDevs;
-	BOOL bDevAttached;
 
     if((wNumDevs = joyGetNumDevs()) == 0)
         return false;
@@ -46,11 +45,7 @@ bool joystick_load(int id)
         return false;
     }
 
-	bDevAttached = joyGetPos(JOYSTICKID1 + id, &joyinfo) != JOYERR_UNPLUGGED;
-    if (!bDevAttached)
-        return false;
-
-	return true;
+	return (joyGetPos(JOYSTICKID1 + id, &joyinfo) == JOYERR_NOERROR);
 }
 
 double joystick_axis(int id, int axisnum) {
@@ -169,4 +164,3 @@ double joystick_pov(int id, int axis1, int axis2) {
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSsystem.cpp
@@ -30,7 +30,7 @@ void os_powersave_enable(bool enable) {}
 
 bool os_is_network_connected() {
 	DWORD dwFlags = 0;
-	return InternetGetConnectedState(&dwFlags, NULL);
+	return InternetGetConnectedState(&dwFlags, 0);
 }
 
 }  // namespace enigma_user


### PR DESCRIPTION
More warnings cleanup, this time for Windows. Very obvious, `joystick_load` was using a lot more boilerplate than it needed to just to return whether it was successful. Apparently GCC also doesn't like passing `NULL` as an argument to non-pointer parameters which was giving a warning in `os_is_network_connected()`.