### PR TITLE
Cleanup Object Warnings

### DIFF
--- a/CompilerSource/compiler/components/write_object_data.cpp
+++ b/CompilerSource/compiler/components/write_object_data.cpp
@@ -645,7 +645,6 @@ static inline string resname(string name) {
 static inline void write_object_data_structs(std::ostream &wto,
       const ParsedObjectVec &parsed_objects) {
   wto << "  objectstruct objs[] = {\n" << std::fixed;
-  int obmx = 0;
   for (parsed_object *object : parsed_objects) {
     wto << "    { "
         << resname(object->sprite_name)  << ", "
@@ -657,12 +656,10 @@ static inline void write_object_data_structs(std::ostream &wto,
         << resname(object->parent_name)  << ", "
         << object->id
         << " },\n";
-    if (object->id >= obmx) obmx = object->id;
   }
   wto.unsetf(ios_base::floatfield);
   wto << "  };\n";
   wto << "  int objectcount = " << parsed_objects.size() << ";\n";
-  wto << "  int obj_idmax = " << obmx+1 << ";\n";
 }
 
 static inline void write_object_declarations(lang_CPP* lcpp, const GameData &game, const CompileState &state, robertmap &parent_undefinitions) {

--- a/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_system.cpp
@@ -42,7 +42,7 @@ namespace enigma
   inst_iter::inst_iter(object_basic* i,inst_iter *n = NULL,inst_iter *p = NULL):
       inst(i), next(n), prev(p) {}
   inst_iter::inst_iter() {}
-  
+
   objectid_base::objectid_base(): inst_iter(NULL,NULL,this), count(0) {}
   event_iter::event_iter(string n): inst_iter(NULL,NULL,this), name(n) {}
   event_iter::event_iter(): inst_iter(NULL,NULL,this) {}
@@ -60,7 +60,7 @@ namespace enigma
   void iterator::addme() {
     central_iterator_cache.insert(this);
   }
-  
+
   void iterator::copy(const iterator& other) {
     // If the other pointer indicates its own temporary object, copy
     // it into our temporary object and point to ours, instead.
@@ -74,7 +74,7 @@ namespace enigma
       it = other.it;
     }
   }
-  
+
   void iterator::handle_unlink(const inst_iter *dead) {
     if (it) {
       if (it->next == dead) {
@@ -119,7 +119,7 @@ namespace enigma
     it = &temp_iter;
     return *this;
   }
-  
+
   // Always add ourself to the central iterator cache, because future
   // assignment could cause us to point to something deleteable
   iterator::iterator(): it(NULL) {
@@ -254,7 +254,7 @@ namespace enigma
     }
 
     if (x < 100000)
-      return x < object_idmax ? objects[x].next ? objects[x].next->inst : NULL : NULL;
+      return size_t(x) < object_idmax ? objects[x].next ? objects[x].next->inst : NULL : NULL;
 
     iliter a = instance_list.find(x);
     return a != instance_list.end() ? a->second->inst : NULL;

--- a/ENIGMAsystem/SHELL/Universal_System/object.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/object.cpp
@@ -77,11 +77,11 @@ namespace enigma
     bool object_basic::can_cast(int obj) const { return false; }
 
     extern objectstruct objs[];
-    extern int obj_idmax;
+    extern size_t object_idmax;
 
     void objectdata_load()
     {
-        objectdata = new objectstruct*[obj_idmax];
+        objectdata = new objectstruct*[object_idmax];
         for (int i = 0; i < objectcount; i++)
             objectdata[objs[i].id] = &objs[i];
     }
@@ -89,10 +89,10 @@ namespace enigma
 
 #if defined(SHOW_ERRORS) && SHOW_ERRORS
   #define errcheck(objid,err) \
-  if (objid < 0 or objid >= enigma::objectcount or !enigma::objectdata[objid]) \
+  if (objid < 0 or size_t(objid) >= enigma::object_idmax or !enigma::objectdata[objid]) \
     return (show_error(err,0), 0)
   #define errcheck(objid,err) \
-  if (objid < 0 or objid >= enigma::objectcount or !enigma::objectdata[objid]) \
+  if (objid < 0 or size_t(objid) >= enigma::object_idmax or !enigma::objectdata[objid]) \
     show_error(err,0)
 #else
   #define errcheck(objid,err)
@@ -104,7 +104,7 @@ namespace enigma_user
 
 bool object_exists(int objid)
 {
-  return ((objid >= 0) && (unsigned(objid) < enigma::obj_idmax) && bool(enigma::objectdata[objid]));
+  return ((objid >= 0) && (size_t(objid) < enigma::object_idmax) && bool(enigma::objectdata[objid]));
 }
 
 void object_set_depth(int objid, int val)


### PR DESCRIPTION
I chose to keep this out of #1596 because this cleanup was a wee bit more involved and I didn't want to lose sight of why these warnings are being fixed. So basically we had `obj_idmax` in `IDE_EDIT_objectdeclarations.h` which was a duplicate of `object_idmax` in `IDE_EDIT_resourcenames.h`. This was creating confusion in our code because `obj_idmax` was `int` and `object_idmax` is `size_t` like the rest of the `*_idmax` resource globals. Git blame tells me that in 542bf10014a9068e23006dc4872a053e126b59c2 it was polygonz who added this duplication.

* Removed `obj_idmax` which is a duplicate of `object_idmax` so the compiler doesn't write it anymore.
* Cast an instance id in `fetch_instance_by_int` to `size_t` in order to safely compare it with `object_idmax`.
* Changed references of `obj_idmax` to `object_idmax` in `Universal_System/object.cpp`.
* Changed `objectcount` to `object_idmax` to fix the condition of the `errcheck` macro in `Universal_System/object.cpp`. I also cast the object id to `size_t` in order for it to be safely compared with `object_idmax` in the `errcheck` macro.
* Changed the object id cast from `unsigned` to `size_t` in `object_exists` so that it matches the `errcheck` macro and can safely be compared with `object_idmax`.