### PR TITLE
Cleanup Event Proto & Rename to Action Proto

### DIFF
--- a/CommandLine/libEGM/action.h
+++ b/CommandLine/libEGM/action.h
@@ -15,7 +15,7 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "Event.pb.h"
+#include "Action.pb.h"
 
 #include <vector>
 

--- a/CompilerSource/compiler/components/write_defragged_events.cpp
+++ b/CompilerSource/compiler/components/write_defragged_events.cpp
@@ -46,7 +46,7 @@ struct foundevent {
 };
 typedef map<string,foundevent>::iterator evfit;
 
-static inline int event_get_number(const buffers::resources::Event &event) {
+static inline int event_get_number(const buffers::resources::Object::Event &event) {
   if (event.has_name()) {
     std::cerr << "ERROR! IMPLEMENT ME: Event names not supported in compiler.\n";
   }
@@ -169,7 +169,7 @@ int lang_CPP::compile_writeDefraggedEvents(const GameData &game, const ParsedObj
   // Here's the initializer
   wto << "  int event_system_initialize()" << endl << "  {" << endl;
   wto << "    events = new event_iter[" << used_events.size() << "]; // Allocated here; not really meant to change." << endl;
-  
+
   int obj_high_id = 0;
   for (parsed_object *obj : parsed_objects) {
     if (obj->id > obj_high_id) obj_high_id = obj->id;

--- a/shared/protos/Action.proto
+++ b/shared/protos/Action.proto
@@ -73,12 +73,3 @@ message Action {
   optional bool is_not = 12 [(gmx) = "isnot"];
   repeated Argument arguments = 13 [(gmx) = "arguments/argument"];
 }
-
-message Event {
-  optional int32 type = 1 [(gmx) = "eventtype"];
-  oneof reference {
-    int32 number = 2 [(gmx) = "enumb"];
-    string name = 3 [(gmx) = "ename", (yyp_id) = "collisionObjectId"];
-  }
-  optional string code = 4 [(gmx) = "action"];
-}

--- a/shared/protos/Object.proto
+++ b/shared/protos/Object.proto
@@ -2,21 +2,16 @@ syntax = "proto2";
 package buffers.resources;
 
 import "options.proto";
-import "Event.proto";
 
 message Object {
-  optional int32 id = 2 [(gmx) = "GMX_DEPRECATED"];
-
-  optional string parent_name = 3 [(resource_ref)="object", (gmx) = "parentName", (yyp_id) = "parentObjectId"];
-  optional string sprite_name = 4 [(resource_ref)="sprite", (gmx) = "spriteName", (yyp_id) = "spriteId"];
-  optional string mask_name = 5 [(resource_ref)="sprite", (gmx) = "maskName", (yyp_id) = "maskSpriteId"];
-
-  optional int32 depth = 6 [(yyp) = "YYP_DEPRECATED"];
-  optional bool solid = 7;
-  optional bool visible = 8;
-  optional bool persistent = 9;
-
-  repeated Event events = 10 [(gmx) = "events/event", (yyp) = "eventList"];
+  message Event {
+    optional int32 type = 1 [(gmx) = "eventtype"];
+    oneof reference {
+      int32 number = 2 [(gmx) = "enumb"];
+      string name = 3 [(gmx) = "ename", (yyp_id) = "collisionObjectId"];
+    }
+    optional string code = 4 [(gmx) = "action"];
+  }
 
   enum PhysicsShape { CIRCLE = 0; BOX = 1; SHAPE = 2; }
 
@@ -39,6 +34,19 @@ message Object {
     optional bool phy_kinematic = 11 [(gmx) = "PhysicsObjectKinematic", (yyp) = "physicsKinematic"];
     repeated PhysicsShapePoint phy_shape = 12 [(gmx) = "PhysicsShapePoints/point", (yyp) = "physicsShapePoints"];
   }
+
+  optional int32 id = 2 [(gmx) = "GMX_DEPRECATED"];
+
+  optional string parent_name = 3 [(resource_ref)="object", (gmx) = "parentName", (yyp_id) = "parentObjectId"];
+  optional string sprite_name = 4 [(resource_ref)="sprite", (gmx) = "spriteName", (yyp_id) = "spriteId"];
+  optional string mask_name = 5 [(resource_ref)="sprite", (gmx) = "maskName", (yyp_id) = "maskSpriteId"];
+
+  optional int32 depth = 6 [(yyp) = "YYP_DEPRECATED"];
+  optional bool solid = 7;
+  optional bool visible = 8;
+  optional bool persistent = 9;
+
+  repeated Event events = 10 [(gmx) = "events/event", (yyp) = "eventList"];
 
   optional ObjectPhysicsSettings physics_settings = 11 [(gmx) = "EGM_NESTED"];
 }

--- a/shared/protos/Timeline.proto
+++ b/shared/protos/Timeline.proto
@@ -2,7 +2,6 @@ syntax = "proto2";
 package buffers.resources;
 
 import "options.proto";
-import "Event.proto";
 
 message Timeline {
   message Moment {


### PR DESCRIPTION
I don't know how I missed this in #1555. If you build the current master you'll see a warning about `Timeline.proto` importing `Event.proto` but not using it. That is vestigial from before #1555 was merged. `Timeline.proto` has its own Moment message now. I moved the Event message to `Object.proto` where it needs to be and then renamed `Event.proto` to `Action.proto` since it no longer has anything to do with events.