### PR TITLE
Fix FreeType Extension DPI

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp
@@ -67,7 +67,8 @@ namespace enigma_user {
     if (error != 0)
       return -1;
     
-    error = FT_Set_Char_Size( face, size * 64, 0, 72, 0); // 72 dpi, 64 is 26.6 fixed point conversion
+    // GameMaker has always generated fonts at 96 dpi, default Windows dpi since 1980s
+    error = FT_Set_Char_Size( face, size * 64, 0, 96, 0); // 96 dpi, 64 is 26.6 fixed point conversion
     
     if (error != 0)
       return -1;


### PR DESCRIPTION
The FreeType extension should be rendering fonts at 96 dpi, which is what GameMaker has always rendered fonts at and continues to this day. The 96 dpi comes from the fact that this has been the default Windows dpi setting since the 1980s, though it's 72 dpi for Apple/Mac. I am splitting this out from #1288 so it isn't forgotten. The same change has already been made for LateralGM.
https://github.com/enigma-dev/lgmplugin/pull/65