### PR TITLE
Render State Centralization

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.h
@@ -18,8 +18,6 @@
 namespace enigma {
 
 extern unsigned char currentcolor[4];
-extern int currentblendmode[2];
-extern int currentblendtype;
 
 } // namespace enigma
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DIRECTX11Std.h
@@ -15,12 +15,6 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-namespace enigma {
-
-extern unsigned char currentcolor[4];
-
-} // namespace enigma
-
 #include "../General/GScolors.h"
 #include "../General/GSprimitives.h"
 #include "../General/GSd3d.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
@@ -17,6 +17,7 @@
 
 #include "Direct3D11Headers.h"
 #include "Graphics_Systems/General/GSblend.h"
+#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 
 using namespace enigma::dx11;
@@ -36,9 +37,6 @@ void update_blend_state() {
 } // namespace anonymous
 
 namespace enigma {
-
-extern int currentblendmode[2];
-extern int currentblendtype;
 
 void init_blend_state() {
   blendStateDesc.RenderTarget[0].BlendEnable = TRUE;
@@ -78,18 +76,6 @@ int draw_set_blend_mode_ext(int src, int dest) {
 
   update_blend_state();
   return 0;
-}
-
-int draw_get_blend_mode(){
-  return enigma::currentblendmode[0];
-}
-
-int draw_get_blend_mode_ext(bool src){
-  return enigma::currentblendmode[(src==true?0:1)];
-}
-
-int draw_get_blend_mode_type(){
-  return enigma::currentblendtype;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11blend.cpp
@@ -17,7 +17,6 @@
 
 #include "Direct3D11Headers.h"
 #include "Graphics_Systems/General/GSblend.h"
-#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 
 using namespace enigma::dx11;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11colors.cpp
@@ -23,10 +23,6 @@
 
 using namespace enigma::dx11;
 
-namespace enigma {
-  extern unsigned char currentcolor[4];
-}
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -40,11 +40,6 @@ void update_depth_stencil_state() {
 
 namespace enigma {
 
-bool d3dMode = false;
-bool d3dHidden = false;
-bool d3dZWriteEnable = true;
-int d3dCulling = 0;
-
 void graphics_set_matrix(int type) {
   enigma_user::draw_batch_flush(enigma_user::batch_flush_deferred);
 }
@@ -171,20 +166,6 @@ void d3d_set_culling(int mode)
 {
 	enigma::d3dCulling = mode;
 
-}
-
-bool d3d_get_mode()
-{
-    return enigma::d3dMode;
-}
-
-bool d3d_get_hidden()
-{
-    return enigma::d3dHidden;
-}
-
-int d3d_get_culling() {
-	return enigma::d3dCulling;
 }
 
 void d3d_set_fill_mode(int fill)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -200,12 +200,10 @@ void d3d_set_clip_plane(bool enable)
    ///TODO: Code this
 }
 
-}
+} // namespace enigma_user
 
 // ***** LIGHTS BEGIN *****
 #include <map>
-#include <list>
-#include "Universal_System/fileio.h"
 
 struct posi { // Homogenous point.
     gs_scalar x;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
@@ -29,10 +29,6 @@
 #include <stdio.h>
 using std::vector;
 
-namespace enigma {
-extern unsigned char currentcolor[4];
-}
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.h
@@ -18,8 +18,6 @@
 namespace enigma
 {
   extern unsigned char currentcolor[4];
-  extern int currentblendmode[2];
-  extern int currentblendtype;
 }
 
 #include "../General/GScolors.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.h
@@ -15,11 +15,6 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-namespace enigma
-{
-  extern unsigned char currentcolor[4];
-}
-
 #include "../General/GScolors.h"
 #include "../General/GSprimitives.h"
 #include "../General/GSd3d.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9blend.cpp
@@ -17,16 +17,10 @@
 
 #include "Direct3D9Headers.h"
 #include "Graphics_Systems/General/GSblend.h"
+#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 
 using namespace enigma::dx9;
-
-namespace enigma {
-
-extern int currentblendmode[2];
-extern int currentblendtype;
-
-} // namespace enigma
 
 namespace enigma_user {
 
@@ -57,18 +51,6 @@ int draw_set_blend_mode_ext(int src, int dest){
   d3dmgr->SetRenderState(D3DRS_DESTBLEND, blendequivs[(dest-1)%11]);
 
   return 0;
-}
-
-int draw_get_blend_mode(){
-  return enigma::currentblendmode[0];
-}
-
-int draw_get_blend_mode_ext(bool src){
-  return enigma::currentblendmode[(src==true?0:1)];
-}
-
-int draw_get_blend_mode_type(){
-  return enigma::currentblendtype;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9blend.cpp
@@ -17,7 +17,6 @@
 
 #include "Direct3D9Headers.h"
 #include "Graphics_Systems/General/GSblend.h"
-#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 
 using namespace enigma::dx9;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9colors.cpp
@@ -25,7 +25,6 @@
 using namespace enigma::dx9;
 
 namespace enigma {
-  extern unsigned char currentcolor[4];
   D3DCOLOR get_currentcolor() {
 	return D3DCOLOR_RGBA(currentcolor[0], currentcolor[1], currentcolor[2], currentcolor[3]);
   }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -61,11 +61,6 @@ D3DFOGMODE fogmodes[3] = {
 
 namespace enigma {
 
-bool d3dMode = false;
-bool d3dHidden = false;
-bool d3dZWriteEnable = true;
-int d3dCulling = 0;
-
 void graphics_set_matrix(int type) {
   enigma_user::draw_batch_flush(enigma_user::batch_flush_deferred);
   D3DTRANSFORMSTATETYPE state;
@@ -213,20 +208,6 @@ void d3d_set_culling(int mode)
 	draw_batch_flush(batch_flush_deferred);
 	enigma::d3dCulling = mode;
 	d3dmgr->SetRenderState(D3DRS_CULLMODE, cullingstates[mode]);
-}
-
-bool d3d_get_mode()
-{
-    return enigma::d3dMode;
-}
-
-bool d3d_get_hidden()
-{
-    return enigma::d3dHidden;
-}
-
-int d3d_get_culling() {
-	return enigma::d3dCulling;
 }
 
 void d3d_set_fill_mode(int fill)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -246,16 +246,10 @@ void d3d_set_clip_plane(bool enable)
    ///TODO: Code this
 }
 
-}
-
-namespace enigma {
-  extern unsigned char currentcolor[4];
-}
+} // namespace enigma_user
 
 // ***** LIGHTS BEGIN *****
 #include <map>
-#include <list>
-#include "Universal_System/fileio.h"
 
 struct posi { // Homogenous point.
     gs_scalar x;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -32,10 +32,6 @@ using std::vector;
 
 using namespace enigma::dx9;
 
-namespace enigma {
-extern unsigned char currentcolor[4];
-}
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.cpp
@@ -1,0 +1,42 @@
+/** Copyright (C) 2008-2013 Josh Ventura
+*** Copyright (C) 2013, 2019 Robert B. Colton
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include "GSblend.h"
+
+namespace enigma {
+
+int currentblendmode[2] = {0,0};
+int currentblendtype = 0;
+
+} // namespace enigma
+
+namespace enigma_user {
+
+int draw_get_blend_mode() {
+  return enigma::currentblendmode[0];
+}
+
+int draw_get_blend_mode_ext(bool src) {
+  return enigma::currentblendmode[(src==true?0:1)];
+}
+
+int draw_get_blend_mode_type() {
+  return enigma::currentblendtype;
+}
+
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.h
@@ -60,4 +60,3 @@ namespace enigma_user
 }
 
 #endif // ENIGMA_GSBLEND_H
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.h
@@ -28,6 +28,13 @@ int draw_set_blend_mode_ext(ARG src,ARG2 dest)
 #ifndef ENIGMA_GSBLEND_H
 #define ENIGMA_GSBLEND_H
 
+namespace enigma {
+
+extern int currentblendmode[2];
+extern int currentblendtype;
+
+} // namespace enigma
+
 namespace enigma_user
 {
   enum {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.cpp
@@ -16,6 +16,7 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
+
 #include "GScolors.h"
 #include "GScolor_macros.h"
 
@@ -25,27 +26,13 @@ static inline int min(int x,int y){return x<y ? x:y;}
 static inline int max(int x,int y){return x>y ? x:y;}
 static inline int bclamp(int x){return x > 255 ? 255 : x < 0 ? 0 : x;}
 
-namespace enigma
-{
-	unsigned char currentcolor[4] = {0,0,0,255};
-	int currentblendmode[2] = {0,0};
-	int currentblendtype = 0;
-}
+namespace enigma {
 
-namespace enigma_user
-{
+unsigned char currentcolor[4] = {0,0,0,255};
 
-int draw_get_blend_mode() {
-  return enigma::currentblendmode[0];
-}
+} // namespace enigma
 
-int draw_get_blend_mode_ext(bool src) {
-  return enigma::currentblendmode[(src==true?0:1)];
-}
-
-int draw_get_blend_mode_type() {
-  return enigma::currentblendtype;
-}
+namespace enigma_user {
 
 	int merge_color(int c1,int c2,double amount)
 	{

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.cpp
@@ -34,6 +34,19 @@ namespace enigma
 
 namespace enigma_user
 {
+
+int draw_get_blend_mode() {
+  return enigma::currentblendmode[0];
+}
+
+int draw_get_blend_mode_ext(bool src) {
+  return enigma::currentblendmode[(src==true?0:1)];
+}
+
+int draw_get_blend_mode_type() {
+  return enigma::currentblendtype;
+}
+
 	int merge_color(int c1,int c2,double amount)
 	{
 		amount = amount > 1 ? 1 : (amount < 0 ? 0 : amount);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
@@ -18,6 +18,13 @@
 #ifndef ENIGMA_GSCOLORS_H
 #define ENIGMA_GSCOLORS_H
 
+namespace enigma {
+
+extern int currentblendmode[2];
+extern int currentblendtype;
+
+} // namespace enigma
+
 namespace enigma_user
 {
   enum {
@@ -77,4 +84,3 @@ namespace enigma_user
 }
 
 #endif // ENIGMA_GSCOLORS_H
-

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
@@ -21,8 +21,6 @@
 namespace enigma {
 
 extern unsigned char currentcolor[4];
-extern int currentblendmode[2];
-extern int currentblendtype;
 
 } // namespace enigma
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
@@ -20,6 +20,7 @@
 
 namespace enigma {
 
+extern unsigned char currentcolor[4];
 extern int currentblendmode[2];
 extern int currentblendtype;
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScurves.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScurves.cpp
@@ -23,10 +23,6 @@
 #include <algorithm> // min/max
 #include <math.h>
 
-namespace enigma{
-    extern unsigned char currentcolor[4];
-}
-
 int pr_curve_detail = 20;
 int pr_curve_mode = enigma_user::pr_linestrip;
 int pr_spline_points = 0;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -1,0 +1,36 @@
+#include "GSd3d.h"
+
+namespace enigma {
+
+bool d3dMode=false, d3dPerspective=false, d3dHidden=false, d3dZWriteEnable=true;
+int d3dCulling = enigma_user::rs_none;
+
+} // namespace enigma
+
+namespace enigma_user {
+
+void d3d_set_perspective(bool enable) {
+  // in GM8.1 and GMS v1.4 this does not take effect
+  // until the next frame in screen_redraw
+  enigma::d3dPerspective = enable;
+}
+
+bool d3d_get_perspective() {
+  return enigma::d3dPerspective;
+}
+
+bool d3d_get_mode()
+{
+  return enigma::d3dMode;
+}
+
+bool d3d_get_hidden()
+{
+  return enigma::d3dHidden;
+}
+
+int d3d_get_culling() {
+  return enigma::d3dCulling;
+}
+
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -33,22 +33,4 @@ void d3d_set_perspective(bool enable) {
   enigma::d3dPerspective = enable;
 }
 
-bool d3d_get_perspective() {
-  return enigma::d3dPerspective;
-}
-
-bool d3d_get_mode()
-{
-  return enigma::d3dMode;
-}
-
-bool d3d_get_hidden()
-{
-  return enigma::d3dHidden;
-}
-
-int d3d_get_culling() {
-  return enigma::d3dCulling;
-}
-
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -1,3 +1,21 @@
+/** Copyright (C) 2008-2013 Josh Ventura, Polygone
+*** Copyright (C) 2013,2019 Robert B. Colton
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
 #include "GSd3d.h"
 
 namespace enigma {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
@@ -23,12 +23,11 @@
 #include <string>
 
 namespace enigma {
-  extern bool d3dMode;
-  extern bool d3dHidden;
-  extern bool d3dZWriteEnable;
-  extern bool d3dPerspective;
-  extern int d3dCulling;
-}
+
+extern bool d3dMode, d3dPerspective, d3dHidden, d3dZWriteEnable;
+extern int d3dCulling;
+
+} // namespace enigma
 
 // ***** RENDER STATE CONSTANTS *****
 namespace enigma_user {
@@ -94,6 +93,7 @@ namespace enigma_user {
   void d3d_clear_depth(double value=1.0L);
   void d3d_start();
   void d3d_end();
+  void d3d_set_perspective(bool enable);
   void d3d_set_hidden(bool enable);
   void d3d_set_clip_plane(bool enable);
   void d3d_set_zwriteenable(bool enable);
@@ -119,6 +119,7 @@ namespace enigma_user {
   void d3d_set_color_mask(bool r, bool g, bool b, bool a);
 
   bool d3d_get_mode();
+  bool d3d_get_perspective();
   int d3d_get_culling();
   bool d3d_get_hidden();
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
@@ -118,11 +118,6 @@ namespace enigma_user {
   void d3d_set_shading(bool smooth);
   void d3d_set_color_mask(bool r, bool g, bool b, bool a);
 
-  bool d3d_get_mode();
-  bool d3d_get_perspective();
-  int d3d_get_culling();
-  bool d3d_get_hidden();
-
   // ***** LIGHTS BEGIN *****
   bool d3d_light_define_direction(int id, gs_scalar dx, gs_scalar dy, gs_scalar dz, int col);
   bool d3d_light_define_point(int id, gs_scalar x, gs_scalar y, gs_scalar z, double range, int col);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.cpp
@@ -74,7 +74,6 @@ inline void stack_clear(std::stack<T> &stack) {
 
 namespace enigma {
 
-bool d3dPerspective = false;
 glm::mat4 world = glm::mat4(1.0f),
           view  = glm::mat4(1.0f),
           projection = glm::mat4(1.0f);
@@ -203,16 +202,6 @@ void matrix_stack_pop() {
 
 var matrix_stack_top() {
   return matrix_vararray(matrix_stack.top());
-}
-
-void d3d_set_perspective(bool enable) {
-  // in GM8.1 and GMS v1.4 this does not take effect
-  // until the next frame in screen_redraw
-  enigma::d3dPerspective = enable;
-}
-
-bool d3d_get_perspective() {
-  return enigma::d3dPerspective;
 }
 
 void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmatrix.h
@@ -64,8 +64,6 @@ bool is_matrix(const var& value);
 bool is_vec3(const var& value);
 bool is_vec4(const var& value);
 
-void d3d_set_perspective(bool enable);
-bool d3d_get_perspective();
 void d3d_set_projection(gs_scalar xfrom, gs_scalar yfrom, gs_scalar zfrom,
                         gs_scalar xto, gs_scalar yto, gs_scalar zto,
                         gs_scalar xup, gs_scalar yup, gs_scalar zup);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSmodel.cpp
@@ -41,7 +41,6 @@ using namespace std;
 namespace enigma {
 
 vector<Model*> models;
-extern unsigned char currentcolor[4];
 
 unsigned int split(const std::string &txt, std::vector<std::string> &strs, char ch)
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -171,8 +171,8 @@ static inline void draw_gui()
 {
   // turn some state off automatically for the user to draw the GUI
   // this is exactly what GMSv1.4 does
-  int culling = d3d_get_culling();
-  bool hidden = d3d_get_hidden();
+  int culling = enigma::d3dCulling;
+  bool hidden = enigma::d3dHidden;
   bool zwrite = enigma::d3dZWriteEnable;
   d3d_set_zwriteenable(false);
   d3d_set_culling(rs_none);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
@@ -32,7 +32,6 @@ using std::vector;
 
 namespace enigma {
   float circleprecision=24;
-  extern unsigned char currentcolor[4];
 
   //List of vertices we are buffering to draw.
   std::list<PolyVertex> currComplexPoly;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEStd.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEStd.h
@@ -30,8 +30,6 @@
 
 namespace enigma
 {
-  extern unsigned char currentcolor[4];
-
 	unsigned get_texture(int texid);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEStd.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEStd.h
@@ -32,8 +32,6 @@ namespace enigma
 {
   extern unsigned char currentcolor[4];
 
-  extern int currentblendmode[2];
-  extern int currentblendtype;
 	unsigned get_texture(int texid);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEblend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEblend.cpp
@@ -16,8 +16,8 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
+
 #include "Graphics_Systems/General/GSblend.h"
-#include "Graphics_Systems/General/GScolors.h"
 
 namespace enigma_user
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEblend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEblend.cpp
@@ -16,13 +16,8 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-#include "../General/GSblend.h"
-
-namespace enigma
-{
-	extern int currentblendmode[2];
-	extern int currentblendtype;
-}
+#include "Graphics_Systems/General/GSblend.h"
+#include "Graphics_Systems/General/GScolors.h"
 
 namespace enigma_user
 {
@@ -39,17 +34,5 @@ namespace enigma_user
 			enigma::currentblendmode[0] = src;
 			enigma::currentblendmode[1] = dest;
 			return 0;
-	}
-
-	int draw_get_blend_mode(){
-			return enigma::currentblendmode[0];
-	}
-
-	int draw_get_blend_mode_ext(bool src){
-			return enigma::currentblendmode[(src==true?0:1)];
-	}
-
-	int draw_get_blend_mode_type(){
-			return enigma::currentblendtype;
 	}
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEcolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEcolors.cpp
@@ -20,11 +20,6 @@
 #include "Graphics_Systems/General/GScolor_macros.h"
 #include <math.h>
 
-namespace enigma
-{
-	extern unsigned char currentcolor[4];
-}
-
 namespace enigma_user
 {
 	void draw_set_color(int color)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/NONEd3d.cpp
@@ -34,13 +34,6 @@ struct posi { // Homogenous point.
     posi(gs_scalar x1, gs_scalar y1, gs_scalar z1, gs_scalar w1) : x(x1), y(y1), z(z1), w(w1){}
 };
 
-namespace enigma {
-  bool d3dMode = false;
-  bool d3dHidden = false;
-  bool d3dZWriteEnable = true;
-  int d3dCulling = 0;
-}
-
 namespace enigma_user
 {
 	void d3d_clear_depth(double value){}
@@ -82,18 +75,5 @@ namespace enigma_user
 	void d3d_set_culling(int mode)
 	{
 		enigma::d3dCulling = mode;
-	}
-
-	bool d3d_get_mode()
-	{
-			return enigma::d3dMode;
-	}
-
-	bool d3d_get_hidden(){
-		return enigma::d3dHidden;
-	}
-
-	int d3d_get_culling(){
-		return enigma::d3dCulling;
 	}
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLblend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLblend.cpp
@@ -17,7 +17,6 @@
 
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSblend.h"
-#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 
 namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLblend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLblend.cpp
@@ -17,13 +17,8 @@
 
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSblend.h"
+#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
-
-namespace enigma
-{
-  extern int currentblendmode[2];
-  extern int currentblendtype;
-}
 
 namespace enigma_user
 {
@@ -63,18 +58,6 @@ int draw_set_blend_mode_ext(int src,int dest){
     enigma::currentblendmode[1] = dest;
 	glBlendFunc(blendequivs[(src-1)%10],blendequivs[(dest-1)%10]);
 	return 0;
-}
-
-int draw_get_blend_mode(){
-    return enigma::currentblendmode[0];
-}
-
-int draw_get_blend_mode_ext(bool src){
-    return enigma::currentblendmode[(src==true?0:1)];
-}
-
-int draw_get_blend_mode_type(){
-    return enigma::currentblendtype;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLcolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLcolors.cpp
@@ -21,10 +21,6 @@
 #include "Graphics_Systems/General/GSprimitives.h"
 #include <math.h>
 
-namespace enigma {
-  extern unsigned char currentcolor[4];
-}
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -36,11 +36,6 @@ namespace enigma {
 
 void d3d_light_update_positions(); // forward declare
 
-bool d3dMode = false;
-bool d3dHidden = false;
-bool d3dZWriteEnable = true;
-int d3dCulling = 0;
-
 void graphics_set_matrix(int type) {
   enigma_user::draw_batch_flush(enigma_user::batch_flush_deferred);
   glm::mat4 matrix;
@@ -246,19 +241,6 @@ void d3d_set_culling(int mode)
   if (mode > 0){
     glFrontFace(windingstates[mode-1]);
   }
-}
-
-bool d3d_get_mode()
-{
-  return enigma::d3dMode;
-}
-
-bool d3d_get_hidden() {
-  return enigma::d3dHidden;
-}
-
-int d3d_get_culling() {
-  return enigma::d3dCulling;
 }
 
 void d3d_set_fill_mode(int fill)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -282,11 +282,9 @@ void d3d_set_clip_plane(bool enable)
   //printf("warning: d3d_set_clip_plane(bool enable) called even though GL1 doesn't support this!\n");
 }
 
-}
+} // namespace enigma_user
 
 #include <map>
-#include <list>
-#include "Universal_System/fileio.h"
 
 struct posi { // Homogenous point.
     gs_scalar x;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
@@ -39,10 +39,6 @@
 #  endif
 #endif
 
-namespace enigma {
-extern unsigned char currentcolor[4];
-}
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.h
@@ -24,11 +24,6 @@
 
 //#include "OpenGLHeaders.h"
 
-namespace enigma
-{
-  extern unsigned char currentcolor[4];
-}
-
 #include "../General/GScolors.h"
 #include "../General/GSprimitives.h"
 #include "../General/GSd3d.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.h
@@ -27,8 +27,6 @@
 namespace enigma
 {
   extern unsigned char currentcolor[4];
-  extern int currentblendmode[2];
-  extern int currentblendtype;
 }
 
 #include "../General/GScolors.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3blend.cpp
@@ -17,7 +17,6 @@
 
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSblend.h"
-#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 
 namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3blend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3blend.cpp
@@ -17,13 +17,8 @@
 
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSblend.h"
+#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GSprimitives.h"
-
-namespace enigma
-{
-  extern int currentblendmode[2];
-  extern int currentblendtype;
-}
 
 namespace enigma_user
 {
@@ -63,18 +58,6 @@ int draw_set_blend_mode_ext(int src, int dest){
   enigma::currentblendmode[1] = dest;
 	glBlendFunc(blendequivs[(src-1)%10],blendequivs[(dest-1)%10]);
 	return 0;
-}
-
-int draw_get_blend_mode(){
-  return enigma::currentblendmode[0];
-}
-
-int draw_get_blend_mode_ext(bool src){
-  return enigma::currentblendmode[(src==true?0:1)];
-}
-
-int draw_get_blend_mode_type(){
-  return enigma::currentblendtype;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3colors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3colors.cpp
@@ -22,10 +22,6 @@
 
 #include <math.h>
 
-namespace enigma {
-  extern unsigned char currentcolor[4];
-}
-
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -38,10 +38,6 @@ namespace enigma {
 
 void d3d_light_update_positions(); // forward declare
 
-bool d3dMode = false;
-bool d3dHidden = false;
-bool d3dZWriteEnable = true;
-int d3dCulling = 0;
 extern unsigned bound_shader;
 extern vector<enigma::ShaderProgram*> shaderprograms;
 
@@ -235,19 +231,6 @@ void d3d_set_culling(int mode)
 void d3d_set_color_mask(bool r, bool g, bool b, bool a){
   draw_batch_flush(batch_flush_deferred);
   glColorMask(r,g,b,a);
-}
-
-bool d3d_get_mode()
-{
-  return enigma::d3dMode;
-}
-
-bool d3d_get_hidden() {
-	return enigma::d3dHidden;
-}
-
-int d3d_get_culling() {
-	return enigma::d3dCulling;
 }
 
 void d3d_set_fill_mode(int fill)

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -275,11 +275,9 @@ void d3d_set_clip_plane(bool enable)
   (enable?glEnable:glDisable)(GL_CLIP_DISTANCE0);
 }
 
-}
+} // namespace enigma_user
 
 #include <map>
-#include <list>
-#include "Universal_System/fileio.h"
 
 namespace enigma
 {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.h
@@ -26,7 +26,6 @@ using std::string;
 
 namespace enigma
 {
-  extern unsigned char currentcolor[4];
   extern unsigned bound_vbo;
   extern unsigned bound_vboi;
   extern unsigned bound_shader;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
@@ -32,7 +32,6 @@
 
 namespace enigma {
 
-extern unsigned char currentcolor[4];
 extern unsigned bound_shader;
 extern vector<enigma::ShaderProgram*> shaderprograms;
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -24,6 +24,7 @@
 #include "Graphics_Systems/General/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSvertex_impl.h"
 #include "Graphics_Systems/General/GSprimitives.h"
+#include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
 
 #include <map>

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.h
@@ -24,11 +24,6 @@
 
 //#include "OpenGLHeaders.h"
 
-namespace enigma
-{
-  extern unsigned char currentcolor[4];
-}
-
 #include "../General/GScolors.h"
 #include "../General/GSprimitives.h"
 #include "../General/GSd3d.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.h
@@ -27,8 +27,6 @@
 namespace enigma
 {
   extern unsigned char currentcolor[4];
-  extern int currentblendmode[2];
-  extern int currentblendtype;
 }
 
 #include "../General/GScolors.h"


### PR DESCRIPTION
This is a cleanup and centralization of all the redundant state definitions in each of the graphics systems. This covers d3d state, blend state, and color state. Instead of having all the sources, even in the same graphics system, externally link the current color, they can include the proper general header. The getter functions were also moved to general because there's no need to duplicate them either once the state is generically declared and defined.

**NOTE:** It's important to mention that the getters are returning _cached_ state, just like master, which could theoretically be different than what is actually on the device/context. Imagine if the user made an extension to change D3D9 state using the `window_device()` function.

**UPDATE:** I later discovered, before removing the getters, the real purpose of them was for the GUI event to reset those states after changing them. In that particular case I don't think there's much possibility for a user extension to mess that up by injecting state.