### PR TITLE
Direct3D9 Fatal Display Reset

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -16,7 +16,7 @@
 **/
 
 #include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h"
+#include "Widget_Systems/widgets_mandatory.h" // for show_error()
 #include "Platforms/platforms_mandatory.h"
 #include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/graphics_mandatory.h"
@@ -26,11 +26,8 @@
 #include "Bridges/Win32/WINDOWShandle.h" // for get_window_handle()
 
 #include <windows.h>
-#include <windowsx.h>
 #include <d3d9.h>
-#include <string>
 
-using namespace std;
 using namespace enigma::dx9;
 
 namespace {
@@ -77,12 +74,7 @@ ContextManager* d3dmgr; // the pointer to the device class
     OnDeviceLost();
     HRESULT hr = d3dmgr->device->Reset(d3dpp);
     if (FAILED(hr)) {
-      MessageBox(
-        enigma::hWnd,
-        TEXT("Device Reset Failed"), TEXT("Error"),
-        MB_ICONERROR | MB_OK
-      );
-      return;  // should probably force the game closed
+      show_error("Direct3D 9 Device Reset Failed", true);
     }
     // Reapply the stored render states and what not
     d3dmgr->RestoreState();


### PR DESCRIPTION
This one is pretty obvious, I am switching from `MessageBox` to `show_error` so that I can force the game closed whenever a display reset is not successful in the Direct3D9 bridge. It's important to do this because this is not a scenario in which we can continue running the game. It does not matter if the display reset is caused by us or the result of a lost device. I tested to ensure this does what I think. I put myself in the managed Direct3D9, commented out releasing of the surfaces on lost device, and noticed the `MessageBox` version segfaults after showing the reset failed message. The new version shows our standard error dialog and then forces the game closed with `Game returned 0`. I also removed some unused headers and namespaces while I was in here.