### PR TITLE
Cleanup Direct3D Bridges

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D11.cpp
@@ -25,9 +25,8 @@
 #include "Bridges/Win32/WINDOWShandle.h" // for get_window_handle()
 
 #include <windows.h>
-#include <windowsx.h>
 #include <d3d11.h>
-#include <string>
+
 using namespace std;
 
 namespace enigma {

--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -51,8 +51,8 @@ ContextManager* d3dmgr; // the pointer to the device class
 
 } // namespace dx9
 
-  extern bool forceSoftwareVertexProcessing;
-  bool Direct3D9Managed = true;
+extern HWND hWnd;
+extern bool forceSoftwareVertexProcessing;
 
   void OnDeviceLost() {
     d3dmgr->device->EndScene();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -205,6 +205,8 @@ void d3d_set_clip_plane(bool enable)
 // ***** LIGHTS BEGIN *****
 #include <map>
 
+using std::map;
+
 struct posi { // Homogenous point.
     gs_scalar x;
     gs_scalar y;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11shader.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11shader.h
@@ -18,6 +18,9 @@
 #ifndef ENIGMA_DX11SHADER_H
 #define ENIGMA_DX11SHADER_H
 
+#include <string>
+using std::string;
+
 namespace enigma_user
 {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/Direct3D11Headers.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/Direct3D11Headers.h
@@ -19,9 +19,6 @@
 #define ENIGMA_DIRECT3D11_HEADERS_H
 
 #include <d3d11.h>
-#include <cmath>
-#include <string>
-using namespace std;
 
 namespace enigma {
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DIRECTX9Std.cpp
@@ -30,6 +30,7 @@ using namespace std;
 namespace enigma
 {
 
+bool Direct3D9Managed = true;
 void graphicssystem_initialize() {}
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/Direct3D9Headers.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/Direct3D9Headers.h
@@ -19,12 +19,8 @@
 #define ENIGMA_DIRECT3D9_HEADERS_H
 
 #include <map>
-#include <string>
-#include <cmath>
 
 #include <d3d9.h>
-#include <windows.h>
-#include <windowsx.h>
 
 using namespace std;
 
@@ -32,7 +28,6 @@ using std::map;
 
 namespace enigma {
 
-extern HWND hWnd;
 extern bool Direct3D9Managed;
 
 namespace dx9 {


### PR DESCRIPTION
This is just me removing a few more unused includes in the Direct3D systems and moving stuff where it needs to be. Specifically the `extern HWND hWnd;` declaration I moved out of `Direct3D9Headers.h` and over to the Direct3D9 bridge because none of D3D9 actually needs it and it's better to expose less rather than more when it comes to headers. Some of these unused headers were also causing misplaced dependencies, such as `<string>` which wasn't even needed by `Direct3D9Headers.h` just `DX11shader.h`.