### PR TITLE
Direct3D9 State Reset

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -76,8 +76,8 @@ extern bool forceSoftwareVertexProcessing;
     if (FAILED(hr)) {
       show_error("Direct3D 9 Device Reset Failed", true);
     }
-    // Reapply the stored render states and what not
-    d3dmgr->RestoreState();
+    // the normal, managed d3d 9.0 does not automatically restore render state
+    if (Direct3D9Managed) d3dmgr->RestoreState();
     OnDeviceReset();
   }
 


### PR DESCRIPTION
This is a very simple oversight I made. When we reset the Direct3D9 device, we only need to restore our state cache if we are using the normal, managed Direct3D 9.0 device. A 9Ex device does not lose state information. So this pull request simply adds a condition to our Reset helper to only restore the state when using the managed device.

>Calling IDirect3DDevice9::Reset causes all texture memory surfaces to be lost, managed textures to be flushed from video memory, and all **state information** to be lost.
https://docs.microsoft.com/en-us/windows/desktop/api/d3d9/nf-d3d9-idirect3ddevice9-reset

>Unlike previous versions of DirectX, calling IDirect3DDevice9Ex::ResetEx **does not cause** surfaces, textures or **state information** to be lost.
https://docs.microsoft.com/en-us/windows/desktop/api/d3d9/nf-d3d9-idirect3ddevice9ex-resetex