### PR TITLE
Error Dialog Debug Stack Formatting

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/debugscope.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/debugscope.cpp
@@ -24,22 +24,25 @@
 namespace enigma {
 
   static std::vector<std::string> scope_stack;
-  
-  debug_scope::debug_scope(std::string x) 
-  { 
+
+  debug_scope::debug_scope(std::string x)
+  {
     scope_stack.push_back(x);
   }
-  
-  debug_scope::~debug_scope() { 
+
+  debug_scope::~debug_scope() {
     scope_stack.pop_back();
-  }  
-  
+  }
+
   std::string debug_scope::GetErrors()
   {
-    std::string str;
+    if (scope_stack.empty())
+      return "Debug error stack is empty. Error may stem from engine internals.";
+
+    std::string str = "Stack trace (most recent frame first):\n";
     for (std::vector<std::string>::reverse_iterator it = scope_stack.rbegin(); it != scope_stack.rend(); it++)
-      str += "\n" + *it;
-      
+      str += "  " + *it + "\n";
+
     return str;
   }
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -60,7 +60,7 @@ static inline string add_slash(const string& dir) {
 void show_error(string errortext, const bool fatal)
 {
   #ifdef DEBUG_MODE
-  errortext += enigma::debug_scope::GetErrors();
+  errortext += "\n\n" + enigma::debug_scope::GetErrors();
   #endif
 
   if (MessageBox(NULL,errortext.c_str(),"Error",MB_ABORTRETRYIGNORE | MB_ICONERROR)==IDABORT)


### PR DESCRIPTION
I am proposing this change to make debug error dialogs a little nicer to read. I am taking some inspiration from Python and Java stack trace formatting.

* Return a special debug stack message when the debug stack is empty.
* Indent the frames of the stack trace by two spaces.
* Append a newline at the end of a stack frame instead of prepending it to the beginning.
* Add a blank line between the debug error message and the debug stack message.

### Master
![Master Debug Error Message](https://user-images.githubusercontent.com/3212801/55151912-a5dee980-5125-11e9-9db8-9dec0ad40fe7.png)

### Pull Request
![Formatted Debug Error Message](https://user-images.githubusercontent.com/3212801/55151802-6b754c80-5125-11e9-88d0-06ba7c087438.png)

### Special Handling for Empty Stack/Engine Internals
![Special Message for Empty Debug Stack](https://user-images.githubusercontent.com/3212801/55151724-408af880-5125-11e9-8885-cdcca4f24cb2.png)
