### PR TITLE
Forbid copying of ey_data

### DIFF
--- a/shared/eyaml/eyaml.cpp
+++ b/shared/eyaml/eyaml.cpp
@@ -62,6 +62,11 @@ ey_string::ey_string(string x, string y): ey_base(x, true), value(y) {}
 
 ey_data::ey_data(): ey_base(false), values(), values_order() {}
 ey_data::ey_data(string n): ey_base(n, false), values(), values_order() {}
+ey_data::ey_data(ey_data &&ed):
+    ey_base(ed.name, false), values(std::move(ed.values)),
+    values_order(ed.values_order), values_order_last(ed.values_order_last) {
+  ed.values_order.next = NULL;
+}
 ey_data::~ey_data() {
   for (eycit it = values_order.next; it != NULL; ) {
     eycit t = it; it = it->next;

--- a/shared/eyaml/eyaml.h
+++ b/shared/eyaml/eyaml.h
@@ -74,6 +74,8 @@ struct ey_data: ey_base // Contains multiple members
        begin(), end(); // Iterator to first element and to end of data map (an invalid iterator)
   eylist* first(); // Get the first element defined chronologically
   
+  ey_data(ey_data &&data);
+  ey_data(const ey_data&) = delete;
   ey_data(string); // Construct with a name
   ey_data(); ~ey_data(); // Background work
 };


### PR DESCRIPTION
Seems as though MSVC doesn't know what RVO is, which shouldn't surprise anyone.