### PR TITLE
Travis Exit Trap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ before_install:
     # install general dependencies used by more than one job
     set -eo pipefail
 
+    function finish {
+      travis_terminate $?
+    }
+    trap finish EXIT
+
+
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       sudo add-apt-repository -y ppa:maarten-fonville/protobuf;
       sudo add-apt-repository -y ppa:mhier/libboost-latest;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
     }
     trap finish EXIT
 
-
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       sudo add-apt-repository -y ppa:maarten-fonville/protobuf;
       sudo add-apt-repository -y ppa:mhier/libboost-latest;


### PR DESCRIPTION
This should stop any of the log from getting cut off by early exit. The `set -e` causes the log to be cutoff because Travis is not properly exited. Calling `exit` directly also causes the log to get cut off. This is why we had to call `travis_terminate` for the test harness. With this exit there should be no more cutting off of the log. We want `set -e` though because we want the installation of any dependencies to immediately fail the build, which it obviously should do, otherwise Travis will continue installing more dependencies (which is stupid).