### PR TITLE
Format Win32-Direct3D9 Bridge

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/General/Win32-Direct3D9.cpp
@@ -54,168 +54,169 @@ ContextManager* d3dmgr; // the pointer to the device class
 extern HWND hWnd;
 extern bool forceSoftwareVertexProcessing;
 
-  void OnDeviceLost() {
-    d3dmgr->device->EndScene();
-    if (!Direct3D9Managed) return; // lost device only happens in managed d3d9
-    for (BaseSurface* surf : surfaces) {
-      if (!surf) continue;
-      ((Surface*)surf)->OnDeviceLost();
-    }
+void OnDeviceLost() {
+  d3dmgr->device->EndScene();
+  if (!Direct3D9Managed) return; // lost device only happens in managed d3d9
+  for (BaseSurface* surf : surfaces) {
+    if (!surf) continue;
+    ((Surface*)surf)->OnDeviceLost();
+  }
+}
+
+void OnDeviceReset() {
+  d3dmgr->device->BeginScene();
+  if (!Direct3D9Managed) return; // lost device only happens in managed d3d9
+  for (BaseSurface* surf : surfaces) {
+    if (!surf) continue;
+    ((Surface*)surf)->OnDeviceReset();
+  }
+}
+
+void Reset(D3DPRESENT_PARAMETERS *d3dpp) {
+  OnDeviceLost();
+  HRESULT hr = d3dmgr->device->Reset(d3dpp);
+  if (FAILED(hr)) {
+    show_error("Direct3D 9 Device Reset Failed", true);
+  }
+  // the normal, managed d3d 9.0 does not automatically restore render state
+  if (Direct3D9Managed) d3dmgr->RestoreState();
+  OnDeviceReset();
+}
+
+extern void (*WindowResizedCallback)();
+void WindowResized() {
+  if (d3dmgr == NULL) { return; }
+  D3DPRESENT_PARAMETERS d3dpp;
+  get_d3d_present_params(&d3dpp);
+  int ww = enigma_user::window_get_width(),
+      wh = enigma_user::window_get_height();
+  d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
+  d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
+  Reset(&d3dpp);
+
+  // clear the window color, viewport does not need set because backbuffer was just recreated
+  enigma_user::draw_clear(enigma_user::window_get_color());
+}
+
+void EnableDrawing(void* handle) {
+  get_window_handle();
+  WindowResizedCallback = &WindowResized;
+
+  d3dmgr = new ContextManager();
+  HRESULT hr;
+
+  D3DPRESENT_PARAMETERS d3dpp; // create a struct to hold various device information
+  D3DFORMAT format = D3DFMT_A8R8G8B8;
+
+  ZeroMemory(&d3dpp, sizeof(d3dpp)); // clear out the struct for use
+  d3dpp.Windowed = TRUE; // program windowed, not fullscreen
+  int ww = enigma_user::window_get_width(),
+      wh = enigma_user::window_get_height();
+  d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
+  d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
+  d3dpp.MultiSampleType = D3DMULTISAMPLE_NONE;                // 0 Levels of multi-sampling
+  d3dpp.MultiSampleQuality = 0;                               // No multi-sampling
+  d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;                   // Throw away previous frames, we don't need them
+  d3dpp.hDeviceWindow = hWnd;                                 // This is our main (and only) window
+  d3dpp.Flags = 0;                                            // No flags to set
+  d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT; // Default Refresh Rate
+  d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE; // Present the frame immediately
+  d3dpp.BackBufferCount = 1;                                  // We only need a single back buffer
+  d3dpp.BackBufferFormat = format;                            // Display format
+  d3dpp.EnableAutoDepthStencil = TRUE;                        // Automatic depth stencil buffer
+  d3dpp.AutoDepthStencilFormat = D3DFMT_D24S8;                // 32-bit zbuffer 24bits for depth 8 for stencil buffer
+  // create a device class using this information and information from the d3dpp stuct
+  DWORD behaviors = D3DCREATE_MIXED_VERTEXPROCESSING;
+  if (forceSoftwareVertexProcessing) {
+    behaviors = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
   }
 
-  void OnDeviceReset() {
-    d3dmgr->device->BeginScene();
-    if (!Direct3D9Managed) return; // lost device only happens in managed d3d9
-    for (BaseSurface* surf : surfaces) {
-      if (!surf) continue;
-      ((Surface*)surf)->OnDeviceReset();
-    }
-  }
+  // Manually load the d3d9.dll library to check for D3D9Ex
+  HMODULE libHandle = NULL;
+  libHandle = LoadLibrary("d3d9.dll");
 
-  void Reset(D3DPRESENT_PARAMETERS *d3dpp) {
-    OnDeviceLost();
-    HRESULT hr = d3dmgr->device->Reset(d3dpp);
-    if (FAILED(hr)) {
-      show_error("Direct3D 9 Device Reset Failed", true);
-    }
-    // the normal, managed d3d 9.0 does not automatically restore render state
-    if (Direct3D9Managed) d3dmgr->RestoreState();
-    OnDeviceReset();
-  }
+  if (libHandle != NULL) {
+    // Define a function pointer to the Direct3DCreate9Ex function.
+    typedef HRESULT (WINAPI *LPDIRECT3DCREATE9EX)( UINT, void **);
 
-  extern void (*WindowResizedCallback)();
-  void WindowResized() {
-    if (d3dmgr == NULL) { return; }
-    D3DPRESENT_PARAMETERS d3dpp;
-    get_d3d_present_params(&d3dpp);
-    int ww = enigma_user::window_get_width(),
-        wh = enigma_user::window_get_height();
-    d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
-    d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
-    Reset(&d3dpp);
+    // Obtain the address of the Direct3DCreate9Ex function.
+    LPDIRECT3DCREATE9EX Direct3DCreate9ExPtr = NULL;
 
-    // clear the window color, viewport does not need set because backbuffer was just recreated
-    enigma_user::draw_clear(enigma_user::window_get_color());
-  }
+    Direct3DCreate9ExPtr = (LPDIRECT3DCREATE9EX)GetProcAddress(libHandle, "Direct3DCreate9Ex");
 
-  void EnableDrawing(void* handle) {
-    get_window_handle();
-    WindowResizedCallback = &WindowResized;
+    if (Direct3DCreate9ExPtr != NULL) {
+      // create Direct3D 9 Ex interface
+      IDirect3D9Ex* d3dexobj = NULL;
+      hr = Direct3DCreate9Ex(D3D_SDK_VERSION, &d3dexobj);
 
-    d3dmgr = new ContextManager();
-    HRESULT hr;
+      if (d3dexobj != NULL) {
+        IDirect3DDevice9Ex* d3dexdev = NULL;
 
-    D3DPRESENT_PARAMETERS d3dpp; // create a struct to hold various device information
-    D3DFORMAT format = D3DFMT_A8R8G8B8;
+        hr = d3dexobj->CreateDeviceEx(D3DADAPTER_DEFAULT,
+                                      D3DDEVTYPE_HAL,
+                                      hWnd,
+                                      behaviors,
+                                      &d3dpp,
+                                      NULL,
+                                      &d3dexdev);
 
-    ZeroMemory(&d3dpp, sizeof(d3dpp)); // clear out the struct for use
-    d3dpp.Windowed = TRUE; // program windowed, not fullscreen
-    int ww = enigma_user::window_get_width(),
-        wh = enigma_user::window_get_height();
-    d3dpp.BackBufferWidth = ww <= 0 ? 1 : ww;
-    d3dpp.BackBufferHeight = wh <= 0 ? 1 : wh;
-    d3dpp.MultiSampleType = D3DMULTISAMPLE_NONE;                // 0 Levels of multi-sampling
-    d3dpp.MultiSampleQuality = 0;                               // No multi-sampling
-    d3dpp.SwapEffect = D3DSWAPEFFECT_DISCARD;                   // Throw away previous frames, we don't need them
-    d3dpp.hDeviceWindow = hWnd;                                 // This is our main (and only) window
-    d3dpp.Flags = 0;                                            // No flags to set
-    d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT; // Default Refresh Rate
-    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE; // Present the frame immediately
-    d3dpp.BackBufferCount = 1;                                  // We only need a single back buffer
-    d3dpp.BackBufferFormat = format;                            // Display format
-    d3dpp.EnableAutoDepthStencil = TRUE;                        // Automatic depth stencil buffer
-    d3dpp.AutoDepthStencilFormat = D3DFMT_D24S8;                // 32-bit zbuffer 24bits for depth 8 for stencil buffer
-    // create a device class using this information and information from the d3dpp stuct
-    DWORD behaviors = D3DCREATE_MIXED_VERTEXPROCESSING;
-    if (forceSoftwareVertexProcessing) {
-      behaviors = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
-    }
-
-    // Manually load the d3d9.dll library to check for D3D9Ex
-    HMODULE libHandle = NULL;
-    libHandle = LoadLibrary("d3d9.dll");
-
-    if (libHandle != NULL) {
-      // Define a function pointer to the Direct3DCreate9Ex function.
-      typedef HRESULT (WINAPI *LPDIRECT3DCREATE9EX)( UINT, void **);
-
-      // Obtain the address of the Direct3DCreate9Ex function.
-      LPDIRECT3DCREATE9EX Direct3DCreate9ExPtr = NULL;
-
-      Direct3DCreate9ExPtr = (LPDIRECT3DCREATE9EX)GetProcAddress(libHandle, "Direct3DCreate9Ex");
-
-      if (Direct3DCreate9ExPtr != NULL) {
-        // create Direct3D 9 Ex interface
-        IDirect3D9Ex* d3dexobj = NULL;
-        hr = Direct3DCreate9Ex(D3D_SDK_VERSION, &d3dexobj);
-
-        if (d3dexobj != NULL) {
-          IDirect3DDevice9Ex* d3dexdev = NULL;
-
-          hr = d3dexobj->CreateDeviceEx(D3DADAPTER_DEFAULT,
-                                        D3DDEVTYPE_HAL,
-                                        hWnd,
-                                        behaviors,
-                                        &d3dpp,
-                                        NULL,
-                                        &d3dexdev);
-
-          if (FAILED(hr)) {
-            // release the d3d9 ex object and fall through to
-            // try creating a regular d3d9 object instead
-            // (might be Windows Vista with non-WDDM drivers)
-            d3dexobj->Release();
-          } else {
-            d3dobj = d3dexobj;
-            d3dmgr->device = d3dexdev;
-            Direct3D9Managed = false;
-          }
+        if (FAILED(hr)) {
+          // release the d3d9 ex object and fall through to
+          // try creating a regular d3d9 object instead
+          // (might be Windows Vista with non-WDDM drivers)
+          d3dexobj->Release();
+        } else {
+          d3dobj = d3dexobj;
+          d3dmgr->device = d3dexdev;
+          Direct3D9Managed = false;
         }
       }
-
-      // Free the library.
-      FreeLibrary(libHandle);
     }
 
-    if (Direct3D9Managed) {
-      // try creating legacy Direct3D 9 interface
-      d3dobj = Direct3DCreate9(D3D_SDK_VERSION);
+    // Free the library.
+    FreeLibrary(libHandle);
+  }
 
-      hr = d3dobj->CreateDevice(D3DADAPTER_DEFAULT,
-                                D3DDEVTYPE_HAL,
-                                hWnd,
-                                behaviors,
-                                &d3dpp,
-                                &d3dmgr->device);
+  if (Direct3D9Managed) {
+    // try creating legacy Direct3D 9 interface
+    d3dobj = Direct3DCreate9(D3D_SDK_VERSION);
 
-      if (FAILED(hr)) {
-        show_error("Failed to create Direct3D 9.0 Device", true);
-      }
+    hr = d3dobj->CreateDevice(D3DADAPTER_DEFAULT,
+                              D3DDEVTYPE_HAL,
+                              hWnd,
+                              behaviors,
+                              &d3dpp,
+                              &d3dmgr->device);
+
+    if (FAILED(hr)) {
+      show_error("Failed to create Direct3D 9.0 Device", true);
     }
+  }
 
-    d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE);
+  d3dmgr->SetRenderState(D3DRS_MULTISAMPLEANTIALIAS, FALSE);
 
-    enigma_user::display_aa = 0;
-    for (int i = 16; i > 1; i--) {
-      if (SUCCEEDED(d3dobj->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, format, TRUE, (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + i), NULL))) {
-        enigma_user::display_aa += i;
-      }
+  enigma_user::display_aa = 0;
+  for (int i = 16; i > 1; i--) {
+    if (SUCCEEDED(d3dobj->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, format, TRUE, (D3DMULTISAMPLE_TYPE)((int)D3DMULTISAMPLE_NONE + i), NULL))) {
+      enigma_user::display_aa += i;
     }
-
-    d3dmgr->device->BeginScene();
   }
 
-  void DisableDrawing(void* handle) {
-    d3dmgr->device->EndScene();
-    d3dmgr->Release(); // close and release the 3D device
-    d3dobj->Release(); // close and release Direct3D
-  }
+  d3dmgr->device->BeginScene();
+}
 
-  void ScreenRefresh() {
-    d3dmgr->device->EndScene();
-    d3dmgr->device->Present(NULL, NULL, NULL, NULL);
-    d3dmgr->device->BeginScene();
-  }
+void DisableDrawing(void* handle) {
+  d3dmgr->device->EndScene();
+  d3dmgr->Release(); // close and release the 3D device
+  d3dobj->Release(); // close and release Direct3D
+}
+
+void ScreenRefresh() {
+  d3dmgr->device->EndScene();
+  d3dmgr->device->Present(NULL, NULL, NULL, NULL);
+  d3dmgr->device->BeginScene();
+}
+
 } // namespace enigma
 
 namespace enigma_user {
@@ -242,4 +243,4 @@ void set_synchronization(bool enable)
   enigma::Reset(&d3dpp);
 }
 
-}
+} // namespace enigma_user


### PR DESCRIPTION
I literally cannot stand the extra indentation within namespaces. That's all this change does, is reset the indentation level in namespace `enigma` to match other sources.