### PR TITLE
Use only the contents of enigma_user for compilation.

### DIFF
--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -260,7 +260,7 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
 
 
   // First, we make a space to put our globals.
-  jdi::using_scope globals_scope("<ENIGMA Resources>", main_context->get_global());
+  jdi::using_scope globals_scope("<ENIGMA Resources>", namespace_enigma_user);
 
   idpr("Copying resources",1);
 

--- a/CompilerSource/compiler/jdi_utility.cpp
+++ b/CompilerSource/compiler/jdi_utility.cpp
@@ -118,14 +118,14 @@ size_t lang_CPP::definition_overload_count(jdi::definition *d) {
 
 #include "languages/lang_CPP.h"
 definition* lang_CPP::find_typename(string n) {
-  definition* d = main_context->get_global()->look_up(n);
+  definition* d = look_up(n);
   if (!d) return NULL;
   if (d->flags & DEF_TYPENAME) return d;
   return NULL;
 }
 
 bool lang_CPP::global_exists(string n) {
-  definition* d = main_context->get_global()->look_up(n);
+  definition* d = look_up(n);
   return d;
 }
 

--- a/CompilerSource/languages/lang_CPP.cpp
+++ b/CompilerSource/languages/lang_CPP.cpp
@@ -210,6 +210,8 @@ int lang_CPP::load_shared_locals() {
 }
 
 jdi::definition* lang_CPP::look_up(const string &name) {
+  auto builtin = jdip::builtin_declarators.find(name);
+  if (builtin != jdip::builtin_declarators.end()) return builtin->second->def;
   return namespace_enigma_user->find_local(name);
 }
 

--- a/CompilerSource/languages/lang_CPP.cpp
+++ b/CompilerSource/languages/lang_CPP.cpp
@@ -127,6 +127,12 @@ syntax_error *lang_CPP::definitionsModified(const char* wscode, const char* targ
       } else cerr << "ERROR! No varargs type found!" << endl;
     } else cerr << "ERROR! Namespace enigma is... not a namespace!" << endl;
   } else cerr << "ERROR! Namespace enigma not found!" << endl;
+  namespace_enigma_user = main_context->get_global();
+  if ((d = main_context->get_global()->look_up("enigma_user"))) {
+    if (d->flags & jdi::DEF_NAMESPACE) {
+      namespace_enigma_user = (jdi::definition_scope*) d;
+    } else cerr << "ERROR! Namespace enigma_user is... not a namespace!" << endl;
+  } else cerr << "ERROR! Namespace enigma_user not found!" << endl;
   
   if (res) {
     cout << "ERROR in parsing engine file: The parser isn't happy. Don't worry, it's never happy.\n";
@@ -201,6 +207,10 @@ int lang_CPP::load_shared_locals() {
 
   load_extension_locals();
   return 0;
+}
+
+jdi::definition* lang_CPP::look_up(const string &name) {
+  return namespace_enigma_user->find_local(name);
 }
 
 lang_CPP::~lang_CPP() {

--- a/CompilerSource/languages/lang_CPP.h
+++ b/CompilerSource/languages/lang_CPP.h
@@ -31,7 +31,7 @@ struct lang_CPP: language_adapter {
   jdi::context definitions;
 
   /// The ENIGMA namespace.
-  jdi::definition_scope *namespace_enigma;
+  jdi::definition_scope *namespace_enigma, *namespace_enigma_user;
   jdi::definition *enigma_type__var, *enigma_type__variant, *enigma_type__varargs;
 
   // Utility
@@ -91,6 +91,8 @@ struct lang_CPP: language_adapter {
   void quickmember_integer(jdi::definition_scope* scope, string name) {
     return quickmember_variable(scope, jdi::builtin_type__int, name);
   }
+  /// Look up an enigma_user definition by its name.
+  jdi::definition* look_up(const string &name);
 
   virtual ~lang_CPP();
 

--- a/CompilerSource/languages/language_adapter.h
+++ b/CompilerSource/languages/language_adapter.h
@@ -92,6 +92,8 @@ struct language_adapter {
   virtual void quickmember_script(jdi::definition_scope* scope, string name) = 0;
   /// Create a standard integer variable member in the given scope.
   virtual void quickmember_integer(jdi::definition_scope* scope, string name) = 0;
+  /// Look up an enigma_user definition by its name.
+  virtual jdi::definition* look_up(const string &name) = 0;
 
   virtual ~language_adapter();
 };

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -157,7 +157,7 @@ int parser_ready_input(string &code,string &synt,unsigned int &strc, varray<stri
       if (itt != edl_tokens.end()) {
         c = itt->second;
       }
-      else if ((d = main_context->get_global()->look_up(name)))
+      else if ((d = current_language->look_up(name)))
       {
         if (d->flags & jdi::DEF_TYPENAME)
           c = 't';
@@ -398,7 +398,7 @@ int parser_reinterpret(string &code,string &synt)
     {
       const pt spos = pos;
       while ((synt[pos] = 'n', synt[++pos] == 'V'));
-      jdi::definition_function *d = (jdi::definition_function*)main_context->get_global()->look_up(code.substr(spos,pos-spos));
+      jdi::definition_function *d = (jdi::definition_function*)current_language->look_up(code.substr(spos,pos-spos));
       const pt epos = pos;
       int en = current_language->function_variadic_after(d);
       if (en == -1) continue;
@@ -936,7 +936,7 @@ int parser_fix_templates(string &code,pt pos,pt spos,string *synt)
   cout << " <" << ((synt && code.length()) == (synt && synt->length()) ? "equivalent" : "UNEQUAL") << "> [" << (pos > code.length()) << "]";
   cout << "ass: " << spos << ", " << epos << ": " << code.length() << endl;
   string ptname = code.substr(spos,epos-spos+1); // Isolate the potential template's name
-  jdi::definition* a = main_context->get_global()->look_up(ptname);
+  jdi::definition* a = current_language->look_up(ptname);
   if (!a) return 0;
   
   if (a->flags & jdi::DEF_TEMPLATE)

--- a/CompilerSource/syntax/syntax.cpp
+++ b/CompilerSource/syntax/syntax.cpp
@@ -81,7 +81,7 @@ namespace syncheck
     TT_DIGIT,           // 0 1 2... (...)
     TT_STRING,          // "", ''
     TT_SCOPEACCESS,     // ::
-    TT_FUNCTION,   // game_end
+    TT_FUNCTION,        // game_end
     TT_TYPE_NAME,       // int, double, whatever
     TT_NAMESPACE,       // std, enigma, sf
     TT_LOCGLOBAL,       // global/local
@@ -310,7 +310,7 @@ namespace syncheck
 
         if (shared_object_locals.find(name) == shared_object_locals.end())
         {
-          jdi::definition *d = main_context->get_global()->look_up(name);
+          jdi::definition *d = current_language->look_up(name);
           if (d)
           {
             // Handle typenames

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -44,7 +44,7 @@ void EnableDrawing(void*) {
 
   GLenum err = glewInit();
   if (GLEW_OK != err)
-    show_error(std::string("Failed to initialize glew for OpenGL. ") + glewGetErrorString(err), true);
+    show_error(std::string("Failed to initialize glew for OpenGL. ") + (const char*)glewGetErrorString(err), true);
 }
 
 void DisableDrawing(void*) {

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL1/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL1/graphics_bridge.cpp
@@ -72,7 +72,7 @@ void EnableDrawing(void*)
 
   GLenum err = glewInit();
   if (GLEW_OK != err)
-    show_error(std::string("Failed to initialize glew for OpenGL. ") + glewGetErrorString(err), true);
+    show_error(std::string("Failed to initialize glew for OpenGL. ") + (const char*)glewGetErrorString(err), true);
 
   //TODO: This never reports higher than 8, but display_aa should be 14 if 2,4,and 8 are supported and 8 only when only 8 is supported
   glGetIntegerv(GL_MAX_SAMPLES_EXT, &enigma_user::display_aa);

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL3/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL3/graphics_bridge.cpp
@@ -112,7 +112,7 @@ void EnableDrawing(void*)
 
   GLenum err = glewInit();
   if (GLEW_OK != err)
-    show_error(std::string("Failed to initialize glew for OpenGL. ") + glewGetErrorString(err), true);
+    show_error(std::string("Failed to initialize glew for OpenGL. ") + (const char*)glewGetErrorString(err), true);
 
   // -- Define an array of Context Attributes
   int attribs[] =

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -62,7 +62,7 @@ namespace enigma {
 
     GLenum err = glewInit();
     if (GLEW_OK != err)
-      show_error(std::string("Failed to initialize glew for OpenGL. ") + glewGetErrorString(err), true);
+      show_error(std::string("Failed to initialize glew for OpenGL. ") + (const char*)glewGetErrorString(err), true);
   }
 
   void DisableDrawing(void* handle) {

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/include.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/include.h
@@ -4,6 +4,8 @@
 #include "libEGMstd.h"
 
 #ifdef JUST_DEFINE_IT_RUN
+namespace enigma_user {
+
 void gtest_assert_true(bool exp,  std::string message = "");
 void gtest_assert_false(bool exp, std::string message = "");
 
@@ -30,6 +32,9 @@ void gtest_expect_lt(var a, var b, std::string message = "");
 void gtest_expect_le(var a, var b, std::string message = "");
 void gtest_expect_gt(var a, var b, std::string message = "");
 void gtest_expect_ge(var a, var b, std::string message = "");
+
+} //enigma_user
+
 #else
 
 namespace enigma {

--- a/ENIGMAsystem/SHELL/Universal_System/var4.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.cpp
@@ -57,6 +57,8 @@ template<>           inline bool varzero(double x) { return codebloxt(x >= 0 && 
 #  define div0c(x)
 #endif
 
+namespace enigma_user {
+
 variant::operator int()       { ccast(0); return int  (rval.d); }
 variant::operator bool()      { ccast(0); return lrint(rval.d) > 0; }
 variant::operator char()      { ccast(0); return char (rval.d); }
@@ -339,9 +341,9 @@ double    variant::operator+  () EVCONST { return  rval.d; }
 #undef EVCONST
 #define EVCONST
 
-namespace enigma_user {
-  bool is_undefined(variant val)   { return val.type == ty_undefined; }
-  bool is_real(variant val)   { return val.type == real; }
-  bool is_string(variant val) { return val.type == tstr;  }
-  bool is_ptr(variant val)   { return val.type == ty_pointer; }
-}
+bool is_undefined(variant val)   { return val.type == ty_undefined; }
+bool is_real(variant val)   { return val.type == real; }
+bool is_string(variant val) { return val.type == tstr;  }
+bool is_ptr(variant val)   { return val.type == ty_pointer; }
+
+} //enigma_user

--- a/ENIGMAsystem/SHELL/Universal_System/var4.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.h
@@ -45,6 +45,8 @@ namespace enigma {
   };
 }
 
+namespace enigma_user {
+
 struct var;
 
 struct variant
@@ -321,5 +323,10 @@ namespace enigma_user {
   bool is_string(variant val);
   bool is_ptr(variant var);
 }
+
+} //enigma_user
+
+using enigma_user::variant;
+using enigma_user::var;
 
 #endif //ENIGMA_VAR4_H

--- a/ENIGMAsystem/SHELL/Universal_System/var4.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.h
@@ -310,19 +310,17 @@ types_binary_extrapolate_alldecce(bool, operator<,  const variant&)
 
 #undef unsigll
 
-namespace enigma_user {
-  enum {
+enum {
     ty_undefined = -1,
     ty_real = 0,
     ty_string = 1,
     ty_pointer = 2
-  };
+};
 
-  bool is_undefined(variant var);
-  bool is_real(variant val);
-  bool is_string(variant val);
-  bool is_ptr(variant var);
-}
+bool is_undefined(variant var);
+bool is_real(variant val);
+bool is_string(variant val);
+bool is_ptr(variant var);
 
 } //enigma_user
 


### PR DESCRIPTION
Types and global variable names will not be usable in EDL unless they are explicitly defined or used (via `using` directive) from the `enigma_user` namespace.

This removes conflicts with Bessel `y0`/`y1` functions and `time` as variable names.