### PR TITLE
Fix Math Clamp

### DIFF
--- a/CommandLine/testing/SimpleTests/math_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/math_test.sog/create.edl
@@ -149,6 +149,15 @@ gtest_assert_eq(min(-1, -2.0, -3.0, -4, -2.5),  -4);
 gtest_assert_eq_eps(lengthdir_x(10, 60), 5);
 gtest_assert_eq_eps(lengthdir_y(10, -30), 5);
 
+// Tests for clamping values in range
+gtest_assert_eq(clamp(2, 0, 1), 1);
+gtest_assert_eq(clamp(1, 0, 1), 1);
+gtest_assert_eq(clamp(0.5, 0, 1), 0.5);
+gtest_assert_eq(clamp(0, 0, 1), 0);
+gtest_assert_eq(clamp(-0.1, 0, 1), 0);
+gtest_assert_eq(clamp(-1, 0, 1), 0);
+gtest_assert_eq(clamp(-2, 0, 1), 0);
+
 // A more complicated helper, angle_difference
 gtest_assert_eq(angle_difference(359, 1), -2);
 gtest_assert_eq(angle_difference(1, 359), +2);

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -22,12 +22,6 @@ int frames_count = 0;
 unsigned long current_time_mcs = 0;
 bool game_window_focused = true;
 
-long clamp(long value, long min, long max) {
-  if (value < min) return min;
-  if (value > max) return max;
-  return value;
-}
-
 int gameWait() {
   if (enigma_user::os_is_paused()) {
     if (pausedSteps < 1) {

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -34,7 +34,6 @@ namespace enigma {
 
   int enigma_main(int argc, char** argv);
   int game_ending();
-  long clamp(long value, long min, long max);
   void Sleep(int ms);
   void compute_window_size();
   void initialize_directory_globals();

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -1,5 +1,7 @@
 #include "Platforms/General/PFmain.h"
 
+#include "Universal_System/mathnc.h" // enigma_user::clamp
+
 #include <time.h> //CLOCK_MONOTONIC
 #include <sys/types.h>     //getpid
 #include <unistd.h>        //usleep
@@ -38,7 +40,7 @@ int updateTimer() {
   {
     long passed_mcs = (time_current.tv_sec - time_offset.tv_sec) * 1000000 +
                       (time_current.tv_nsec / 1000 - +time_offset.tv_nsec / 1000);
-    passed_mcs = clamp(passed_mcs, 0, 1000000);
+    passed_mcs = enigma_user::clamp(passed_mcs, 0, 1000000);
     if (passed_mcs >= 1000000) {  // Handle resetting.
 
       enigma_user::fps = frames_count;
@@ -54,7 +56,7 @@ int updateTimer() {
   if (current_room_speed > 0) {
     spent_mcs = (time_current.tv_sec - time_offset_slowing.tv_sec) * 1000000 +
                 (time_current.tv_nsec / 1000 - time_offset_slowing.tv_nsec / 1000);
-    spent_mcs = clamp(spent_mcs, 0, 1000000);
+    spent_mcs = enigma_user::clamp(spent_mcs, 0, 1000000);
     long remaining_mcs = 1000000 - spent_mcs;
     long needed_mcs = long((1.0 - 1.0 * frames_count / current_room_speed) * 1e6);
     const int catchup_limit_ms = 50;
@@ -67,7 +69,7 @@ int updateTimer() {
       time_offset_slowing.tv_nsec += 1000 * (needed_mcs - (remaining_mcs + catchup_limit_ms * 1000));
       spent_mcs = (time_current.tv_sec - time_offset_slowing.tv_sec) * 1000000 +
                   (time_current.tv_nsec / 1000 - time_offset_slowing.tv_nsec / 1000);
-      spent_mcs = clamp(spent_mcs, 0, 1000000);
+      spent_mcs = enigma_user::clamp(spent_mcs, 0, 1000000);
       remaining_mcs = 1000000 - spent_mcs;
       needed_mcs = long((1.0 - 1.0 * frames_count / current_room_speed) * 1e6);
     }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -23,6 +23,7 @@
 #include "Platforms/General/PFwindow.h"
 #include "Platforms/platforms_mandatory.h"
 
+#include "Universal_System/mathnc.h" // enigma_user::clamp
 #include "Universal_System/estring.h"
 #include "Universal_System/roomsystem.h"
 #include "Universal_System/var4.h"
@@ -65,14 +66,14 @@ HWND get_window_handle() {
 }
 
 } // namespace enigma
-  
+
 static inline string add_slash(const string& dir) {
   if (dir.empty() || dir.back() != '\\') return dir + '\\';
   return dir;
 }
 
 namespace enigma_user {
-  
+
 bool set_working_directory(string dname) {
   tstring tstr_dname = widen(dname);
   replace(tstr_dname.begin(), tstr_dname.end(), '/', '\\');
@@ -86,7 +87,7 @@ bool set_working_directory(string dname) {
 
   return false;
 }
-  
+
 } // enigma_user
 
 namespace enigma {
@@ -127,17 +128,17 @@ void update_current_time() {
 }
 long get_current_offset_difference_mcs() {
   if (use_pc) {
-    return clamp((time_current_pc.QuadPart - time_offset_pc.QuadPart) * 1000000 / frequency_pc.QuadPart, 0, 1000000);
+    return enigma_user::clamp((time_current_pc.QuadPart - time_offset_pc.QuadPart) * 1000000 / frequency_pc.QuadPart, 0, 1000000);
   } else {
-    return clamp((time_current_ft.QuadPart - time_offset_ft.QuadPart) / 10, 0, 1000000);
+    return enigma_user::clamp((time_current_ft.QuadPart - time_offset_ft.QuadPart) / 10, 0, 1000000);
   }
 }
 long get_current_offset_slowing_difference_mcs() {
   if (use_pc) {
-    return clamp((time_current_pc.QuadPart - time_offset_slowing_pc.QuadPart) * 1000000 / frequency_pc.QuadPart, 0,
+    return enigma_user::clamp((time_current_pc.QuadPart - time_offset_slowing_pc.QuadPart) * 1000000 / frequency_pc.QuadPart, 0,
                  1000000);
   } else {
-    return clamp((time_current_ft.QuadPart - time_offset_slowing_ft.QuadPart) / 10, 0, 1000000);
+    return enigma_user::clamp((time_current_ft.QuadPart - time_offset_slowing_ft.QuadPart) / 10, 0, 1000000);
   }
 }
 void increase_offset_slowing(long increase_mcs) {
@@ -325,7 +326,7 @@ void initialize_directory_globals() {
   enigma_user::program_directory = shorten(buffer);
   enigma_user::program_directory =
     enigma_user::program_directory.substr(0, enigma_user::program_directory.find_last_of("\\/"));
-  
+
   // Set the temp_directory
   buffer[0] = 0;
   GetTempPathW(MAX_PATH + 1, buffer);

--- a/ENIGMAsystem/SHELL/Universal_System/mathnc.h
+++ b/ENIGMAsystem/SHELL/Universal_System/mathnc.h
@@ -37,10 +37,6 @@
 #include "dynamic_args.h"
 #include "generic_args.h"
 
-#ifndef INCLUDED_FROM_SHELLMAIN
-//#error ln2math and stop including this damn header.
-#endif
-
 #include "math_consts.h"
 #include "scalar.h"
 #include "var4.h"

--- a/ENIGMAsystem/SHELL/Universal_System/mathnc.h
+++ b/ENIGMAsystem/SHELL/Universal_System/mathnc.h
@@ -38,7 +38,7 @@
 #include "generic_args.h"
 
 #ifndef INCLUDED_FROM_SHELLMAIN
-#error ln2math and stop including this damn header.
+//#error ln2math and stop including this damn header.
 #endif
 
 #include "math_consts.h"


### PR DESCRIPTION
I am trying to fix clamp and keep it that way by adding it to the math CI test. I first added it to the CI test to prove that it fails/is ambiguous since #1677 exposed namespace `enigma::` to the user's codegen headers. This specifically effects my "Modern Economy" city simulation game which uses clamp to keep the current simulated month in the range of 0-11.

I talked to Josh and he told me it's time to deduplicate the two clamps. He said it was ok to use the user function in the platforms, which is what I've done here. Platforms uses the clamp function in its timing functionality. This resolves the ambiguity, but it required that I allow including `mathnc.h` from engine source's (something we previously disallowed).

Going further, this doesn't actually solve the root problem here, which is that none of the user's codegen headers are putting code in `enigma_user` where it belongs. This means we are exposing `namespace enigma` to user code, which is exactly what we don't want. So the alternative way of fixing this, or I could just add it on top of this change, is to move the codegen to `enigma_user`.