### PR TITLE
Remove Texture State Functions From Backends

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
@@ -128,16 +128,6 @@ void texture_set_priority(int texid, double prio)
   // Deprecated in ENIGMA and GM: Studio, all textures are automatically preloaded.
 }
 
-void texture_set_enabled(bool enable)
-{
-
-}
-
-void texture_set_blending(bool enable)
-{
-
-}
-
 bool texture_mipmapping_supported()
 {
   return false; //TODO: implement

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.cpp
@@ -105,6 +105,10 @@ void texture_reset() {
   enigma::samplers[0].texture = -1;
 }
 
+void texture_set_enabled(bool enable){}
+
+void texture_set_blending(bool enable){}
+
 void texture_set_interpolation_ext(int sampler, bool enable) {
   enigma::draw_set_state_dirty();
   enigma::samplers[sampler].interpolate = enable;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.h
@@ -64,6 +64,7 @@ namespace enigma_user
   gs_scalar texture_get_texel_height(int texid);
   void texture_set_priority(int texid, double prio);
   void texture_set_enabled(bool enable);
+  void texture_set_blending(bool enable);
   void texture_set(int texid);
   void texture_set_stage(int stage, int texid);
   int texture_get();
@@ -71,7 +72,6 @@ namespace enigma_user
   #define texture_set(texid) texture_set_stage(0, texid)
   #define texture_get(texid) texture_get_stage(0)
   void texture_reset();
-  void texture_set_blending(bool enable);
 
   void texture_set_repeat(bool repeat);
   void texture_set_repeat_ext(int sampler, bool repeat);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
@@ -96,8 +96,6 @@ namespace enigma_user
 	void index_submit_range(int buffer, int vertex, int primitive, unsigned start, unsigned count) {}
 
 	void texture_set_priority(int texid, double prio){}
-	void texture_set_enabled(bool enable){}
-	void texture_set_blending(bool enable){}
 	bool texture_mipmapping_supported(){return false;}
 	bool texture_anisotropy_supported(){return false;}
 	float texture_anisotropy_maxlevel(){return 0;}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
@@ -57,8 +57,6 @@ namespace enigma_user
 	string draw_get_graphics_error();
 
 	void texture_set_priority(int texid, double prio);
-	void texture_set_enabled(bool enable);
-	void texture_set_blending(bool enable);
 	bool texture_mipmapping_supported();
 	bool texture_anisotropy_supported();
 	float texture_anisotropy_maxlevel();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtextures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtextures.cpp
@@ -216,18 +216,6 @@ void texture_set_priority(int texid, double prio)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_PRIORITY, prio);
 }
 
-void texture_set_enabled(bool enable)
-{
-  draw_batch_flush(batch_flush_deferred);
-  (enable?glEnable:glDisable)(GL_TEXTURE_2D);
-}
-
-void texture_set_blending(bool enable)
-{
-  draw_batch_flush(batch_flush_deferred);
-  (enable?glEnable:glDisable)(GL_BLEND);
-}
-
 bool texture_mipmapping_supported()
 {
   return strstr((char*)glGetString(GL_EXTENSIONS),

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
@@ -289,18 +289,6 @@ void texture_set_priority(int texid, double prio)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_PRIORITY, prio);
 }
 
-void texture_set_enabled(bool enable)
-{
-  draw_batch_flush(batch_flush_deferred);
-  (enable?glEnable:glDisable)(GL_TEXTURE_2D);
-}
-
-void texture_set_blending(bool enable)
-{
-  draw_batch_flush(batch_flush_deferred);
-  (enable?glEnable:glDisable)(GL_BLEND);
-}
-
 bool texture_mipmapping_supported()
 {
   return enigma::gl_extension_supported("glGenerateMipmap");


### PR DESCRIPTION
I forgot to remove two texture state functions from the backends in #1636.