### PR TITLE
Fix Direct3D9 Fog Color

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9d3d.cpp
@@ -91,7 +91,8 @@ void graphics_state_flush_fog() {
   d3ddev->SetRenderState(D3DRS_RANGEFOGENABLE, d3dFogEnabled);
   d3ddev->SetRenderState(D3DRS_FOGTABLEMODE, fogmodes[d3dFogMode]);
   d3ddev->SetRenderState(D3DRS_FOGVERTEXMODE, fogmodes[d3dFogMode]);
-  d3ddev->SetRenderState(D3DRS_FOGCOLOR, *d3dFogColor);
+  d3ddev->SetRenderState(D3DRS_FOGCOLOR,
+    D3DCOLOR_RGBA(COL_GET_R(d3dFogColor), COL_GET_G(d3dFogColor), COL_GET_B(d3dFogColor), 255));
 
   // NOTE: DWORD is 32 bits maximum meaning it can only hold single-precision
   // floats, so yes, we must cast double to float first too.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -44,9 +44,8 @@ int d3dCulling=0, d3dDepthOperator=enigma_user::rs_lequal;
 float d3dLightingAmbient[4]={0.0f,0.0f,0.0f,1.0f};
 
 bool d3dFogEnabled=false;
-int d3dFogMode=enigma_user::rs_linear, d3dFogHint=enigma_user::rs_nicest;
+int d3dFogColor=enigma_user::c_gray, d3dFogMode=enigma_user::rs_linear, d3dFogHint=enigma_user::rs_nicest;
 float d3dFogStart=0.0f, d3dFogEnd=0.0f, d3dFogDensity=0.0f;
-float d3dFogColor[3]={0.0f,0.0f,0.0f};
 
 int d3dLightsActive = 0;
 const Light& get_active_light(int id) {
@@ -169,9 +168,7 @@ void d3d_set_fog_hint(int mode) {
 
 void d3d_set_fog_color(int color) {
   enigma::draw_set_state_dirty();
-  enigma::d3dFogColor[0] = COL_GET_Rf(color);
-  enigma::d3dFogColor[1] = COL_GET_Gf(color);
-  enigma::d3dFogColor[2] = COL_GET_Bf(color);
+  enigma::d3dFogColor = color;
 }
 
 void d3d_set_fog_start(double start) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.h
@@ -33,9 +33,8 @@ extern float d3dLightingAmbient[4];
 extern int d3dCulling, d3dDepthOperator;
 
 extern bool d3dFogEnabled;
-extern int d3dFogMode, d3dFogHint;
+extern int d3dFogColor, d3dFogMode, d3dFogHint;
 extern float d3dFogStart, d3dFogEnd, d3dFogDensity;
-extern float d3dFogColor[3];
 
 struct Light {
   gs_scalar x=0, y=0, z=0, range=0;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -58,7 +58,8 @@ void graphics_state_flush_samplers() {
 void graphics_state_flush_fog() {
   glFogi(GL_FOG_MODE, fogmodes[d3dFogMode]);
   glHint(GL_FOG_HINT, d3dFogHint);
-  glFogfv(GL_FOG_COLOR, d3dFogColor);
+  const float glFogColor[] = {COL_GET_Rf(d3dFogColor),COL_GET_Gf(d3dFogColor),COL_GET_Bf(d3dFogColor)};
+  glFogfv(GL_FOG_COLOR, glFogColor);
   glFogf(GL_FOG_START, d3dFogStart);
   glFogf(GL_FOG_END, d3dFogEnd);
   glFogf(GL_FOG_DENSITY, d3dFogDensity);


### PR DESCRIPTION
This fixes a regression to the fog color for Direct3D9 that was introduced in #1636.