### PR TITLE
Fix OpenGL Multisampling FBO For Xlib/Non-WGL

### DIFF
--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL/graphics_bridge.cpp
@@ -31,8 +31,6 @@ extern "C" {
 }
 
 namespace enigma {
-  GLuint msaa_fbo = 0;
-
   extern void (*WindowResizedCallback)();
   void WindowResized() {
     // clear the window color, viewport does not need set because backbuffer was just recreated
@@ -54,10 +52,5 @@ namespace enigma {
 namespace enigma_user {
   void set_synchronization(bool enable) {
 
-  }
-
-  void display_reset(int samples, bool vsync) {
-    set_synchronization(vsync);
-    //TODO: Copy over from the Win32 bridge
   }
 }

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -26,8 +26,6 @@ namespace enigma {
 
 extern unsigned sdl_window_flags;
 
-int msaa_fbo = 0;
-
 SDL_GLContext context;
 
 void init_sdl_window_bridge_attributes() {
@@ -62,10 +60,6 @@ namespace enigma_user {
 
 void set_synchronization(bool enable) {
   SDL_GL_SetSwapInterval(enable);
-}
-
-void display_reset(int samples, bool vsync) {
-  set_synchronization(vsync);
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
@@ -29,7 +29,6 @@
 
 namespace enigma {
 
-GLuint msaa_fbo = 0;
 extern HGLRC hRC;
 
 extern void (*WindowResizedCallback)();
@@ -89,9 +88,6 @@ void EnableDrawing(void*)
   } else { // unable to get a core context, use the legacy context
     hRC = LegacyRC;
   }
-
-  //TODO: This never reports higher than 8, but display_aa should be 14 if 2,4,and 8 are supported and 8 only when only 8 is supported
-  glGetIntegerv(GL_MAX_SAMPLES_EXT, &enigma_user::display_aa);
 }
 
 void DisableDrawing(void*)
@@ -128,46 +124,6 @@ void ScreenRefresh() {
 }
 
 namespace enigma_user {
-
-void display_reset(int samples, bool vsync) {
-  int interval = vsync ? 1 : 0;
-
-  if (enigma::is_ext_swapcontrol_supported()) {
-    wglSwapIntervalEXT(interval);
-  }
-
-  GLint fbo;
-  glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &fbo);
-
-  GLuint ColorBufferID, DepthBufferID;
-
-  // Cleanup the multi-sampler fbo if turning off multi-sampling
-  if (samples == 0) {
-    if (enigma::msaa_fbo != 0) {
-      glDeleteFramebuffers(1, &enigma::msaa_fbo);
-      enigma::msaa_fbo = 0;
-    }
-    return;
-  }
-
-  //TODO: Change the code below to fix this to size properly to views
-  // If we don't already have a multi-sample fbo then create one
-  if (enigma::msaa_fbo == 0) {
-    glGenFramebuffersEXT(1, &enigma::msaa_fbo);
-  }
-  glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, enigma::msaa_fbo);
-  // Now make a multi-sample color buffer
-  glGenRenderbuffersEXT(1, &ColorBufferID);
-  glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, ColorBufferID);
-  glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER_EXT, samples, GL_RGBA8, window_get_region_width(), window_get_region_height());
-  // We also need a depth buffer
-  glGenRenderbuffersEXT(1, &DepthBufferID);
-  glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, DepthBufferID);
-  glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER_EXT, samples, GL_DEPTH_COMPONENT24, window_get_region_width(), window_get_region_height());
-  // Attach the render buffers to the multi-sampler fbo
-  glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, ColorBufferID);
-  glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, DepthBufferID);
-}
 
 void set_synchronization(bool enable) {
   // General notes:

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -30,7 +30,6 @@
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL3 version.
 
 namespace enigma {
-  GLuint msaa_fbo = 0;
   GLXContext glxc;
   XVisualInfo *vi;
 
@@ -141,10 +140,5 @@ namespace enigma_user {
       // be zero or less, so therefore it is not used here.
       // See http://www.opengl.org/registry/specs/SGI/swap_control.txt for more information.
     }
-  }
-
-  void display_reset(int samples, bool vsync) {
-    set_synchronization(vsync);
-    //TODO: Copy over from the Win32 bridge
   }
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/GLscreen.cpp
@@ -1,0 +1,70 @@
+#include "GLscreen.h"
+#include "OpenGLHeaders.h"
+#include "Platforms/General/PFwindow.h"
+
+namespace enigma {
+
+GLuint msaa_fbo = 0;
+
+void gl_screen_init() {
+  //TODO: This never reports higher than 8, but display_aa should be 14 if 2,4,and 8 are supported and 8 only when only 8 is supported
+  glGetIntegerv(GL_MAX_SAMPLES_EXT, &enigma_user::display_aa);
+}
+
+void msaa_fbo_blit() {
+  if (!GLEW_EXT_framebuffer_object || !msaa_fbo) return;
+  GLint fbo;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &fbo);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, enigma::msaa_fbo);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+  //TODO: Change the code below to fix this to size properly to views
+  glBlitFramebuffer(0, 0, enigma_user::window_get_region_width_scaled(), enigma_user::window_get_region_height_scaled(),
+                    0, 0, enigma_user::window_get_region_width_scaled(), enigma_user::window_get_region_height_scaled(),
+					GL_COLOR_BUFFER_BIT, GL_NEAREST);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
+  // glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, pixels);
+}
+
+} // namespace enigma
+
+namespace enigma_user {
+
+void display_reset(int samples, bool vsync) {
+  set_synchronization(vsync);
+
+  if (!GLEW_EXT_framebuffer_object) return;
+
+  GLint fbo;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &fbo);
+
+  GLuint ColorBufferID, DepthBufferID;
+
+  // Cleanup the multi-sampler fbo if turning off multi-sampling
+  if (samples == 0) {
+    if (enigma::msaa_fbo != 0) {
+      glDeleteFramebuffers(1, &enigma::msaa_fbo);
+      enigma::msaa_fbo = 0;
+    }
+    return;
+  }
+
+  //TODO: Change the code below to fix this to size properly to views
+  // If we don't already have a multi-sample fbo then create one
+  if (enigma::msaa_fbo == 0) {
+    glGenFramebuffersEXT(1, &enigma::msaa_fbo);
+  }
+  glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, enigma::msaa_fbo);
+  // Now make a multi-sample color buffer
+  glGenRenderbuffersEXT(1, &ColorBufferID);
+  glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, ColorBufferID);
+  glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER_EXT, samples, GL_RGBA8, window_get_region_width(), window_get_region_height());
+  // We also need a depth buffer
+  glGenRenderbuffersEXT(1, &DepthBufferID);
+  glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, DepthBufferID);
+  glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER_EXT, samples, GL_DEPTH_COMPONENT24, window_get_region_width(), window_get_region_height());
+  // Attach the render buffers to the multi-sampler fbo
+  glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, ColorBufferID);
+  glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, DepthBufferID);
+}
+
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/GLscreen.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/GLscreen.h
@@ -1,0 +1,7 @@
+
+namespace enigma {
+
+void gl_screen_init();
+void msaa_fbo_blit();
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/Makefile
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/Makefile
@@ -1,0 +1,10 @@
+SOURCES += $(wildcard Graphics_Systems/OpenGL/*.cpp)
+
+ifeq ($(TARGET-PLATFORM), Windows)
+	override CXXFLAGS += -DGLEW_STATIC
+	override LDLIBS += -lglew32 -lopengl32
+else ifeq ($(TARGET-PLATFORM), Linux)
+	override LDLIBS += -lGL -lGLEW
+else ifeq ($(TARGET-PLATFORM), MacOSX)
+	override LDLIBS += -framework OpenGL -lGLEW
+endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -18,6 +18,7 @@
 **/
 
 #include "Graphics_Systems/graphics_mandatory.h"
+#include "Graphics_Systems/OpenGL/GLscreen.h"
 #include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSscreen.h"
 #include "Graphics_Systems/General/GSbackground.h"
@@ -44,7 +45,6 @@ using namespace enigma;
 
 namespace enigma {
 
-extern GLuint msaa_fbo;
 unsigned int bound_framebuffer = 0; //Shows the bound framebuffer, so glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &fbo); don't need to be called (they are very slow)
 int viewport_x, viewport_y, viewport_w, viewport_h; //These are used by surfaces, to set back the viewport
 
@@ -53,7 +53,7 @@ void scene_begin() {
 }
 
 void scene_end() {
-
+	msaa_fbo_blit();
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/Makefile
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/Makefile
@@ -1,10 +1,2 @@
+include Graphics_Systems/OpenGL/Makefile
 SOURCES += $(wildcard Graphics_Systems/OpenGL1/*.cpp) $(wildcard Graphics_Systems/General/*.cpp)
-
-ifeq ($(TARGET-PLATFORM), Windows)
-	override CXXFLAGS += -DGLEW_STATIC
-	override LDLIBS += -lglew32 -lopengl32
-else ifeq ($(TARGET-PLATFORM), Linux)
-	override LDLIBS += -lGL -lGLEW
-else ifeq ($(TARGET-PLATFORM), MacOSX)
-	override LDLIBS += -framework OpenGL -lGLEW
-endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -19,6 +19,7 @@
 #include "GLshader.h"
 #include "GLSLshader.h"
 
+#include "Graphics_Systems/OpenGL/GLscreen.h"
 #include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
 
 #include "Universal_System/shaderstruct.h"
@@ -37,6 +38,7 @@ namespace enigma {
 
   void graphicssystem_initialize()
   {
+    gl_screen_init();
     graphics_init_vbo_method();
 
     glEnable(GL_SCISSOR_TEST); // constrain clear to viewport like D3D9

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -18,6 +18,7 @@
 **/
 
 #include "GL3profiler.h"
+#include "Graphics_Systems/OpenGL/GLscreen.h"
 #include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSscreen.h"
 #include "Graphics_Systems/General/GSbackground.h"
@@ -45,7 +46,6 @@ using namespace enigma_user;
 
 namespace enigma {
 
-extern GLuint msaa_fbo;
 unsigned int bound_framebuffer = 0; //Shows the bound framebuffer, so glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &fbo); don't need to be called (they are very slow)
 int viewport_x, viewport_y, viewport_w, viewport_h; //These are used by surfaces, to set back the viewport
 
@@ -53,17 +53,7 @@ void scene_begin() {}
 
 void scene_end() {
   gpuprof.end_frame();
-
-  if (enigma::msaa_fbo != 0) {
-    GLint fbo;
-    glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &fbo);
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, enigma::msaa_fbo);
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-    //TODO: Change the code below to fix this to size properly to views
-    glBlitFramebuffer(0, 0, window_get_region_width_scaled(), window_get_region_height_scaled(), 0, 0, window_get_region_width_scaled(), window_get_region_height_scaled(), GL_COLOR_BUFFER_BIT, GL_NEAREST);
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
-    // glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, pixels);
-  }
+  msaa_fbo_blit();
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/Makefile
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/Makefile
@@ -1,10 +1,2 @@
+include Graphics_Systems/OpenGL/Makefile
 SOURCES += $(wildcard Graphics_Systems/OpenGL3/*.cpp) $(wildcard Graphics_Systems/General/*.cpp)
-
-ifeq ($(TARGET-PLATFORM), Windows)
-	override CXXFLAGS += -DGLEW_STATIC
-	override LDLIBS += -lglew32 -lopengl32
-else ifeq ($(TARGET-PLATFORM), Linux)
-	override LDLIBS += -lGL -lGLEW
-else ifeq ($(TARGET-PLATFORM), MacOSX)
-	override LDLIBS += -framework OpenGL -lGLEW
-endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
@@ -19,6 +19,7 @@
 #include "GL3shader.h"
 #include "GLSLshader.h"
 
+#include "Graphics_Systems/OpenGL/GLscreen.h"
 #include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
 
 #ifdef DEBUG_MODE
@@ -106,6 +107,8 @@ namespace enigma {
     glDebugMessageControlARB(GL_DEBUG_SOURCE_API_ARB, GL_DEBUG_TYPE_PERFORMANCE_ARB, GL_DONT_CARE, 2, performance_ids, GL_FALSE); //Disable some notifications shown below:
     //OpenGL: Program/shader state performance warning: Vertex shader in program 9 is being recompiled based on GL state. [source=API type=PERFORMANCE severity=MEDIUM id=131218] - This is NVidia only and doesn't tell much
     #endif
+
+    gl_screen_init();
 
     glEnable(GL_SCISSOR_TEST); // constrain clear to viewport like D3D9
     glDepthFunc(GL_LEQUAL); // to match GM8's D3D8 default


### PR DESCRIPTION
This has been an issue for a while. The MSAA `display_reset` does not work at all in OpenGL1 on master. The `display_reset` also just doesn't work at all on any platform except Windows because we had the code to create the MSAA fbo in the bridge. This pull request fixes all of that.

I moved the MSAA fbo handling out of the `Win32-OpenGL` bridge and into the `Graphics_System/OpenGL/` general OpenGL folder. I left the vsync control in the bridges since that is windowing system specific. Then I made the GL general `display_reset` call the backend vsync control helper then finally create the MSAA fbo. I included checks for whether fbo support is actually available so people like polygonz won't feel left out. I also decided to deduplicate the OpenGL makefiles while I was in here.

Edit: Also, I had hugar test and he said his game works on this branch. I've showed him how to check out branches, he's picking up fast.