### PR TITLE
Rename DS Map Overwrite

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -78,7 +78,7 @@ void process_async_jobs() {
   // and fire the async dialog event from the main thread
   if (last_job_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
     // increment job counter so we can move to the next job
-    ds_map_replaceanyway(async_load, "id", last_job++);
+    ds_map_overwrite(async_load, "id", last_job++);
     last_job_started = false;
     // only one async dialog event should be fired at a time
     // and it should be fired from the main thread
@@ -111,7 +111,7 @@ namespace enigma_user {
     auto fnc = [=] {
       show_message(str);
       //TODO: Stupido lolz, gives a cancel operation for a rhetorical message according to the manual
-      ds_map_replaceanyway(async_load, "status", true);
+      ds_map_overwrite(async_load, "status", true);
     };
     return queue_async_job(fnc);
   }
@@ -119,7 +119,7 @@ namespace enigma_user {
   int show_question_async(string str) {
     auto fnc = [=] {
       bool status = show_question(str);
-      ds_map_replaceanyway(async_load, "status", status);
+      ds_map_overwrite(async_load, "status", status);
     };
     return queue_async_job(fnc);
   }
@@ -127,8 +127,8 @@ namespace enigma_user {
   int get_string_async(string message, string def, string cap) {
     auto fnc = [=] {
       string result = get_string(message, def, cap);
-      ds_map_replaceanyway(async_load, "status", true);
-      ds_map_replaceanyway(async_load, "result", result);
+      ds_map_overwrite(async_load, "status", true);
+      ds_map_overwrite(async_load, "result", result);
     };
     return queue_async_job(fnc);
   }
@@ -136,8 +136,8 @@ namespace enigma_user {
   int get_integer_async(string message, string def, string cap) {
     auto fnc = [=] {
       int result = get_integer(message, def, cap);
-      ds_map_replaceanyway(async_load, "status", true);
-      ds_map_replaceanyway(async_load, "result", result);
+      ds_map_overwrite(async_load, "status", true);
+      ds_map_overwrite(async_load, "result", result);
     };
     return queue_async_job(fnc);
   }
@@ -151,12 +151,12 @@ namespace enigma_user {
       if (end != string::npos) {
         username = result.substr(0, end);
         password = result.substr(end + 1, result.size() - end);
-        ds_map_replaceanyway(async_load, "status", true);
+        ds_map_overwrite(async_load, "status", true);
       } else {
-        ds_map_replaceanyway(async_load, "status", false);
+        ds_map_overwrite(async_load, "status", false);
       }
-      ds_map_replaceanyway(async_load, "username", username);
-      ds_map_replaceanyway(async_load, "password", password);
+      ds_map_overwrite(async_load, "username", username);
+      ds_map_overwrite(async_load, "password", password);
     };
     return queue_async_job(fnc);
   }

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/data_structures.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/data_structures.cpp
@@ -892,12 +892,12 @@ void ds_map_replace(const unsigned int id, const variant key, const variant val)
 {
   //TODO: Studio made it so this function will add the value if it is not in the map.
   //GM 8.1 does not have this behaviour. This has also been tested.
-  //We will probably not add support for that, but it may cause issues down the road.
-  //If a decision is made, you should probably ask Josh for clarification, but when the
-  //decision is made, please replace my comment here whether or not we support it.
+  //Possible solution is to check compatibility setting once it's fixed for sources.
+  //https://github.com/enigma-dev/enigma-dev/issues/1461
   //If this function is changed to behave this way, please fix it in the Asynchronous dialog
   //extension which had to create a special function to replace a value adding it if it does
   //not exist in the global async_load map.
+
   //Replaces the value corresponding with the key with a new value
   multimap<variant, variant>::iterator it = ds_maps[id].find(key);
   if (it != ds_maps[id].end())
@@ -908,7 +908,7 @@ void ds_map_replace(const unsigned int id, const variant key, const variant val)
 }
 
 //NOTE: Special function, see todo comment above.
-void ds_map_replaceanyway(const unsigned int id, const variant key, const variant val)
+void ds_map_overwrite(const unsigned int id, const variant key, const variant val)
 {
   //Replaces the value corresponding with the key with a new value, adding it if it was not found in the map.
   multimap<variant, variant>::iterator it = ds_maps[id].find(key);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/include.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/include.h
@@ -82,7 +82,7 @@ unsigned int ds_map_size(const unsigned int id);
 bool ds_map_empty(const unsigned int id);
 void ds_map_add(const unsigned int id, const variant key, const variant val);
 void ds_map_replace(const unsigned int id, const variant key, const variant val);
-void ds_map_replaceanyway(const unsigned int id, const variant key, const variant val);
+void ds_map_overwrite(const unsigned int id, const variant key, const variant val);
 void ds_map_delete(const unsigned int id, const variant key);
 void ds_map_delete(const unsigned int id, const variant first, const variant last);
 bool ds_map_exists(const unsigned int id, const variant key);


### PR DESCRIPTION
I documented this pretty clearly already.
GMSv1.4: `ds_map_replace` inserts value at key, erasing old value at key if it exists
GM8.1: `ds_map_replace` if key is found, erases old value at key and inserts new value at key

This pull request does not actually fix the underlying compatibility issue, but #1461 would. What this pull request does is just rename `ds_map_replaceanyway` to `ds_map_overwrite` which is a name Josh gave me that I like better.