### PR TITLE
New OpenGL ES Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,10 @@ matrix:
   include:
     # SDL
     - env: PLATFORM=SDL
-      before_script: sudo apt-get -y install libsdl2-dev libegl1-mesa-dev libgles2-mesa-dev
+      before_script: sudo apt-get -y install libsdl2-dev
+    # Graphics
+    - env: GRAPHICS=OpenGLES PLATFORM=SDL
+      before_script: sudo apt-get -y install libepoxy-dev libsdl2-dev libegl1-mesa-dev libgles2-mesa-dev
     # Widgets
     - env: WIDGETS=GTK+
       before_script: sudo apt-get -y install libgtk2.0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ matrix:
   include:
     # SDL
     - env: PLATFORM=SDL
-      before_script: sudo apt-get -y install libsdl2-dev
+      before_script: sudo apt-get -y install libsdl2-dev libegl1-mesa-dev libgles2-mesa-dev
     # Graphics
     - env: GRAPHICS=OpenGLES PLATFORM=SDL
       before_script: sudo apt-get -y install libepoxy-dev libsdl2-dev libegl1-mesa-dev libgles2-mesa-dev

--- a/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Cocoa-OpenGL/graphics_bridge.cpp
@@ -15,13 +15,14 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include <GL/glxew.h>
 #include "Platforms/Cocoa/CocoaMain.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GScolors.h"
 
 #include <iostream>
 #include <cstring>
+
+#include <GL/glxew.h>
 
 // NOTE: Changes/fixes that applies to this likely also applies to the OpenGL3 version.
 

--- a/ENIGMAsystem/SHELL/Bridges/OpenGL/OpenGLHeaders.h
+++ b/ENIGMAsystem/SHELL/Bridges/OpenGL/OpenGLHeaders.h
@@ -1,4 +1,4 @@
-/** Copyright (C) 2014 Harijs Grinbergs
+/** Copyright (C) 2010-2013 Josh Ventura, Robert B. Colton, Alasdair Morrison
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***
@@ -14,18 +14,8 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-#include <cstring>
-#include "OpenGLHeaders.h"
-#include "GL3aux.h"
 
-namespace enigma {
+// TGMG: I've replaced your include of the switchboard with this hard-coded job until I find
+// something more elegant.          -Josh
 
-	bool gl_extension_supported(std::string extension){
-		GLint n, i;
-		glGetIntegerv(GL_NUM_EXTENSIONS, &n);
-		for (i = 0; i < n; ++i) {
-			if (std::strstr((char*)glGetStringi(GL_EXTENSIONS, i),extension.c_str())!=NULL) return true;
-		}
-		return false;
-	}
-}
+#include <GL/glew.h>

--- a/ENIGMAsystem/SHELL/Bridges/OpenGLES/GLload.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/OpenGLES/GLload.cpp
@@ -1,0 +1,8 @@
+#include "GLload.h"
+
+namespace enigma {
+
+// this isn't needed by epoxy used for GLES
+void gl_load_exts() {}
+
+}

--- a/ENIGMAsystem/SHELL/Bridges/OpenGLES/GLload.h
+++ b/ENIGMAsystem/SHELL/Bridges/OpenGLES/GLload.h
@@ -1,0 +1,5 @@
+namespace enigma {
+
+void gl_load_exts();
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Bridges/OpenGLES/Makefile
+++ b/ENIGMAsystem/SHELL/Bridges/OpenGLES/Makefile
@@ -1,0 +1,1 @@
+SOURCES += $(wildcard Bridges/OpenGLES/*.cpp)

--- a/ENIGMAsystem/SHELL/Bridges/OpenGLES/OpenGLHeaders.h
+++ b/ENIGMAsystem/SHELL/Bridges/OpenGLES/OpenGLHeaders.h
@@ -18,11 +18,4 @@
 // TGMG: I've replaced your include of the switchboard with this hard-coded job until I find
 // something more elegant.          -Josh
 
-#include <GL/glew.h>
-
-namespace enigma {
-
-// whether bridge creates a core or compatibility context
-extern const bool graphics_opengl_core;
-
-}
+#include <epoxy/gl.h>

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGL/graphics_bridge.cpp
@@ -15,8 +15,9 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "OpenGLHeaders.h"
+#include "Graphics_Systems/OpenGL/GLversion.h"
 #include "Bridges/OpenGL/GLload.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/SDL/Window.h"
 
@@ -28,12 +29,13 @@ extern unsigned sdl_window_flags;
 
 SDL_GLContext context;
 
+const static SDL_GLprofile profile_types[3] = {SDL_GL_CONTEXT_PROFILE_CORE,SDL_GL_CONTEXT_PROFILE_COMPATIBILITY,SDL_GL_CONTEXT_PROFILE_ES};
+
 void init_sdl_window_bridge_attributes() {
   #ifdef DEBUG_MODE
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
   #endif
-  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
-    graphics_opengl_core?SDL_GL_CONTEXT_PROFILE_CORE:SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,profile_types[graphics_opengl_profile]);
   SDL_GL_SetSwapInterval(0);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);

--- a/ENIGMAsystem/SHELL/Bridges/SDL-OpenGLES/Makefile
+++ b/ENIGMAsystem/SHELL/Bridges/SDL-OpenGLES/Makefile
@@ -1,0 +1,2 @@
+include Bridges/OpenGLES/Makefile
+SOURCES += $(wildcard Bridges/SDL-OpenGLES/*.cpp) $(wildcard Bridges/SDL-OpenGL/*.cpp)

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
@@ -16,12 +16,13 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "OpenGLHeaders.h"
+#include "Graphics_Systems/OpenGL/GLversion.h"
+#include "Graphics_Systems/General/GScolors.h"
 #include "Bridges/OpenGL/GLload.h"
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/Win32/WINDOWSmain.h"
 #include "Platforms/General/PFwindow.h"
-#include "Graphics_Systems/General/GScolors.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
 
 #include <string>
 #include <GL/wglew.h>
@@ -69,12 +70,14 @@ void EnableDrawing(void*)
 
   gl_load_exts();
 
-  if (graphics_opengl_core && wglewIsSupported("WGL_ARB_create_context"))
+  const bool gl_core = (graphics_opengl_profile==gl_profile_core);
+
+  if (gl_core && wglewIsSupported("WGL_ARB_create_context"))
   {
     // -- Define an array of Context Attributes
     int attribs[] =
     {
-      WGL_CONTEXT_PROFILE_MASK_ARB, graphics_opengl_core?WGL_CONTEXT_CORE_PROFILE_BIT_ARB:WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+      WGL_CONTEXT_PROFILE_MASK_ARB,gl_core?WGL_CONTEXT_CORE_PROFILE_BIT_ARB:WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
       #ifdef DEBUG_MODE
         WGL_CONTEXT_FLAGS_ARB, WGL_CONTEXT_DEBUG_BIT_ARB,
       #endif

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -15,9 +15,10 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "Bridges/OpenGL/GLload.h"
-#include "Graphics_Systems/graphics_mandatory.h"
+#include "OpenGLHeaders.h"
+#include "Graphics_Systems/OpenGL/GLversion.h"
 #include "Graphics_Systems/General/GScolors.h"
+#include "Bridges/OpenGL/GLload.h"
 
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Platforms/xlib/XLIBwindow.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/GLversion.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/GLversion.h
@@ -1,0 +1,11 @@
+namespace enigma {
+
+enum gl_profile_type {
+  gl_profile_core = 0,
+  gl_profile_compat,
+  gl_profile_es
+};
+
+extern const gl_profile_type graphics_opengl_profile;
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/Makefile
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/Makefile
@@ -1,4 +1,5 @@
 SOURCES += $(wildcard Graphics_Systems/OpenGL/*.cpp)
+override CXXFLAGS += -IBridges/OpenGL
 
 ifeq ($(TARGET-PLATFORM), Windows)
 	override CXXFLAGS += -DGLEW_STATIC

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLSLshader.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLSLshader.h
@@ -23,7 +23,7 @@
 using std::string;
 using std::vector;
 
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 
 extern GLenum shadertypes[];
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLd3d.cpp
@@ -16,9 +16,9 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/OpenGL/GLenums.h"
 #include "Graphics_Systems/OpenGL/GLtextures_impl.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSd3d.h"
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GSblend.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -19,7 +19,7 @@
 
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/OpenGL/GLscreen.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSscreen.h"
 #include "Graphics_Systems/General/GSbackground.h"
 #include "Graphics_Systems/General/GSsprite.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLshader.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLshader.cpp
@@ -17,7 +17,7 @@
 
 #include "GLshader.h"
 #include "GLSLshader.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 
 #include <iostream>

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
@@ -15,7 +15,7 @@
 *** You should have received a copy of the GNU General Public License along
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSstdraw.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GStextures.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsurface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLsurface.cpp
@@ -18,7 +18,7 @@
 
 #include "Graphics_Systems/OpenGL/GLsurface_impl.h"
 #include "Graphics_Systems/OpenGL/GLtextures_impl.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GSsurface.h"
 #include "Graphics_Systems/General/GSprimitives.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtextures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLtextures.cpp
@@ -17,7 +17,7 @@
 **/
 
 #include "Graphics_Systems/OpenGL/GLtextures_impl.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GStextures_impl.h"
 #include "Graphics_Systems/General/GSprimitives.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLvertex.cpp
@@ -19,7 +19,7 @@
 //extension, then please be sure to update the graphics_init_vbo_method() helper below to ensure any
 //functions are properly aliased and will continue working on affected graphics cards.
 
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSvertex_impl.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GScolor_macros.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/OPENGLStd.cpp
@@ -19,8 +19,9 @@
 #include "GLshader.h"
 #include "GLSLshader.h"
 
+#include "Graphics_Systems/OpenGL/GLversion.h"
 #include "Graphics_Systems/OpenGL/GLscreen.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 
 #include "Universal_System/shaderstruct.h"
 #include "Universal_System/var4.h"
@@ -32,7 +33,7 @@
 using namespace std;
 
 namespace enigma {
-  const bool graphics_opengl_core = false;
+  const gl_profile_type graphics_opengl_profile = gl_profile_compat;
 
   void graphics_init_vbo_method();
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3d3d.cpp
@@ -20,7 +20,7 @@
 #include "GL3shader.h"
 #include "Graphics_Systems/OpenGL/GLenums.h"
 #include "Graphics_Systems/OpenGL/GLtextures_impl.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSd3d.h"
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GSblend.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -19,7 +19,7 @@
 
 #include "GL3profiler.h"
 #include "Graphics_Systems/OpenGL/GLscreen.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSscreen.h"
 #include "Graphics_Systems/General/GSbackground.h"
 #include "Graphics_Systems/General/GSsprite.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.cpp
@@ -17,7 +17,7 @@
 
 #include "GL3shader.h"
 #include "GLSLshader.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GStextures.h"
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3shader.h
@@ -20,7 +20,7 @@
 #define GL_SHADER_H
 
 #include "GLSLshader.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include <string>
 using std::string;
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
@@ -19,7 +19,7 @@
 #include "GLSLshader.h"
 #include "GL3shader.h"
 
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSstdraw.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GStextures.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3surface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3surface.cpp
@@ -18,7 +18,7 @@
 
 #include "Graphics_Systems/OpenGL/GLsurface_impl.h"
 #include "Graphics_Systems/OpenGL/GLtextures_impl.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSsurface.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GSscreen.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3textures.cpp
@@ -18,7 +18,7 @@
 
 #include "GL3aux.h" //glExtension_supported
 #include "Graphics_Systems/OpenGL/GLtextures_impl.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GStextures_impl.h"
 #include "Graphics_Systems/General/GSprimitives.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -21,7 +21,7 @@
 #include "GL3shader.h"
 #include "GLSLshader.h"
 
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSvertex_impl.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GScolors.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GLSLshader.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GLSLshader.h
@@ -26,7 +26,7 @@ using std::string;
 using std::vector;
 using std::unordered_map;
 
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 
 extern GLenum shadertypes[];
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
@@ -19,8 +19,9 @@
 #include "GL3shader.h"
 #include "GLSLshader.h"
 
+#include "Graphics_Systems/OpenGL/GLversion.h"
 #include "Graphics_Systems/OpenGL/GLscreen.h"
-#include "Graphics_Systems/OpenGL/OpenGLHeaders.h"
+#include "OpenGLHeaders.h"
 
 #ifdef DEBUG_MODE
 #include "Widget_Systems/widgets_mandatory.h"
@@ -42,7 +43,7 @@ extern string shader_get_name(int i);
 } // namespace enigma_user
 
 namespace enigma {
-  const bool graphics_opengl_core = true;
+  const gl_profile_type graphics_opengl_profile = gl_profile_core;
 
   unsigned default_shader;
   unsigned main_shader;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/Info/About.ey
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/Info/About.ey
@@ -1,0 +1,13 @@
+%e-yaml
+---
+
+Name: OpenGL ES
+Identifier: OpenGLES
+Description: Hardware-accelerated rendering on mobile and embedded systems using OpenGL ES.
+Author: Harijs Grinbergs, Robert B. Colton et al.
+
+Depends:
+	Windowing: SDL
+
+Represents:
+	Build-platforms: None

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/Info/graphics_info.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/Info/graphics_info.h
@@ -1,0 +1,5 @@
+// Informative header designed to grant superior control over platform-
+// or API-dependent behavior. This file can define any number of macros
+// describing various compatibility and feature points.
+
+#define ENIGMA_GS_OPENGLES 1

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/Makefile
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/Makefile
@@ -1,0 +1,11 @@
+SOURCES += $(wildcard Graphics_Systems/OpenGLES/*.cpp) $(wildcard Graphics_Systems/General/*.cpp) $(wildcard Graphics_Systems/None/*.cpp)
+override CXXFLAGS += -IBridges/OpenGLES
+override LDLIBS += -lepoxy
+
+ifeq ($(TARGET-PLATFORM), Windows)
+	override LDLIBS += -lopengl32
+else ifeq ($(TARGET-PLATFORM), Linux)
+	override LDLIBS += -lGL
+else ifeq ($(TARGET-PLATFORM), MacOSX)
+	override LDLIBS += -framework OpenGL
+endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/OPENGLESStd.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/OPENGLESStd.cpp
@@ -1,0 +1,7 @@
+#include "Graphics_Systems/OpenGL/GLversion.h"
+
+namespace enigma {
+
+const gl_profile_type graphics_opengl_profile = gl_profile_es;
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/include.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES/include.h
@@ -1,0 +1,2 @@
+#include "Info/graphics_info.h"
+#include "Graphics_Systems/General/include.h"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,9 @@ environment:
     - {PLATFORM: SDL, PACKAGES: "SDL2:x"}
 
     # Graphics
-    - {GRAPHICS: Direct3D11, PACKAGES: "glm:x"}
+    - {GRAPHICS: Direct3D11}
     - {GRAPHICS: OpenGL1, PACKAGES: "glew:x"}
+    - {GRAPHICS: OpenGLES, PLATFORM: SDL, PACKAGES: "libepoxy:x SDL2:x"}
 
     # Audio
     - {AUDIO: DirectSound}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ environment:
   WIDGETS: None
   EXTENSIONS: "None"
   PACKAGES: ""
+  PACKAGES_LATEST: ""
 
   matrix:
     # Game Modes
@@ -40,7 +41,7 @@ environment:
     # Graphics
     - {GRAPHICS: Direct3D11}
     - {GRAPHICS: OpenGL1, PACKAGES: "glew:x"}
-    - {GRAPHICS: OpenGLES, PLATFORM: SDL, PACKAGES: "libepoxy:x SDL2:x"}
+    - {GRAPHICS: OpenGLES, PLATFORM: SDL, PACKAGES_LATEST: "libepoxy:x", PACKAGES: "SDL2:x" }
 
     # Audio
     - {AUDIO: DirectSound}
@@ -78,6 +79,8 @@ install:
   - set PATH=C:\msys64;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;%PATH%
   - > # Install packages common to all builds
     bash -lc "pacboy --noconfirm -S boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x glm:x libpng:x %PACKAGES%"
+  - > # Install latest packages (OpenGLES needs fundies' patched libepoxy)
+    bash -lc "pacboy --noconfirm -Sy %PACKAGES_LATEST%"
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {


### PR DESCRIPTION
We're on the yellow brick road to GLES support now. To continue making this easier to digest I want to send this in little bits and pieces at a time. I want @JoshDreamland to be able to easily pick up on the architectural changes that are happening so he may offer better solutions if he has any. This pull request creates the new SDL-OpenGLES system combination and makes it compile on the CI to prevent it from breaking.

### Summary of Changes
* An OpenGL ES bridge folder has been created which uses libepoxy to load the GL ES extension points.
* An SDL to OpenGL ES bridge has been created. This bridge uses the GL ES libepoxy bridge for loading and compiles it with the SDL OpenGL bridge. I would like @JoshDreamland to consider that this bridge's makefile is using a wildcard on the SDL OpenGL bridge rather than including its makefile because that makefile includes GLEW.
* Created a GL version header with a new enum `gl_profile_type` to allow GL ES profile types. Replaced `graphics_opengl_core` boolean variable with `graphics_opengl_profile` so each backend can inform the bridge how to initialize the context.
* Moved `OpenGLHeaders.h` to the OpenGL bridge folder. This makes it easier to inject a different include, in our case `epoxy/gl.h`, in the OpenGL sources.
* Copied `OpenGLHeaders.h` to the OpenGLES bridge folder using epoxy to include GL.
* Created a new OpenGL ES graphics system. The system links to libepoxy so that bridges associated with it can load the OpenGL ES extension points. I compile the `None` system sources for now to make this diff small while allowing it to compile on an empty game. I do **NOT** include the general OpenGL makefile in this system's makefile because that makefile links to glew and includes the glew include.

### Problems I Forsee
* It seems like our build system is not friendly to injecting includes into sources like I am trying to do with `OpenGLHeaders.h` which may break switching between GL and GLES systems. What I mean is that despite using a different makefile with different include paths, the sources are not recompiled.
* The SDL/GL/GLES bridges may get messy because I am trying to use makefile inheritance rather than composition. I can change it to composition, but that will require a few net locs in the desktop SDL-GL bridges.