### PR TITLE
Add DS Priority Tests To CI

### DIFF
--- a/CommandLine/testing/SimpleTests/data_structure_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/data_structure_test.sog/create.edl
@@ -163,4 +163,60 @@ gtest_assert_true(ds_stack_exists(test_stack));
 ds_stack_destroy(test_stack);
 gtest_assert_false(ds_stack_exists(test_stack));
 
+/// DS Priority
+///////////////////////////////////////////////
+
+test_priority = ds_priority_create();
+test_priority2 = ds_priority_create();
+gtest_assert_true(ds_priority_exists(test_priority));
+gtest_assert_true(ds_priority_empty(test_priority));
+gtest_assert_true(ds_priority_exists(test_priority2));
+gtest_assert_true(ds_priority_empty(test_priority2));
+
+gtest_assert_true(is_undefined(ds_priority_find_min(test_priority)));
+gtest_assert_true(is_undefined(ds_priority_find_max(test_priority)));
+gtest_assert_true(is_undefined(ds_priority_find_priority(test_priority, "hello")));
+
+ds_priority_add(test_priority, "one", 56);
+ds_priority_add(test_priority, "two", 0);
+ds_priority_add(test_priority, "three", -5);
+gtest_assert_eq(ds_priority_size(test_priority), 3);
+gtest_assert_eq(ds_priority_find_min(test_priority), "three");
+gtest_assert_eq(ds_priority_find_max(test_priority), "one");
+gtest_assert_eq(ds_priority_find_priority(test_priority, "one"), 56);
+gtest_assert_eq(ds_priority_find_priority(test_priority, "two"), 0);
+
+ds_priority_copy(test_priority2, test_priority);
+gtest_assert_eq(ds_priority_size(test_priority2), 3);
+gtest_assert_false(ds_priority_empty(test_priority2));
+
+ds_priority_add(test_priority2, "five", 1);
+gtest_assert_eq(ds_priority_size(test_priority2), 4);
+
+gtest_assert_eq(ds_priority_delete_max(test_priority2), "one");
+gtest_assert_eq(ds_priority_size(test_priority2), 3);
+gtest_assert_eq(ds_priority_find_max(test_priority2), "five");
+
+gtest_assert_eq(ds_priority_delete_min(test_priority2), "three");
+gtest_assert_eq(ds_priority_size(test_priority2), 2);
+gtest_assert_eq(ds_priority_find_min(test_priority2), "two");
+
+ds_priority_add(test_priority2, "six", 101.1);
+ds_priority_add(test_priority2, "seven", -969);
+ds_priority_add(test_priority2, "eight", 42);
+gtest_assert_eq(ds_priority_size(test_priority2), 5);
+
+gtest_assert_false(is_undefined(ds_priority_find_priority(test_priority2, "six")));
+ds_priority_delete_value(test_priority2, "six");
+gtest_assert_eq(ds_priority_size(test_priority2), 4);
+gtest_assert_true(is_undefined(ds_priority_find_priority(test_priority2, "six")));
+
+ds_priority_clear(test_priority);
+gtest_assert_true(ds_priority_empty(test_priority));
+gtest_assert_eq(ds_priority_size(test_priority), 0);
+gtest_assert_true(ds_priority_exists(test_priority));
+
+ds_priority_destroy(test_priority);
+gtest_assert_false(ds_priority_exists(test_priority));
+
 game_end();

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/data_structures.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/data_structures.cpp
@@ -1503,7 +1503,7 @@ variant ds_priority_find_min(const unsigned int id)
 {
   //Returns the value with the smallest priority but does not delete it from the priority queue
   multimap<variant, variant>::iterator it = ds_prioritys[id].begin(), it_check;
-  if (it == ds_prioritys[id].end()) {return 0;}
+  if (it == ds_prioritys[id].end()) {return variant();}
   it_check = it++;
   while (it != ds_prioritys[id].end())
   {
@@ -1517,7 +1517,7 @@ variant ds_priority_delete_max(const unsigned int id)
 {
   //Returns the value with the smallest priority but does not delete it from the priority queue
   multimap<variant, variant>::iterator it = ds_prioritys[id].begin(), it_check;
-  if (it == ds_prioritys[id].end()) {return 0;}
+  if (it == ds_prioritys[id].end()) {return variant();}
   it_check = it++;
   while (it != ds_prioritys[id].end())
   {
@@ -1533,7 +1533,7 @@ variant ds_priority_find_max(const unsigned int id)
 {
   //Returns the value with the smallest priority but does not delete it from the priority queue
   multimap<variant, variant>::iterator it = ds_prioritys[id].begin(), it_check;
-  if (it == ds_prioritys[id].end()) {return 0;}
+  if (it == ds_prioritys[id].end()) {return variant();}
   it_check = it++;
   while (it != ds_prioritys[id].end())
   {


### PR DESCRIPTION
Friend of #1697, #1698, and #1699 expanding coverage of the CI to include data structure priority.

Like the changes I made for maps in #1697, I have changed the find functions of priority to return an undefined var when the value can't be found. I tested GMSv1.4 to make sure this is consistent, and it is. I find this to be sane and like the idea because the user is able to check the return value with `is_undefined` to see if something was found.
```cpp
var lol;
lol = ds_priority_create();
show_message(string(is_undefined(ds_priority_find_min(lol))));
show_message(string(is_undefined(ds_priority_find_max(lol))));
show_message(string(is_undefined(ds_priority_find_priority(lol, "ok"))));
```