### PR TITLE
Fix Show Error Scope

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.h
@@ -18,6 +18,11 @@
 #ifndef ENIGMA_DS_SYSTEM_H
 #define ENIGMA_DS_SYSTEM_H
 
+#ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
+#include "libEGMstd.h"
+#endif
+
 #include <dsound.h>
 #include <mmsystem.h>
 #include <stddef.h>

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.h
@@ -34,13 +34,13 @@ int get_free_channel(double priority);
 #ifdef DEBUG_MODE
 #define get_sound(snd, id, failure)                                              \
   if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {  \
-    show_error("Sound " + enigma_user::toString(id) + " does not exist", false); \
+    enigma_user::show_error("Sound " + enigma_user::toString(id) + " does not exist", false); \
     return failure;                                                              \
   }                                                                              \
   SoundResource *const snd = sound_resources[id];
 #define get_soundv(snd, id)                                                      \
   if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {  \
-    show_error("Sound " + enigma_user::toString(id) + " does not exist", false); \
+    enigma_user::show_error("Sound " + enigma_user::toString(id) + " does not exist", false); \
     return;                                                                      \
   }                                                                              \
   SoundResource *const snd = sound_resources[id];

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.h
@@ -37,17 +37,17 @@ namespace enigma {
 int get_free_channel(double priority);
 
 #ifdef DEBUG_MODE
-#define get_sound(snd, id, failure)                                              \
-  if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {  \
+#define get_sound(snd, id, failure)                                                           \
+  if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {               \
     enigma_user::show_error("Sound " + enigma_user::toString(id) + " does not exist", false); \
-    return failure;                                                              \
-  }                                                                              \
+    return failure;                                                                           \
+  }                                                                                           \
   SoundResource *const snd = sound_resources[id];
-#define get_soundv(snd, id)                                                      \
-  if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {  \
+#define get_soundv(snd, id)                                                                   \
+  if (id < 0 or size_t(id) >= sound_resources.size() or !sound_resources[id]) {               \
     enigma_user::show_error("Sound " + enigma_user::toString(id) + " does not exist", false); \
-    return;                                                                      \
-  }                                                                              \
+    return;                                                                                   \
+  }                                                                                           \
   SoundResource *const snd = sound_resources[id];
 #else
 #define get_sound(snd, id, failure) SoundResource *const snd = sound_resources[id];

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
@@ -18,11 +18,6 @@
 #ifndef ENIGMA_SOUND_RESOURCE_H
 #define ENIGMA_SOUND_RESOURCE_H
 
-#ifdef DEBUG_MODE
-#include "Widget_Systems/widgets_mandatory.h"  // show_error
-#include "libEGMstd.h"
-#endif
-
 #include <vector>
 using std::vector;
 

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALadvanced.cpp
@@ -34,11 +34,6 @@ using std::string;
 #include <AL/alure.h>
 #endif
 
-#ifdef DEBUG_MODE
-#include "Widget_Systems/widgets_mandatory.h"  // show_error
-#include "libEGMstd.h"
-#endif
-
 #include "Universal_System/estring.h"
 
 #include <vector>

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALsystem.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALsystem.h
@@ -21,6 +21,11 @@
 
 #ifndef ENIGMA_AL_SYSTEM_H
 #define ENIGMA_AL_SYSTEM_H
+
+#ifdef DEBUG_MODE
+#include "Widget_Systems/widgets_mandatory.h"  // show_error
+#endif
+
 #include <stddef.h>
 
 #ifdef __APPLE__
@@ -50,13 +55,13 @@ int get_free_channel(double priority);
 #ifdef DEBUG_MODE
 #define get_sound(snd, id, failure)                                                          \
   if (id < 0 or sound_resources.find(id) == sound_resources.end() or !sound_resources[id]) { \
-    show_error("Sound " + enigma_user::toString(id) + " does not exist", false);             \
+    enigma_user::show_error("Sound " + enigma_user::toString(id) + " does not exist", false);\
     return failure;                                                                          \
   }                                                                                          \
   SoundResource *const snd = sound_resources[id];
 #define get_soundv(snd, id)                                                                  \
   if (id < 0 or sound_resources.find(id) == sound_resources.end() or !sound_resources[id]) { \
-    show_error("Sound " + enigma_user::toString(id) + " does not exist", false);             \
+    enigma_user::show_error("Sound " + enigma_user::toString(id) + " does not exist", false);\
     return;                                                                                  \
   }                                                                                          \
   SoundResource *const snd = sound_resources[id];

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundChannel.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundChannel.h
@@ -20,11 +20,6 @@
 
 #include "ALsystem.h"
 
-#ifdef DEBUG_MODE
-#include "Widget_Systems/widgets_mandatory.h"  // show_error
-#include "libEGMstd.h"
-#endif
-
 #include <vector>
 using std::vector;
 

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundEmitter.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundEmitter.h
@@ -20,11 +20,6 @@
 
 #include "ALsystem.h"
 
-#ifdef DEBUG_MODE
-#include "Widget_Systems/widgets_mandatory.h"  // show_error
-#include "libEGMstd.h"
-#endif
-
 #include <vector>
 using std::vector;
 

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/SoundResource.h
@@ -21,11 +21,6 @@
 
 #include "ALsystem.h"
 
-#ifdef DEBUG_MODE
-#include "Widget_Systems/widgets_mandatory.h"  // show_error
-#include "libEGMstd.h"
-#endif
-
 #include <map>
 
 enum load_state { LOADSTATE_NONE, LOADSTATE_INDICATED, LOADSTATE_COMPLETE };

--- a/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/SoundChannel.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/SoundChannel.h
@@ -20,11 +20,6 @@
 #include "../General/ASadvanced.h"
 #include "XAsystem.h"
 
-#ifdef DEBUG_MODE
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
-#endif
-
 #include <vector>
 using std::vector;
 

--- a/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/SoundEmitter.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/SoundEmitter.h
@@ -18,11 +18,6 @@
 #ifndef ENIGMA_SOUND_EMITTER_H
 #define ENIGMA_SOUND_EMITTER_H
 
-#ifdef DEBUG_MODE
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
-#endif
-
 #include <vector>
 using std::vector;
 

--- a/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/SoundResource.h
@@ -19,11 +19,6 @@
 #define ENIGMA_SOUND_RESOURCE_H
 #include "../General/ASadvanced.h"
 
-#ifdef DEBUG_MODE
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
-#endif
-
 #include <vector>
 using std::vector;
 

--- a/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/XAadvanced.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/XAadvanced.cpp
@@ -26,11 +26,6 @@ using std::string;
 #include "SoundEmitter.h"
 #include "XAsystem.h"
 
-#ifdef DEBUG_MODE
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
-#endif
-
 #include "Universal_System/estring.h"
 
 #include <vector>
@@ -255,4 +250,3 @@ void audio_play_sound_on(int emitter, int sound, bool loop, double priority)
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/XAbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/XAudio2/XAbasic.cpp
@@ -26,11 +26,6 @@ using std::string;
 #include "SoundEmitter.h"
 #include "XAsystem.h"
 
-#ifdef DEBUG_MODE
-#include "libEGMstd.h"
-#include "Widget_Systems/widgets_mandatory.h" // show_error
-#endif
-
 #include "Universal_System/estring.h"
 
 #include <vector>

--- a/ENIGMAsystem/SHELL/Bridges/OpenGL/GLload.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/OpenGL/GLload.cpp
@@ -8,7 +8,7 @@ namespace enigma {
 void gl_load_exts() {
   GLenum err = glewInit();
   if (GLEW_OK != err)
-    show_error(std::string("Failed to initialize glew for OpenGL. ") + (const char*)glewGetErrorString(err), true);
+    enigma_user::show_error(std::string("Failed to initialize glew for OpenGL. ") + (const char*)glewGetErrorString(err), true);
 }
 
 }

--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D11/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D11/graphics_bridge.cpp
@@ -26,6 +26,8 @@
 #include <windows.h>
 #include <d3d11.h>
 
+using enigma_user::show_error;
+
 namespace enigma {
 
 extern HWND hWnd;

--- a/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-Direct3D9/graphics_bridge.cpp
@@ -76,7 +76,7 @@ void Reset(D3DPRESENT_PARAMETERS *d3dpp) {
   OnDeviceLost();
   HRESULT hr = d3ddev->Reset(d3dpp);
   if (FAILED(hr)) {
-    show_error("Direct3D 9 Device Reset Failed", true);
+    enigma_user::show_error("Direct3D 9 Device Reset Failed", true);
   }
   // the normal, managed d3d 9.0 does not automatically restore render state
   if (Direct3D9Managed) graphics_state_flush();
@@ -188,7 +188,7 @@ void EnableDrawing(void* handle) {
                               &d3ddev);
 
     if (FAILED(hr)) {
-      show_error("Failed to create Direct3D 9.0 Device", true);
+      enigma_user::show_error("Failed to create Direct3D 9.0 Device", true);
     }
   }
 

--- a/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/Win32-OpenGL/graphics_bridge.cpp
@@ -62,7 +62,7 @@ void EnableDrawing(void*)
   pfd.iLayerType = PFD_MAIN_PLANE;
   iFormat = ChoosePixelFormat (enigma::window_hDC, &pfd);
 
-  if (iFormat==0) { show_error("Failed to set the format of the OpenGL graphics device.",1); }
+  if (iFormat==0) { enigma_user::show_error("Failed to set the format of the OpenGL graphics device.",1); }
 
   SetPixelFormat ( enigma::window_hDC, iFormat, &pfd );
   LegacyRC = wglCreateContext( enigma::window_hDC );

--- a/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
+++ b/ENIGMAsystem/SHELL/Bridges/xlib-OpenGL/graphics_bridge.cpp
@@ -46,7 +46,7 @@ namespace enigma {
     GLint att[] = { GLX_RGBA, GLX_DOUBLEBUFFER, GLX_DEPTH_SIZE, 24, None };
     vi = glXChooseVisual(enigma::x11::disp,0,att);
     if (!vi)
-      show_error("Failed to Obtain GL Visual Info", true);
+      enigma_user::show_error("Failed to Obtain GL Visual Info", true);
     return vi;
   }
 
@@ -56,7 +56,7 @@ namespace enigma {
     //give us a GL context
     glxc = glXCreateContext(enigma::x11::disp, vi, NULL, True);
     if (!glxc)
-      show_error("Failed to Create Graphics Context", true);
+      enigma_user::show_error("Failed to Create Graphics Context", true);
 
     //apply context
     glXMakeCurrent(enigma::x11::disp,enigma::x11::win,glxc); //flushes

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/OPENGL3Std.cpp
@@ -90,7 +90,7 @@ namespace enigma {
     char finalMessage[256];
     FormatDebugOutputARB(finalMessage, 256, source, type, id, severity, message);
     printf("%s\n", finalMessage);
-    show_error(toString(finalMessage), false);
+    enigma_user::show_error(toString(finalMessage), false);
   }
 #endif
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BasicGUI/elements.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BasicGUI/elements.h
@@ -37,6 +37,7 @@
   #include <string>
   #include "libEGMstd.h"
   #include "Widget_Systems/widgets_mandatory.h"
+  using enigma_user::show_error;
   //This checks and returns an element
   #define get_elementv(element,clastype,entype,id,ret)\
     if (gui::gui_elements.find(id) == gui::gui_elements.end() || gui::gui_elements[id].type != entype) {\

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2DPhysics/Box2DJoint.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2DPhysics/Box2DJoint.h
@@ -43,12 +43,12 @@ extern vector<B2DJoint*> b2djoints;
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_jointr(j,id,r) \
     if (unsigned(id) >= b2djoints.size() || id < 0) { \
-      show_error("Cannot access Box2D physics joint with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics joint with id " + toString(id), false); \
       return r; \
     } B2DJoint* j = b2djoints[id];
   #define get_joint(j,id) \
     if (unsigned(id) >= b2djoints.size() || id < 0) { \
-      show_error("Cannot access Box2D physics joint with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics joint with id " + toString(id), false); \
       return; \
     } B2DJoint* j = b2djoints[id];
 #else

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2DPhysics/Box2DShape.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2DPhysics/Box2DShape.h
@@ -67,27 +67,27 @@ extern vector<B2DFixture*> b2dfixtures;
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_shaper(s,id,r) \
     if (unsigned(id) >= b2dshapes.size() || id < 0) { \
-      show_error("Cannot access Box2D physics shape with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics shape with id " + toString(id), false); \
       return r; \
     } B2DShape* s = b2dshapes[id];
   #define get_shape(s,id) \
     if (unsigned(id) >= b2dshapes.size() || id < 0) { \
-      show_error("Cannot access Box2D physics shape with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics shape with id " + toString(id), false); \
       return; \
     } B2DShape* s = b2dshapes[id];
   #define get_fixturer(f,id,r) \
     if (unsigned(id) >= b2dfixtures.size() || id < 0) { \
-      show_error("Cannot access Box2D physics fixture with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics fixture with id " + toString(id), false); \
       return r; \
     } B2DFixture* f = b2dfixtures[id];
   #define get_fixture(f,id) \
     if (unsigned(id) >= b2dfixtures.size() || id < 0) { \
-      show_error("Cannot access Box2D physics fixture with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics fixture with id " + toString(id), false); \
       return; \
     } B2DFixture* f = b2dfixtures[id];
   #define check_cast(obj, shapeid, failv) { \
     if ((obj)->shape != shapeid) { \
-      show_error("Invalid cast of Box2D shape.", false); return failv; \
+      enigma_user::show_error("Invalid cast of Box2D shape.", false); return failv; \
     } }
 #else
   #define get_shaper(s,id,r) \

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2DPhysics/Box2DWorld.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Box2DPhysics/Box2DWorld.h
@@ -76,22 +76,22 @@ extern vector<B2DBody*> b2dbodies;
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_worldr(w,id,r) \
     if (unsigned(id) >= b2dworlds.size() || id < 0) { \
-      show_error("Cannot access Box2D physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics world with id " + toString(id), false); \
       return r; \
     } B2DWorld* w = b2dworlds[id];
   #define get_world(w,id) \
     if (unsigned(id) >= b2dworlds.size() || id < 0) { \
-      show_error("Cannot access Box2D physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics world with id " + toString(id), false); \
       return; \
     } B2DWorld* w = b2dworlds[id];
   #define get_bodyr(b,id,r) \
     if (unsigned(id) >= b2dbodies.size() || id < 0) { \
-      show_error("Cannot access Box2D physics body with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics body with id " + toString(id), false); \
       return r; \
     } B2DBody* b = b2dbodies[id];
   #define get_body(b,id) \
     if (unsigned(id) >= b2dbodies.size() || id < 0) { \
-      show_error("Cannot access Box2D physics body with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Box2D physics body with id " + toString(id), false); \
       return; \
     } B2DBody* b = b2dbodies[id];
 #else

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletRigidBody.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletRigidBody.h
@@ -20,12 +20,12 @@
   #include "libEGMstd.h"
   #define get_bodyr(w,id,r) \
     if (unsigned(id) >= bulletBodies.size() || id < 0) { \
-      show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \
       return r; \
     } BulletBody* w = bulletBodies[id];
   #define get_body(w,id) \
     if (unsigned(id) >= bulletBodies.size() || id < 0) { \
-      show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \
       return; \
     } BulletBody* w = bulletBodies[id];
 #else

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletShape.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletShape.h
@@ -20,12 +20,12 @@
   #include "libEGMstd.h"
   #define get_shaper(s,id,r) \
     if (unsigned(id) >= bulletShapes.size() || id < 0) { \
-      show_error("Cannot access Bullet Dynamics physics shape with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Bullet Dynamics physics shape with id " + toString(id), false); \
       return r; \
     } BulletShape* s = bulletShapes[id];
   #define get_shape(s,id) \
     if (unsigned(id) >= bulletShapes.size() || id < 0) { \
-      show_error("Cannot access Bullet Dynamics physics shape with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Bullet Dynamics physics shape with id " + toString(id), false); \
       return; \
     } BulletShape* s = bulletShapes[id];
 #else

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletSoftBody.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletSoftBody.h
@@ -20,12 +20,12 @@
   #include "libEGMstd.h"
   #define get_softbodyr(w,id,r) \
     if (unsigned(id) >= bulletSoftBodies.size() || id < 0) { \
-      show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \
       return r; \
     } BulletSoftBody* w = bulletSoftBodies[id];
   #define get_softbody(w,id) \
     if (unsigned(id) >= bulletSoftBodies.size() || id < 0) { \
-      show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Bullet Dynamics physics body with id " + toString(id), false); \
       return; \
     } BulletSoftBody* w = bulletSoftBodies[id];
 #else

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletWorld.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/BulletDynamics/BulletWorld.h
@@ -20,17 +20,17 @@
   #include "libEGMstd.h"
   #define get_worldr(w,id,r) \
     if (unsigned(id) >= bulletWorlds.size() || id < 0) { \
-      show_error("Cannot access Bullet Dynamics physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Bullet Dynamics physics world with id " + toString(id), false); \
       return r; \
     } BulletWorld* w = bulletWorlds[id];
   #define get_world(w,id) \
     if (unsigned(id) >= bulletWorlds.size() || id < 0) { \
-      show_error("Cannot access Bullet Dynamics physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access Bullet Dynamics physics world with id " + toString(id), false); \
       return; \
     } BulletWorld* w = bulletWorlds[id];
   #define get_worldc(w,id, c) \
     if (unsigned(id) >= bulletWorlds.size() || id < 0) { \
-      show_error("Cannot cast Bullet Dynamics physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot cast Bullet Dynamics physics world with id " + toString(id), false); \
       return; \
     } c w = (c) bulletWorlds[id]->dynamicsWorld;
 #else

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DirectShow/VideoStruct.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DirectShow/VideoStruct.h
@@ -28,11 +28,11 @@ namespace enigma {
 
 struct VideoStruct {
     IGraphBuilder *pGraph = NULL;
-	
+
 	VideoStruct() {
-	
+
 	}
-	
+
 	~VideoStruct() {
 		pGraph->Release();
 	}
@@ -47,12 +47,12 @@ extern vector<VideoStruct*> videoStructs;
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_videor(s,id,r) \
     if (unsigned(id) >= enigma::videoStructs.size() || id < 0) { \
-      show_error("Cannot access video with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access video with id " + toString(id), false); \
       return r; \
     } enigma::VideoStruct* s = enigma::videoStructs[id];
   #define get_video(s,id) \
     if (unsigned(id) >= enigma::videoStructs.size() || id < 0) { \
-      show_error("Cannot access video with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access video with id " + toString(id), false); \
       return; \
     } enigma::VideoStruct* s = enigma::videoStructs[id];
 #else

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Json/json_reader.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Json/json_reader.cpp
@@ -21,7 +21,7 @@
 #pragma warning( disable : 4996 )   // disable warning about strdup being deprecated.
 #endif
 
-namespace Json 
+namespace Json
 {
 Features::Features()   : allowComments_( true )   , strictRoot_( false )
 {
@@ -96,7 +96,7 @@ bool Reader::parse( std::istream& sin,Value &root,bool collectComments )
 bool Reader::parse( const char *beginDoc, const char *endDoc, Value &root,bool collectComments )
 {
    if ( !features_.allowComments_ )
-   
+
 {
       collectComments = false;
    }
@@ -112,17 +112,17 @@ bool Reader::parse( const char *beginDoc, const char *endDoc, Value &root,bool c
    while ( !nodes_.empty() )
       nodes_.pop();
    nodes_.push( &root );
-   
+
    bool successful = readValue();
    Token token;
    skipCommentTokens( token );
    if ( collectComments_  &&  !commentsBefore_.empty() )
       root.setComment( commentsBefore_, commentAfter );
    if ( features_.strictRoot_ )
-   
+
 {
       if ( !root.isArray()  &&  !root.isObject() )
-      
+
 {
          // Set error location to start of doc, ideally should be first token found in doc
          token.type_ = tokenError;
@@ -144,7 +144,7 @@ bool Reader::readValue()
    bool successful = true;
 
    if ( collectComments_  &&  !commentsBefore_.empty() )
-   
+
 {
       currentValue().setComment( commentsBefore_, commentBefore );
       commentsBefore_ = "";
@@ -152,7 +152,7 @@ bool Reader::readValue()
 
 
    switch ( token.type_ )
-   
+
 {
    case tokenObjectBegin:
       successful = readObject( token );
@@ -180,7 +180,7 @@ bool Reader::readValue()
    }
 
    if ( collectComments_ )
-   
+
 {
       lastValueEnd_ = current_;
       lastValue_ = &currentValue();
@@ -193,17 +193,17 @@ bool Reader::readValue()
 void Reader::skipCommentTokens( Token &token )
 {
    if ( features_.allowComments_ )
-   
+
 {
       do
-      
+
 {
          readToken( token );
       }
       while ( token.type_ == tokenComment );
    }
    else
-   
+
 {
       readToken( token );
    }
@@ -226,7 +226,7 @@ bool Reader::readToken( Token &token )
    Char c = getNextChar();
    bool ok = true;
    switch ( c )
-   
+
 {
    case '{':
       token.type_ = tokenObjectBegin;
@@ -297,7 +297,7 @@ bool Reader::readToken( Token &token )
 void Reader::skipSpaces()
 {
    while ( current_ != end_ )
-   
+
 {
       Char c = *current_;
       if ( c == ' '  ||  c == '\t'  ||  c == '\r'  ||  c == '\n' )
@@ -334,11 +334,11 @@ bool Reader::readComment()
       return false;
 
    if ( collectComments_ )
-   
+
 {
       CommentPlacement placement = commentBefore;
       if ( lastValueEnd_  &&  !containsNewLine( lastValueEnd_, commentBegin ) )
-      
+
 {
          if ( c != '*'  ||  !containsNewLine( commentBegin, current_ ) )
             placement = commentAfterOnSameLine;
@@ -354,13 +354,13 @@ void Reader::addComment( Location begin, Location end, CommentPlacement placemen
 {
    assert( collectComments_ );
    if ( placement == commentAfterOnSameLine )
-   
+
 {
       assert( lastValue_ != 0 );
       lastValue_->setComment( std::string( begin, end ), placement );
    }
    else
-   
+
 {
       if ( !commentsBefore_.empty() )
          commentsBefore_ += "\n";
@@ -372,7 +372,7 @@ void Reader::addComment( Location begin, Location end, CommentPlacement placemen
 bool Reader::readCStyleComment()
 {
    while ( current_ != end_ )
-   
+
 {
       Char c = getNextChar();
       if ( c == '*'  &&  *current_ == '/' )
@@ -385,7 +385,7 @@ bool Reader::readCStyleComment()
 bool Reader::readCppStyleComment()
 {
    while ( current_ != end_ )
-   
+
 {
       Char c = getNextChar();
       if (  c == '\r'  ||  c == '\n' )
@@ -398,7 +398,7 @@ bool Reader::readCppStyleComment()
 void Reader::readNumber()
 {
    while ( current_ != end_ )
-   
+
 {
       if ( !(*current_ >= '0'  &&  *current_ <= '9')  &&
            !in( *current_, '.', 'e', 'E', '+', '-' ) )
@@ -411,7 +411,7 @@ bool Reader::readString()
 {
    Char c = 0;
    while ( current_ != end_ )
-   
+
 {
       c = getNextChar();
       if ( c == '\\' )
@@ -429,7 +429,7 @@ bool Reader::readObject( Token &/*tokenStart*/ )
    std::string name;
    currentValue() = Value( objectValue );
    while ( readToken( tokenName ) )
-   
+
 {
       bool initialTokenOk = true;
       while ( tokenName.type_ == tokenComment  &&  initialTokenOk )
@@ -440,17 +440,17 @@ bool Reader::readObject( Token &/*tokenStart*/ )
          return true;
       if ( tokenName.type_ != tokenString )
          break;
-      
+
       name = "";
       if ( !decodeString( tokenName, name ) )
          return recoverFromError( tokenObjectEnd );
 
       Token colon;
       if ( !readToken( colon ) ||  colon.type_ != tokenMemberSeparator )
-      
+
 {
-         return addErrorAndRecover( "Missing ':' after object member name", 
-                                    colon, 
+         return addErrorAndRecover( "Missing ':' after object member name",
+                                    colon,
                                     tokenObjectEnd );
       }
       Value &value = currentValue()[ name ];
@@ -462,13 +462,13 @@ bool Reader::readObject( Token &/*tokenStart*/ )
 
       Token comma;
       if ( !readToken( comma )
-            ||  ( comma.type_ != tokenObjectEnd  &&  
+            ||  ( comma.type_ != tokenObjectEnd  &&
                   comma.type_ != tokenArraySeparator &&
                   comma.type_ != tokenComment ) )
-      
+
 {
-         return addErrorAndRecover( "Missing ',' or '}' in object declaration", 
-                                    comma, 
+         return addErrorAndRecover( "Missing ',' or '}' in object declaration",
+                                    comma,
                                     tokenObjectEnd );
       }
       bool finalizeTokenOk = true;
@@ -478,8 +478,8 @@ bool Reader::readObject( Token &/*tokenStart*/ )
       if ( comma.type_ == tokenObjectEnd )
          return true;
    }
-   return addErrorAndRecover( "Missing '}' or object member name", 
-                              tokenName, 
+   return addErrorAndRecover( "Missing '}' or object member name",
+                              tokenName,
                               tokenObjectEnd );
 }
 
@@ -489,7 +489,7 @@ bool Reader::readArray( Token &/*tokenStart*/ )
    currentValue() = Value( arrayValue );
    skipSpaces();
    if ( *current_ == ']' ) // empty array
-   
+
 {
       Token endArray;
       readToken( endArray );
@@ -497,7 +497,7 @@ bool Reader::readArray( Token &/*tokenStart*/ )
    }
    int index = 0;
    for (;;)
-   
+
 {
       Value &value = currentValue()[ index++ ];
       nodes_.push( &value );
@@ -510,17 +510,17 @@ bool Reader::readArray( Token &/*tokenStart*/ )
       // Accept Comment after last item in the array.
       ok = readToken( token );
       while ( token.type_ == tokenComment  &&  ok )
-      
+
 {
          ok = readToken( token );
       }
       bool badTokenType = ( token.type_ != tokenArraySeparator  &&
                             token.type_ != tokenArrayEnd );
       if ( !ok  ||  badTokenType )
-      
+
 {
-         return addErrorAndRecover( "Missing ',' or ']' in array declaration", 
-                                    token, 
+         return addErrorAndRecover( "Missing ',' or ']' in array declaration",
+                                    token,
                                     tokenArrayEnd );
       }
       if ( token.type_ == tokenArrayEnd )
@@ -534,10 +534,10 @@ bool Reader::decodeNumber( Token &token )
 {
    bool isDouble = false;
    for ( Location inspect = token.start_; inspect != token.end_; ++inspect )
-   
+
 {
-      isDouble = isDouble  
-                 ||  in( *inspect, '.', 'e', 'E', '+' )  
+      isDouble = isDouble
+                 ||  in( *inspect, '.', 'e', 'E', '+' )
                  ||  ( *inspect == '-'  &&  inspect != token.start_ );
    }
    if ( isDouble )
@@ -549,27 +549,27 @@ bool Reader::decodeNumber( Token &token )
    bool isNegative = *current == '-';
    if ( isNegative )
       ++current;
-   Value::LargestUInt maxIntegerValue = isNegative ? Value::LargestUInt(-Value::minLargestInt) 
+   Value::LargestUInt maxIntegerValue = isNegative ? Value::LargestUInt(-Value::minLargestInt)
                                                    : Value::maxLargestUInt;
    Value::LargestUInt threshold = maxIntegerValue / 10;
    Value::UInt lastDigitThreshold = Value::UInt( maxIntegerValue % 10 );
    assert( lastDigitThreshold >=0  &&  lastDigitThreshold <= 9 );
    Value::LargestUInt value = 0;
    while ( current < token.end_ )
-   
+
 {
       Char c = *current++;
       if ( c < '0'  ||  c > '9' )
          return addError( "'" + std::string( token.start_, token.end_ ) + "' is not a number.", token );
       Value::UInt digit(c - '0');
       if ( value >= threshold )
-      
+
 {
          // If the current digit is not the last one, or if it is
          // greater than the last digit of the maximum integer value,
          // the parse the number as a double.
          if ( current != token.end_  ||  digit > lastDigitThreshold )
-         
+
 {
             return decodeDouble( token );
          }
@@ -593,7 +593,7 @@ bool Reader::decodeDouble( Token &token )
    int count;
    int length = int(token.end_ - token.start_);
    if ( length <= bufferSize )
-   
+
 {
       Char buffer[bufferSize+1];
       memcpy( buffer, token.start_, length );
@@ -601,7 +601,7 @@ bool Reader::decodeDouble( Token &token )
       count = sscanf( buffer, "%lf", &value );
    }
    else
-   
+
 {
       std::string buffer( token.start_, token.end_ );
       count = sscanf( buffer.c_str(), "%lf", &value );
@@ -630,19 +630,19 @@ bool Reader::decodeString( Token &token, std::string &decoded )
    Location current = token.start_ + 1; // skip '"'
    Location end = token.end_ - 1;      // do not include '"'
    while ( current != end )
-   
+
 {
       Char c = *current++;
       if ( c == '"' )
          break;
       else if ( c == '\\' )
-      
+
 {
          if ( current == end )
             return addError( "Empty escape sequence in string", token, current );
          Char escape = *current++;
          switch ( escape )
-         
+
 {
          case '"': decoded += '"'; break;
          case '/': decoded += '/'; break;
@@ -653,7 +653,7 @@ bool Reader::decodeString( Token &token, std::string &decoded )
          case 'r': decoded += '\r'; break;
          case 't': decoded += '\t'; break;
          case 'u':
-            
+
 {
                unsigned int unicode;
                if ( !decodeUnicodeCodePoint( token, current, end, unicode ) )
@@ -666,7 +666,7 @@ bool Reader::decodeString( Token &token, std::string &decoded )
          }
       }
       else
-      
+
 {
          decoded += c;
       }
@@ -680,23 +680,23 @@ bool Reader::decodeUnicodeCodePoint( Token &token, Location &current,    Locatio
    if ( !decodeUnicodeEscapeSequence( token, current, end, unicode ) )
       return false;
    if (unicode >= 0xD800 && unicode <= 0xDBFF)
-   
+
 {
       // surrogate pairs
       if (end - current < 6)
          return addError( "additional six characters expected to parse unicode surrogate pair.", token, current );
       unsigned int surrogatePair;
       if (*(current++) == '\\' && *(current++)== 'u')
-      
+
 {
          if (decodeUnicodeEscapeSequence( token, current, end, surrogatePair ))
-         
+
 {
             unicode = 0x10000 + ((unicode & 0x3FF) << 10) + (surrogatePair & 0x3FF);
-         } 
+         }
          else
             return false;
-      } 
+      }
       else
          return addError( "expecting another \\u token to begin the second half of a unicode surrogate pair", token, current );
    }
@@ -709,7 +709,7 @@ bool Reader::decodeUnicodeEscapeSequence( Token &token,   Location &current,  Lo
       return addError( "Bad unicode escape sequence in string: four digits expected.", token, current );
    unicode = 0;
    for ( int index =0; index < 4; ++index )
-   
+
 {
       Char c = *current++;
       unicode *= 16;
@@ -742,7 +742,7 @@ bool Reader::recoverFromError( TokenType skipUntilToken )
    int errorCount = int(errors_.size());
    Token skip;
    for (;;)
-   
+
 {
       if ( !readToken(skip) )
          errors_.resize( errorCount ); // discard errors caused by recovery
@@ -781,11 +781,11 @@ void Reader::getLocationLineAndColumn( Location location,  int &line, int &colum
    Location lastLineStart = current;
    line = 0;
    while ( current < location  &&  current != end_ )
-   
+
 {
       Char c = *current++;
       if ( c == '\r' )
-      
+
 {
          if ( *current == '\n' )
             ++current;
@@ -793,7 +793,7 @@ void Reader::getLocationLineAndColumn( Location location,  int &line, int &colum
          ++line;
       }
       else if ( c == '\n' )
-      
+
 {
          lastLineStart = current;
          ++line;
@@ -828,7 +828,7 @@ std::string Reader::getFormattedErrorMessages() const
    for ( Errors::const_iterator itError = errors_.begin();
          itError != errors_.end();
          ++itError )
-   
+
 {
       const ErrorInfo &error = *itError;
       formattedMessage += "* " + getLocationLineAndColumn( error.token_.start_ ) + "\n";
@@ -845,7 +845,7 @@ std::istream& operator>>( std::istream &sin, Value &root )
     Json::Reader reader;
     bool ok = reader.parse(sin, root, true);
     //JSON_ASSERT( ok );
-    if (!ok) show_error(reader.getFormattedErrorMessages(), 1);
+    if (!ok) enigma_user::show_error(reader.getFormattedErrorMessages(), 1);
     return sin;
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Json/json_value.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Json/json_value.cpp
@@ -24,8 +24,8 @@
 
 #if DEBUG_MODE || (defined(SHOW_ERRORS) && SHOW_ERRORS)
   #define JSON_ASSERT_UNREACHABLE assert( false )
-  #define JSON_ASSERT( condition ) (condition ? void() : show_error("Assertion failed: " #condition, true))
-  #define JSON_FAIL_MESSAGE( message ) show_error(message, true)
+  #define JSON_ASSERT( condition ) (condition ? void() : enigma_user::show_error("Assertion failed: " #condition, true))
+  #define JSON_FAIL_MESSAGE( message ) enigma_user::show_error(message, true)
   #define JSON_ASSERT_MESSAGE( condition, message ) if (!( condition )) JSON_FAIL_MESSAGE( message )
 #else
   #define JSON_ASSERT_UNREACHABLE
@@ -34,7 +34,7 @@
   #define JSON_ASSERT_MESSAGE( condition, message )
 #endif
 
-namespace Json 
+namespace Json
 {
 const Value Value::null;
 const Int Value::minInt = Int( ~(UInt(-1)/2) );
@@ -73,7 +73,7 @@ static inline void releaseStringValue( char *value )
 # endif // JSON_VALUE_USE_INTERNAL_MAP
 # include "json_valueiterator.inl"
 #endif // if !defined(JSON_IS_AMALGAMATION)
-namespace Json 
+namespace Json
 {
 Value::CommentInfo::CommentInfo(): comment_( 0 )
 {
@@ -129,14 +129,14 @@ Value::CZString & Value::CZString::operator =( const CZString &other )
    return *this;
 }
 
-bool Value::CZString::operator<( const CZString &other ) const 
+bool Value::CZString::operator<( const CZString &other ) const
 {
    if ( cstr_ )
       return strcmp( cstr_, other.cstr_ ) < 0;
    return index_ < other.index_;
 }
 
-bool Value::CZString::operator==( const CZString &other ) const 
+bool Value::CZString::operator==( const CZString &other ) const
 {
    if ( cstr_ )
       return strcmp( cstr_, other.cstr_ ) == 0;
@@ -168,7 +168,7 @@ Value::Value( ValueType type )   : type_( type )   , allocated_( 0 )   , comment
 
 {
    switch ( type )
-   
+
 {
    case nullValue:
       break;
@@ -325,7 +325,7 @@ Value::Value( const Value &other )   : type_( other.type_ )   , comments_( 0 )
 
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
    case intValue:
@@ -336,7 +336,7 @@ Value::Value( const Value &other )   : type_( other.type_ )   , comments_( 0 )
       break;
    case stringValue:
       if ( other.value_.string_ )
-      
+
 {
          value_.string_ = duplicateStringValue( other.value_.string_ );
          allocated_ = true;
@@ -361,11 +361,11 @@ Value::Value( const Value &other )   : type_( other.type_ )   , comments_( 0 )
       JSON_ASSERT_UNREACHABLE;
    }
    if ( other.comments_ )
-   
+
 {
       comments_ = new CommentInfo[numberOfCommentPlacement];
       for ( int comment =0; comment < numberOfCommentPlacement; ++comment )
-      
+
 {
          const CommentInfo &otherComment = other.comments_[comment];
          if ( otherComment.comment_ )
@@ -378,7 +378,7 @@ Value::Value( const Value &other )   : type_( other.type_ )   , comments_( 0 )
 Value::~Value()
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
    case intValue:
@@ -451,7 +451,7 @@ bool Value::operator <( const Value &other ) const
    if ( typeDelta )
       return typeDelta < 0 ? true : false;
    switch ( type_ )
-   
+
 {
    case nullValue:
       return false;
@@ -465,13 +465,13 @@ bool Value::operator <( const Value &other ) const
       return value_.bool_ < other.value_.bool_;
    case stringValue:
       return ( value_.string_ == 0  &&  other.value_.string_ )
-             || ( other.value_.string_  
-                  &&  value_.string_  
+             || ( other.value_.string_
+                  &&  value_.string_
                   && strcmp( value_.string_, other.value_.string_ ) < 0 );
 #ifndef JSON_VALUE_USE_INTERNAL_MAP
    case arrayValue:
    case objectValue:
-      
+
 {
          int delta = int( value_.map_->size() - other.value_.map_->size() );
          if ( delta )
@@ -515,7 +515,7 @@ bool Value::operator ==( const Value &other ) const
    if ( type_ != temp )
       return false;
    switch ( type_ )
-   
+
 {
    case nullValue:
       return true;
@@ -529,8 +529,8 @@ bool Value::operator ==( const Value &other ) const
       return value_.bool_ == other.value_.bool_;
    case stringValue:
       return ( value_.string_ == other.value_.string_ )
-             || ( other.value_.string_  
-                  &&  value_.string_  
+             || ( other.value_.string_
+                  &&  value_.string_
                   && strcmp( value_.string_, other.value_.string_ ) == 0 );
 #ifndef JSON_VALUE_USE_INTERNAL_MAP
    case arrayValue:
@@ -564,7 +564,7 @@ const char * Value::asCString() const
 std::string Value::asString() const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return "";
@@ -585,7 +585,7 @@ std::string Value::asString() const
 }
 
 # ifdef JSON_USE_CPPTL
-CppTL::ConstString 
+CppTL::ConstString
 Value::asConstString() const
 
 {
@@ -596,7 +596,7 @@ Value::asConstString() const
 Value::Int Value::asInt() const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return 0;
@@ -625,7 +625,7 @@ Value::Int Value::asInt() const
 Value::UInt Value::asUInt() const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return 0;
@@ -657,7 +657,7 @@ Value::UInt Value::asUInt() const
 Value::Int64 Value::asInt64() const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return 0;
@@ -687,7 +687,7 @@ Value::asUInt64() const
 
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return 0;
@@ -736,7 +736,7 @@ LargestUInt Value::asLargestUInt() const
 double Value::asDouble() const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return 0.0;
@@ -765,7 +765,7 @@ double Value::asDouble() const
 float Value::asFloat() const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return 0.0f;
@@ -794,7 +794,7 @@ float Value::asFloat() const
 bool Value::asBool() const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return false;
@@ -820,7 +820,7 @@ bool Value::asBool() const
 bool Value::isConvertibleTo( ValueType other ) const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
       return true;
@@ -872,7 +872,7 @@ bool Value::isConvertibleTo( ValueType other ) const
 ArrayIndex Value::size() const
 {
    switch ( type_ )
-   
+
 {
    case nullValue:
    case intValue:
@@ -884,7 +884,7 @@ ArrayIndex Value::size() const
 #ifndef JSON_VALUE_USE_INTERNAL_MAP
    case arrayValue:  // size of the array is highest index + 1
       if ( !value_.map_->empty() )
-      
+
 {
          ObjectValues::const_iterator itLast = value_.map_->end();
          --itLast;
@@ -926,7 +926,7 @@ void Value::clear()
    JSON_ASSERT( type_ == nullValue  ||  type_ == arrayValue  || type_ == objectValue );
 
    switch ( type_ )
-   
+
 {
 #ifndef JSON_VALUE_USE_INTERNAL_MAP
    case arrayValue:
@@ -958,10 +958,10 @@ void Value::resize( ArrayIndex newSize )
    else if ( newSize > oldSize )
       (*this)[ newSize - 1 ];
    else
-   
+
 {
       for ( ArrayIndex index = newSize; index < oldSize; ++index )
-      
+
 {
          value_.map_->erase( index );
       }
@@ -1037,7 +1037,7 @@ Value & Value::resolveReference( const char *key,    bool isStatic )
    if ( type_ == nullValue )
       *this = Value( objectValue );
 #ifndef JSON_VALUE_USE_INTERNAL_MAP
-   CZString actualKey( key, isStatic ? CZString::noDuplication 
+   CZString actualKey( key, isStatic ? CZString::noDuplication
                                      : CZString::duplicateOnCopy );
    ObjectValues::iterator it = value_.map_->lower_bound( actualKey );
    if ( it != value_.map_->end()  &&  (*it).first == actualKey )
@@ -1158,7 +1158,7 @@ Value Value::removeMember( const char* key )
       Value old(*value);
       value_.map_.remove( key );
       return old;
-   } else 
+   } else
 {
       return null;
    }
@@ -1171,7 +1171,7 @@ Value Value::removeMember( const std::string &key )
 }
 
 # ifdef JSON_USE_CPPTL
-Value 
+Value
 Value::get( const CppTL::ConstString &key,
             const Value &defaultValue ) const
 
@@ -1194,7 +1194,7 @@ bool Value::isMember( const std::string &key ) const
 
 
 # ifdef JSON_USE_CPPTL
-bool 
+bool
 Value::isMember( const CppTL::ConstString &key ) const
 
 {
@@ -1253,8 +1253,8 @@ bool Value::isUInt() const
 
 bool Value::isIntegral() const
 {
-   return type_ == intValue  
-          ||  type_ == uintValue  
+   return type_ == intValue
+          ||  type_ == uintValue
           ||  type_ == booleanValue;
 }
 
@@ -1326,12 +1326,12 @@ std::string Value::toStyledString() const
 Value::const_iterator Value::begin() const
 {
    switch ( type_ )
-   
+
 {
 #ifdef JSON_VALUE_USE_INTERNAL_MAP
    case arrayValue:
       if ( value_.array_ )
-      
+
 {
          ValueInternalArray::IteratorState it;
          value_.array_->makeBeginIterator( it );
@@ -1340,7 +1340,7 @@ Value::const_iterator Value::begin() const
       break;
    case objectValue:
       if ( value_.map_ )
-      
+
 {
          ValueInternalMap::IteratorState it;
          value_.map_->makeBeginIterator( it );
@@ -1363,12 +1363,12 @@ Value::const_iterator Value::begin() const
 Value::const_iterator Value::end() const
 {
    switch ( type_ )
-   
+
 {
 #ifdef JSON_VALUE_USE_INTERNAL_MAP
    case arrayValue:
       if ( value_.array_ )
-      
+
 {
          ValueInternalArray::IteratorState it;
          value_.array_->makeEndIterator( it );
@@ -1377,7 +1377,7 @@ Value::const_iterator Value::end() const
       break;
    case objectValue:
       if ( value_.map_ )
-      
+
 {
          ValueInternalMap::IteratorState it;
          value_.map_->makeEndIterator( it );
@@ -1401,12 +1401,12 @@ Value::const_iterator Value::end() const
 Value::iterator Value::begin()
 {
    switch ( type_ )
-   
+
 {
 #ifdef JSON_VALUE_USE_INTERNAL_MAP
    case arrayValue:
       if ( value_.array_ )
-      
+
 {
          ValueInternalArray::IteratorState it;
          value_.array_->makeBeginIterator( it );
@@ -1415,7 +1415,7 @@ Value::iterator Value::begin()
       break;
    case objectValue:
       if ( value_.map_ )
-      
+
 {
          ValueInternalMap::IteratorState it;
          value_.map_->makeBeginIterator( it );
@@ -1438,12 +1438,12 @@ Value::iterator Value::begin()
 Value::iterator Value::end()
 {
    switch ( type_ )
-   
+
 {
 #ifdef JSON_VALUE_USE_INTERNAL_MAP
    case arrayValue:
       if ( value_.array_ )
-      
+
 {
          ValueInternalArray::IteratorState it;
          value_.array_->makeEndIterator( it );
@@ -1452,7 +1452,7 @@ Value::iterator Value::end()
       break;
    case objectValue:
       if ( value_.map_ )
-      
+
 {
          ValueInternalMap::IteratorState it;
          value_.map_->makeEndIterator( it );
@@ -1510,16 +1510,16 @@ void Path::makePath( const std::string &path,                const InArgs &in )
    const char *end = current + path.length();
    InArgs::const_iterator itInArg = in.begin();
    while ( current != end )
-   
+
 {
       if ( *current == '[' )
-      
+
 {
          ++current;
          if ( *current == '%' )
             addPathInArg( path, in, itInArg, PathArgument::kindIndex );
          else
-         
+
 {
             ArrayIndex index = 0;
             for ( ; current != end && *current >= '0'  &&  *current <= '9'; ++current )
@@ -1530,18 +1530,18 @@ void Path::makePath( const std::string &path,                const InArgs &in )
             invalidPath( path, int(current - path.c_str()) );
       }
       else if ( *current == '%' )
-      
+
 {
          addPathInArg( path, in, itInArg, PathArgument::kindKey );
          ++current;
       }
       else if ( *current == '.' )
-      
+
 {
          ++current;
       }
       else
-      
+
 {
          const char *beginName = current;
          while ( current != end  &&  !strchr( "[.", *current ) )
@@ -1555,17 +1555,17 @@ void Path::makePath( const std::string &path,                const InArgs &in )
 void Path::addPathInArg( const std::string &path,                     const InArgs &in,                     InArgs::const_iterator &itInArg,                     PathArgument::Kind kind )
 {
    if ( itInArg == in.end() )
-   
+
 {
       // Error: missing argument %d
    }
    else if ( (*itInArg)->kind_ != kind )
-   
+
 {
       // Error: bad argument type
    }
    else
-   
+
 {
       args_.push_back( **itInArg );
    }
@@ -1582,30 +1582,30 @@ const Value & Path::resolve( const Value &root ) const
 {
    const Value *node = &root;
    for ( Args::const_iterator it = args_.begin(); it != args_.end(); ++it )
-   
+
 {
       const PathArgument &arg = *it;
       if ( arg.kind_ == PathArgument::kindIndex )
-      
+
 {
          if ( !node->isArray()  ||  node->isValidIndex( arg.index_ ) )
-         
+
 {
             // Error: unable to resolve path (array value expected at position...
          }
          node = &((*node)[arg.index_]);
       }
       else if ( arg.kind_ == PathArgument::kindKey )
-      
+
 {
          if ( !node->isObject() )
-         
+
 {
             // Error: unable to resolve path (object value expected at position...)
          }
          node = &((*node)[arg.key_]);
          if ( node == &Value::null )
-         
+
 {
             // Error: unable to resolve path (object has no member named '' at position...)
          }
@@ -1619,18 +1619,18 @@ Value Path::resolve( const Value &root,                const Value &defaultValue
 {
    const Value *node = &root;
    for ( Args::const_iterator it = args_.begin(); it != args_.end(); ++it )
-   
+
 {
       const PathArgument &arg = *it;
       if ( arg.kind_ == PathArgument::kindIndex )
-      
+
 {
          if ( !node->isArray()  ||  node->isValidIndex( arg.index_ ) )
             return defaultValue;
          node = &((*node)[arg.index_]);
       }
       else if ( arg.kind_ == PathArgument::kindKey )
-      
+
 {
          if ( !node->isObject() )
             return defaultValue;
@@ -1647,24 +1647,24 @@ Value & Path::make( Value &root ) const
 {
    Value *node = &root;
    for ( Args::const_iterator it = args_.begin(); it != args_.end(); ++it )
-   
+
 {
       const PathArgument &arg = *it;
       if ( arg.kind_ == PathArgument::kindIndex )
-      
+
 {
          if ( !node->isArray() )
-         
+
 {
             // Error: node is not an array at position ...
          }
          node = &((*node)[arg.index_]);
       }
       else if ( arg.kind_ == PathArgument::kindKey )
-      
+
 {
          if ( !node->isObject() )
-         
+
 {
             // Error: node is not an object at position...
          }

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_effects.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_effects.cpp
@@ -800,7 +800,7 @@ namespace enigma
     }
       default:
         #if DEBUG_MODE
-          show_error("Internal error: invalid particle effect type.", false)
+          enigma_user::show_error("Internal error: invalid particle effect type.", false)
         #endif
         ;
     }
@@ -867,4 +867,3 @@ namespace enigma_user {
     }
   }
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_emitter.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_emitter.cpp
@@ -200,7 +200,7 @@ namespace enigma
     }
     default:
       #if DEBUG_MODE
-      show_error("Internal error: invalid particle shape", false)
+      enigma_user::show_error("Internal error: invalid particle shape", false)
       #endif
       ;
     }
@@ -306,4 +306,3 @@ namespace enigma_user {
     }
   }
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_sprites.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_sprites.cpp
@@ -932,7 +932,7 @@ namespace enigma
     case pt_sh_snow: {generate_snow(); break;}
     default:
       #if DEBUG_MODE
-        show_error("No such particle type", false);
+        enigma_user::show_error("No such particle type", false);
       #endif
       ;
     }
@@ -971,4 +971,3 @@ namespace enigma
     return sprid;
   }
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_system.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_system.cpp
@@ -560,7 +560,7 @@ namespace enigma
       }
       default:
         #if DEBUG_MODE
-          show_error("Interal error: particle color type not known", false)
+          enigma_user::show_error("Interal error: particle color type not known", false)
         #endif
         ;
       }
@@ -643,4 +643,3 @@ namespace enigma
     return changer_max_id;
   }
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/StudioPhysics/Box2DWorld.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/StudioPhysics/Box2DWorld.h
@@ -83,22 +83,22 @@ extern vector<fixtureInstance*> fixtures;
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_worldr(w,id,r) \
     if (unsigned(id) >= worlds.size() || id < 0) { \
-      show_error("Cannot access GayMaker: Stupido physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access GayMaker: Stupido physics world with id " + toString(id), false); \
       return r; \
     } worldInstance* w = worlds[id];
   #define get_world(w,id) \
     if (unsigned(id) >= worlds.size() || id < 0) { \
-      show_error("Cannot access GayMaker: Stupido physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access GayMaker: Stupido physics world with id " + toString(id), false); \
       return; \
     } worldInstance* w = worlds[id];
   #define get_fixturer(f,id,r) \
     if (unsigned(id) >= fixtures.size() || id < 0) { \
-      show_error("Cannot access GayMaker: Stupido physics fixture with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access GayMaker: Stupido physics fixture with id " + toString(id), false); \
       return r; \
     } fixtureInstance* f = fixtures[id];
   #define get_fixture(f,id) \
     if (unsigned(id) >= fixtures.size() || id < 0) { \
-      show_error("Cannot access GayMaker: Stupido physics fixture with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access GayMaker: Stupido physics fixture with id " + toString(id), false); \
       return; \
     } fixtureInstance* f = fixtures[id];
 #else

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/StudioPhysics/SB2Dfunctions.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/StudioPhysics/SB2Dfunctions.cpp
@@ -25,7 +25,7 @@
 declare_recast(enigma::extension_studiophysics);
 
 namespace enigma {
-  extension_studiophysics::extension_studiophysics() { 
+  extension_studiophysics::extension_studiophysics() {
   }
 }
 */
@@ -51,7 +51,7 @@ bool systemPaused = false;
 vector<worldInstance*> worlds(0);
 vector<fixtureInstance*> fixtures;
 
-void worldInstance::world_update() 
+void worldInstance::world_update()
 {
   if (!systemPaused && !paused) {
     world->Step(timeStep, velocityIterations, positionIterations);
@@ -64,22 +64,22 @@ void worldInstance::world_update()
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_worldr(w,id,r) \
     if (unsigned(id) >= worlds.size() || id < 0) { \
-      show_error("Cannot access GayMaker: Stupido physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access GayMaker: Stupido physics world with id " + toString(id), false); \
       return r; \
     } worldInstance* w = worlds[id];
   #define get_world(w,id) \
     if (unsigned(id) >= worlds.size() || id < 0) { \
-      show_error("Cannot access GayMaker: Stupido physics world with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access GayMaker: Stupido physics world with id " + toString(id), false); \
       return; \
     } worldInstance* w = worlds[id];
   #define get_fixturer(f,id,r) \
     if (unsigned(id) >= fixtures.size() || id < 0) { \
-      show_error("Cannot access GayMaker: Stupido physics fixture with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access GayMaker: Stupido physics fixture with id " + toString(id), false); \
       return r; \
     } fixtureInstance* f = fixtures[id];
   #define get_fixture(f,id) \
     if (unsigned(id) >= fixtures.size() || id < 0) { \
-      show_error("Cannot access GayMaker: Stupido physics fixture with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access GayMaker: Stupido physics fixture with id " + toString(id), false); \
       return; \
     } fixtureInstance* f = fixtures[id];
 #else
@@ -134,7 +134,7 @@ int physics_world_create()
 
 void physics_world_delete(int index)
 {
- 
+
 }
 
 void physics_world_pause_enable(int index, bool paused)
@@ -270,7 +270,7 @@ void physics_fixture_set_polygon_shape(int id)
   sb2dfixture->FinishShape();
 }
 
-void physics_fixture_set_edge_shape(int id, bool adjstart, bool adjend) 
+void physics_fixture_set_edge_shape(int id, bool adjstart, bool adjend)
 {
   get_fixture(sb2dfixture, id);
   b2EdgeShape shape;
@@ -511,4 +511,3 @@ void physics_draw_debug()
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/background_internal.h
+++ b/ENIGMAsystem/SHELL/Universal_System/background_internal.h
@@ -75,13 +75,13 @@ namespace enigma
   #include "libEGMstd.h"
   #define get_background(bck2d,back)\
     if (back < 0 or size_t(back) >= enigma::background_idmax or !enigma::backgroundstructarray[back]) {\
-      show_error("Attempting to draw non-existing background " + toString(back), false);\
+      enigma_user::show_error("Attempting to draw non-existing background " + toString(back), false);\
       return;\
     }\
     enigma::background *bck2d = enigma::backgroundstructarray[back];
   #define get_backgroundnv(bck2d,back,r)\
     if (back < 0 or size_t(back) >= enigma::background_idmax or !enigma::backgroundstructarray[back]) {\
-      show_error("Attempting to draw non-existing background " + toString(back), false);\
+      enigma_user::show_error("Attempting to draw non-existing background " + toString(back), false);\
       return r;\
     }\
     enigma::background *bck2d = enigma::backgroundstructarray[back];

--- a/ENIGMAsystem/SHELL/Universal_System/backgroundinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/backgroundinit.cpp
@@ -28,13 +28,15 @@
 #include <cstring>
 #include <cstdio>
 
+using enigma_user::show_error;
+
 namespace enigma
 {
   void exe_loadbackgrounds(FILE *exe)
   {
     int nullhere;
     unsigned bkgid, width, height,transparent,smoothEdges,preload,useAsTileset,tileWidth,tileHeight,hOffset,vOffset,hSep,vSep;
- 
+
     if (!fread(&nullhere, 4, 1, exe)) return;
     if (memcmp(&nullhere, "BKG ", sizeof(int)) != 0) return;
 

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -90,11 +90,11 @@ void file_text_close(int fileid) // Closes the file with the given file id.
 {
    if(fileid == -1) {
     #ifdef DEBUG_MODE
-      show_error("Cannot close an unopened file.",false);
+      enigma_user::show_error("Cannot close an unopened file.",false);
     #endif
     return;
   }
-  
+
   fclose(enigma::files[fileid].f);
   enigma::files[fileid].f = NULL;
 
@@ -224,7 +224,7 @@ bool file_bin_rewrite(int fileid) // Rewrites the file with the given file id, t
 
   if (mf.f == NULL) {
     #ifdef DEBUGMODE
-      show_error("Failed to reopen binary file. Sure it's a binary file? Drive been removed?",false);
+      enigma_user::show_error("Failed to reopen binary file. Sure it's a binary file? Drive been removed?",false);
     #endif
     return false;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/fontinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fontinit.cpp
@@ -32,6 +32,9 @@
 #include <string>
 
 namespace enigma {
+
+using enigma_user::show_error;
+
 void exe_loadfonts(FILE* exe) {
   int nullhere;
   unsigned fontcount, fntid, twid, thgt, gwid, ghgt;

--- a/ENIGMAsystem/SHELL/Universal_System/highscore_functions.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/highscore_functions.cpp
@@ -182,4 +182,3 @@ void draw_highscore(int x1, int y1, int x2, int y2) {
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/instance_create.h
+++ b/ENIGMAsystem/SHELL/Universal_System/instance_create.h
@@ -52,12 +52,12 @@ namespace enigma
           #include "Preprocessor_Environment_Editable/IDE_EDIT_object_switch.h"
           default:
           #if defined(SHOW_ERRORS) && SHOW_ERRORS
-              show_error("Object doesn't exist",0);
+              enigma_user::show_error("Object doesn't exist",0);
           #endif
               return;
       }
       (void)ob;
-      
+
       object_graphics* newinst = (object_graphics*) (*fetch_inst_iter_by_int(idn));
       newinst->x=x; newinst->y=y; newinst->yprevious=yprevious; newinst->xprevious=xprevious;
       newinst->xstart=xstart; newinst->ystart=ystart;
@@ -66,7 +66,7 @@ namespace enigma
       newinst->hspeed=hspeed; newinst->vspeed=vspeed;
       if (perf) newinst->myevent_create();
   }
-  
+
   object_basic* instance_create_id(int x,int y,int object,int idn)
   { //This is for use by the system only. Please leave be.
     if (maxid < idn)
@@ -78,7 +78,7 @@ namespace enigma
       #include "Preprocessor_Environment_Editable/IDE_EDIT_object_switch.h"
       default:
           #if defined(SHOW_ERRORS) && SHOW_ERRORS
-          show_error("Object doesn't exist",0);
+          enigma_user::show_error("Object doesn't exist",0);
           #endif
           return NULL;
     }
@@ -98,7 +98,7 @@ namespace enigma_user
       #include "Preprocessor_Environment_Editable/IDE_EDIT_object_switch.h"
       default:
           #if defined(SHOW_ERRORS) && SHOW_ERRORS
-          show_error("Object doesn't exist",0);
+          enigma_user::show_error("Object doesn't exist",0);
           #endif
         return -1;
     }
@@ -112,7 +112,7 @@ namespace enigma_user
       enigma::object_graphics* inst = (enigma::object_graphics*) enigma::instance_event_iterator->inst;
       enigma::instance_change_inst(obj, perf, inst);
   }
-  
+
   void instance_copy(bool perf)
   {
     enigma::object_graphics* inst = (enigma::object_graphics*) enigma::instance_event_iterator->inst;
@@ -127,13 +127,13 @@ namespace enigma_user
         #include "Preprocessor_Environment_Editable/IDE_EDIT_object_switch.h"
         default:
         #if defined(SHOW_ERRORS) && SHOW_ERRORS
-            show_error("Object doesn't exist",0);
+            enigma_user::show_error("Object doesn't exist",0);
         #endif
             (void)x; (void)y;
             return;
     }
     (void)ob;
-    
+
     enigma::object_graphics* newinst = (enigma::object_graphics*) (*enigma::fetch_inst_iter_by_int(idn));
     if (perf) newinst->myevent_create();
     newinst->yprevious=inst->yprevious; newinst->xprevious=inst->xprevious;
@@ -145,4 +145,3 @@ namespace enigma_user
 } //namespace enigma_user
 
 #endif //ENIGMA_INSTANCE_CREATE_H
-

--- a/ENIGMAsystem/SHELL/Universal_System/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/loading.cpp
@@ -76,7 +76,7 @@ namespace enigma
     windowsystem_write_exename(exename);
     FILE* exe = fopen(exename,"rb");
     if (!exe)
-      show_error("Resource load fail: exe unopenable",0);
+      enigma_user::show_error("Resource load fail: exe unopenable",0);
     else do
     {
       int nullhere;

--- a/ENIGMAsystem/SHELL/Universal_System/object.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/object.cpp
@@ -40,6 +40,7 @@ namespace enigma
     int id_current =0;
 
     #ifdef DEBUG_MODE
+      using enigma_user::show_error;
       static inline int DEBUG_ID_CHECK(int id, int objind) {
         std::map<int, inst_iter*>::iterator it = instance_list.find(id);
         if (it != instance_list.end()) {

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -327,10 +327,10 @@ namespace enigma_user {
 #if DEBUG_MODE || (defined(SHOW_ERRORS) && SHOW_ERRORS)
   #define errcheck(indx,err,v) \
   if (unsigned(indx) >= unsigned(enigma::room_idmax) or !enigma::roomdata[indx]) \
-    return (show_error(err,0), (v))
+    return (enigma_user::show_error(err,0), (v))
   #define errcheck_o(indx,err) \
   if (unsigned(indx) >= unsigned(enigma::room_loadtimecount)) \
-    return (show_error(err,0), 0)
+    return (enigma_user::show_error(err,0), 0)
 #else
   #define errcheck(indx,err,v)
   #define errcheck_o(indx,err)

--- a/ENIGMAsystem/SHELL/Universal_System/spriteinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/spriteinit.cpp
@@ -37,20 +37,20 @@ namespace enigma
     int nullhere;
     unsigned sprid, width, height, bbt, bbb, bbl, bbr, bbm, shape;
     int xorig, yorig;
-    
+
     if (!fread(&nullhere,4,1,exe)) return;
     if (memcmp(&nullhere, "SPR ", sizeof(int)) != 0)
       return;
-    
+
     // Determine how many sprites we have
     int sprcount;
     if (!fread(&sprcount,4,1,exe)) return;
-    
+
     // Fetch the highest ID we will be using
     int spr_highid;
     if (!fread(&spr_highid,4,1,exe)) return;
     sprites_init();
-    
+
     for (int i = 0; i < sprcount; i++)
     {
       if (!fread(&sprid, 4,1,exe)) return;
@@ -76,12 +76,12 @@ namespace enigma
         case ct_circle: coll_type = ct_circle; break;
         default: coll_type = ct_bbox; break;
       };
-      
+
       int subimages;
       if (!fread(&subimages,4,1,exe)) return; //co//ut << "Subimages: " << subimages << endl;
-      
+
       sprite_new_empty(sprid, subimages, width, height, xorig, yorig, bbt, bbb, bbl, bbr, 1,0);
-      for (int ii=0;ii<subimages;ii++) 
+      for (int ii=0;ii<subimages;ii++)
       {
         int unpacked;
         if (!fread(&unpacked,4,1,exe)) return;
@@ -90,22 +90,23 @@ namespace enigma
         unsigned char* cpixels=new unsigned char[size+1];
         if (!cpixels)
         {  //FIXME: Uncomment these when tostring is available
-          show_error("Failed to load sprite: Cannot allocate enough memory "+toString(unpacked),0);
+          enigma_user::show_error("Failed to load sprite: Cannot allocate enough memory "+toString(unpacked),0);
           break;
         }
         unsigned int sz2=fread(cpixels,1,size,exe);
         if (size!=sz2) {
-          show_error("Failed to load sprite: Data is truncated before exe end. Read "+toString(sz2)+" out of expected "+toString(size),0);
+          enigma_user::show_error("Failed to load sprite: Data is truncated before exe end. Read "+toString(sz2)+
+                                  " out of expected "+toString(size),0);
           return;
         }
         unsigned char* pixels=new unsigned char[unpacked+1];
         if (zlib_decompress(cpixels,size,unpacked,pixels) != unpacked)
         {
-          show_error("Sprite load error: Sprite does not match expected size",0);
+          enigma_user::show_error("Sprite load error: Sprite does not match expected size",0);
           continue;
         }
         delete[] cpixels;
-        
+
         unsigned char* collision_data = 0;
         switch (coll_type)
         {
@@ -117,15 +118,15 @@ namespace enigma
           case ct_polygon: collision_data = 0; break; //FIXME: Support vertex data.
           default: collision_data = 0; break;
         };
-        
+
         sprite_set_subimage(sprid, ii, width, height, pixels, collision_data, coll_type);
-        
+
         delete[] pixels;
         if (!fread(&nullhere,4,1,exe)) return;
-        
+
         if (nullhere)
         {
-          show_error("Sprite load error: Null terminator expected",0);
+          enigma_user::show_error("Sprite load error: Null terminator expected",0);
           break;
         }
       }

--- a/ENIGMAsystem/SHELL/Universal_System/spritestruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/spritestruct.cpp
@@ -38,7 +38,7 @@ bool get_sprite(enigma::sprite* &spr, int id)
 {
 #ifdef DEBUG_MODE
     if (id < -1 || size_t(id) > enigma::sprite_idmax || !enigma::spritestructarray[id]) {
-        show_error("Cannot access sprite with id " + toString(id), false);
+        enigma_user::show_error("Cannot access sprite with id " + toString(id), false);
         return false;
     }
 #endif
@@ -223,7 +223,7 @@ namespace enigma
 {
   // INVARIANT: Should always be equal to the actual size of spritestructarray.
   size_t spritestructarray_actualsize = 0;
-  
+
   //Allocates and zero-fills the array at game start
   void sprites_init() {
     spritestructarray_actualsize = sprite_idmax+1;
@@ -276,7 +276,7 @@ namespace enigma
   void sprite_add_to_index(sprite *ns, string filename, int imgnumb,
       bool precise, bool transparent, bool smooth, int x_offset, int y_offset,
       bool mipmap) {
-  
+
         unsigned int width, height, fullwidth, fullheight;
     unsigned char *pxdata = image_load(
         filename, &width, &height, &fullwidth, &fullheight, &imgnumb, false);
@@ -298,8 +298,8 @@ namespace enigma
             int tmp = ih*fullwidth*4;
             for (iw = 0; iw < width; iw++)
             {
-          if (pxdata[tmp] == t_pixel_b 
-              && pxdata[tmp+1] == t_pixel_g 
+          if (pxdata[tmp] == t_pixel_b
+              && pxdata[tmp+1] == t_pixel_g
               && pxdata[tmp+2] == t_pixel_r) {
                 pxdata[tmp+3] = 0;
           }
@@ -466,7 +466,7 @@ namespace enigma
 
     delete[] imgpxdata;
   }
-  
+
   bbox_rect_t dummy_bbox = {32,0,32,0};
 
   const bbox_rect_t &sprite_get_bbox(int sprid)
@@ -477,7 +477,7 @@ namespace enigma
 
     return spr->bbox;
   }
-  
+
   const bbox_rect_t &sprite_get_bbox_relative(int sprid)
   {
     sprite *spr;
@@ -686,7 +686,7 @@ void sprite_collision_mask(int ind, bool sepmasks, int mode,
 
 var sprite_get_uvs(int ind, int subimg){
   var uvs;
-  uvs[4] = 0; 
+  uvs[4] = 0;
 
   enigma::sprite *spr;
   if (!get_sprite(spr,ind))
@@ -700,4 +700,3 @@ var sprite_get_uvs(int ind, int subimg){
 }
 
 }
-

--- a/ENIGMAsystem/SHELL/Universal_System/texture_atlas.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/texture_atlas.cpp
@@ -33,7 +33,7 @@
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_sprite(spr,id) \
     if (id < -1 or size_t(id) > enigma::sprite_idmax or !enigma::spritestructarray[id]) { \
-      show_error("Cannot access sprite with id " + toString(id), false); \
+      enigma_user::show_error("Cannot access sprite with id " + toString(id), false); \
       return; \
     } enigma::sprite *const spr = enigma::spritestructarray[id];
 #else
@@ -49,7 +49,7 @@ namespace enigma {
     unsigned int metric = 0;
     unsigned int size = 0;
     TextureAtlasRect(unsigned int m, unsigned int s) : metric(m), size(s) {}
-    const bool operator<(TextureAtlasRect const &rhs) const{   
+    const bool operator<(TextureAtlasRect const &rhs) const{
       return this->size < rhs.size;
     }
   };

--- a/ENIGMAsystem/SHELL/Universal_System/zlib.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/zlib.cpp
@@ -35,9 +35,9 @@ unsigned char* zlib_compress(unsigned char* inbuffer,int actualsize)
     {
      #if DEBUG_MODE || (defined(SHOW_ERRORS) && SHOW_ERRORS)
      if (res==Z_MEM_ERROR)
-     show_error("Zlib failed to compress the buffer. Out of memory.",0);
+     enigma_user::show_error("Zlib failed to compress the buffer. Out of memory.",0);
      if (res==Z_BUF_ERROR)
-     show_error("Zlib failed to compress the buffer. Output size greater than allotted.",0);
+     enigma_user::show_error("Zlib failed to compress the buffer. Output size greater than allotted.",0);
      #endif
     }
 
@@ -51,17 +51,17 @@ int zlib_decompress(unsigned char* inbuffer, int insize, int uncompresssize,unsi
 	case Z_OK:return outused;
 	case Z_MEM_ERROR:
 		#if DEBUG_MODE || (defined(SHOW_ERRORS) && SHOW_ERRORS)
-			show_error("Zerror: Memory out",0);
+			enigma_user::show_error("Zerror: Memory out",0);
 		#endif
 		return -1;
 	case Z_BUF_ERROR:
 		#if DEBUG_MODE || (defined(SHOW_ERRORS) && SHOW_ERRORS)
-			show_error("Zerror: Output of " + toString(outused) + " above allotted " + toString(uncompresssize),0);
+			enigma_user::show_error("Zerror: Output of " + toString(outused) + " above allotted " + toString(uncompresssize),0);
 		#endif
 		return -2;
 	case Z_DATA_ERROR:
 		#if DEBUG_MODE || (defined(SHOW_ERRORS) && SHOW_ERRORS)
-			show_error("Zerror: Invalid data",0);
+			enigma_user::show_error("Zerror: Invalid data",0);
 		#endif
 		return -3;
 	default:return -4;

--- a/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
@@ -32,11 +32,11 @@
 using std::string;
 
 namespace enigma {
-  
+
 bool widget_system_initialize() {
   return true;
 }
-  
+
 } // namespave enigma
 
 extern "C" const char *cocoa_dialog_caption();
@@ -54,18 +54,18 @@ extern "C" int cocoa_get_color(int defcol, const char *title);
 static string dialog_caption;
 static string error_caption;
 
+namespace enigma_user {
+
 void show_error(string errortext, const bool fatal) {
   #ifdef DEBUG_MODE
   errortext += enigma::debug_scope::GetErrors();
   #endif
-  
+
   if (error_caption == "") error_caption = "Error";
   int result = cocoa_show_error(errortext.c_str(), (const bool)fatal, error_caption.c_str());
   if (result == 1) exit(0);
 }
 
-namespace enigma_user {
-  
 void show_info(string text, int bgcolor, int left, int top, int width, int height,
   bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop,
   bool pauseGame, string caption) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.h
@@ -17,10 +17,9 @@
 
 #include <string>
 
-//  void show_error(std::string errortext, const bool fatal);
-
 namespace enigma_user {
-  
+
+//  void show_error(std::string errortext, const bool fatal);
 //  int show_message(const std::string &str);
 int show_message_cancelable(std::string str);
 bool show_question(std::string str);
@@ -42,5 +41,5 @@ int get_color(int defcol);
 int get_color_ext(int defcol, std::string title);
 std::string message_get_caption();
 void message_set_caption(std::string str);
-  
+
 } // namespave enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/DlgMod/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DlgMod/dialogs.cpp
@@ -35,30 +35,30 @@ using enigma_user::window_handle;
 using std::string;
 
 namespace enigma {
-  
+
 bool widget_system_initialize() {
   return true;
 }
-  
+
 } // namespace enigma
+
+namespace enigma_user {
 
 void show_error(string errortext, const bool fatal) {
   string str_errortext = errortext;
-  
+
   #ifdef DEBUG_MODE
   str_errortext = enigma::debug_scope::GetErrors() + "\n\n" + str_errortext;
   #else
   str_errortext = "Error in some event or another for some object: \r\n\r\n" + str_errortext;
   #endif
-  
+
   bool DialogModule_result;
   DialogModule_result = (bool)external_call(external_define("DialogModule.dll", "show_error", enigma_user::dll_cdecl, enigma_user::ty_real, 2, enigma_user::ty_string, enigma_user::ty_real), (char *)str_errortext.c_str(), (double)fatal);
   external_free("DialogModule.dll");
   if (DialogModule_result || fatal)
     exit(0);
 }
-
-namespace enigma_user {
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) {
 
@@ -197,7 +197,7 @@ int get_color(int defcol) {
   external_free("DialogModule.dll");
   return DialogModule_result;
 }
-  
+
 int get_color_ext(int defcol, string title) {
   string str_title = title;
   int DialogModule_result;
@@ -205,5 +205,5 @@ int get_color_ext(int defcol, string title) {
   external_free("DialogModule.dll");
   return DialogModule_result;
 }
-  
+
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/DlgMod/dialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DlgMod/dialogs.h
@@ -17,10 +17,9 @@
 
 #include <string>
 
-// void show_error(std::string errortext, const bool fatal);
-
 namespace enigma_user {
-  
+
+// void show_error(std::string errortext, const bool fatal);
 // int show_message(std::string str);
 bool show_question(std::string str);
 std::string get_string(std::string str, std::string def);
@@ -37,5 +36,5 @@ std::string get_directory(std::string dname);
 std::string get_directory_alt(std::string capt, std::string root);
 int get_color(int defcol);
 int get_color_ext(int defcol, std::string title);
-  
+
 } // namespave enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/GTK+/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/GTK+/dialogs.cpp
@@ -33,6 +33,8 @@
 
 using namespace std;
 
+namespace enigma_user {
+
 void show_error(string errortext, const bool fatal) {
 //TODO: Implement
 }
@@ -148,8 +150,7 @@ string get_save_filename(string filter, string fname, string caption)
   return ret;
 }
 
-
-
+} // namespace enigma_user
 
 static int* cmret;
 static void menu_item_clicked(gpointer user_data) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/KDialog/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/KDialog/dialogs.cpp
@@ -62,11 +62,11 @@ static bool message_cancel  = false;
 static bool question_cancel = false;
 
 namespace enigma {
-  
+
 bool widget_system_initialize() {
   return true;
 }
-  
+
 } // namespace enigma
 
 static string shellscript_evaluate(string command) {
@@ -167,12 +167,14 @@ static int show_question_helperfunc(string str) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
+namespace enigma_user {
+
 void show_error(string errortext, const bool fatal) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;
   string str_echo;
-  
+
   #ifdef DEBUG_MODE
   errortext += enigma::debug_scope::GetErrors();
   #endif
@@ -189,8 +191,6 @@ void show_error(string errortext, const bool fatal) {
   string str_result = shellscript_evaluate(str_command);
   if (strtod(str_result.c_str(), NULL) == 1) exit(0);
 }
-
-namespace enigma_user {
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) {
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/KDialog/dialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/KDialog/dialogs.h
@@ -17,10 +17,9 @@
 
 #include <string>
 
-//  void show_error(std::string errortext, const bool fatal);
-
 namespace enigma_user {
-  
+
+//  void show_error(std::string errortext, const bool fatal);
 //  int show_message(const std::string &str);
 int show_message_cancelable(std::string str);
 bool show_question(std::string str);
@@ -42,5 +41,5 @@ int get_color(int defcol);
 int get_color_ext(int defcol, std::string title);
 std::string message_get_caption();
 void message_set_caption(std::string str);
-  
+
 } // namespave enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
@@ -36,7 +36,7 @@ using namespace std;
 #  include <termios.h>
 #  include <unistd.h>
 #endif
- 
+
 class PasswordContext {
 # ifdef TC_WINDOWS
   DWORD old_attrs = 0;
@@ -44,7 +44,7 @@ class PasswordContext {
 # else
   termios old_attrs;
 # endif
- 
+
  public:
   PasswordContext() {
 #   ifdef TC_WINDOWS
@@ -58,7 +58,7 @@ class PasswordContext {
       tcsetattr(STDIN_FILENO, TCSANOW, &new_attrs);
 #   endif
   }
- 
+
   ~PasswordContext() {
 #   ifdef TC_WINDOWS
       SetConsoleMode(hStdin, old_attrs);
@@ -74,6 +74,8 @@ namespace enigma {
   }
 }
 
+namespace enigma_user {
+
 void show_error(string err, const bool fatal)
 {
   printf("ERROR in some action of some event for object %d, instance id %d: %s\n",
@@ -88,9 +90,6 @@ void show_error(string err, const bool fatal)
   if (fatal) exit(0);
   ABORT_ON_ALL_ERRORS();
 }
-
-
-namespace enigma_user {
 
 int show_message(const string &message)
 {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -57,24 +57,6 @@ static inline string add_slash(const string& dir) {
   return dir;
 }
 
-void show_error(string errortext, const bool fatal)
-{
-  #ifdef DEBUG_MODE
-  errortext += "\n\n" + enigma::debug_scope::GetErrors();
-  #endif
-
-  if (MessageBox(NULL,errortext.c_str(),"Error",MB_ABORTRETRYIGNORE | MB_ICONERROR)==IDABORT)
-    exit(0);
-
-  if (fatal)
-    printf("FATAL ERROR: %s\n",errortext.c_str()),
-    exit(0);
-  else
-    printf("ERROR: %s\n",errortext.c_str());
-
-  //ABORT_ON_ALL_ERRORS();
-}
-
 namespace enigma {
 
 extern HINSTANCE hInstance;
@@ -267,6 +249,24 @@ void message_text_font(string name, int size, int color, int style) {
 
 void message_text_charset(int type, int charset) {
 
+}
+
+void show_error(string errortext, const bool fatal)
+{
+  #ifdef DEBUG_MODE
+  errortext += "\n\n" + enigma::debug_scope::GetErrors();
+  #endif
+
+  if (MessageBox(NULL,errortext.c_str(),"Error",MB_ABORTRETRYIGNORE | MB_ICONERROR)==IDABORT)
+    exit(0);
+
+  if (fatal)
+    printf("FATAL ERROR: %s\n",errortext.c_str()),
+    exit(0);
+  else
+    printf("ERROR: %s\n",errortext.c_str());
+
+  //ABORT_ON_ALL_ERRORS();
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/widgets.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/widgets.cpp
@@ -60,7 +60,7 @@ namespace enigma {
   {
     // make sure the hWnd and hInstance variables are initialized (e.g, SDL)
     if (get_window_handle() == NULL) {
-      show_error("Cannot initialize Win32 widget system with NULL window handle.", true);
+      enigma_user::show_error("Cannot initialize Win32 widget system with NULL window handle.", true);
     }
     INITCOMMONCONTROLSEX iccex;
     iccex.dwSize = sizeof(iccex);

--- a/ENIGMAsystem/SHELL/Widget_Systems/Zenity/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Zenity/dialogs.cpp
@@ -62,11 +62,11 @@ static bool message_cancel  = false;
 static bool question_cancel = false;
 
 namespace enigma {
-  
+
 bool widget_system_initialize() {
   return true;
 }
-  
+
 } // namespace enigma
 
 static string shellscript_evaluate(string command) {
@@ -158,12 +158,14 @@ static int show_question_helperfunc(string str) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
+namespace enigma_user {
+
 void show_error(string errortext, const bool fatal) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;
   string str_echo;
-  
+
   #ifdef DEBUG_MODE
   errortext += enigma::debug_scope::GetErrors();
   #endif
@@ -180,8 +182,6 @@ void show_error(string errortext, const bool fatal) {
   string str_result = shellscript_evaluate(str_command);
   if (strtod(str_result.c_str(), NULL) == 1) exit(0);
 }
-
-namespace enigma_user {
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) {
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/Zenity/dialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Zenity/dialogs.h
@@ -17,10 +17,9 @@
 
 #include <string>
 
-//  void show_error(std::string errortext, const bool fatal);
-
 namespace enigma_user {
-  
+
+//  void show_error(std::string errortext, const bool fatal);
 //  int show_message(const std::string &str);
 int show_message_cancelable(std::string str);
 bool show_question(std::string str);
@@ -42,5 +41,5 @@ int get_color(int defcol);
 int get_color_ext(int defcol, std::string title);
 std::string message_get_caption();
 void message_set_caption(std::string str);
-  
+
 } // namespave enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/widgets_mandatory.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/widgets_mandatory.h
@@ -33,11 +33,11 @@ namespace enigma
   extern bool gameInfoEmbedGameWindow, gameInfoShowBorder, gameInfoAllowResize, gameInfoStayOnTop, gameInfoPauseGame;
 }
 
+namespace enigma_user {
+
 // This obviously displays an error message.
 // It should offer a button to end the game, and if not fatal, a button to ignore the error.
 void show_error(std::string msg, const bool fatal);
-
-namespace enigma_user {
 
 int show_message(const std::string &msg);
 template<typename T> int show_message(T msg) { return show_message(enigma_user::toString(msg)); }


### PR DESCRIPTION
It was broken by #1677 and you can't call it in a game right now. It needs moved to namespace `enigma_user` anyway, since it is a GML function, which is what this pull request is doing.