### PR TITLE
Draw Batch & Vertex Submit Mixing Fix

### DIFF
--- a/CommandLine/testing/Tests/draw_test.sog/create.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/create.edl
@@ -1,1 +1,22 @@
 spr = sprite_add("CommandLine/testing/data/sprite.png", 4, false, false, 16, 10);
+
+vertex_format_begin();
+vertex_format_add_position();
+vertex_format_add_color();
+vf_pos_col = vertex_format_end();
+
+dx = 70, dy = 20;
+vb_diamond = vertex_create_buffer();
+vertex_begin(vb_diamond,vf_pos_col);
+
+vertex_position(vb_diamond, dx, dy-20);
+vertex_color(vb_diamond, c_red, 1);
+vertex_position(vb_diamond, dx-20, dy);
+vertex_color(vb_diamond, c_green, 0.5);
+vertex_position(vb_diamond, dx+20, dy);
+vertex_color(vb_diamond, c_blue, 0.5);
+vertex_position(vb_diamond, dx, dy+20);
+vertex_color(vb_diamond, c_red, 1);
+
+vertex_end(vb_diamond);
+vertex_freeze(vb_diamond);

--- a/CommandLine/testing/Tests/draw_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/draw.edl
@@ -1,3 +1,10 @@
+// put something in the draw batch
+draw_set_color(c_black);
+draw_rectangle(dx-20,dy-20,dx+20,dy+20,false);
+// ensure user-submit flushes the batch first
+// in which case the diamond should occlude the rect
+vertex_submit(vb_diamond,pr_trianglestrip);
+
 draw_set_color(c_yellow);
 draw_rectangle(50, 50, 600, 400, true);
 draw_set_color(c_olive);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSprimitives.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSprimitives.cpp
@@ -76,9 +76,6 @@ unsigned draw_primitive_count(int kind, unsigned vertex_count) {
 }
 
 void draw_batch_flush(int kind) {
-  if (kind == pr_undefined)
-    kind = draw_get_batch_mode();
-
   static bool flushing = false;
 
   // return if the kind of flush being requested

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSprimitives.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSprimitives.h
@@ -40,7 +40,7 @@ namespace enigma_user
 
   void draw_set_batch_mode(int mode);
   int draw_get_batch_mode();
-  void draw_batch_flush(int kind = pr_undefined);
+  void draw_batch_flush(int kind = draw_get_batch_mode());
   unsigned draw_primitive_count(int kind, unsigned vertex_count);
   void draw_primitive_begin(int kind);
   void draw_primitive_begin_texture(int kind, int texId);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
@@ -54,20 +54,22 @@ void draw_state_flush() {
   // track whether we are already flushing the state
   static bool flushing = false;
 
-  // if the state isn't dirty, we don't have to do anything
-  if (!drawStateDirty) return;
-
   // prevent state flush triggered by batch flush of another state flush
   if (flushing) return;
 
+  // flush the batch even if state is not dirty because this function
+  // means we are about to draw something anyway
+  enigma_user::draw_batch_flush(enigma_user::batch_flush_deferred);
+
+  // if the state isn't dirty, we don't have to do anything
+  if (!drawStateDirty) return;
+
   flushing = true; // we are now flushing the state
 
-  enigma_user::draw_batch_flush(enigma_user::batch_flush_deferred);
   enigma::graphics_state_flush();
+  drawStateDirty = false; // state is not dirty now
 
   flushing = false; // done flushing state
-
-  drawStateDirty = false; // state is not dirty now
 }
 
 void draw_set_msaa_enabled(bool enable) {


### PR DESCRIPTION
The aim of this pull request is to fix a regression I caused in #1636. Basically, if the user submits their own vertex buffer, then anything that's currently in the draw batch needs to be flushed first in order for the depth to be correct. This has actually seriously regressed the D3D11 system, but none of the others believe it or not.

What I am doing first is expanding the draw test to submit a vertex buffer directly after drawing a black rectangle with the state **NOT** dirty in between. What should happen is the vertex buffer should appear on top, but when I test it locally, we get the rect on top of the vertex buffer contents. Once EnigmaBot confirms, I will then actually fix the flushing.

Also reverting 94eb31590716cad9ca36b24df10fe940e28dc91b where fundies broke the batch flush function. The function accepts batch kind, not primitive kind! I can **NOT** stress this enough as it has the potential break literally _every_ game!