### PR TITLE
Mac Travis Fix

### DIFF
--- a/CommandLine/emake/Makefile
+++ b/CommandLine/emake/Makefile
@@ -9,11 +9,11 @@ include $(SHARED_SRC_DIR)/event_reader/Makefile
 
 OS := $(shell uname -s)
 ifeq ($(OS), Linux)
-	OS_LIBS=-lboost_system -Wl,--no-as-needed -Wl,-rpath=./ -lboost_program_options -lboost_iostreams -lboost_filesystem -lboost_system -lpthread -ldl
+	OS_LIBS=-lboost_system -Wl,--no-as-needed -Wl,-rpath,./ -lboost_program_options -lboost_iostreams -lboost_filesystem -lboost_system -lpthread -ldl
 else ifeq ($(OS), Darwin)
 	OS_LIBS=-lboost_system -lboost_program_options -lboost_iostreams -lboost_filesystem -lboost_system -lpthread -ldl
 else
-	OS_LIBS=-lboost_system-mt -Wl,--no-as-needed -Wl,-rpath=./ -lboost_program_options-mt -lboost_iostreams-mt -lboost_filesystem-mt -lboost_system-mt -lpthread
+	OS_LIBS=-lboost_system-mt -Wl,--no-as-needed -Wl,-rpath,./ -lboost_program_options-mt -lboost_iostreams-mt -lboost_filesystem-mt -lboost_system-mt -lpthread
 endif
 
 PROTO_DIR := $(SHARED_SRC_DIR)/protos

--- a/CompilerSource/Makefile
+++ b/CompilerSource/Makefile
@@ -32,7 +32,7 @@ endif
 
 CXX := g++
 CXXFLAGS += -std=c++11 -Wall -O3 -g -I./JDI/src
-LDFLAGS += -shared -O3 -g -L../ -Wl,-rpath=./
+LDFLAGS += -shared -O3 -g -L../ -Wl,-rpath,./
 LDLIBS += -lProtocols -lprotobuf -lz -L$(SHARED_SRC_DIR)/libpng-util -lpng-util -lpng
 
 # This implements a recursive wildcard allowing us to iterate in subdirs

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ emake: $(EMAKE_TARGETS)
 	$(MAKE) -C CommandLine/emake/
 
 gm2egm: libEGM .FORCE
-	$(CXX) -Ishared/protos/ -Ishared/protos/codegen -ICommandLine/libEGM/ CommandLine/gm2egm/main.cpp -Wl,-rpath=. -L. -lEGM -lProtocols -o gm2egm
+	$(CXX) -Ishared/protos/ -Ishared/protos/codegen -ICommandLine/libEGM/ CommandLine/gm2egm/main.cpp -Wl,-rpath,. -L. -lEGM -lProtocols -o gm2egm
 
 test-runner: emake .FORCE
 	$(MAKE) -C CommandLine/testing/


### PR DESCRIPTION
This fixes what I discovered in #1230 and will hopefully make the Travis Mac jobs pass again. Using a comma is more portable than the equal sign (which is GNU Make specific).

Edit: Ok so it did fix it part way, now there's other issues addressed by #1294, but this is a good start.