### PR TITLE
File I/O Tests

### DIFF
--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -14,6 +14,19 @@ file_bin_seek(bin_write,0);
 gtest_expect_eq(file_bin_size(bin_write),3);
 gtest_expect_eq(file_bin_position(bin_write),0);
 gtest_expect_ne(file_bin_position(bin_write),file_bin_size(bin_write));
+
+// reading in write mode should fail
+file_bin_seek(bin_write,0);
+gtest_expect_eq(file_bin_read_byte(bin_write),-1);
+
+// rewrite should change mode from write to read+write
+file_bin_rewrite(bin_write);
+file_bin_write_byte(bin_write,64);
+file_bin_seek(bin_write,0);
+gtest_expect_eq(file_bin_read_byte(bin_write),64);
+
+// restore file for next test
+file_bin_rewrite(bin_write);
 file_bin_write_byte(bin_write,99);
 file_bin_write_byte(bin_write,-1); // underflows to 255
 file_bin_write_byte(bin_write,256); // overflows to 0
@@ -28,6 +41,24 @@ bin_read = file_bin_open(bin_path,0);
 gtest_expect_eq(file_bin_read_byte(bin_read),99);
 gtest_expect_eq(file_bin_read_byte(bin_read),255);
 gtest_expect_eq(file_bin_read_byte(bin_read),0);
+
+// writing in read mode should fail
+file_bin_seek(bin_read,0);
+file_bin_write_byte(bin_read,64);
+file_bin_seek(bin_read,0);
+gtest_expect_eq(file_bin_read_byte(bin_read),99);
+
+// rewrite should change mode from read to read+write
+file_bin_rewrite(bin_read);
+file_bin_write_byte(bin_read,64);
+file_bin_seek(bin_read,0);
+gtest_expect_eq(file_bin_read_byte(bin_read),64);
+
+// restore file for next test
+file_bin_rewrite(bin_read);
+file_bin_write_byte(bin_read,99);
+file_bin_write_byte(bin_read,-1); // underflows to 255
+file_bin_write_byte(bin_read,256); // overflows to 0
 file_bin_close(bin_read);
 
 // BINARY READ & WRITE

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -111,9 +111,9 @@ file_text_write_real(text_write, 0);
 file_text_write_real(text_write, -1);
 file_text_write_real(text_write, 253);
 file_text_writeln(text_write);
-file_text_write_real(text_write, 0.56932);
-file_text_write_real(text_write, -59.003456);
-file_text_write_real(text_write, 253.98997721);
+file_text_write_real(text_write, 0.1875);
+file_text_write_real(text_write, -59.234375);
+file_text_write_real(text_write, 489.703125);
 file_text_writeln(text_write);
 file_text_close(text_write);
 
@@ -143,9 +143,9 @@ gtest_expect_eq(file_text_read_real(text_read),253);
 gtest_expect_false(file_text_eof(text_read));
 gtest_expect_true(file_text_eoln(text_read));
 file_text_readln(text_read);
-file_text_read_real(text_read) // TODO test epsilon
-file_text_read_real(text_read) // TODO test epsilon
-file_text_read_real(text_read) // TODO test epsilon
+gtest_expect_eq(file_text_read_real(text_read),0.1875);
+gtest_expect_eq(file_text_read_real(text_read),-59.234375);
+gtest_expect_eq(file_text_read_real(text_read),489.703125);
 file_text_readln(text_read);
 gtest_expect_eq(file_text_read_real(text_read),2);
 gtest_expect_eq(file_text_read_string(text_read)," 5 b");

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -1,0 +1,19 @@
+var text_file;
+text_file = file_text_open_write("test.txt");
+file_text_write_string(text_file, "apple");
+file_text_write_string(text_file, " pear");
+file_text_write_string(text_file, ' ');
+file_text_write_string(text_file, "bear");
+file_text_writeln(text_file);
+file_text_write_real(text_file, 0);
+file_text_write_real(text_file, -1);
+file_text_write_real(text_file, 253);
+file_text_writeln(text_file);
+file_text_write_real(text_file, 0.56932);
+file_text_write_real(text_file, -59.003456);
+file_text_write_real(text_file, 253.98997721);
+file_text_writeln(text_file);
+file_text_close(text_file);
+
+// We're done!
+game_end();

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -4,6 +4,7 @@ var bin_path = "file_bin_test.bin";
 // BINARY WRITE
 var bin_write;
 bin_write = file_bin_open(bin_path,1);
+gtest_assert_ge(bin_write, 0);
 file_bin_write_byte(bin_write, 3);
 file_bin_write_byte(bin_write, 255);
 file_bin_write_byte(bin_write, 7);
@@ -38,6 +39,7 @@ file_bin_close(bin_write);
 // BINARY READ
 var bin_read;
 bin_read = file_bin_open(bin_path,0);
+gtest_assert_ge(bin_read, 0);
 gtest_expect_eq(file_bin_size(bin_read),3);
 gtest_expect_eq(file_bin_position(bin_read),0);
 gtest_expect_ne(file_bin_position(bin_read),file_bin_size(bin_read));
@@ -70,6 +72,7 @@ file_bin_close(bin_read);
 // BINARY READ & WRITE
 var bin_read_write;
 bin_read_write = file_bin_open(bin_path,2);
+gtest_assert_ge(bin_read_write, 0);
 gtest_expect_eq(file_bin_size(bin_read_write),3);
 gtest_expect_eq(file_bin_position(bin_read_write),0);
 gtest_expect_ne(file_bin_position(bin_read_write),file_bin_size(bin_read_write));
@@ -98,6 +101,7 @@ var text_path = "file_text_test.txt";
 // TEXT WRITING
 var text_write;
 text_write = file_text_open_write(text_path);
+gtest_assert_ge(text_write, 0);
 file_text_write_string(text_write, "apple");
 file_text_write_string(text_write, " pear");
 file_text_write_string(text_write, ' ');
@@ -116,6 +120,7 @@ file_text_close(text_write);
 // TEXT APPEND
 var text_append;
 text_append = file_text_open_append(text_path);
+gtest_assert_ge(text_append, 0);
 file_text_write_real(text_append, 2);
 file_text_write_real(text_append, 5);
 file_text_write_string(text_append, " b");
@@ -125,6 +130,7 @@ file_text_close(text_append);
 // TEXT READ
 var text_read;
 text_read = file_text_open_read(text_path);
+gtest_assert_ge(text_read, 0);
 gtest_expect_false(file_text_eof(text_read));
 gtest_expect_false(file_text_eoln(text_read));
 gtest_expect_eq(file_text_read_string(text_read),"apple pear bear");

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -1,19 +1,60 @@
-var text_file;
-text_file = file_text_open_write("test.txt");
-file_text_write_string(text_file, "apple");
-file_text_write_string(text_file, " pear");
-file_text_write_string(text_file, ' ');
-file_text_write_string(text_file, "bear");
-file_text_writeln(text_file);
-file_text_write_real(text_file, 0);
-file_text_write_real(text_file, -1);
-file_text_write_real(text_file, 253);
-file_text_writeln(text_file);
-file_text_write_real(text_file, 0.56932);
-file_text_write_real(text_file, -59.003456);
-file_text_write_real(text_file, 253.98997721);
-file_text_writeln(text_file);
-file_text_close(text_file);
+var text_path = "test.txt";
 
-// We're done!
+/// TEXT WRITING
+var text_write;
+text_write = file_text_open_write(text_path);
+file_text_write_string(text_write, "apple");
+file_text_write_string(text_write, " pear");
+file_text_write_string(text_write, ' ');
+file_text_write_string(text_write, "bear");
+file_text_writeln(text_write);
+file_text_write_real(text_write, 0);
+file_text_write_real(text_write, -1);
+file_text_write_real(text_write, 253);
+file_text_writeln(text_write);
+file_text_write_real(text_write, 0.56932);
+file_text_write_real(text_write, -59.003456);
+file_text_write_real(text_write, 253.98997721);
+file_text_writeln(text_write);
+file_text_close(text_write);
+
+/// TEXT APPEND
+var text_append;
+text_append = file_text_open_append(text_path);
+file_text_write_real(text_append, 2);
+file_text_write_real(text_append, 5);
+file_text_write_string(text_append, " b");
+file_text_writeln(text_append);
+file_text_close(text_append);
+
+/// TEXT READ
+var text_read;
+text_read = file_text_open_read(text_path);
+gtest_assert_false(file_text_eof(text_read));
+gtest_assert_false(file_text_eoln(text_read));
+gtest_expect_eq(file_text_read_string(text_read),"apple pear bear");
+gtest_assert_false(file_text_eof(text_read));
+gtest_assert_true(file_text_eoln(text_read));
+file_text_readln(text_read);
+gtest_expect_eq(file_text_read_real(text_read),0);
+gtest_expect_eq(file_text_read_real(text_read),-1);
+gtest_expect_eq(file_text_read_real(text_read),253);
+gtest_assert_false(file_text_eof(text_read));
+gtest_assert_true(file_text_eoln(text_read));
+file_text_readln(text_read);
+file_text_read_real(text_read) // TODO test epsilon
+file_text_read_real(text_read) // TODO test epsilon
+file_text_read_real(text_read) // TODO test epsilon
+file_text_readln(text_read);
+gtest_expect_eq(file_text_read_real(text_read),2);
+gtest_expect_eq(file_text_read_string(text_read)," 5 b");
+file_text_readln(text_read);
+// Unix convention/end of file line is empty
+gtest_assert_false(file_text_eof(text_read));
+gtest_assert_true(file_text_eoln(text_read));
+file_text_readln(text_read);
+gtest_assert_true(file_text_eof(text_read));
+gtest_assert_true(file_text_eoln(text_read));
+file_text_close(text_read);
+
 game_end();

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -189,6 +189,9 @@ gtest_expect_eq(filename_name("C:/John/Doe/Smoe.txt"),"Smoe.txt");
 gtest_expect_eq(filename_path("C:/John/Doe/Smoe.txt"),"C:/John/Doe/");
 gtest_expect_eq(filename_dir("C:/John/Doe/Smoe.txt"),"C:/John/Doe");
 gtest_expect_eq(filename_drive("C:/John/Doe/Smoe.txt"),"C:");
+gtest_expect_eq(filename_drive("C/John/Doe/Smoe.txt"),"");
+gtest_expect_eq(filename_drive("/c/John/Doe/Smoe.txt"),"");
+gtest_expect_eq(filename_drive("Smoe.txt"),"");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.txt"),".txt");
 gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/Doe/Smoe.dingtwo");
 

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -38,9 +38,15 @@ file_bin_close(bin_write);
 // BINARY READ
 var bin_read;
 bin_read = file_bin_open(bin_path,0);
+gtest_expect_eq(file_bin_size(bin_read),3);
+gtest_expect_eq(file_bin_position(bin_read),0);
+gtest_expect_ne(file_bin_position(bin_read),file_bin_size(bin_read));
 gtest_expect_eq(file_bin_read_byte(bin_read),99);
 gtest_expect_eq(file_bin_read_byte(bin_read),255);
 gtest_expect_eq(file_bin_read_byte(bin_read),0);
+gtest_expect_eq(file_bin_size(bin_read),3);
+gtest_expect_eq(file_bin_position(bin_read),3);
+gtest_expect_eq(file_bin_position(bin_read),file_bin_size(bin_read));
 
 // writing in read mode should fail
 file_bin_seek(bin_read,0);

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -125,17 +125,17 @@ file_text_close(text_append);
 // TEXT READ
 var text_read;
 text_read = file_text_open_read(text_path);
-gtest_assert_false(file_text_eof(text_read));
-gtest_assert_false(file_text_eoln(text_read));
+gtest_expect_false(file_text_eof(text_read));
+gtest_expect_false(file_text_eoln(text_read));
 gtest_expect_eq(file_text_read_string(text_read),"apple pear bear");
-gtest_assert_false(file_text_eof(text_read));
-gtest_assert_true(file_text_eoln(text_read));
+gtest_expect_false(file_text_eof(text_read));
+gtest_expect_true(file_text_eoln(text_read));
 file_text_readln(text_read);
 gtest_expect_eq(file_text_read_real(text_read),0);
 gtest_expect_eq(file_text_read_real(text_read),-1);
 gtest_expect_eq(file_text_read_real(text_read),253);
-gtest_assert_false(file_text_eof(text_read));
-gtest_assert_true(file_text_eoln(text_read));
+gtest_expect_false(file_text_eof(text_read));
+gtest_expect_true(file_text_eoln(text_read));
 file_text_readln(text_read);
 file_text_read_real(text_read) // TODO test epsilon
 file_text_read_real(text_read) // TODO test epsilon
@@ -145,12 +145,46 @@ gtest_expect_eq(file_text_read_real(text_read),2);
 gtest_expect_eq(file_text_read_string(text_read)," 5 b");
 file_text_readln(text_read);
 // Unix convention/end of file line is empty
-gtest_assert_false(file_text_eof(text_read));
-gtest_assert_true(file_text_eoln(text_read));
+gtest_expect_false(file_text_eof(text_read));
+gtest_expect_true(file_text_eoln(text_read));
 file_text_readln(text_read);
-gtest_assert_true(file_text_eof(text_read));
-gtest_assert_true(file_text_eoln(text_read));
+gtest_expect_true(file_text_eof(text_read));
+gtest_expect_true(file_text_eoln(text_read));
 file_text_close(text_read);
+
+/// General File Functions
+gtest_expect_false(file_exists("ENIGMA John Doe.txt"));
+gtest_expect_false(directory_exists("ENIGMA Folders"));
+file_text_close(file_text_open_write("ENIGMA John Doe.txt"));
+directory_create("ENIGMA Folders");
+gtest_expect_true(file_exists("ENIGMA John Doe.txt"));
+gtest_expect_true(directory_exists("ENIGMA Folders"));
+
+gtest_expect_false(file_exists("Games Are Fun.txt"));
+file_rename("ENIGMA John Doe.txt","Games Are Fun.txt");
+gtest_expect_false(file_exists("ENIGMA John Doe.txt"));
+gtest_expect_true(file_exists("Games Are Fun.txt"));
+
+gtest_expect_false(file_exists("Development Community.txt"));
+file_copy("Games Are Fun.txt","Development Community.txt");
+gtest_expect_true(file_exists("Games Are Fun.txt"));
+gtest_expect_true(file_exists("Development Community.txt"));
+
+file_delete("Development Community.txt");
+gtest_expect_true(file_exists("Games Are Fun.txt"));
+gtest_expect_false(file_exists("Development Community.txt"));
+
+file_delete("Games Are Fun.txt");
+gtest_expect_false(file_exists("Games Are Fun.txt"));
+gtest_expect_false(file_exists("Development Community.txt"));
+gtest_expect_false(file_exists("ENIGMA John Doe.txt"));
+
+gtest_expect_eq(filename_name("C:/John/Doe/Smoe.txt"),"Smoe.txt");
+gtest_expect_eq(filename_path("C:/John/Doe/Smoe.txt"),"C:/John/Doe/");
+gtest_expect_eq(filename_dir("C:/John/Doe/Smoe.txt"),"C:/John/Doe");
+gtest_expect_eq(filename_drive("C:/John/Doe/Smoe.txt"),"C:");
+gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.txt"),".txt");
+gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/Doe/Smoe.dingtwo");
 
 /// We're done!
 game_end();

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -1,6 +1,64 @@
-var text_path = "test.txt";
+/// BINARY FILES
+var bin_path = "file_bin_test.bin";
 
-/// TEXT WRITING
+// BINARY WRITE
+var bin_write;
+bin_write = file_bin_open(bin_path,1);
+file_bin_write_byte(bin_write, 3);
+file_bin_write_byte(bin_write, 255);
+file_bin_write_byte(bin_write, 7);
+gtest_expect_eq(file_bin_size(bin_write),3);
+gtest_expect_eq(file_bin_position(bin_write),3);
+gtest_expect_eq(file_bin_position(bin_write),file_bin_size(bin_write));
+file_bin_seek(bin_write,0);
+gtest_expect_eq(file_bin_size(bin_write),3);
+gtest_expect_eq(file_bin_position(bin_write),0);
+gtest_expect_ne(file_bin_position(bin_write),file_bin_size(bin_write));
+file_bin_write_byte(bin_write,99);
+file_bin_write_byte(bin_write,-1); // underflows to 255
+file_bin_write_byte(bin_write,256); // overflows to 0
+gtest_expect_eq(file_bin_size(bin_write),3);
+gtest_expect_eq(file_bin_position(bin_write),3);
+gtest_expect_eq(file_bin_position(bin_write),file_bin_size(bin_write));
+file_bin_close(bin_write);
+
+// BINARY READ
+var bin_read;
+bin_read = file_bin_open(bin_path,0);
+gtest_expect_eq(file_bin_read_byte(bin_read),99);
+gtest_expect_eq(file_bin_read_byte(bin_read),255);
+gtest_expect_eq(file_bin_read_byte(bin_read),0);
+file_bin_close(bin_read);
+
+// BINARY READ & WRITE
+var bin_read_write;
+bin_read_write = file_bin_open(bin_path,2);
+gtest_expect_eq(file_bin_size(bin_read_write),3);
+gtest_expect_eq(file_bin_position(bin_read_write),0);
+gtest_expect_ne(file_bin_position(bin_read_write),file_bin_size(bin_read_write));
+file_bin_seek(bin_read_write,file_bin_size(bin_read_write));
+gtest_expect_eq(file_bin_size(bin_read_write),3);
+gtest_expect_eq(file_bin_position(bin_read_write),3);
+gtest_expect_eq(file_bin_position(bin_read_write),file_bin_size(bin_read_write));
+file_bin_rewrite(bin_read_write);
+gtest_expect_eq(file_bin_size(bin_read_write),0);
+gtest_expect_eq(file_bin_position(bin_read_write),0);
+gtest_expect_eq(file_bin_position(bin_read_write),file_bin_size(bin_read_write));
+file_bin_write_byte(bin_read_write,1);
+file_bin_write_byte(bin_read_write,2);
+file_bin_write_byte(bin_read_write,3);
+file_bin_seek(bin_read_write,0);
+gtest_expect_eq(file_bin_size(bin_read_write),3);
+gtest_expect_eq(file_bin_position(bin_read_write),0);
+gtest_expect_eq(file_bin_read_byte(bin_read_write),1);
+gtest_expect_eq(file_bin_read_byte(bin_read_write),2);
+gtest_expect_eq(file_bin_read_byte(bin_read_write),3);
+file_bin_close(bin_read_write);
+
+/// TEXT FILES
+var text_path = "file_text_test.txt";
+
+// TEXT WRITING
 var text_write;
 text_write = file_text_open_write(text_path);
 file_text_write_string(text_write, "apple");
@@ -18,7 +76,7 @@ file_text_write_real(text_write, 253.98997721);
 file_text_writeln(text_write);
 file_text_close(text_write);
 
-/// TEXT APPEND
+// TEXT APPEND
 var text_append;
 text_append = file_text_open_append(text_path);
 file_text_write_real(text_append, 2);
@@ -27,7 +85,7 @@ file_text_write_string(text_append, " b");
 file_text_writeln(text_append);
 file_text_close(text_append);
 
-/// TEXT READ
+// TEXT READ
 var text_read;
 text_read = file_text_open_read(text_path);
 gtest_assert_false(file_text_eof(text_read));
@@ -57,4 +115,5 @@ gtest_assert_true(file_text_eof(text_read));
 gtest_assert_true(file_text_eoln(text_read));
 file_text_close(text_read);
 
+/// We're done!
 game_end();

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXfilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXfilemanip.cpp
@@ -48,7 +48,8 @@ int file_delete(string fname) { return remove(fname.c_str()); }
 int file_rename(string oldname, string newname) { return rename(oldname.c_str(), newname.c_str()); }
 
 int file_copy(string fname, string newname) {
-  return system(("cp " + fname + " " + newname).c_str());  // Hackish, but there's no good implementation on Linux
+  // Hackish, but there's no good implementation on Linux
+  return system(("cp \"" + fname + "\" \"" + newname + "\"").c_str());
 }
 
 int directory_exists(string dname) {

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXfilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXfilemanip.cpp
@@ -17,6 +17,7 @@
 
 #include "Platforms/General/PFfilemanip.h"
 
+#include <fstream> // for file_copy
 #include <cstdio>
 #include <cstdlib>
 #include <string>
@@ -48,8 +49,12 @@ int file_delete(string fname) { return remove(fname.c_str()); }
 int file_rename(string oldname, string newname) { return rename(oldname.c_str(), newname.c_str()); }
 
 int file_copy(string fname, string newname) {
-  // Hackish, but there's no good implementation on Linux
-  return system(("cp \"" + fname + "\" \"" + newname + "\"").c_str());
+  std::ifstream from(fname);
+  if (!from.good()) return false;
+  std::ofstream to(newname);
+  if (!to.good()) return false;
+  to << from.rdbuf();
+  return true;
 }
 
 int directory_exists(string dname) {

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -342,7 +342,7 @@ string filename_dir(string fname)
 
 string filename_drive(string fname)
 {
-  size_t fp = fname.find("/\\");
+  size_t fp = fname.find_first_of("/\\");
   return fname.substr(0, fp);
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -343,6 +343,8 @@ string filename_dir(string fname)
 string filename_drive(string fname)
 {
   size_t fp = fname.find_first_of("/\\");
+  if (!fp || fp == string::npos || fname[fp-1] != ':')
+    return "";
   return fname.substr(0, fp);
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -220,7 +220,7 @@ int file_bin_open(string fname,int mode) // Opens the file with the indicated na
 bool file_bin_rewrite(int fileid) // Rewrites the file with the given file id, that is, clears it and starts writing at the start.
 {
   enigma::openFile &mf = enigma::files[fileid];
-  mf.f = freopen (mf.sdata.c_str(), "wb", mf.f);
+  mf.f = freopen (mf.sdata.c_str(), "wb+", mf.f);
 
   if (mf.f == NULL) {
     #ifdef DEBUGMODE


### PR DESCRIPTION
Adding a simple CI test to cover file input output for text and binary files. The strategy is to write out some test files on the spot and then verify what we read back in.

I fixed the `file_bin_rewrite` function to be more GM8.1 compatible. Now it will allow you to read bytes if you rewrite, write some bytes, seek, read the bytes just written. Basically the function changes the mode of the file to be read and write, regardless of what mode it was originally opened in. This is not GMSv1.4 compatible however, because they changed it to not do this.

I fixed `file_copy` in here for POSIX/Linux using code provided by Josh which uses standard streams to accomplish the task. It worked pretty good locally, even copying files that were 0 bytes in size. This had to be done because the old hack didn't work with filenames that have spaces in them.

I also fixed `filename_drive` which was using the wrong string find function. Since we programmed it to look for forward and backslash, we wanted `find_first_of`, not `find`, since the former accepts multiple characters where the latter does not.
https://en.cppreference.com/w/cpp/string/basic_string/find_first_of
https://en.cppreference.com/w/cpp/string/basic_string/find