### PR TITLE
File Text Read Line Return

### DIFF
--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -125,6 +125,12 @@ file_text_write_real(text_append, 2);
 file_text_write_real(text_append, 5);
 file_text_write_string(text_append, " b");
 file_text_writeln(text_append);
+file_text_write_real(text_append, 45);
+file_text_write_real(text_append, -89);
+file_text_write_real(text_append, -102.5);
+file_text_writeln(text_append);
+file_text_write_string(text_append, "holy moly moo");
+file_text_writeln(text_append);
 file_text_close(text_append);
 
 // TEXT READ
@@ -150,6 +156,9 @@ file_text_readln(text_read);
 gtest_expect_eq(file_text_read_real(text_read),2);
 gtest_expect_eq(file_text_read_string(text_read)," 5 b");
 file_text_readln(text_read);
+gtest_expect_eq(file_text_read_real(text_read),45);
+gtest_expect_eq(file_text_readln(text_read)," -89 -102.5");
+gtest_expect_eq(file_text_readln(text_read),"holy moly moo");
 // Unix convention/end of file line is empty
 gtest_expect_false(file_text_eof(text_read));
 gtest_expect_true(file_text_eoln(text_read));

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -164,14 +164,15 @@ double file_text_read_real(int fileid) { // Reads a real value from the file and
   return r1;
 }
 
-void file_text_readln(int fileid) // Skips the rest of the line in the file and starts at the start of the next line.
+std::string file_text_readln(int fileid) // Skips the rest of the line in the file and starts at the start of the next line.
 {
-  if (feof(enigma::files[fileid].f))
-    enigma::files[fileid].eof = true;
+  enigma::openFile &mf = enigma::files[fileid];
+  if (feof(mf.f))
+    mf.eof = true;
   string ret;
   char buf[BUFSIZ];
     buf[0] = 0;
-  while (fgets(buf,BUFSIZ,enigma::files[fileid].f))
+  while (fgets(buf,BUFSIZ,mf.f))
   {
     ret += buf;
     if (ret[ret.length()-1] == '\n' or ret[ret.length()-1] == '\r')
@@ -181,8 +182,10 @@ void file_text_readln(int fileid) // Skips the rest of the line in the file and 
   size_t dp;
   for (dp = ret.length()-1; dp != size_t(-1) and (ret[dp] == '\n' or ret[dp] == '\r'); dp--);
   ret.erase(dp+1);
-  enigma::files[fileid].sdata = ret;
-  enigma::files[fileid].spos = 0;
+  std::string last = mf.sdata.substr(mf.spos);
+  mf.sdata = ret;
+  mf.spos = 0;
+  return last;
 }
 
 bool file_text_eof(int fileid) { // Returns whether we reached the end of the file.

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -169,21 +169,21 @@ std::string file_text_readln(int fileid) // Skips the rest of the line in the fi
   enigma::openFile &mf = enigma::files[fileid];
   if (feof(mf.f))
     mf.eof = true;
-  string ret;
+  string next;
   char buf[BUFSIZ];
     buf[0] = 0;
   while (fgets(buf,BUFSIZ,mf.f))
   {
-    ret += buf;
-    if (ret[ret.length()-1] == '\n' or ret[ret.length()-1] == '\r')
+    next += buf;
+    if (next[next.length()-1] == '\n' or next[next.length()-1] == '\r')
       break;
     buf[0] = 0;
   }
   size_t dp;
-  for (dp = ret.length()-1; dp != size_t(-1) and (ret[dp] == '\n' or ret[dp] == '\r'); dp--);
-  ret.erase(dp+1);
+  for (dp = next.length()-1; dp != size_t(-1) and (next[dp] == '\n' or next[dp] == '\r'); dp--);
+  next.erase(dp+1);
   std::string last = mf.sdata.substr(mf.spos);
-  mf.sdata = ret;
+  mf.sdata = next;
   mf.spos = 0;
   return last;
 }

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.h
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.h
@@ -20,6 +20,7 @@
 #define ENIGMA_FILEIO_H
 
 #include <string>
+using std::string;
 
 namespace enigma_user
 {
@@ -30,13 +31,13 @@ void    file_text_close(int fileid);
 void    file_text_write_string(int fileid, std::string str);
 void    file_text_write_real(int fileid, double x);
 void    file_text_writeln(int fileid);
-std::string file_text_read_string(int fileid);
-std::string file_text_read_all(int fileid);
+string  file_text_read_string(int fileid);
+string  file_text_read_all(int fileid);
 double  file_text_read_real(int fileid);
-std::string file_text_readln(int fileid);
+string  file_text_readln(int fileid);
 bool    file_text_eof(int fileid);
-bool file_text_eoln(int fileid);
-void load_info(std::string fname); // game information function
+bool    file_text_eoln(int fileid);
+void    load_info(std::string fname); // game information function
 
 int     file_bin_open(std::string fname,int mode);
 bool    file_bin_rewrite(int fileid);

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.h
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.h
@@ -33,7 +33,7 @@ void    file_text_writeln(int fileid);
 std::string file_text_read_string(int fileid);
 std::string file_text_read_all(int fileid);
 double  file_text_read_real(int fileid);
-void    file_text_readln(int fileid);
+std::string file_text_readln(int fileid);
 bool    file_text_eof(int fileid);
 bool file_text_eoln(int fileid);
 void load_info(std::string fname); // game information function


### PR DESCRIPTION
This attempts to resolve #1136 for @time-killer-games by making `file_text_readln` return the contents of the line read as a string. This is in fact GMSv1.4 behavior, and I agree with it as it makes it more like the C#/Java functions. It's also a lot less verbose to read files with this. I expanded the file I/O test to cover this change in behavior as well.