### PR TITLE
Miscellaneous Data Structure Tests

### DIFF
--- a/CommandLine/testing/SimpleTests/data_structure_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/data_structure_test.sog/create.edl
@@ -12,6 +12,9 @@ ds_list_add(list_str, "alarm");
 ds_list_add(list_str, "bank");
 ds_list_add(list_str, "cash");
 gtest_assert_eq(ds_list_size(list_str), 3);
+gtest_assert_eq(ds_list_find_index(list_str, "alarm"), 0);
+gtest_assert_eq(ds_list_find_index(list_str, "bank"), 1);
+gtest_assert_eq(ds_list_find_index(list_str, "notfound"), -1);
 gtest_assert_false(ds_list_empty(list_str));
 
 list_dup = ds_list_duplicate(list_str);
@@ -30,11 +33,24 @@ gtest_assert_eq(ds_list_find_value(list_str, 0), "alarm");
 gtest_assert_eq(ds_list_find_value(list_str, 1), "bank");
 gtest_assert_eq(ds_list_find_value(list_str, 2), "cash");
 
+ds_list_delete(list_str, 0, 1);
+gtest_assert_eq(ds_list_size(list_str), 1);
+gtest_assert_eq(ds_list_find_value(list_str, 0), "cash");
+
 ds_list_add(list_num, 5);
 ds_list_add(list_num, 2);
 ds_list_add(list_num, 98);
 gtest_assert_eq(ds_list_size(list_num), 3);
+gtest_assert_eq(ds_list_find_index(list_num, 2), 1);
+gtest_assert_eq(ds_list_find_index(list_num, 98), 2);
+gtest_assert_eq(ds_list_find_index(list_num, 404), -1);
 gtest_assert_false(ds_list_empty(list_num));
+
+ds_list_copy(list_dup, list_num);
+gtest_assert_eq(ds_list_size(list_dup), 3);
+gtest_assert_eq(ds_list_find_value(list_dup, 0), 5);
+gtest_assert_eq(ds_list_find_value(list_dup, 1), 2);
+gtest_assert_eq(ds_list_find_value(list_dup, 2), 98);
 
 ds_list_sort(list_num, false);
 gtest_assert_eq(ds_list_find_value(list_num, 0), 98);
@@ -62,6 +78,10 @@ gtest_assert_eq(ds_list_size(list_num), 3);
 gtest_assert_eq(ds_list_find_value(list_num, 0), 2);
 gtest_assert_eq(ds_list_find_value(list_num, 1), 5);
 gtest_assert_eq(ds_list_find_value(list_num, 2), 88);
+
+ds_list_delete(list_num, 1, 2);
+gtest_assert_eq(ds_list_size(list_num), 1);
+gtest_assert_eq(ds_list_find_value(list_num, 0), 2);
 
 ds_list_clear(list_num);
 gtest_assert_true(ds_list_empty(list_num));
@@ -112,10 +132,25 @@ ds_map_add(map_num, 2, 50);
 gtest_assert_eq(ds_map_size(map_num), 3);
 // We still have GM 8.1 replace behavior
 ds_map_replace(map_num, 5, 50);
+gtest_assert_false(ds_map_exists(map_num, 5));
 gtest_assert_true(is_undefined(ds_map_find_value(map_num, 5)));
 // This is our special function that acts like GMSv1.4 replace
-ds_map_overwrite(map_num, 5, 50);
+ds_map_overwrite(map_num, 5, 6667);
 gtest_assert_false(is_undefined(ds_map_find_value(map_num, 5)));
+gtest_assert_eq(ds_map_find_value(map_num, 5), 6667);
+// Actually test overwriting an existing value
+ds_map_overwrite(map_num, 5, 23482348);
+gtest_assert_eq(ds_map_find_value(map_num, 5), 23482348);
+// Actually test replace too
+ds_map_replace(map_num, 5, 78);
+gtest_assert_true(ds_map_exists(map_num, 5));
+gtest_assert_eq(ds_map_find_value(map_num, 5), 78);
+
+ds_map_delete(map_num,5);
+gtest_assert_false(ds_map_exists(map_num, 5));
+gtest_assert_true(is_undefined(ds_map_find_value(map_num, 5)));
+ds_map_add(map_num,5,50);
+gtest_assert_true(ds_map_exists(map_num, 5));
 gtest_assert_eq(ds_map_find_value(map_num, 5), 50);
 
 // lmao GM API is so dumb, this should really be called assign
@@ -242,6 +277,7 @@ gtest_assert_true(ds_priority_empty(test_priority2));
 gtest_assert_true(is_undefined(ds_priority_find_min(test_priority)));
 gtest_assert_true(is_undefined(ds_priority_find_max(test_priority)));
 gtest_assert_true(is_undefined(ds_priority_find_priority(test_priority, "hello")));
+gtest_assert_false(ds_priority_value_exists(test_priority, "hello"));
 
 ds_priority_add(test_priority, "one", 56);
 ds_priority_add(test_priority, "two", 0);
@@ -251,12 +287,16 @@ gtest_assert_eq(ds_priority_find_min(test_priority), "three");
 gtest_assert_eq(ds_priority_find_max(test_priority), "one");
 gtest_assert_eq(ds_priority_find_priority(test_priority, "one"), 56);
 gtest_assert_eq(ds_priority_find_priority(test_priority, "two"), 0);
+gtest_assert_true(ds_priority_value_exists(test_priority, "one"));
+
+ds_priority_change_priority(priority_dup, "one", -5000);
+gtest_assert_eq(ds_priority_find_priority(test_priority, "one"), -5000);
 
 priority_dup = ds_priority_duplicate(test_priority);
 gtest_assert_eq(ds_priority_size(priority_dup), 3);
-gtest_assert_eq(ds_priority_delete_max(priority_dup), "one");
 gtest_assert_eq(ds_priority_delete_max(priority_dup), "two");
 gtest_assert_eq(ds_priority_delete_max(priority_dup), "three");
+gtest_assert_eq(ds_priority_delete_max(priority_dup), "one");
 
 ds_priority_copy(test_priority2, test_priority);
 gtest_assert_eq(ds_priority_size(test_priority2), 3);
@@ -265,13 +305,13 @@ gtest_assert_false(ds_priority_empty(test_priority2));
 ds_priority_add(test_priority2, "five", 1);
 gtest_assert_eq(ds_priority_size(test_priority2), 4);
 
-gtest_assert_eq(ds_priority_delete_max(test_priority2), "one");
+gtest_assert_eq(ds_priority_delete_max(test_priority2), "five");
 gtest_assert_eq(ds_priority_size(test_priority2), 3);
-gtest_assert_eq(ds_priority_find_max(test_priority2), "five");
+gtest_assert_eq(ds_priority_find_max(test_priority2), "two");
 
-gtest_assert_eq(ds_priority_delete_min(test_priority2), "three");
+gtest_assert_eq(ds_priority_delete_min(test_priority2), "one");
 gtest_assert_eq(ds_priority_size(test_priority2), 2);
-gtest_assert_eq(ds_priority_find_min(test_priority2), "two");
+gtest_assert_eq(ds_priority_find_min(test_priority2), "three");
 
 ds_priority_add(test_priority2, "six", 101.1);
 ds_priority_add(test_priority2, "seven", -969);

--- a/CommandLine/testing/SimpleTests/data_structure_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/data_structure_test.sog/create.edl
@@ -36,6 +36,12 @@ gtest_assert_eq(ds_list_find_value(list_str, 2), "cash");
 ds_list_delete(list_str, 0, 1);
 gtest_assert_eq(ds_list_size(list_str), 1);
 gtest_assert_eq(ds_list_find_value(list_str, 0), "cash");
+ds_list_add(list_str,"moo");
+gtest_assert_eq(ds_list_size(list_str), 2);
+gtest_assert_eq(ds_list_find_value(list_str, 1), "moo");
+ds_list_delete(list_str, 1, 1);
+gtest_assert_eq(ds_list_size(list_str), 1);
+gtest_assert_eq(ds_list_find_value(list_str, 0), "cash");
 
 ds_list_add(list_num, 5);
 ds_list_add(list_num, 2);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/data_structures.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DataStructures/data_structures.cpp
@@ -1240,7 +1240,7 @@ void ds_list_delete(const unsigned int id, const unsigned int first, const unsig
   //Deletes the values in the range between first and last
   if (first < ds_lists[id].size() && last < ds_lists[id].size())
   {
-    ds_lists[id].erase(ds_lists[id].begin() + first, ds_lists[id].begin() + last);
+    ds_lists[id].erase(ds_lists[id].begin() + first, ds_lists[id].begin() + last+1);
   }
 }
 


### PR DESCRIPTION
This is a friend of #1716 expanding the data structures test to cover other misc functions I missed. Some are unique to ENIGMA and some are not. Regardless, I discovered them by actually looking at the code coverage's covered lines in the data structure source code.

I still am not testing grid disk functions yet because they are tricky. I am also not testing the read and write functions for each data structure because I originally thought they were unimplemented. Even though they are implemented, they too are complicated to test, so I am not bothering for now.

While I was in here I changed the `ds_list_delete` range overload to be inclusive of the last element. I did this because the condition seemed like that's what was originally intended. If somebody wants to dispute me, go ahead.