### PR TITLE
File Text Write Line Overload

### DIFF
--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -125,6 +125,12 @@ file_text_write_real(text_append, 2);
 file_text_write_real(text_append, 5);
 file_text_write_string(text_append, " b");
 file_text_writeln(text_append);
+file_text_write_real(text_append, 45);
+file_text_write_real(text_append, -89);
+file_text_write_real(text_append, -102.5);
+file_text_writeln(text_append);
+file_text_write_string(text_append, "holy moly moo");
+file_text_writeln(text_append);
 file_text_close(text_append);
 
 // TEXT READ
@@ -150,6 +156,9 @@ file_text_readln(text_read);
 gtest_expect_eq(file_text_read_real(text_read),2);
 gtest_expect_eq(file_text_read_string(text_read)," 5 b");
 file_text_readln(text_read);
+gtest_expect_eq(file_text_read_real(text_read),45);
+gtest_expect_eq(file_text_readln(text_read)," -89 -102.5");
+gtest_expect_eq(file_text_readln(text_read),"holy moly moo");
 // Unix convention/end of file line is empty
 gtest_expect_false(file_text_eof(text_read));
 gtest_expect_true(file_text_eoln(text_read));

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -125,12 +125,8 @@ file_text_write_real(text_append, 2);
 file_text_write_real(text_append, 5);
 file_text_write_string(text_append, " b");
 file_text_writeln(text_append);
-file_text_write_real(text_append, 45);
-file_text_write_real(text_append, -89);
-file_text_write_real(text_append, -102.5);
-file_text_writeln(text_append);
-file_text_write_string(text_append, "holy moly moo");
-file_text_writeln(text_append);
+file_text_writeln(text_append, " 45 -89 -102.5");
+file_text_writeln(text_append, "holy moly moo");
 file_text_close(text_append);
 
 // TEXT READ

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -120,6 +120,12 @@ void file_text_writeln(int fileid) // Write a newline character to the file.
   fputc('\n',mf.f);
 }
 
+void file_text_writeln(int fileid,string str) // Write a string and newline character to the file.
+{
+  file_text_write_string(fileid,str);
+  file_text_writeln(fileid);
+}
+
 string file_text_read_string(int fileid) { // Reads a string from the file with the given file id and returns this string. A string ends at the end of line.
   enigma::openFile &mf = enigma::files[fileid];
   if (!mf.sdata[mf.spos]) return "";

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -164,14 +164,15 @@ double file_text_read_real(int fileid) { // Reads a real value from the file and
   return r1;
 }
 
-void file_text_readln(int fileid) // Skips the rest of the line in the file and starts at the start of the next line.
+std::string file_text_readln(int fileid) // Skips the rest of the line in the file and starts at the start of the next line.
 {
-  if (feof(enigma::files[fileid].f))
-    enigma::files[fileid].eof = true;
+  enigma::openFile &mf = enigma::files[fileid];
+  if (feof(mf.f))
+    mf.eof = true;
   string ret;
   char buf[BUFSIZ];
     buf[0] = 0;
-  while (fgets(buf,BUFSIZ,enigma::files[fileid].f))
+  while (fgets(buf,BUFSIZ,mf.f))
   {
     ret += buf;
     if (ret[ret.length()-1] == '\n' or ret[ret.length()-1] == '\r')
@@ -181,8 +182,10 @@ void file_text_readln(int fileid) // Skips the rest of the line in the file and 
   size_t dp;
   for (dp = ret.length()-1; dp != size_t(-1) and (ret[dp] == '\n' or ret[dp] == '\r'); dp--);
   ret.erase(dp+1);
-  enigma::files[fileid].sdata = ret;
-  enigma::files[fileid].spos = 0;
+  std::string last = mf.sdata.substr(mf.spos);
+  mf.sdata = ret;
+  mf.spos = 0;
+  return last;
 }
 
 bool file_text_eof(int fileid) { // Returns whether we reached the end of the file.

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.h
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.h
@@ -30,6 +30,7 @@ void    file_text_close(int fileid);
 void    file_text_write_string(int fileid, std::string str);
 void    file_text_write_real(int fileid, double x);
 void    file_text_writeln(int fileid);
+void    file_text_writeln(int fileid, std::string str);
 std::string file_text_read_string(int fileid);
 std::string file_text_read_all(int fileid);
 double  file_text_read_real(int fileid);

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.h
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.h
@@ -33,7 +33,7 @@ void    file_text_writeln(int fileid);
 std::string file_text_read_string(int fileid);
 std::string file_text_read_all(int fileid);
 double  file_text_read_real(int fileid);
-void    file_text_readln(int fileid);
+std::string file_text_readln(int fileid);
 bool    file_text_eof(int fileid);
 bool file_text_eoln(int fileid);
 void load_info(std::string fname); // game information function


### PR DESCRIPTION
This pull request is a friend of #1717 and does the same thing for writing. I want to provide a new overload for `file_text_writeln` that accepts a string. I used to always make a script for this in my GM games, and that includes Project Mario. I also expanded the file I/O test to cover the new write line overload.