### PR TITLE
Generic Screen Transfer

### DIFF
--- a/CommandLine/testing/Tests/draw_test.sog/create.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/create.edl
@@ -49,3 +49,6 @@ surface_reset_target();
 gtest_expect_eq(surface_getpixel(surf_dup,2,2),c_red);
 gtest_expect_eq(surface_getpixel(surf_dup,2,10),c_green);
 gtest_expect_eq(surface_getpixel(surf_dup,16,16),c_blue);
+
+screen_spr = -1;
+screen_bkg = -1;

--- a/CommandLine/testing/Tests/draw_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/draw.edl
@@ -59,4 +59,22 @@ draw_sprite(spr2,0,0,25);
 draw_surface(surf_test,0,room_height-32);
 draw_sprite(surf_spr,0,32,room_height-32);
 draw_background(surf_back,0,room_height-64);
-draw_surface(surf_dup,32,room_height-64);
+var surf_dupx, surf_dupy;
+surf_dupx = 32;
+surf_dupy = room_height-64;
+draw_surface(surf_dup,surf_dupx,surf_dupy);
+
+// screen copy tests
+if (screen_spr == -1) {
+	// test reading screen pixels just once
+	gtest_expect_eq(draw_getpixel(surf_dupx+2,surf_dupy+2),c_red);
+	gtest_expect_eq(draw_getpixel(surf_dupx+2,surf_dupy+10),c_green);
+	gtest_expect_eq(draw_getpixel(surf_dupx+16,surf_dupy+16),c_blue);
+
+	screen_spr = sprite_create_from_screen(0,room_height-64,32,32,false,false,false,0,0);
+}
+if (screen_bkg == -1) {
+	screen_bkg = background_create_from_screen(0,room_height-32,32,32,false,false);
+}
+draw_sprite(screen_spr,0,64,room_height-64);
+draw_background(screen_bkg,64,room_height-32);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11draw.cpp
@@ -22,14 +22,6 @@
 #include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
 
-#include "Universal_System/roomsystem.h"
-
-#include <vector>
-#include <math.h>
-#include <stdio.h>
-
-using std::vector;
-
 using namespace enigma::dx11;
 
 namespace enigma_user {
@@ -72,27 +64,6 @@ int draw_get_msaa_maxlevel()
 bool draw_get_msaa_supported()
 {
   return false; //TODO: implement
-}
-
-} // namespace enigma_user
-
-//#include <endian.h>
-//TODO: Though serprex, the author of the function below, never included endian.h,
-//   // Doing so is necessary for the function to work at its peak.
-//   // When ENIGMA generates configuration files, one should be included here.
-
-namespace enigma_user {
-
-int draw_getpixel(int x, int y)
-{
-  draw_batch_flush(batch_flush_deferred);
-  return 0; //TODO: implement
-}
-
-int draw_getpixel_ext(int x, int y)
-{
-  draw_batch_flush(batch_flush_deferred);
-  return 0; //TODO: implement
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -36,6 +36,14 @@ void scene_end() {
 
 }
 
+unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped) {
+  return nullptr;
+}
+
+unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
+  return nullptr;
+}
+
 } // namespace enigma
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -17,22 +17,12 @@
 
 #include "Direct3D11Headers.h"
 #include "Graphics_Systems/General/GSscreen.h"
-#include "Graphics_Systems/General/GSbackground.h"
-#include "Graphics_Systems/General/GSsprite.h"
 #include "Graphics_Systems/General/GSprimitives.h"
 #include "Graphics_Systems/General/GScolors.h"
 
-#include "Universal_System/image_formats.h"
-#include "Universal_System/nlpo2.h"
-#include "Universal_System/Resources/background_internal.h"
-#include "Universal_System/Resources/sprites_internal.h"
 #include "Universal_System/roomsystem.h"
 #include "Platforms/General/PFwindow.h"
 
-#include <string>
-#include <cstdio>
-
-using namespace std;
 using namespace enigma;
 using namespace enigma::dx11;
 
@@ -70,35 +60,6 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   viewport.MaxDepth = 1.0f;
 
   m_deviceContext->RSSetViewports(1, &viewport);
-}
-
-int screen_save(string filename)
-{
-  draw_batch_flush(batch_flush_deferred);
-  return -1; //TODO: implement
-}
-
-int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h)
-{
-  draw_batch_flush(batch_flush_deferred);
-  return -1; //TODO: implement
-}
-
-int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
-{
-  return -1; //TODO: implement
-}
-
-int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
-  return -1; //TODO: implement
-}
-
-int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
-  return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
-}
-
-void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth) {
-
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -37,11 +37,22 @@ void scene_end() {
 }
 
 unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, bool* flipped) {
-  return nullptr;
+  if (flipped) *flipped = false;
+
+  unsigned char* ret = new unsigned char[width*height*4];
+  return ret;
 }
 
 unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
-  return nullptr;
+  DXGI_SWAP_CHAIN_DESC desc;
+  m_swapChain->GetDesc(&desc);
+
+  const int fw = desc.BufferDesc.Width,
+            fh = desc.BufferDesc.Height;
+
+  *fullwidth = fw, *fullheight = fh;
+
+  return graphics_copy_screen_pixels(0,0,fw,fh,flipped);
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11screen.cpp
@@ -36,11 +36,11 @@ void scene_end() {
 
 }
 
-unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped) {
+unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, bool* flipped) {
   return nullptr;
 }
 
-unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
+unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
   return nullptr;
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/Direct3D11Headers.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/Direct3D11Headers.h
@@ -24,6 +24,7 @@ namespace enigma {
 
 namespace dx11 {
 
+extern IDXGISwapChain* m_swapChain;
 extern ID3D11Device* m_device;
 extern ID3D11DeviceContext* m_deviceContext;
 extern ID3D11RenderTargetView* m_renderTargetView;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9draw.cpp
@@ -22,14 +22,6 @@
 #include "Graphics_Systems/General/GScolors.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
 
-#include "Universal_System/roomsystem.h"
-
-#include <vector>
-#include <math.h>
-#include <stdio.h>
-
-using std::vector;
-
 using namespace enigma::dx9;
 
 namespace enigma_user {
@@ -54,93 +46,6 @@ int draw_get_msaa_maxlevel()
 bool draw_get_msaa_supported()
 {
   return false; //TODO: implement
-}
-
-} // namespace enigma_user
-
-//#include <endian.h>
-//TODO: Though serprex, the author of the function below, never included endian.h,
-//   // Doing so is necessary for the function to work at its peak.
-//   // When ENIGMA generates configuration files, one should be included here.
-
-namespace enigma_user {
-
-int draw_getpixel(int x, int y)
-{
-    if (view_enabled)
-    {
-        x = x + enigma_user::view_xview[enigma_user::view_current];
-        y = (y + enigma_user::view_yview[enigma_user::view_current]) - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::view_wview[enigma_user::view_current] || y > enigma_user::view_hview[enigma_user::view_current]) return 0;
-    } else {
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::room_width || y > enigma_user::room_height) return 0;
-    }
-
-	draw_batch_flush(batch_flush_deferred);
-
-	LPDIRECT3DSURFACE9 pBackBuffer;
-	LPDIRECT3DSURFACE9 pDestBuffer;
-	d3ddev->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
-	D3DSURFACE_DESC desc;
-	pBackBuffer->GetDesc(&desc);
-
-	d3ddev->CreateOffscreenPlainSurface( desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pDestBuffer, NULL );
-	d3ddev->GetRenderTargetData(pBackBuffer, pDestBuffer);
-
-	D3DLOCKED_RECT rect;
-
-	pDestBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
-	unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
-	unsigned offset = y * rect.Pitch + x * 4;
-	int ret = bitmap[offset + 2] | (bitmap[offset + 1] << 8) | (bitmap[offset + 0] << 16);
-	pDestBuffer->UnlockRect();
-
-	pBackBuffer->Release();
-	pDestBuffer->Release();
-
-	return ret;
-}
-
-int draw_getpixel_ext(int x, int y)
-{
-    if (view_enabled)
-    {
-        x = x + enigma_user::view_xview[enigma_user::view_current];
-        y = (y + enigma_user::view_yview[enigma_user::view_current]) - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::view_wview[enigma_user::view_current] || y > enigma_user::view_hview[enigma_user::view_current]) return 0;
-    } else {
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::room_width || y > enigma_user::room_height) return 0;
-    }
-
-	draw_batch_flush(batch_flush_deferred);
-
-	LPDIRECT3DSURFACE9 pBackBuffer;
-	LPDIRECT3DSURFACE9 pDestBuffer;
-	d3ddev->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
-	D3DSURFACE_DESC desc;
-	pBackBuffer->GetDesc(&desc);
-	d3ddev->CreateOffscreenPlainSurface( desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pDestBuffer, NULL );
-	d3ddev->GetRenderTargetData(pBackBuffer, pDestBuffer);
-
-	D3DLOCKED_RECT rect;
-
-	pDestBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
-	unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
-	unsigned offset = y * rect.Pitch + x * 4;
-	int ret = bitmap[offset + 2] | (bitmap[offset + 1] << 8) | (bitmap[offset + 0] << 16) | (bitmap[offset + 3] << 24);
-	pDestBuffer->UnlockRect();
-
-	pBackBuffer->Release();
-	pDestBuffer->Release();
-	return ret;
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9screen.cpp
@@ -17,22 +17,13 @@
 
 #include "Direct3D9Headers.h"
 #include "Graphics_Systems/General/GSscreen.h"
-#include "Graphics_Systems/General/GSbackground.h"
-#include "Graphics_Systems/General/GSsprite.h"
 #include "Graphics_Systems/General/GSprimitives.h"
-#include "Graphics_Systems/General/GScolors.h"
 
-#include "Universal_System/image_formats.h"
-#include "Universal_System/nlpo2.h"
-#include "Universal_System/Resources/background_internal.h"
-#include "Universal_System/Resources/sprites_internal.h"
 #include "Universal_System/roomsystem.h"
 
 #include "Platforms/General/PFwindow.h"
 
-using namespace enigma;
 using namespace enigma::dx9;
-using namespace std;
 
 namespace enigma {
 
@@ -56,82 +47,6 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   sy = (window_get_height() - window_get_region_height_scaled()) / 2;
 	D3DVIEWPORT9 pViewport = { (DWORD)(sx + x), (DWORD)(sy + y), (DWORD)width, (DWORD)height, 0, 1.0f };
 	d3ddev->SetViewport(&pViewport);
-}
-
-int screen_save(string filename) //Assumes native integers are little endian
-{
-  draw_batch_flush(batch_flush_deferred);
-
-	string ext = enigma::image_get_format(filename);
-
-	LPDIRECT3DSURFACE9 pBackBuffer;
-	LPDIRECT3DSURFACE9 pDestBuffer;
-	d3ddev->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
-	D3DSURFACE_DESC desc;
-	pBackBuffer->GetDesc(&desc);
-
-	d3ddev->CreateOffscreenPlainSurface( desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pDestBuffer, NULL );
-	d3ddev->GetRenderTargetData(pBackBuffer, pDestBuffer);
-
-	D3DLOCKED_RECT rect;
-
-	pDestBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
-	unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
-	pDestBuffer->UnlockRect();
-
-	int ret = image_save(filename, bitmap, desc.Width, desc.Height, desc.Width, desc.Height, false);
-
-  pBackBuffer->Release();
-	pDestBuffer->Release();
-
-	//delete[] bitmap; <- no need cause RAII
-	return ret;
-}
-
-int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h) //Assumes native integers are little endian
-{
-  draw_batch_flush(batch_flush_deferred);
-
-	string ext = enigma::image_get_format(filename);
-
-	LPDIRECT3DSURFACE9 pBackBuffer;
-	LPDIRECT3DSURFACE9 pDestBuffer;
-	d3ddev->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
-	D3DSURFACE_DESC desc;
-	pBackBuffer->GetDesc(&desc);
-
-	d3ddev->CreateOffscreenPlainSurface( desc.Width, desc.Height, desc.Format, D3DPOOL_SYSTEMMEM, &pDestBuffer, NULL );
-	d3ddev->GetRenderTargetData(pBackBuffer, pDestBuffer);
-
-	D3DLOCKED_RECT rect;
-
-	pDestBuffer->LockRect(&rect, NULL, D3DLOCK_READONLY);
-	unsigned char* bitmap = static_cast<unsigned char*>(rect.pBits);
-	pDestBuffer->UnlockRect();
-
-	int ret = image_save(filename, bitmap, w, h, desc.Width, desc.Height, false);
-
-  pBackBuffer->Release();
-	pDestBuffer->Release();
-
-  return ret;
-}
-
-int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
-{
-  return -1; //TODO: implement
-}
-
-int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
-  return -1; //TODO: implement
-}
-
-int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
-  return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
-}
-
-void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth) {
-
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -68,7 +68,7 @@ unsigned char* surface_copy_pixels(LPDIRECT3DSURFACE9 pBuffer, int x, int y, int
 
 namespace enigma {
 
-unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped) {
+unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, bool* flipped) {
   if (flipped) *flipped = false;
 
 	LPDIRECT3DSURFACE9 pBackBuffer;
@@ -77,7 +77,7 @@ unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int hei
   return surface_copy_pixels(pBackBuffer, x, y, width, height);
 }
 
-unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
+unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
   if (flipped) *flipped = false;
 
   LPDIRECT3DSURFACE9 pBackBuffer;
@@ -89,7 +89,7 @@ unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* f
 
   *fullwidth = fw;
   *fullheight = fh;
-  return graphics_copy_back_buffer_pixels(0,0,fw,fh,flipped);
+  return graphics_copy_screen_pixels(0,0,fw,fh,flipped);
 }
 
 LPDIRECT3DTEXTURE9 get_texture_peer(int texid) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -53,11 +53,10 @@ unsigned char* surface_copy_pixels(LPDIRECT3DSURFACE9 pBuffer, int x, int y, int
 
   bool subsurf = false;
 
-  // copy render target textures to system memory first
-  // use system memory copy to read pixel data
+  // use system memory surface to copy texture
   D3DSURFACE_DESC desc;
   pBuffer->GetDesc(&desc);
-  if (desc.Usage == D3DUSAGE_RENDERTARGET && desc.Pool == D3DPOOL_DEFAULT) {
+  if (desc.Pool == D3DPOOL_DEFAULT) {
     surface_copy_to_ram(&pBuffer,&pRamBuffer,rect,subsurf);
     pBuffer = pRamBuffer;
   }
@@ -111,26 +110,10 @@ int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth,
 {
   LPDIRECT3DTEXTURE9 texture = NULL;
 
-  DWORD usage = Direct3D9Managed ? 0 : D3DUSAGE_DYNAMIC;
-  if (mipmap) usage |= D3DUSAGE_AUTOGENMIPMAP;
+  DWORD usage = mipmap?D3DUSAGE_AUTOGENMIPMAP:0;
   d3ddev->CreateTexture(fullwidth, fullheight, 1, usage, D3DFMT_A8R8G8B8, Direct3D9Managed ? D3DPOOL_MANAGED : D3DPOOL_DEFAULT, &texture, 0);
 
-  if (pxdata != nullptr) {
-    D3DLOCKED_RECT rect;
-    texture->LockRect(0, &rect, NULL, D3DLOCK_DISCARD);
-    // we have to respect the pitch returned by the lock because some GPU's
-    // have exhibited a minimum pitch size for small textures
-    // (e.g, 8x8 and 16x16 texture both have 64 pitch when created in the default pool)
-    // NOTE: sometime soon we must finally do texture paging...
-    for (size_t i = 0; i < height; ++i) {
-      memcpy((void*)((intptr_t)rect.pBits + i * rect.Pitch), (void*)((intptr_t)pxdata + i * fullwidth * 4), width * 4);
-    }
-    texture->UnlockRect(0);
-  }
-
-  if (mipmap) {
-    texture->GenerateMipSubLevels();
-  }
+  if (mipmap) texture->GenerateMipSubLevels();
 
   DX9Texture* textureStruct = new DX9Texture(texture);
   textureStruct->width = width;
@@ -139,6 +122,7 @@ int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth,
   textureStruct->fullheight = fullheight;
   const int id = textures.size();
   textures.push_back(textureStruct);
+  if (pxdata != nullptr) graphics_push_texture_pixels(id, width, height, (unsigned char*)pxdata);
   return id;
 }
 
@@ -169,16 +153,16 @@ void graphics_push_texture_pixels(int texture, int x, int y, int width, int heig
   LPDIRECT3DSURFACE9 pBuffer,pRamBuffer=nullptr;
   peer->GetSurfaceLevel(0,&pBuffer);
 
-  // use system memory surface to update render target texture
+  // use system memory surface to update texture
   D3DSURFACE_DESC desc;
   pBuffer->GetDesc(&desc);
-  if (desc.Usage == D3DUSAGE_RENDERTARGET) {
+  if (desc.Pool == D3DPOOL_DEFAULT) {
     d3ddev->CreateOffscreenPlainSurface(width, height, desc.Format, D3DPOOL_SYSTEMMEM, &pRamBuffer, NULL);
   }
 
   RECT rect = {(LONG)x, (LONG)y, (LONG)(x+width), (LONG)(y+height)};
   D3DLOCKED_RECT lock;
-  (pRamBuffer?pRamBuffer:pBuffer)->LockRect(&lock, pRamBuffer?NULL:&rect, 0);
+  (pRamBuffer?pRamBuffer:pBuffer)->LockRect(&lock, pRamBuffer?NULL:&rect, D3DLOCK_DISCARD);
   for (int i = 0; i < height; ++i) {
     memcpy((void*)((intptr_t)lock.pBits + i * lock.Pitch), (void*)((intptr_t)pxdata + i * width * 4), width * 4);
   }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -35,7 +35,8 @@ void surface_copy_to_ram(IDirect3DSurface9 **src, IDirect3DSurface9 **dest, cons
 
   // lockable render target is only faster when requested area is less than half of total area
   // this should make sense intuitively since the lockable render target will have to copy twice
-  if (width*height < (desc.Width*desc.Height)/2) {
+  // lockable render target is also the only way to get back non-RT video memory texture
+  if (width*height < (desc.Width*desc.Height)/2 || desc.Usage != D3DUSAGE_RENDERTARGET) {
     subsurf = true;
     d3ddev->CreateRenderTarget(width, height, desc.Format, D3DMULTISAMPLE_NONE, 0, true, dest, NULL);
     d3ddev->StretchRect(*src, &rect, *dest, NULL, D3DTEXF_NONE);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -89,8 +89,6 @@ unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, 
 }
 
 unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
-  if (flipped) *flipped = false;
-
   LPDIRECT3DSURFACE9 pBackBuffer;
   d3ddev->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
   D3DSURFACE_DESC desc;
@@ -98,8 +96,7 @@ unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullhe
 
   const int fw = desc.Width, fh = desc.Height;
 
-  *fullwidth = fw;
-  *fullheight = fh;
+  *fullwidth = fw, *fullheight = fh;
   return graphics_copy_screen_pixels(0,0,fw,fh,flipped);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -447,9 +447,6 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
   delete[] rgba;
 }
 
-// The following two leave a bad taste in my mouth because they depend on views, which should be removable.
-// However, for now, they stay.
-
 int draw_getpixel(int x,int y)
 {
   if (clamp_view(x,y)) return 0;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -351,4 +351,41 @@ void screen_redraw()
   screen_refresh();
 }
 
+int screen_save(string filename) { //Assumes native integers are little endian
+  return -1;
+}
+
+int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h) { //Assumes native integers are little endian
+  return -1;
+}
+
+// The following three leave a bad taste in my mouth because they depend on views, which should be removable.
+// However, for now, they stay.
+
+int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
+{
+  return -1;
+}
+
+int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
+  return -1;
+}
+
+int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
+	return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
+}
+
+void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth) {
+}
+
+int draw_getpixel(int x,int y)
+{
+  return 0;
+}
+
+int draw_getpixel_ext(int x,int y)
+{
+  return 0;
+}
+
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -377,7 +377,7 @@ int screen_save(string filename) { //Assumes native integers are little endian
 
   unsigned int fw = 0, fh = 0;
   bool flipped = false;
-  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(&fw,&fh,&flipped);
+  unsigned char* rgba = enigma::graphics_copy_screen_pixels(&fw,&fh,&flipped);
   int ret = image_save(filename, rgba, fw, fh, fw, fh, flipped);
 
   delete[] rgba;
@@ -388,7 +388,7 @@ int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h
   draw_batch_flush(batch_flush_deferred);
 
   bool flipped = false;
-  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,w,h,&flipped);
+  unsigned char* rgba = enigma::graphics_copy_screen_pixels(x,y,w,h,&flipped);
   int ret = image_save(filename, rgba, w, h, w, h, flipped);
 
   delete[] rgba;
@@ -400,7 +400,7 @@ int background_create_from_screen(int x, int y, int w, int h, bool removeback, b
   draw_batch_flush(batch_flush_deferred);
 
   bool flipped = false;
-  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,w,h,&flipped);
+  unsigned char* rgba = enigma::graphics_copy_screen_pixels(x,y,w,h,&flipped);
 
   if (flipped)
     rgba = enigma::image_flip(rgba, w, h, 4);
@@ -417,7 +417,7 @@ int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool 
   draw_batch_flush(batch_flush_deferred);
 
   bool flipped = false;
-  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,w,h,&flipped);
+  unsigned char* rgba = enigma::graphics_copy_screen_pixels(x,y,w,h,&flipped);
 
   if (flipped)
     rgba = enigma::image_flip(rgba, w, h, 4);
@@ -438,7 +438,7 @@ void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback,
   draw_batch_flush(batch_flush_deferred);
 
   bool flipped = false;
-  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,w,h,&flipped);
+  unsigned char* rgba = enigma::graphics_copy_screen_pixels(x,y,w,h,&flipped);
 
   if (flipped)
     rgba = enigma::image_flip(rgba, w, h, 4);
@@ -455,7 +455,7 @@ int draw_getpixel(int x,int y)
   if (clamp_view(x,y)) return 0;
   draw_batch_flush(batch_flush_deferred);
 
-  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,1,1);
+  unsigned char* rgba = enigma::graphics_copy_screen_pixels(x,y,1,1);
   int ret = rgba[2] | rgba[1] << 8 | rgba[0] << 16;
   delete[] rgba;
   return ret;
@@ -466,7 +466,7 @@ int draw_getpixel_ext(int x,int y)
   if (clamp_view(x,y)) return 0;
   draw_batch_flush(batch_flush_deferred);
 
-  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,1,1);
+  unsigned char* rgba = enigma::graphics_copy_screen_pixels(x,y,1,1);
   int ret = rgba[2] | rgba[1] << 8 | rgba[0] << 16 | rgba[3] << 24;
   delete[] rgba;
   return ret;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -52,7 +52,7 @@ namespace {
 bool clamp_view(int& x, int& y) {
   if (view_enabled) {
     x = x - enigma_user::view_xview[enigma_user::view_current];
-    x = y - enigma_user::view_yview[enigma_user::view_current];
+    y = y - enigma_user::view_yview[enigma_user::view_current];
     if (x > enigma_user::view_wview[enigma_user::view_current] || y > enigma_user::view_hview[enigma_user::view_current]) return true;
   } else {
     if (x > enigma_user::room_width || y > enigma_user::room_height) return true;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -27,11 +27,15 @@
 #include "GSvertex.h"
 #include "GScolors.h"
 
+#include "Universal_System/nlpo2.h"
+#include "Universal_System/image_formats.h"
 #include "Universal_System/Resources/background.h"
 #include "Universal_System/Object_Tiers/graphics_object.h"
 #include "Universal_System/depth_draw.h"
 #include "Universal_System/Instances/instance_system.h"
 #include "Universal_System/roomsystem.h"
+#include "Universal_System/Resources/background_internal.h"
+#include "Universal_System/Resources/sprites_internal.h"
 #include "Platforms/General/PFwindow.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 
@@ -42,6 +46,23 @@
 using namespace enigma;
 using namespace enigma_user;
 using namespace std;
+
+namespace {
+
+bool clamp_view(int& x, int& y) {
+  if (view_enabled) {
+    x = x - enigma_user::view_xview[enigma_user::view_current];
+    x = y - enigma_user::view_yview[enigma_user::view_current];
+    if (x > enigma_user::view_wview[enigma_user::view_current] || y > enigma_user::view_hview[enigma_user::view_current]) return true;
+  } else {
+    if (x > enigma_user::room_width || y > enigma_user::room_height) return true;
+  }
+  if (x < 0) x = 0;
+  if (y < 0) y = 0;
+  return false;
+}
+
+} // namespace anonymous
 
 namespace enigma {
 
@@ -352,40 +373,103 @@ void screen_redraw()
 }
 
 int screen_save(string filename) { //Assumes native integers are little endian
-  return -1;
+  draw_batch_flush(batch_flush_deferred);
+
+  unsigned int fw = 0, fh = 0;
+  bool flipped = false;
+  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(&fw,&fh,&flipped);
+  int ret = image_save(filename, rgba, fw, fh, fw, fh, flipped);
+
+  delete[] rgba;
+  return ret;
 }
 
 int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h) { //Assumes native integers are little endian
-  return -1;
-}
+  draw_batch_flush(batch_flush_deferred);
 
-// The following three leave a bad taste in my mouth because they depend on views, which should be removable.
-// However, for now, they stay.
+  bool flipped = false;
+  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,w,h,&flipped);
+  int ret = image_save(filename, rgba, w, h, w, h, flipped);
+
+  delete[] rgba;
+  return ret;
+}
 
 int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
 {
-  return -1;
+  draw_batch_flush(batch_flush_deferred);
+
+  bool flipped = false;
+  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,w,h,&flipped);
+
+  if (flipped)
+    rgba = enigma::image_flip(rgba, w, h, 4);
+
+  enigma::backgroundstructarray_reallocate();
+  int bckid=enigma::background_idmax;
+  enigma::background_new(bckid, w, h, &rgba[0], removeback, smooth, preload, false, 0, 0, 0, 0, 0, 0);
+  delete[] rgba;
+  enigma::background_idmax++;
+  return bckid;
 }
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
-  return -1;
+  draw_batch_flush(batch_flush_deferred);
+
+  bool flipped = false;
+  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,w,h,&flipped);
+
+  if (flipped)
+    rgba = enigma::image_flip(rgba, w, h, 4);
+
+  enigma::spritestructarray_reallocate();
+  int sprid=enigma::sprite_idmax;
+  enigma::sprite_new_empty(sprid, 1, w, h, xorig, yorig, 0, h, 0, w, preload, smooth);
+  enigma::sprite_set_subimage(sprid, 0, w, h, rgba, rgba, enigma::ct_precise); //TODO: Support toggling of precise.
+  delete[] rgba;
+  return sprid;
 }
 
 int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
-	return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
+  return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
 }
 
 void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth) {
+  draw_batch_flush(batch_flush_deferred);
+
+  bool flipped = false;
+  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,w,h,&flipped);
+
+  if (flipped)
+    rgba = enigma::image_flip(rgba, w, h, 4);
+
+  enigma::sprite_add_subimage(id, w, h, rgba, rgba, enigma::ct_precise); //TODO: Support toggling of precise.
+  delete[] rgba;
 }
+
+// The following two leave a bad taste in my mouth because they depend on views, which should be removable.
+// However, for now, they stay.
 
 int draw_getpixel(int x,int y)
 {
-  return 0;
+  if (clamp_view(x,y)) return 0;
+  draw_batch_flush(batch_flush_deferred);
+
+  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,1,1);
+  int ret = rgba[2] | rgba[1] << 8 | rgba[0] << 16;
+  delete[] rgba;
+  return ret;
 }
 
 int draw_getpixel_ext(int x,int y)
 {
-  return 0;
+  if (clamp_view(x,y)) return 0;
+  draw_batch_flush(batch_flush_deferred);
+
+  unsigned char* rgba = enigma::graphics_copy_back_buffer_pixels(x,y,1,1);
+  int ret = rgba[2] | rgba[1] << 8 | rgba[0] << 16 | rgba[3] << 24;
+  delete[] rgba;
+  return ret;
 }
 
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
@@ -110,14 +110,7 @@ namespace enigma_user
 	int draw_get_msaa_maxlevel(){return 0;}
 	bool draw_get_msaa_supported(){return false;}
 
-	int draw_getpixel(int x,int y){return -1;}
-	int draw_getpixel_ext(int x,int y){return -1;}
-
 	extern int window_get_region_height_scaled();
-
-	int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig){return -1;}
-	int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig){return -1;}
-	void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth){}
 
 	int glsl_shader_create(int type){return -1;}
 	int glsl_shader_load(int id, string fname){return -1;}
@@ -148,8 +141,6 @@ namespace enigma_user
 	extern int window_get_region_width();
 	extern int window_get_region_height();
 
-	int screen_save(string filename){return -1;}
-	int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h){return -1;}
 	void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height){}
 
 	void draw_clear_alpha(int col,float alpha){}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
@@ -66,11 +66,12 @@ using namespace std;
 //the GPU (such as surfaces) and as such have no business in a headless mode
 namespace enigma
 {
-
 	void graphicssystem_initialize(){}
 
 	int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, void* pxdata, bool mipmap){return -1;}
 	void graphics_delete_texture(int texid){}
+	unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, bool* flipped) {return nullptr;}
+	unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {return nullptr;}
 	unsigned char* graphics_copy_texture_pixels(int texture, unsigned* fullwidth, unsigned* fullheight) {return NULL;}
 	unsigned char* graphics_copy_texture_pixels(int texture, int x, int y, int width, int height) {return NULL;}
 	void graphics_push_texture_pixels(int texture, int x, int y, int width, int height, unsigned char* pxdata) {}
@@ -149,7 +150,4 @@ namespace enigma_user
 	void d3d_stencil_clear_value(int value) {}
 	void d3d_stencil_clear() {}
 	void d3d_set_software_vertex_processing(bool software){}
-
-	extern int window_get_region_height_scaled();
-	int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload){return -1;}
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
@@ -80,8 +80,5 @@ namespace enigma_user
 
 	void draw_clear_alpha(int col,float alpha);
 	void draw_clear(int col);
-
-	extern int window_get_region_height_scaled();
-	int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload);
 }
 #endif

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.h
@@ -55,14 +55,7 @@ namespace enigma_user
 	int draw_get_msaa_maxlevel();
 	bool draw_get_msaa_supported();
 
-	int draw_getpixel(int x,int y);
-	int draw_getpixel_ext(int x,int y);
-
 	extern int window_get_region_height_scaled();
-
-	int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig);
-	int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig);
-	void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth);
 
 	void shader_set(int id);
 	void shader_reset();
@@ -82,8 +75,6 @@ namespace enigma_user
 	extern int window_get_region_width();
 	extern int window_get_region_height();
 
-	int screen_save(string filename);
-	int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h);
 	unsigned int display_get_gui_width();
 	unsigned int display_get_gui_height();
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/GLtextures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL/GLtextures.cpp
@@ -25,6 +25,8 @@
 
 #include <cstring> // for std::memcpy
 
+#include "Platforms/General/PFwindow.h"
+
 /*enum {
   //Formats and internal formats
   tx_rgba = GL_RGBA,

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -42,7 +42,7 @@ void scene_end() {
 	msaa_fbo_blit();
 }
 
-unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped) {
+unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, bool* flipped) {
   if (flipped) *flipped = true;
 
   const int bpp = 4; // bytes per pixel
@@ -58,7 +58,7 @@ unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int hei
   return pxdata;
 }
 
-unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
+unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
   if (flipped) *flipped = true;
 
   const int fw = enigma_user::window_get_region_width_scaled(),
@@ -66,7 +66,7 @@ unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* f
 
   *fullwidth = fw;
   *fullheight = fh;
-  return graphics_copy_back_buffer_pixels(0,0,fw,fh,flipped);
+  return graphics_copy_screen_pixels(0,0,fw,fh,flipped);
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -21,26 +21,12 @@
 #include "Graphics_Systems/OpenGL/GLscreen.h"
 #include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSscreen.h"
-#include "Graphics_Systems/General/GSbackground.h"
-#include "Graphics_Systems/General/GSsprite.h"
-#include "Graphics_Systems/General/GStextures.h"
-#include "Graphics_Systems/General/GSd3d.h"
 #include "Graphics_Systems/General/GSprimitives.h"
-#include "Graphics_Systems/General/GSmatrix.h"
-#include "Graphics_Systems/General/GScolors.h"
 
-#include "Universal_System/image_formats.h"
 #include "Universal_System/var4.h"
 #include "Universal_System/roomsystem.h"
-#include "Universal_System/nlpo2.h"
-#include "Universal_System/Resources/background_internal.h"
-#include "Universal_System/Resources/sprites_internal.h"
 #include "Platforms/General/PFwindow.h"
 
-#include <string>
-#include <cstdio>
-
-using namespace std;
 using namespace enigma;
 
 namespace enigma {
@@ -78,119 +64,6 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   //NOTE: OpenGL viewports are bottom left unlike Direct3D viewports which are top left
   glViewport(viewport_x, viewport_y, viewport_w, viewport_h);
   glScissor(viewport_x, viewport_y, viewport_w, viewport_h);
-}
-
-int screen_save(string filename) { //Assumes native integers are little endian
-  draw_batch_flush(batch_flush_deferred);
-
-	unsigned int w=window_get_width(),h=window_get_height(),sz=w*h;
-	string ext = enigma::image_get_format(filename);
-
-	unsigned char *rgbdata = new unsigned char[sz*4];
-	GLint prevFbo;
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &prevFbo);
-	glPixelStorei(GL_PACK_ALIGNMENT, 1);
- 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
-	glReadPixels(0,0,w,h, GL_BGRA, GL_UNSIGNED_BYTE, rgbdata);
-	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
-
-	int ret = image_save(filename, rgbdata, w, h, w, h, false);
-
-	delete[] rgbdata;
-	return ret;
-}
-
-int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h) { //Assumes native integers are little endian
-  draw_batch_flush(batch_flush_deferred);
-
-	unsigned sz = w*h;
-	string ext = enigma::image_get_format(filename);
-
-	unsigned char *rgbdata = new unsigned char[sz*4];
-	GLint prevFbo;
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &prevFbo);
-	glPixelStorei(GL_PACK_ALIGNMENT, 1);
- 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
-	glReadPixels(x,window_get_region_height_scaled()-h-y,w,h, GL_BGRA, GL_UNSIGNED_BYTE, rgbdata);
-	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
-
-	int ret = image_save(filename, rgbdata, w, h, w, h, false);
-
-	delete[] rgbdata;
-	return ret;
-}
-
-// The following three leave a bad taste in my mouth because they depend on views, which should be removable.
-// However, for now, they stay.
-
-int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload)
-{
-	draw_batch_flush(batch_flush_deferred);
-
-  int full_width=enigma::nlpo2dc(w)+1, full_height=enigma::nlpo2dc(h)+1;
-	int prevFbo;
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &prevFbo);
- 	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
-	int patchSize = full_width*full_height;
-	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
-	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, prevFbo);
-
-	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
-
-	enigma::backgroundstructarray_reallocate();
-  int bckid=enigma::background_idmax;
-	enigma::background_new(bckid, w, h, &data[0], removeback, smooth, preload, false, 0, 0, 0, 0, 0, 0);
-  delete[] data;
-	rgbdata.clear();
-	enigma::background_idmax++;
-  return bckid;
-}
-
-int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
-  draw_batch_flush(batch_flush_deferred);
-
-  int full_width=enigma::nlpo2dc(w)+1, full_height=enigma::nlpo2dc(h)+1;
-	int prevFbo;
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &prevFbo);
- 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
-	int patchSize = full_width*full_height;
-	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
-	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
-
-	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
-
-	enigma::spritestructarray_reallocate();
-  int sprid=enigma::sprite_idmax;
-  enigma::sprite_new_empty(sprid, 1, w, h, xorig, yorig, 0, h, 0, w, preload, smooth);
-	enigma::sprite_set_subimage(sprid, 0, w, h, &data[0], &data[0], enigma::ct_precise); //TODO: Support toggling of precise.
-  rgbdata.clear(); // Clear the temporary array
-	delete[] data;
-  return sprid;
-}
-
-int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
-	return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
-}
-
-void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth) {
-  draw_batch_flush(batch_flush_deferred);
-
-  int full_width=enigma::nlpo2dc(w)+1, full_height=enigma::nlpo2dc(h)+1;
-	int prevFbo;
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &prevFbo);
- 	glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
-	int patchSize = full_width*full_height;
-	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
-	glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
-
-	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
-
-	enigma::sprite_add_subimage(id, w, h, &data[0], &data[0], enigma::ct_precise); //TODO: Support toggling of precise.
-	delete[] data;
-	rgbdata.clear();
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLscreen.cpp
@@ -42,6 +42,33 @@ void scene_end() {
 	msaa_fbo_blit();
 }
 
+unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped) {
+  if (flipped) *flipped = true;
+
+  const int bpp = 4; // bytes per pixel
+  const int topY = enigma_user::window_get_region_height_scaled()-height-y;
+  unsigned char* pxdata = new unsigned char[width*height*bpp];
+
+  GLint prevFbo;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &prevFbo);
+  glPixelStorei(GL_PACK_ALIGNMENT, 1);
+  glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+  glReadPixels(x,topY,width,height,GL_BGRA,GL_UNSIGNED_BYTE,pxdata);
+  glBindFramebuffer(GL_FRAMEBUFFER_EXT, prevFbo);
+  return pxdata;
+}
+
+unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
+  if (flipped) *flipped = true;
+
+  const int fw = enigma_user::window_get_region_width_scaled(),
+            fh = enigma_user::window_get_region_height_scaled();
+
+  *fullwidth = fw;
+  *fullheight = fh;
+  return graphics_copy_back_buffer_pixels(0,0,fw,fh,flipped);
+}
+
 } // namespace enigma
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/GLstdraw.cpp
@@ -18,14 +18,7 @@
 #include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSstdraw.h"
 #include "Graphics_Systems/General/GSprimitives.h"
-#include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
-
-#include "Universal_System/roomsystem.h"
-
-#include <cstdlib>
-#include <math.h>
-#include <stdio.h>
 
 namespace enigma_user
 {
@@ -54,85 +47,6 @@ int draw_get_msaa_maxlevel()
 bool draw_get_msaa_supported()
 {
   return GLEW_EXT_multisample;
-}
-
-} // namespace enigma_user
-
-//#include <endian.h>
-//TODO: Though serprex, the author of the function below, never included endian.h,
-//   // Doing so is necessary for the function to work at its peak.
-//   // When ENIGMA generates configuration files, one should be included here.
-
-namespace enigma_user {
-
-int draw_getpixel(int x,int y)
-{
-    if (view_enabled)
-    {
-        x = x - enigma_user::view_xview[enigma_user::view_current];
-        y = enigma_user::view_hview[enigma_user::view_current] - (y - enigma_user::view_yview[enigma_user::view_current]) - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::view_wview[enigma_user::view_current] || y > enigma_user::view_hview[enigma_user::view_current]) return 0;
-    }
-    else
-    {
-        y = enigma_user::room_height - y - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::room_width || y > enigma_user::room_height) return 0;
-    }
-
-    draw_batch_flush(batch_flush_deferred);
-
-  #if defined __BIG_ENDIAN__ || defined __BIG_ENDIAN
-    int ret;
-    glReadPixels(x,y,1,1,GL_RGB,GL_UNSIGNED_BYTE,&ret);
-    return ret;
-  #elif defined __LITTLE_ENDIAN__ || defined __LITTLE_ENDIAN
-    int ret;
-    glReadPixels(x,y,1,1,GL_BGR,GL_UNSIGNED_BYTE,&ret);
-    return ret>>8;
-  #else
-    unsigned char rgb[3];
-    glReadPixels(x,y,1,1,GL_RGB,GL_UNSIGNED_BYTE,&rgb);
-    return rgb[0] | rgb[1] << 8 | rgb[2] << 16;
-  #endif
-}
-
-int draw_getpixel_ext(int x,int y)
-{
-    if (view_enabled)
-    {
-        x = x - enigma_user::view_xview[enigma_user::view_current];
-        y = enigma_user::view_hview[enigma_user::view_current] - (y - enigma_user::view_yview[enigma_user::view_current]) - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::view_wview[enigma_user::view_current] || y > enigma_user::view_hview[enigma_user::view_current]) return 0;
-    }
-    else
-    {
-        y = enigma_user::room_height - y - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::room_width || y > enigma_user::room_height) return 0;
-    }
-
-    draw_batch_flush(batch_flush_deferred);
-
-  #if defined __BIG_ENDIAN__ || defined __BIG_ENDIAN
-    int ret;
-    glReadPixels(x,y,1,1,GL_RGBA,GL_UNSIGNED_BYTE,&ret);
-    return ret;
-  #elif defined __LITTLE_ENDIAN__ || defined __LITTLE_ENDIAN
-    int ret;
-    glReadPixels(x,y,1,1,GL_BGRA,GL_UNSIGNED_BYTE,&ret);
-    return ret>>8;
-  #else
-    unsigned char rgba[4];
-    glReadPixels(x,y,1,1,GL_RGBA,GL_UNSIGNED_BYTE,&rgba);
-    return rgba[0] | rgba[1] << 8 | rgba[2] << 16 | rgba[3] << 24;
-  #endif
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -40,7 +40,7 @@ void scene_end() {
   msaa_fbo_blit();
 }
 
-unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped) {
+unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, bool* flipped) {
   if (flipped) *flipped = true;
 
   const int bpp = 4; // bytes per pixel
@@ -56,7 +56,7 @@ unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int hei
   return pxdata;
 }
 
-unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
+unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
   if (flipped) *flipped = true;
 
   const int fw = enigma_user::window_get_region_width_scaled(),
@@ -64,7 +64,7 @@ unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* f
 
   *fullwidth = fw;
   *fullheight = fh;
-  return graphics_copy_back_buffer_pixels(0,0,fw,fh,flipped);
+  return graphics_copy_screen_pixels(0,0,fw,fh,flipped);
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -21,28 +21,12 @@
 #include "Graphics_Systems/OpenGL/GLscreen.h"
 #include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSscreen.h"
-#include "Graphics_Systems/General/GSbackground.h"
-#include "Graphics_Systems/General/GSsprite.h"
-#include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GSprimitives.h"
-#include "Graphics_Systems/General/GSmatrix.h"
-#include "Graphics_Systems/General/GScolors.h"
 
-#include "Universal_System/image_formats.h"
-#include "Universal_System/nlpo2.h"
-#include "Universal_System/Resources/background_internal.h"
-#include "Universal_System/Resources/sprites_internal.h"
 #include "Universal_System/roomsystem.h"
 #include "Platforms/General/PFwindow.h"
 
-#include <string>
-#include <cstdio>
-
-//WE SHOULDN'T DO THIS! Don't specify namespaces like this - Harijs
-using namespace std;
-
 using namespace enigma;
-using namespace enigma_user;
 
 namespace enigma {
 
@@ -78,120 +62,6 @@ void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar he
   //NOTE: OpenGL viewports are bottom left unlike Direct3D viewports which are top left
   glViewport(viewport_x, viewport_y, viewport_w, viewport_h);
   glScissor(viewport_x, viewport_y, viewport_w, viewport_h);
-}
-
-int screen_save(string filename) //Assumes native integers are little endian
-{
-  draw_batch_flush(batch_flush_deferred);
-
-  unsigned int w=window_get_width(),h=window_get_height(),sz=w*h;
-  string ext = enigma::image_get_format(filename);
-
-  unsigned char *rgbdata = new unsigned char[sz*4];
-  GLint prevFbo;
-  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
-  glPixelStorei(GL_PACK_ALIGNMENT, 1);
-  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-  glReadPixels(0,0,w,h, GL_BGRA, GL_UNSIGNED_BYTE, rgbdata);
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
-
-  int ret = image_save(filename, rgbdata, w, h, w, h, false);
-
-  delete[] rgbdata;
-  return ret;
-}
-
-int screen_save_part(string filename,unsigned x,unsigned y,unsigned w,unsigned h) //Assumes native integers are little endian
-{
-  draw_batch_flush(batch_flush_deferred);
-
-  unsigned sz = w*h;
-  string ext = enigma::image_get_format(filename);
-
-  unsigned char *rgbdata = new unsigned char[sz*4];
-  GLint prevFbo;
-  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
-  glPixelStorei(GL_PACK_ALIGNMENT, 1);
-  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-  glReadPixels(x,window_get_region_height_scaled()-h-y,w,h, GL_BGRA, GL_UNSIGNED_BYTE, rgbdata);
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
-
-  int ret = image_save(filename, rgbdata, w, h, w, h, false);
-
-  delete[] rgbdata;
-  return ret;
-}
-
-// The following three leave a bad taste in my mouth because they depend on views, which should be removable.
-// However, for now, they stay.
-
-int background_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload) {
-	draw_batch_flush(batch_flush_deferred);
-
-  int full_width=enigma::nlpo2dc(w)+1, full_height=enigma::nlpo2dc(h)+1;
-	int prevFbo;
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
-	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-	int patchSize = full_width*full_height;
-	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
-
-	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
-
-	enigma::backgroundstructarray_reallocate();
-  int bckid=enigma::background_idmax;
-	enigma::background_new(bckid, w, h, &data[0], removeback, smooth, preload, false, 0, 0, 0, 0, 0, 0);
-  delete[] data;
-	rgbdata.clear();
-	enigma::background_idmax++;
-  return bckid;
-}
-
-int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, bool preload, int xorig, int yorig) {
-  draw_batch_flush(batch_flush_deferred);
-
-  int full_width=enigma::nlpo2dc(w)+1, full_height=enigma::nlpo2dc(h)+1;
-	int prevFbo;
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
- 	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-	int patchSize = full_width*full_height;
-	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x,enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
-
-	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
-
-	enigma::spritestructarray_reallocate();
-  int sprid=enigma::sprite_idmax;
-  enigma::sprite_new_empty(sprid, 1, w, h, xorig, yorig, 0, h, 0, w, preload, smooth);
-	enigma::sprite_set_subimage(sprid, 0, w, h, &data[0], &data[0], enigma::ct_precise); //TODO: Support toggling of precise.
-  rgbdata.clear(); // Clear the temporary array
-	delete[] data;
-  return sprid;
-}
-
-int sprite_create_from_screen(int x, int y, int w, int h, bool removeback, bool smooth, int xorig, int yorig) {
-	return sprite_create_from_screen(x, y, w, h, removeback, smooth, true, xorig, yorig);
-}
-
-void sprite_add_from_screen(int id, int x, int y, int w, int h, bool removeback, bool smooth) {
-  draw_batch_flush(batch_flush_deferred);
-
-  int full_width=enigma::nlpo2dc(w)+1, full_height=enigma::nlpo2dc(h)+1;
-	int prevFbo;
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
- 	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-	int patchSize = full_width*full_height;
-	std::vector<unsigned char> rgbdata(4*patchSize);
-	glReadPixels(x, enigma_user::window_get_region_height_scaled()-h-y,w,h,GL_BGRA, GL_UNSIGNED_BYTE, &rgbdata[0]);
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prevFbo);
-
-	unsigned char* data = enigma::image_flip(&rgbdata[0], w, h, 4);
-
-	enigma::sprite_add_subimage(id, w, h, &data[0], &data[0], enigma::ct_precise); //TODO: Support toggling of precise.
-	delete[] data;
-	rgbdata.clear();
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3screen.cpp
@@ -40,6 +40,33 @@ void scene_end() {
   msaa_fbo_blit();
 }
 
+unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped) {
+  if (flipped) *flipped = true;
+
+  const int bpp = 4; // bytes per pixel
+  const int topY = enigma_user::window_get_region_height_scaled()-height-y;
+  unsigned char* pxdata = new unsigned char[width*height*bpp];
+
+  GLint prevFbo;
+  glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &prevFbo);
+  glPixelStorei(GL_PACK_ALIGNMENT, 1);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+  glReadPixels(x,topY,width,height,GL_BGRA,GL_UNSIGNED_BYTE,pxdata);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, prevFbo);
+  return pxdata;
+}
+
+unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped) {
+  if (flipped) *flipped = true;
+
+  const int fw = enigma_user::window_get_region_width_scaled(),
+            fh = enigma_user::window_get_region_height_scaled();
+
+  *fullwidth = fw;
+  *fullheight = fh;
+  return graphics_copy_back_buffer_pixels(0,0,fw,fh,flipped);
+}
+
 } // namespace enigma
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3stdraw.cpp
@@ -16,26 +16,10 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "GLSLshader.h"
-#include "GL3shader.h"
-
 #include "OpenGLHeaders.h"
 #include "Graphics_Systems/General/GSstdraw.h"
 #include "Graphics_Systems/General/GSprimitives.h"
-#include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
-
-#include "Universal_System/roomsystem.h"
-
-#include <stdio.h>
-#include <math.h>
-
-namespace enigma {
-
-extern unsigned bound_shader;
-extern vector<enigma::ShaderProgram*> shaderprograms;
-
-} // namespace enigma
 
 namespace enigma_user {
 
@@ -63,85 +47,6 @@ int draw_get_msaa_maxlevel()
 bool draw_get_msaa_supported()
 {
   return GLEW_EXT_multisample;
-}
-
-} // namespace enigma_user
-
-//#include <endian.h>
-//TODO: Though serprex, the author of the function below, never included endian.h,
-//   // Doing so is necessary for the function to work at its peak.
-//   // When ENIGMA generates configuration files, one should be included here.
-
-namespace enigma_user {
-
-int draw_getpixel(int x,int y)
-{
-    if (view_enabled)
-    {
-        x = x - enigma_user::view_xview[enigma_user::view_current];
-        y = enigma_user::view_hview[enigma_user::view_current] - (y - enigma_user::view_yview[enigma_user::view_current]) - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::view_wview[enigma_user::view_current] || y > enigma_user::view_hview[enigma_user::view_current]) return 0;
-    }
-    else
-    {
-        y = enigma_user::room_height - y - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::room_width || y > enigma_user::room_height) return 0;
-    }
-
-    draw_batch_flush(batch_flush_deferred);
-
-  #if defined __BIG_ENDIAN__ || defined __BIG_ENDIAN
-    int ret;
-    glReadPixels(x,y,1,1,GL_RGB,GL_UNSIGNED_BYTE,&ret);
-    return ret;
-  #elif defined __LITTLE_ENDIAN__ || defined __LITTLE_ENDIAN
-    int ret;
-    glReadPixels(x,y,1,1,GL_BGR,GL_UNSIGNED_BYTE,&ret);
-    return ret>>8;
-  #else
-    unsigned char rgb[3];
-    glReadPixels(x,y,1,1,GL_RGB,GL_UNSIGNED_BYTE,&rgb);
-    return rgb[0] | rgb[1] << 8 | rgb[2] << 16;
-  #endif
-}
-
-int draw_getpixel_ext(int x,int y)
-{
-    if (view_enabled)
-    {
-        x = x - enigma_user::view_xview[enigma_user::view_current];
-        y = enigma_user::view_hview[enigma_user::view_current] - (y - enigma_user::view_yview[enigma_user::view_current]) - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::view_wview[enigma_user::view_current] || y > enigma_user::view_hview[enigma_user::view_current]) return 0;
-    }
-    else
-    {
-        y = enigma_user::room_height - y - 1;
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (x > enigma_user::room_width || y > enigma_user::room_height) return 0;
-    }
-
-    draw_batch_flush(batch_flush_deferred);
-
-  #if defined __BIG_ENDIAN__ || defined __BIG_ENDIAN
-    int ret;
-    glReadPixels(x,y,1,1,GL_RGBA,GL_UNSIGNED_BYTE,&ret);
-    return ret;
-  #elif defined __LITTLE_ENDIAN__ || defined __LITTLE_ENDIAN
-    int ret;
-    glReadPixels(x,y,1,1,GL_BGRA,GL_UNSIGNED_BYTE,&ret);
-    return ret>>8;
-  #else
-    unsigned char rgba[4];
-    glReadPixels(x,y,1,1,GL_RGBA,GL_UNSIGNED_BYTE,&rgba);
-    return rgba[0] | rgba[1] << 8 | rgba[2] << 16 | rgba[3] << 24;
-  #endif
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/graphics_mandatory.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/graphics_mandatory.h
@@ -34,8 +34,9 @@ namespace enigma
   void graphics_delete_texture(int tex);
 
   /// Retrieve image data from back buffer, in unsigned char, BGRA format.
-  unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped=nullptr);
-  unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped=nullptr);
+  /// Flipped parameter is optional, but backend must provide it when nonzero.
+  unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped=nullptr);
+  unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, bool* flipped=nullptr);
   /// Retrieve image data from a texture, in unsigned char, BGRA format.
   /// This data will be allocated afresh; the pointer and data are yours to manipulate
   /// and must be freed once you are done.

--- a/ENIGMAsystem/SHELL/Graphics_Systems/graphics_mandatory.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/graphics_mandatory.h
@@ -33,6 +33,9 @@ namespace enigma
   /// Delete a texture's native peer data in the backend.
   void graphics_delete_texture(int tex);
 
+  /// Retrieve image data from back buffer, in unsigned char, BGRA format.
+  unsigned char* graphics_copy_back_buffer_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped=nullptr);
+  unsigned char* graphics_copy_back_buffer_pixels(int x, int y, int width, int height, bool* flipped=nullptr);
   /// Retrieve image data from a texture, in unsigned char, BGRA format.
   /// This data will be allocated afresh; the pointer and data are yours to manipulate
   /// and must be freed once you are done.


### PR DESCRIPTION
This pull request is a friend of #1722 and #1648. The idea behind this pull request is that the screen is a surface too. I have created here a new mandatory interface for reading the screen backbuffer to generically reimplement all of the screen transfer functions. There is only read provided, no write like textures, as I don't see the need.

```cpp
/// Retrieve image data from back buffer, in unsigned char, BGRA format.
/// Flipped parameter is optional, but backend must provide it when nonzero.
unsigned char* graphics_copy_screen_pixels(unsigned* fullwidth, unsigned* fullheight, bool* flipped=nullptr);
unsigned char* graphics_copy_screen_pixels(int x, int y, int width, int height, bool* flipped=nullptr);
```

This pull request actually fixes a crash on exit in @time-killer-games Key to Success game when it is run in Direct3D9. The reason is because he uses one of the screen copy functions to tint the screen when escape is pressed, which was an unimplemented function in the D3D9 backend.

I was able to reuse the exact same fix as before for copying the screen surface to system memory for Direct3D9. This means we use the exact same logic now to lock and read the screen, surfaces, and textures and I am quite happy about it!

Another positive side effect of this change is that Direct3D9 is now super fast at surface readback. I optimized the surface copying to RAM to only copy a subrect using a lockable render target when it makes sense to do so (requested area less than half the total area of the surface). I decided to benchmark it against master using the [Wild Racing demo](https://enigma-dev.org/edc/games.php?game=30) from the EDC.

```cpp
//store the height in the array read from the pixel colors of the height map
var start;
start = get_timer();
for (xx = 0; xx < xp; xx += 1)
{
	for (yy = 0; yy < yp; yy += 1)
	{
	    ds_grid_set(g, xx, yy, color_get_value(draw_getpixel(xx, yy)));
	}
}
show_message(string(get_timer()-start));
```

Timing data recorded in microseconds.

|        | GL1   | GL3   | D3D9   |
|--------|-------|-------|--------|
| Branch | 84091 | 75452 | 239592 |
| Master | 76190 | 78865 | 1.33128e+06 |