### PR TITLE
Fix Flipped for libpng Extension Saving

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/libpng/libpng-ext.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/libpng/libpng-ext.cpp
@@ -82,7 +82,7 @@ int image_save_png(string filename, const unsigned char* data, unsigned width, u
   for (unsigned i = 0; i < height; i++) {
     unsigned tmp = i;
     unsigned bmp = i;
-    if (flipped) tmp = height - 1 - tmp;
+    if (flipped) bmp = height - 1 - tmp;
     tmp *= bytes * fullwidth;
     bmp *= bytes * width;
     for (unsigned ii = 0; ii < width*bytes; ii += bytes) {

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/libpng/libpng-ext.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/libpng/libpng-ext.cpp
@@ -82,10 +82,7 @@ int image_save_png(string filename, const unsigned char* data, unsigned width, u
   for (unsigned i = 0; i < height; i++) {
     unsigned tmp = i;
     unsigned bmp = i;
-    if (!flipped) {
-      tmp = height - 1 - tmp;
-      bmp = height - 1 - bmp;
-    }
+    if (flipped) tmp = height - 1 - tmp;
     tmp *= bytes * fullwidth;
     bmp *= bytes * width;
     for (unsigned ii = 0; ii < width*bytes; ii += bytes) {


### PR DESCRIPTION
I ran onto this while working on #1725 and hugar also mentioned it to me and on the forums at the same time. The libpng extension was not respecting the flipped parameter when saving. The reason is because we were flipping both the source read and destination write indices, where one obviously undoes the other. We only need to flip one of the indexes, not both. The one we should flip is the destination write index, since it is bounded by height, where the source read index is bounded by fullheight.