### PR TITLE
Blend States CI Test

### DIFF
--- a/CommandLine/testing/Tests/draw_blend_test.cpp
+++ b/CommandLine/testing/Tests/draw_blend_test.cpp
@@ -1,0 +1,23 @@
+#include "TestHarness.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(Regression, draw_blend_test) {
+  if (!TestHarness::windowing_supported()) return;
+  auto test_harness = LAUNCH_HARNESS_FOR_SOG(TestConfig());
+  if (!test_harness) FAIL() << "Game could not be run.";
+
+  test_harness->wait();  // Let the game render a frame first.
+  ASSERT_TRUE(test_harness->game_is_running())
+      << "Game stopped running unexpectedly";
+
+  test_harness->screen_save("./test-harness-out/enigma_draw_blend_test.png");
+
+  test_harness->close_window();
+  bool game_running = test_harness->game_is_running();
+  for (int i = 0; game_running && i < 10; ++i) {
+    test_harness->wait();
+    game_running = test_harness->game_is_running();
+  }
+  ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
+}

--- a/CommandLine/testing/Tests/draw_blend_test.cpp
+++ b/CommandLine/testing/Tests/draw_blend_test.cpp
@@ -4,7 +4,9 @@
 
 TEST(Regression, draw_blend_test) {
   if (!TestHarness::windowing_supported()) return;
-  auto test_harness = LAUNCH_HARNESS_FOR_SOG(TestConfig());
+  TestConfig tc;
+  tc.extensions = "Paths,libpng";
+  auto test_harness = LAUNCH_HARNESS_FOR_SOG(tc);
   if (!test_harness) FAIL() << "Game could not be run.";
 
   test_harness->wait();  // Let the game render a frame first.

--- a/CommandLine/testing/Tests/draw_blend_test.sog/create.edl
+++ b/CommandLine/testing/Tests/draw_blend_test.sog/create.edl
@@ -1,0 +1,1 @@
+spr_hugar = sprite_add("CommandLine/testing/data/hugar.png", 1, false, false, 0, 0);

--- a/CommandLine/testing/Tests/draw_blend_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_blend_test.sog/draw.edl
@@ -1,11 +1,24 @@
-draw_rectangle_color(0, 0, 352, 320, c_red, c_green, c_blue, c_yellow, 0);
+draw_rectangle_color(0, 0, 352, 352, c_red, c_green, c_blue, c_yellow, 0);
 
 var blend_mode_count = bm_src_alpha_sat - bm_zero;
 for (var i = 0; i <= blend_mode_count; i += 1) {
+    var src = i + bm_zero;
+
+    // GL 1.4 or greater required else invalid enum
+    // Travis Mesa driver is too old for now
+    if (src == bm_src_color || src == bm_inv_src_color) continue;
+
     // OpenGL/OpenGL ES does not accept bm_src_alpha_sat (aka GL_SRC_ALPHA_SATURATE) for destination
     // so this inner loop needs to be exclusive of that constant (< instead of <=)
+    // https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glBlendFunc.xml
     for (var j = 0; j < blend_mode_count; j += 1) {
-        draw_set_blend_mode_ext(i + bm_zero, j + bm_zero);
+        var dst = j + bm_zero;
+
+        // GL 1.4 or greater required else invalid enum
+        // Travis Mesa driver is too old for now
+        if (dst == bm_dest_color || dst == bm_inv_dest_color) continue;
+
+        draw_set_blend_mode_ext(src, dst);
         draw_sprite(spr_hugar, 0, i*32, j*32);
         draw_set_blend_mode(bm_normal);
     }

--- a/CommandLine/testing/Tests/draw_blend_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_blend_test.sog/draw.edl
@@ -1,7 +1,9 @@
-draw_rectangle_color(0, 0, 320, 320, c_red, c_green, c_blue, c_yellow, 0);
+draw_rectangle_color(0, 0, 352, 320, c_red, c_green, c_blue, c_yellow, 0);
 
 var blend_mode_count = bm_src_alpha_sat - bm_zero;
-for (var i = 0; i < blend_mode_count; i += 1) {
+for (var i = 0; i <= blend_mode_count; i += 1) {
+    // OpenGL/OpenGL ES does not accept bm_src_alpha_sat (aka GL_SRC_ALPHA_SATURATE) for destination
+    // so this inner loop needs to be exclusive of that constant (< instead of <=)
     for (var j = 0; j < blend_mode_count; j += 1) {
         draw_set_blend_mode_ext(i + bm_zero, j + bm_zero);
         draw_sprite(spr_hugar, 0, i*32, j*32);

--- a/CommandLine/testing/Tests/draw_blend_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_blend_test.sog/draw.edl
@@ -1,0 +1,10 @@
+draw_rectangle_color(0, 0, 320, 320, c_red, c_green, c_blue, c_yellow, 0);
+
+var blend_mode_count = bm_src_alpha_sat - bm_zero;
+for (var i = 0; i < blend_mode_count; i += 1) {
+    for (var j = 0; j < blend_mode_count; j += 1) {
+        draw_set_blend_mode_ext(i + bm_zero, j + bm_zero);
+        draw_sprite(spr_hugar, 0, i*32, j*32);
+        draw_set_blend_mode(bm_normal);
+    }
+}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsprite.cpp
@@ -70,7 +70,7 @@ using namespace enigma_user;
 namespace enigma
 {
 
-void draw_sprite_pos_raw(const enigma::sprite* spr2d, int subimg, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar x3, gs_scalar y3, gs_scalar x4, gs_scalar y4, gs_scalar color, gs_scalar alpha)
+void draw_sprite_pos_raw(const enigma::sprite *const spr2d, int subimg, gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar x3, gs_scalar y3, gs_scalar x4, gs_scalar y4, gs_scalar color, gs_scalar alpha)
 {
   alpha = CLAMP_ALPHAF(alpha);
   get_subimg(usi, spr2d, subimg);
@@ -86,7 +86,8 @@ void draw_sprite_pos_raw(const enigma::sprite* spr2d, int subimg, gs_scalar x1, 
   draw_vertex_texture_color(x3,y3, tx+tw, ty+th, color,alpha);
   draw_primitive_end();
 }
-void draw_sprite_pos_part_raw(const enigma::sprite* spr2d, int subimg,
+
+void draw_sprite_pos_part_raw(const enigma::sprite *const spr2d, int subimg,
   gs_scalar px, gs_scalar py, gs_scalar pw, gs_scalar ph,
   gs_scalar x1, gs_scalar y1, gs_scalar x2, gs_scalar y2, gs_scalar x3, gs_scalar y3, gs_scalar x4, gs_scalar y4,
   gs_scalar color, gs_scalar alpha


### PR DESCRIPTION
This is a recreation of #1518 which expands the continuous integration tests to include a test for the blend mode states. I am excluding from the blend matrix the enums which Travis's Mesa driver does not support.
https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glBlendFunc.xml

This includes the following columns and rows which are excluded:
* `GL_SRC_COLOR` and `GL_ONE_MINUS_SRC_COLOR` for source
* `GL_DST_COLOR` and `GL_ONE_MINUS_DST_COLOR` for destination
* `GL_SRC_ALPHA_SATURATE` for destination