### PR TITLE
Fix 32 bit MinGW FFI Include Directory

### DIFF
--- a/Compilers/Windows/gcc.ey
+++ b/Compilers/Windows/gcc.ey
@@ -12,7 +12,7 @@ Make-Vars:
   makeflags:
   binpath:
   cppflags:
-  cxxflags: -std=c++11 -I/mingw64/lib/libffi-3.2.1/include -I/mingw32/lib/libffi-3.2.1/include -I../Additional/i686-w64-mingw32/include
+  cxxflags: -std=c++11 -I/lib/libffi-3.2.1/include -I../Additional/i686-w64-mingw32/include
   cflags:
   ldflags: -L../Additional/i686-w64-mingw32/lib -static-libgcc -static-libstdc++ -static
   rcflags: 

--- a/Compilers/Windows/gcc.ey
+++ b/Compilers/Windows/gcc.ey
@@ -12,10 +12,10 @@ Make-Vars:
   makeflags:
   binpath:
   cppflags:
-  cxxflags: -std=c++11 -I/lib/libffi-3.2.1/include -I../Additional/i686-w64-mingw32/include
+  cxxflags: -std=c++11 -I../Additional/i686-w64-mingw32/include
   cflags:
   ldflags: -L../Additional/i686-w64-mingw32/lib -static-libgcc -static-libstdc++ -static
-  rcflags: 
+  rcflags:
   links:
 
 Parser-Vars:

--- a/Compilers/Windows/gcc.ey
+++ b/Compilers/Windows/gcc.ey
@@ -12,7 +12,7 @@ Make-Vars:
   makeflags:
   binpath:
   cppflags:
-  cxxflags: -std=c++11 -I/mingw64/lib/libffi-3.2.1/include -I../Additional/i686-w64-mingw32/include
+  cxxflags: -std=c++11 -I/mingw64/lib/libffi-3.2.1/include -I/mingw32/lib/libffi-3.2.1/include -I../Additional/i686-w64-mingw32/include
   cflags:
   ldflags: -L../Additional/i686-w64-mingw32/lib -static-libgcc -static-libstdc++ -static
   rcflags: 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/Makefile
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/Makefile
@@ -1,3 +1,3 @@
 SOURCES += $(wildcard Platforms/Win32/*.cpp)
-override CXXFLAGS += -DENIGMA_PLATFORM_WINDOWS
+override CXXFLAGS += -DENIGMA_PLATFORM_WINDOWS $(shell pkg-config --cflags libffi)
 override LDLIBS += -lffi -lcomdlg32 -lgdi32 -lwinmm -lwininet


### PR DESCRIPTION
We had the workaround to find the FFI header for 64 bit, but didn't have it for 32 bit MinGW. We can actually just remove fundies previous hack and use pkg-config now. This addresses #1734.

NOTE: Special thanks to Sociopart!