### PR TITLE
Use the version 47 IID_ID3D11ShaderReflection GUID for D3D11

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/Makefile
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/Makefile
@@ -1,2 +1,3 @@
 SOURCES += $(wildcard Graphics_Systems/Direct3D11/*.cpp) $(wildcard Graphics_Systems/General/*.cpp)
-override LDLIBS += -ldxgi -ldxguid -ld3d11 -lD3DCompiler
+override CPPFLAGS += -DINITGUID -DD3D_COMPILER_VERSION=47
+override LDLIBS += -ldxgi -ld3d11 -lD3DCompiler


### PR DESCRIPTION
MinGW's bundled `dxguid.lib` provides the old version 43 GUID. This replaces it with the header's copy by defining `INITGUID`, and selects the newest version by defining `D3D_COMPILER_VERSION` to 47.

This should be unnecessary when using the Windows SDK, but these macro definitions should be harmless in that case so I don't believe they need to be gated on the toolchain in use.