### PR TITLE
Refactor the libProtocols Makefile

### DIFF
--- a/CommandLine/emake/EnigmaCallbacks.hpp
+++ b/CommandLine/emake/EnigmaCallbacks.hpp
@@ -6,7 +6,7 @@
 //Should be:
 //#include "backend/EnigmaCallbacks.h"
 
-#include "codegen/compiler.pb.h"
+#include "compiler.pb.h"
 
 #include <fstream>
 #include <string>

--- a/CommandLine/emake/Makefile
+++ b/CommandLine/emake/Makefile
@@ -17,7 +17,7 @@ else
 endif
 
 PROTO_DIR := $(SHARED_SRC_DIR)/protos
-CXXFLAGS  := -I$(SRC_DIR) -I../../CompilerSource -I$(SHARED_SRC_DIR) -I$(PROTO_DIR) -I$(PROTO_DIR)/codegen -std=c++11 -Wall -Wextra -Wpedantic -g
+CXXFLAGS  := -I$(SRC_DIR) -I../../CompilerSource -I$(SHARED_SRC_DIR) -I$(PROTO_DIR)/.eobjs -std=c++11 -Wall -Wextra -Wpedantic -g
 LDFLAGS   := $(OS_LIBS) -L../../ -lProtocols -lprotobuf
 
 rwildcard=$(wildcard $1/$2) $(foreach d,$(wildcard $1/*),$(call rwildcard,$d,$2))

--- a/CommandLine/emake/OptionsParser.hpp
+++ b/CommandLine/emake/OptionsParser.hpp
@@ -1,7 +1,7 @@
 #ifndef EMAKE_OPTIONSPARSER_HPP
 #define EMAKE_OPTIONSPARSER_HPP
 
-#include "codegen/Settings.pb.h"
+#include "Settings.pb.h"
 
 #include <boost/program_options.hpp>
 #include <functional>

--- a/CommandLine/libEGM/CMakeLists.txt
+++ b/CommandLine/libEGM/CMakeLists.txt
@@ -53,7 +53,7 @@ endif(MSVC)
 find_package(yaml-cpp CONFIG REQUIRED)
 target_link_libraries(${LIB} PRIVATE yaml-cpp)
 
-include_directories(. ../ "${ENIGMA_DIR}/shared/" "${ENIGMA_DIR}/shared/protos/codegen" "${ENIGMA_DIR}/shared/libpng-util")
+include_directories(. ../ "${ENIGMA_DIR}/shared/" "${ENIGMA_DIR}/shared/protos/.eobjs" "${ENIGMA_DIR}/shared/libpng-util")
 
 include(FindProtobuf)
 target_link_libraries(${LIB} PRIVATE ${Protobuf_LIBRARY})

--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -14,7 +14,7 @@ PROTO_DIR := ../../shared/protos
 SRC_DIR   := .
 OBJ_DIR   := .eobjs
 
-CXXFLAGS  := -I$(SRC_DIR) -I../ $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR)/codegen -I$(SHARED_SOURCES) -I$(SHARED_SOURCES)/libpng-util -Wall -Wextra -Wpedantic -g -fPIC
+CXXFLAGS  := -I$(SRC_DIR) -I../ $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR)/.eobjs -I$(SHARED_SOURCES) -I$(SHARED_SOURCES)/libpng-util -Wall -Wextra -Wpedantic -g -fPIC
 LDFLAGS   := -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -lstdc++fs -L$(SHARED_SOURCES)/libpng-util -lpng-util -lpng
 
 #if gcc >= 8 use std::filesystem instead of boost

--- a/CompilerSource/Makefile
+++ b/CompilerSource/Makefile
@@ -43,7 +43,7 @@ OBJECTS := $(addprefix .eobjs/,$(SOURCES:.cpp=.o))
 DEPENDS := $(OBJECTS:.o=.d)
 PROTO_DIR := $(SHARED_SRC_DIR)/protos
 
-CXXFLAGS += -I$(SHARED_SRC_DIR) -I$(SHARED_SRC_DIR)/libpng-util -I$(PROTO_DIR)/codegen $(addprefix -I$(SHARED_SRC_DIR)/, $(SHARED_INCLUDES))
+CXXFLAGS += -I$(SHARED_SRC_DIR) -I$(SHARED_SRC_DIR)/libpng-util -I$(PROTO_DIR)/.eobjs $(addprefix -I$(SHARED_SRC_DIR)/, $(SHARED_INCLUDES))
 SOURCES += $(addprefix $(SHARED_SRC_DIR),$(SHARED_SOURCES))
 OBJECTS += $(addprefix .eobjs/shared/,$(SHARED_SOURCES:.cpp=.o))
 DEPENDS += $(addprefix .eobjs/shared/,$(SHARED_SOURCES:.cpp=.d))

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ emake: $(EMAKE_TARGETS)
 	$(MAKE) -C CommandLine/emake/
 
 gm2egm: libEGM .FORCE
-	$(CXX) -Ishared/protos/ -Ishared/protos/codegen -ICommandLine/libEGM/ CommandLine/gm2egm/main.cpp -Wl,-rpath,. -L. -lEGM -lProtocols -o gm2egm
+	$(CXX) -Ishared/protos/ -Ishared/protos/.eobjs -ICommandLine/libEGM/ CommandLine/gm2egm/main.cpp -Wl,-rpath,. -L. -lEGM -lProtocols -o gm2egm
 
 test-runner: emake .FORCE
 	$(MAKE) -C CommandLine/testing/

--- a/shared/protos/CMakeLists.txt
+++ b/shared/protos/CMakeLists.txt
@@ -78,10 +78,10 @@ target_link_libraries(${LIB} PRIVATE ${Protobuf_LIBRARIES})
 
 foreach(_proto ${PROTO_FILES})
     get_filename_component(_basename ${_proto} NAME_WE)
-	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_basename}.pb.h" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/codegen")
+	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_basename}.pb.h" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/.eobjs")
 endforeach()
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/server.grpc.pb.h" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/codegen")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/server.grpc.pb.h" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/.eobjs")
 get_filename_component(ENIGMA_DIR "${CMAKE_CURRENT_SOURCE_DIR}" PATH)
 get_filename_component(ENIGMA_DIR "${ENIGMA_DIR}" PATH)
 install(TARGETS ${LIB} DESTINATION "${ENIGMA_DIR}")

--- a/shared/protos/Makefile
+++ b/shared/protos/Makefile
@@ -1,84 +1,68 @@
 OS := $(shell uname -s)
-GRPC_CPP_PLUGIN = grpc_cpp_plugin
-GRPC_CPP_PLUGIN_PATH ?= $(shell which grpc_cpp_plugin)
 ifeq ($(OS), Linux)
-	EXT := .so
+	LIB_EXT := .so
+	BIN_EXT :=
 else ifeq ($(OS), Darwin)
-	EXT := .dylib
+	LIB_EXT := .dylib
+	BIN_EXT :=
 else
-	EXT := .dll
-	GRPC_CPP_PLUGIN_PATH := $(GRPC_CPP_PLUGIN_PATH).exe
+	LIB_EXT := .dll
+	BIN_EXT := .exe
 endif
 
-LIBRARY := ../../libProtocols$(EXT)
-PROTO_DIR := codegen/
-CXXFLAGS := -I$(PROTO_DIR) -std=c++11 -Wall -Wextra -Wpedantic -g -fPIC
-SRC_DIR := .
-OBJ_DIR := .eobjs
+LIBRARY := ../../libProtocols$(LIB_EXT)
+OBJDIR := .eobjs
 
-rwildcard=$(wildcard $1/$2) $(foreach d,$(wildcard $1/*),$(call rwildcard,$d,$2))
-PROTOS := $(call rwildcard,$(SRC_DIR),*.proto)
-ifneq ($(CLI_ENABLE_SERVER), TRUE)
-	# older protobuf does not even support the RPC syntax
-	# so don't even run protoc on server.proto when off
-	PROTOS := $(filter-out ./server.proto,$(PROTOS))
-endif
-PROTO_OUT := $(patsubst $(SRC_DIR)/%, $(PROTO_DIR)/%, $(patsubst %.proto, %.pb.cc, $(PROTOS)))
+CXXFLAGS := -I$(OBJDIR) -std=c++11 -Wall -Wextra -Wpedantic -g -fPIC
+LDFLAGS := -shared
+LDLIBS := -lprotobuf
 
-ifeq ($(CLI_ENABLE_SERVER), TRUE)
-	PROTO_OUT += $(PROTO_DIR)/server.grpc.pb.cc
-	PROTO_OBJECTS += $(OBJ_DIR)/codegen/server.o
-	LIBLDFLAGS := -lgrpc++
-	CXXFLAGS += -D_WIN32_WINNT=0x0600
-endif
+.PHONY: all clean
 
-$(PROTO_DIR)/%.grpc.pb.cc: $(SRC_DIR)/server.proto
-	protoc -I=. -I=/usr/include --cpp_out=$(PROTO_DIR) server.proto
-	protoc -I=. -I=/usr/include --grpc_out=$(PROTO_DIR) --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN_PATH) server.proto
-
-$(PROTO_DIR)/%.pb.cc: $(SRC_DIR)/%.proto
-	protoc -I=. -I=/usr/include --cpp_out=$(PROTO_DIR) $<
-
-SOURCES := $(call rwildcard,$(SRC_DIR),*.cpp)
-OBJECTS := $(patsubst $(SRC_DIR)/%, $(OBJ_DIR)/%, $(patsubst %.cpp, %.o, $(SOURCES)))
-
-PROTO_SOURCES = $(call rwildcard,$(SRC_DIR),*.pb.cc)
-PROTO_OBJECTS = $(patsubst $(SRC_DIR)/%, $(OBJ_DIR)/%, $(patsubst %.pb.cc, %.o, $(PROTO_SOURCES)))
-
-OBJDIRS = $(sort $(OBJ_DIR) $(dir $(PROTO_OBJECTS)) $(dir $(OBJECTS)))
-DEPENDS = $(PROTO_OBJECTS:.o=.d) $(OBJECTS:.o=.d)
-
-lib:
-	$(MAKE) codegen
-	$(MAKE) $(LIBRARY)
-
-codegen: protodir $(PROTO_OUT)
-
-# Old make has a bug which requires this nonsense...
-obj_dirs: $(OBJDIRS)
+all: $(LIBRARY)
 
 clean:
-	rm -rf $(LIBRARY) $(OBJ_DIR) $(PROTO_DIR)
+	$(RM) -r $(LIBRARY) $(OBJDIR)
 
-$(LIBRARY): $(PROTO_OBJECTS) $(OBJECTS)
-	$(CXX) -shared -o $@ $^ $(LIBLDFLAGS) -lprotobuf
+SOURCES := $(wildcard *.proto)
+SOURCES_GRPC :=
+ifeq ($(CLI_ENABLE_SERVER), TRUE)
+	SOURCES_GRPC += server.proto
+	LDLIBS += -lgrpc++
+	CXXFLAGS += -D_WIN32_WINNT=0x0600
 
-# Create the object directories
+	GRPC_CPP_PLUGIN_PATH ?= $(shell which grpc_cpp_plugin)$(BIN_EXT)
+else
+	# older protobuf does not even support the RPC syntax
+	# so don't even run protoc on server.proto when off
+	SOURCES := $(filter-out server.proto,$(SOURCES))
+endif
+
+GENERATED := $(addprefix $(OBJDIR)/,$(SOURCES:.proto=.pb.cc) $(SOURCES:.proto=.pb.h) $(SOURCES_GRPC:.proto=.grpc.pb.cc) $(SOURCES_GRPC:.proto=.grpc.pb.h))
+OBJECTS := $(addprefix $(OBJDIR)/,$(SOURCES:.proto=.pb.o) $(SOURCES_GRPC:.proto=.grpc.pb.o))
+DEPENDS = $(OBJECTS:.o=.d)
+
+OBJDIRS = $(sort $(dir $(OBJECTS)))
+
+$(LIBRARY): $(OBJECTS)
+	$(CXX) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+# The order-only dependency on $(GENERATED) is an over-approximation to force all protos to be built
+# before any object files. This matters on the first run when Make can't yet know about #includes.
+$(OBJDIR)/%.pb.o $(OBJDIR)/%.pb.d: $(OBJDIR)/%.pb.cc | $(GENERATED)
+	$(CXX) $(CXXFLAGS) -MMD -MP -c -o $(OBJDIR)/$*.pb.o $(OBJDIR)/$*.pb.cc
+
+$(OBJDIR)/%.pb.cc $(OBJDIR)/%.pb.h: %.proto | $(OBJDIRS)
+	protoc -I. --cpp_out=$(OBJDIR) $<
+
+$(OBJDIR)/%.grpc.pb.cc $(OBJDIR)/%.grpc.pb.h: %.proto | $(OBJDIRS)
+	protoc -I. --grpc_out=$(OBJDIR) --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN_PATH) $<
+
 $(OBJDIRS):
 	mkdir -p $@
 
-protodir:
-	mkdir -p $(PROTO_DIR)
+.PRECIOUS: $(GENERATED)
 
-# Generate rules for new (unbuilt) files
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.pb.cc | obj_dirs
-	$(CXX) $(CXXFLAGS) -MMD -c -o $@ $<
-
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp | obj_dirs
-	$(CXX) $(CXXFLAGS) -MMD -c -o $@ $<
-
-# Include rules for known (previously-built) files
+ifneq ($(MAKECMDGOALS),clean)
 -include $(DEPENDS)
-.SUFFIXES:
-
-.PHONY: lib codegen clean obj_dirs
+endif


### PR DESCRIPTION
- Simplify the recursive $(MAKE) invocations to a single-layered dependency
  graph.
- Move the generated .pb.cc files into .eobjs/.
- Don't emit a spurious error looking for gRPC without CLI_ENABLE_SERVER.