### PR TITLE
Encapsulate Render State

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -55,12 +55,12 @@ ID3D11ShaderResourceView *getDefaultWhiteTexture() {
 
 namespace enigma {
 
-void graphics_state_flush_samplers() {
+void graphics_state_flush_samplers(const RenderState& state) {
   static ID3D11ShaderResourceView *nullTextureView = getDefaultWhiteTexture();
   static ID3D11SamplerState *pSamplerStates[8];
 
   for (int i = 0; i < 8; ++i) {
-    const auto sampler = samplers[i];
+    const auto sampler = state.samplers[i];
 
     ID3D11ShaderResourceView *view = (sampler.texture == -1)?
       nullTextureView:((enigma::DX11Texture*)enigma::textures[sampler.texture])->view;
@@ -90,7 +90,7 @@ void graphics_state_flush_samplers() {
   }
 }
 
-void graphics_state_flush() {
+void graphics_state_flush(const RenderState& state) {
   // Setup the raster description which will determine how and what polygons will be drawn.
   D3D11_RASTERIZER_DESC rasterDesc = { };
   rasterDesc.AntialiasedLineEnable = false;
@@ -98,9 +98,9 @@ void graphics_state_flush() {
   rasterDesc.DepthBias = 0;
   rasterDesc.DepthBiasClamp = 0.0f;
   rasterDesc.DepthClipEnable = false;
-  rasterDesc.FillMode = fillmodes[drawFillMode];
+  rasterDesc.FillMode = fillmodes[state.drawFillMode];
   rasterDesc.FrontCounterClockwise = false;
-  rasterDesc.MultisampleEnable = msaaEnabled;
+  rasterDesc.MultisampleEnable = state.msaaEnabled;
   rasterDesc.ScissorEnable = false;
   rasterDesc.SlopeScaledDepthBias = 0.0f;
 
@@ -111,8 +111,8 @@ void graphics_state_flush() {
 
   D3D11_DEPTH_STENCIL_DESC depthStencilDesc = { };
 
-  depthStencilDesc.DepthEnable = d3dHidden;
-  depthStencilDesc.DepthWriteMask = d3dZWriteEnable ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
+  depthStencilDesc.DepthEnable = state.d3dHidden;
+  depthStencilDesc.DepthWriteMask = state.d3dZWriteEnable ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
   depthStencilDesc.DepthFunc = D3D11_COMPARISON_LESS_EQUAL;
 
   depthStencilDesc.StencilEnable = false;
@@ -140,14 +140,14 @@ void graphics_state_flush() {
 
   blendStateDesc.RenderTarget[0].BlendEnable = TRUE;
 
-  blendStateDesc.RenderTarget[0].SrcBlendAlpha = blendStateDesc.RenderTarget[0].SrcBlend = blend_equivs[(blendMode[0]-1)%11];
-  blendStateDesc.RenderTarget[0].DestBlendAlpha = blendStateDesc.RenderTarget[0].DestBlend = blend_equivs[(blendMode[1]-1)%11];
+  blendStateDesc.RenderTarget[0].SrcBlendAlpha = blendStateDesc.RenderTarget[0].SrcBlend = blend_equivs[(state.blendMode[0]-1)%11];
+  blendStateDesc.RenderTarget[0].DestBlendAlpha = blendStateDesc.RenderTarget[0].DestBlend = blend_equivs[(state.blendMode[1]-1)%11];
   blendStateDesc.RenderTarget[0].BlendOpAlpha = blendStateDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
   UINT8 colorWriteMask = 0;
-  if (enigma::colorWriteEnable[0]) colorWriteMask |= D3D11_COLOR_WRITE_ENABLE_RED;
-  if (enigma::colorWriteEnable[1]) colorWriteMask |= D3D11_COLOR_WRITE_ENABLE_GREEN;
-  if (enigma::colorWriteEnable[2]) colorWriteMask |= D3D11_COLOR_WRITE_ENABLE_BLUE;
-  if (enigma::colorWriteEnable[3]) colorWriteMask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
+  if (state.colorWriteEnable[0]) colorWriteMask |= D3D11_COLOR_WRITE_ENABLE_RED;
+  if (state.colorWriteEnable[1]) colorWriteMask |= D3D11_COLOR_WRITE_ENABLE_GREEN;
+  if (state.colorWriteEnable[2]) colorWriteMask |= D3D11_COLOR_WRITE_ENABLE_BLUE;
+  if (state.colorWriteEnable[3]) colorWriteMask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
   blendStateDesc.RenderTarget[0].RenderTargetWriteMask = colorWriteMask;
 
   static ID3D11BlendState* pBlendState = NULL;
@@ -155,7 +155,7 @@ void graphics_state_flush() {
   m_device->CreateBlendState(&blendStateDesc, &pBlendState);
   m_deviceContext->OMSetBlendState(pBlendState, NULL, 0xffffffff);
 
-  graphics_state_flush_samplers();
+  graphics_state_flush_samplers(state);
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.cpp
@@ -17,13 +17,8 @@
 **/
 
 #include "GSblend.h"
+#include "GSd3d.h"
 #include "GSstdraw.h"
-
-namespace enigma {
-
-int blendMode[2]={enigma_user::bm_src_alpha,enigma_user::bm_inv_src_alpha};
-
-} // namespace enigma
 
 namespace enigma_user {
 
@@ -31,17 +26,17 @@ void draw_set_blend_mode(int mode) {
   enigma::draw_set_state_dirty();
   const static int dest_modes[] = {bm_inv_src_alpha,bm_one,bm_inv_src_color,bm_inv_src_color};
 
-  enigma::blendMode[0] = (mode == bm_subtract) ? bm_zero : bm_src_alpha;
-  enigma::blendMode[1] = dest_modes[mode % 4];
+  enigma::render_state.blendMode[0] = (mode == bm_subtract) ? bm_zero : bm_src_alpha;
+  enigma::render_state.blendMode[1] = dest_modes[mode % 4];
 }
 
 void draw_set_blend_mode_ext(int src, int dest) {
   enigma::draw_set_state_dirty();
-  enigma::blendMode[0] = src;
-  enigma::blendMode[1] = dest;
+  enigma::render_state.blendMode[0] = src;
+  enigma::render_state.blendMode[1] = dest;
 }
 
-int draw_get_blend_mode_src() { return enigma::blendMode[0]; }
-int draw_get_blend_mode_dest() { return enigma::blendMode[1]; }
+int draw_get_blend_mode_src() { return enigma::render_state.blendMode[0]; }
+int draw_get_blend_mode_dest() { return enigma::render_state.blendMode[1]; }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSblend.h
@@ -28,12 +28,6 @@ int draw_set_blend_mode_ext(ARG src,ARG2 dest)
 #ifndef ENIGMA_GSBLEND_H
 #define ENIGMA_GSBLEND_H
 
-namespace enigma {
-
-extern int blendMode[2];
-
-} // namespace enigma
-
 namespace enigma_user {
 
 enum {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.cpp
@@ -20,6 +20,7 @@
 #include "GScolors.h"
 #include "GScolor_macros.h"
 #include "GSstdraw.h"
+#include "GSd3d.h"
 
 #include <math.h>
 
@@ -27,52 +28,45 @@ static inline int min(int x,int y){return x<y ? x:y;}
 static inline int max(int x,int y){return x>y ? x:y;}
 static inline int bclamp(int x){return x > 255 ? 255 : x < 0 ? 0 : x;}
 
-namespace enigma {
-
-unsigned char currentcolor[4] = {255,255,255,255};
-bool colorWriteEnable[4] = {true,true,true,true};
-
-} // namespace enigma
-
 namespace enigma_user {
 
 void draw_set_color(int color)
 {
   enigma::draw_set_state_dirty();
-  enigma::currentcolor[0] = COL_GET_R(color);
-  enigma::currentcolor[1] = COL_GET_G(color);
-  enigma::currentcolor[2] = COL_GET_B(color);
+  enigma::render_state.currentcolor[0] = COL_GET_R(color);
+  enigma::render_state.currentcolor[1] = COL_GET_G(color);
+  enigma::render_state.currentcolor[2] = COL_GET_B(color);
 }
 
 void draw_set_color_rgb(unsigned char red,unsigned char green,unsigned char blue)
 {
   enigma::draw_set_state_dirty();
-  enigma::currentcolor[0] = red;
-  enigma::currentcolor[1] = green;
-  enigma::currentcolor[2] = blue;
+  enigma::render_state.currentcolor[0] = red;
+  enigma::render_state.currentcolor[1] = green;
+  enigma::render_state.currentcolor[2] = blue;
 }
 
 void draw_set_alpha(float alpha)
 {
   enigma::draw_set_state_dirty();
-  enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
+  enigma::render_state.currentcolor[3] = CLAMP_ALPHA(alpha);
 }
 
 void draw_set_color_rgba(unsigned char red,unsigned char green,unsigned char blue,float alpha)
 {
   enigma::draw_set_state_dirty();
-  enigma::currentcolor[0] = red;
-  enigma::currentcolor[1] = green;
-  enigma::currentcolor[2] = blue;
-  enigma::currentcolor[3] = CLAMP_ALPHA(alpha);
+  enigma::render_state.currentcolor[0] = red;
+  enigma::render_state.currentcolor[1] = green;
+  enigma::render_state.currentcolor[2] = blue;
+  enigma::render_state.currentcolor[3] = CLAMP_ALPHA(alpha);
 }
 
 void draw_set_color_write_enable(bool red, bool green, bool blue, bool alpha) {
   enigma::draw_set_state_dirty();
-  enigma::colorWriteEnable[0] = red;
-  enigma::colorWriteEnable[1] = green;
-  enigma::colorWriteEnable[2] = blue;
-  enigma::colorWriteEnable[3] = alpha;
+  enigma::render_state.colorWriteEnable[0] = red;
+  enigma::render_state.colorWriteEnable[1] = green;
+  enigma::render_state.colorWriteEnable[2] = blue;
+  enigma::render_state.colorWriteEnable[3] = alpha;
 }
 
 int merge_color(int c1,int c2,double amount)
@@ -84,14 +78,14 @@ int merge_color(int c1,int c2,double amount)
 }
 
 int draw_get_color(){
-  return enigma::currentcolor[0] | (enigma::currentcolor[1] << 8) | (enigma::currentcolor[2] << 16);
+  return enigma::render_state.currentcolor[0] | (enigma::render_state.currentcolor[1] << 8) | (enigma::render_state.currentcolor[2] << 16);
 }
-int draw_get_red(){return enigma::currentcolor[0];}
-int draw_get_green(){return enigma::currentcolor[1];}
-int draw_get_blue(){return enigma::currentcolor[2];}
+int draw_get_red(){return enigma::render_state.currentcolor[0];}
+int draw_get_green(){return enigma::render_state.currentcolor[1];}
+int draw_get_blue(){return enigma::render_state.currentcolor[2];}
 
 float draw_get_alpha(){
-  return enigma::currentcolor[3] / 255.0;
+  return enigma::render_state.currentcolor[3] / 255.0;
 }
 
 int color_get_red  (int c){return COL_GET_R(c);}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScolors.h
@@ -18,13 +18,6 @@
 #ifndef ENIGMA_GSCOLORS_H
 #define ENIGMA_GSCOLORS_H
 
-namespace enigma {
-
-extern unsigned char currentcolor[4];
-extern bool colorWriteEnable[4];
-
-} // namespace enigma
-
 namespace enigma_user
 {
   enum {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GScurves.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GScurves.cpp
@@ -17,11 +17,14 @@
 #include "GScolors.h"
 #include "GScurves.h"
 #include "GSprimitives.h"
+#include "GSd3d.h"
 
 #include <stack>
 #include <vector>
 #include <algorithm> // min/max
 #include <math.h>
+
+namespace {
 
 int pr_curve_detail = 20;
 int pr_curve_mode = enigma_user::pr_linestrip;
@@ -35,6 +38,8 @@ struct splinePoint {
 typedef std::vector< splinePoint > spline;
 static std::stack< spline*, std::vector<spline*> > startedSplines;
 static std::stack< int > startedSplinesMode;
+
+} // namespace anonymous
 
 namespace enigma_user
 {
@@ -348,7 +353,7 @@ void draw_spline_begin(int mode)
 
 void draw_spline_vertex(gs_scalar x, gs_scalar y)
 {
-    splinePoint point={x,y,gs_scalar(enigma::currentcolor[3]), int(enigma::currentcolor[0] + (enigma::currentcolor[1] << 8) + (enigma::currentcolor[2] << 16))};
+    splinePoint point={x,y,gs_scalar(enigma::render_state.currentcolor[3]), int(enigma::render_state.currentcolor[0] + (enigma::render_state.currentcolor[1] << 8) + (enigma::render_state.currentcolor[2] << 16))};
     startedSplines.top()->push_back(point);
 }
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -38,28 +38,15 @@ std::vector<int> d3dLightsEnabled;
 
 namespace enigma {
 
-bool d3dMode=false, d3dHidden=false, d3dClipPlane=false, d3dZWriteEnable=true,
-     d3dPerspective=true, d3dLighting=false, d3dShading=true;
-int d3dCulling=0, d3dDepthOperator=enigma_user::rs_lequal;
+RenderState render_state;
 
-bool d3dFogEnabled=false;
-int d3dFogColor=enigma_user::c_gray, d3dFogMode=enigma_user::rs_linear, d3dFogHint=enigma_user::rs_nicest;
-float d3dFogStart=0.0f, d3dFogEnd=0.0f, d3dFogDensity=0.0f;
-
-int d3dLightsActive=0, d3dLightingAmbient=enigma_user::c_black;
 const Light& get_active_light(int id) {
   static const Light null_light;
-  if (id >= d3dLightsActive) return null_light;
+  if (id >= render_state.d3dLightsActive) return null_light;
   auto it = d3dLights.find(d3dLightsEnabled[id]);
   if (it == d3dLights.end()) return null_light;
   return it->second;
 }
-
-bool d3dStencilTest = false;
-unsigned int d3dStencilMask = 0x0;
-int d3dStencilFunc = enigma_user::rs_always, d3dStencilFuncRef = 0, d3dStencilFuncMask = -1,
-    d3dStencilOpStencilFail = enigma_user::rs_keep, d3dStencilOpDepthFail = enigma_user::rs_keep,
-    d3dStencilOpPass = enigma_user::rs_keep;
 
 } // namespace enigma
 
@@ -67,12 +54,12 @@ namespace enigma_user {
 
 void d3d_start() {
   enigma::draw_set_state_dirty();
-  enigma::d3dMode = true;
-  enigma::d3dPerspective = true;
-  enigma::d3dHidden = true;
-  enigma::d3dZWriteEnable = true;
-  enigma::d3dCulling = rs_none;
-  enigma::alphaTest = true;
+  enigma::render_state.d3dMode = true;
+  enigma::render_state.d3dPerspective = true;
+  enigma::render_state.d3dHidden = true;
+  enigma::render_state.d3dZWriteEnable = true;
+  enigma::render_state.d3dCulling = rs_none;
+  enigma::render_state.alphaTest = true;
 
   // Set up projection matrix
   d3d_set_projection_perspective(0, 0, view_wview[view_current], view_hview[view_current], 0);
@@ -86,12 +73,12 @@ void d3d_start() {
 
 void d3d_end() {
   enigma::draw_set_state_dirty();
-  enigma::d3dMode = false;
-  enigma::d3dPerspective = false;
-  enigma::d3dHidden = false;
-  enigma::d3dZWriteEnable = false;
-  enigma::d3dCulling = rs_none;
-  enigma::alphaTest = false;
+  enigma::render_state.d3dMode = false;
+  enigma::render_state.d3dPerspective = false;
+  enigma::render_state.d3dHidden = false;
+  enigma::render_state.d3dZWriteEnable = false;
+  enigma::render_state.d3dCulling = rs_none;
+  enigma::render_state.alphaTest = false;
 
   d3d_set_projection_ortho(0, 0, view_wview[view_current], view_hview[view_current], 0); //This should probably be changed not to use views
 }
@@ -100,37 +87,37 @@ void d3d_set_perspective(bool enable) {
   enigma::draw_set_state_dirty();
   // in GM8.1 and GMS v1.4 this does not take effect
   // until the next frame in screen_redraw
-  enigma::d3dPerspective = enable;
+  enigma::render_state.d3dPerspective = enable;
 }
 
 void d3d_set_hidden(bool enable) {
   enigma::draw_set_state_dirty();
-  enigma::d3dHidden = enable;
+  enigma::render_state.d3dHidden = enable;
 }
 
 void d3d_set_zwriteenable(bool enable) {
   enigma::draw_set_state_dirty();
-  enigma::d3dZWriteEnable = enable;
+  enigma::render_state.d3dZWriteEnable = enable;
 }
 
 void d3d_set_culling(int mode) {
   enigma::draw_set_state_dirty();
-  enigma::d3dCulling = mode;
+  enigma::render_state.d3dCulling = mode;
 }
 
 void d3d_set_lighting(bool enable) {
   enigma::draw_set_state_dirty();
-  enigma::d3dLighting = enable;
+  enigma::render_state.d3dLighting = enable;
 }
 
 void d3d_set_shading(bool enable) {
   enigma::draw_set_state_dirty();
-  enigma::d3dShading = enable;
+  enigma::render_state.d3dShading = enable;
 }
 
 void d3d_set_depth_operator(int mode) {
   enigma::draw_set_state_dirty();
-  enigma::d3dDepthOperator = mode;
+  enigma::render_state.d3dDepthOperator = mode;
 }
 
 void d3d_set_depth(double dep) {
@@ -140,7 +127,7 @@ void d3d_set_depth(double dep) {
 
 void d3d_set_clip_plane(bool enable) {
   enigma::draw_set_state_dirty();
-  enigma::d3dClipPlane = enable;
+  enigma::render_state.d3dClipPlane = enable;
 }
 
 void d3d_set_fog(bool enable, int color, double start, double end) {
@@ -152,42 +139,42 @@ void d3d_set_fog(bool enable, int color, double start, double end) {
 
 void d3d_set_fog_enabled(bool enable) {
   enigma::draw_set_state_dirty();
-  enigma::d3dFogEnabled = enable;
+  enigma::render_state.d3dFogEnabled = enable;
 }
 
 void d3d_set_fog_mode(int mode) {
   enigma::draw_set_state_dirty();
-  enigma::d3dFogMode = mode;
+  enigma::render_state.d3dFogMode = mode;
 }
 
 void d3d_set_fog_hint(int mode) {
   enigma::draw_set_state_dirty();
-  enigma::d3dFogHint = mode;
+  enigma::render_state.d3dFogHint = mode;
 }
 
 void d3d_set_fog_color(int color) {
   enigma::draw_set_state_dirty();
-  enigma::d3dFogColor = color;
+  enigma::render_state.d3dFogColor = color;
 }
 
 void d3d_set_fog_start(double start) {
   enigma::draw_set_state_dirty();
-  enigma::d3dFogStart = start;
+  enigma::render_state.d3dFogStart = start;
 }
 
 void d3d_set_fog_end(double end) {
   enigma::draw_set_state_dirty();
-  enigma::d3dFogEnd = end;
+  enigma::render_state.d3dFogEnd = end;
 }
 
 void d3d_set_fog_density(double density) {
   enigma::draw_set_state_dirty();
-  enigma::d3dFogDensity = density;
+  enigma::render_state.d3dFogDensity = density;
 }
 
 void d3d_light_define_ambient(int col) {
   enigma::draw_set_state_dirty();
-  enigma::d3dLightingAmbient = col;
+  enigma::render_state.d3dLightingAmbient = col;
 }
 
 void d3d_light_define_direction(int id, gs_scalar dx, gs_scalar dy, gs_scalar dz, int col) {
@@ -228,7 +215,7 @@ void d3d_light_shininess(int facemode, int shine) {
 }
 
 void d3d_light_enable(int id, bool enable) {
-  if (enable && enigma::d3dLightsActive >= 8) return;
+  if (enable && enigma::render_state.d3dLightsActive >= 8) return;
   const auto& it = std::find(d3dLightsEnabled.begin(), d3dLightsEnabled.end(), id);
   if (enable) {
     if (it != d3dLightsEnabled.end()) return;
@@ -238,7 +225,7 @@ void d3d_light_enable(int id, bool enable) {
     d3dLightsEnabled.erase(it);
   }
   enigma::draw_set_state_dirty();
-  enigma::d3dLightsActive = d3dLightsEnabled.size();
+  enigma::render_state.d3dLightsActive = d3dLightsEnabled.size();
 }
 
 void d3d_stencil_start_mask() {
@@ -276,34 +263,34 @@ void d3d_stencil_end_mask() {
 
 void d3d_stencil_enable(bool enable) {
   enigma::draw_set_state_dirty();
-  enigma::d3dStencilTest = enable;
+  enigma::render_state.d3dStencilTest = enable;
 }
 
 void d3d_stencil_mask(unsigned int mask) {
   enigma::draw_set_state_dirty();
-  enigma::d3dStencilMask = mask;
+  enigma::render_state.d3dStencilMask = mask;
 }
 
 void d3d_stencil_function(int func, int ref, unsigned int mask) {
   enigma::draw_set_state_dirty();
-  enigma::d3dStencilFunc = func;
-  enigma::d3dStencilFuncRef = ref;
-  enigma::d3dStencilFuncMask = mask;
+  enigma::render_state.d3dStencilFunc = func;
+  enigma::render_state.d3dStencilFuncRef = ref;
+  enigma::render_state.d3dStencilFuncMask = mask;
 }
 
 void d3d_stencil_operator(int sfail, int dpfail, int dppass) {
   enigma::draw_set_state_dirty();
-  enigma::d3dStencilOpStencilFail = sfail;
-  enigma::d3dStencilOpDepthFail = dpfail;
-  enigma::d3dStencilOpPass = dppass;
+  enigma::render_state.d3dStencilOpStencilFail = sfail;
+  enigma::render_state.d3dStencilOpDepthFail = dpfail;
+  enigma::render_state.d3dStencilOpPass = dppass;
 }
 
-bool d3d_get_mode() { return enigma::d3dMode; }
-bool d3d_get_perspective() { return enigma::d3dPerspective; }
-bool d3d_get_hidden() { return enigma::d3dHidden; }
-bool d3d_get_zwriteenable() { return enigma::d3dZWriteEnable; }
-int d3d_get_culling() { return enigma::d3dCulling; }
-bool d3d_get_lighting() { return enigma::d3dLighting; }
-bool d3d_get_shading() { return enigma::d3dShading; }
+bool d3d_get_mode() { return enigma::render_state.d3dMode; }
+bool d3d_get_perspective() { return enigma::render_state.d3dPerspective; }
+bool d3d_get_hidden() { return enigma::render_state.d3dHidden; }
+bool d3d_get_zwriteenable() { return enigma::render_state.d3dZWriteEnable; }
+int d3d_get_culling() { return enigma::render_state.d3dCulling; }
+bool d3d_get_lighting() { return enigma::render_state.d3dLighting; }
+bool d3d_get_shading() { return enigma::render_state.d3dShading; }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -179,7 +179,7 @@ static inline int draw_tiles()
 
 void clear_view(float x, float y, float w, float h, float angle, bool showcolor)
 {
-  if (enigma::d3dMode && enigma::d3dPerspective)
+  if (enigma::render_state.d3dMode && enigma::render_state.d3dPerspective)
     d3d_set_projection_perspective(x, y, w, h, angle);
   else
     d3d_set_projection_ortho(x, y, w, h, angle);
@@ -189,7 +189,7 @@ void clear_view(float x, float y, float w, float h, float angle, bool showcolor)
 
   // Clear the depth buffer if 3d mode is on at the beginning of the draw step.
   // Always clear the depth buffer for every view, this was Game Maker 8.1 behaviour
-  if (enigma::d3dMode)
+  if (enigma::render_state.d3dMode)
     enigma_user::d3d_clear_depth();
 }
 
@@ -197,9 +197,9 @@ static inline void draw_gui()
 {
   // turn some state off automatically for the user to draw the GUI
   // this is exactly what GMSv1.4 does
-  int culling = enigma::d3dCulling;
-  bool hidden = enigma::d3dHidden;
-  bool zwrite = enigma::d3dZWriteEnable;
+  int culling = enigma::render_state.d3dCulling;
+  bool hidden = enigma::render_state.d3dHidden;
+  bool zwrite = enigma::render_state.d3dZWriteEnable;
   d3d_set_zwriteenable(false);
   d3d_set_culling(rs_none);
   d3d_set_hidden(false);
@@ -290,9 +290,9 @@ void screen_init() {
     }
   }
 
-  enigma::d3dHidden = false;
-  enigma::d3dCulling = rs_none;
-  enigma::alphaBlend = true;
+  enigma::render_state.d3dHidden = false;
+  enigma::render_state.d3dCulling = rs_none;
+  enigma::render_state.alphaBlend = true;
   texture_reset();
 
   // make sure all of the default state values are
@@ -372,7 +372,7 @@ void screen_redraw()
     d3d_set_projection_ortho(0, 0, enigma::gui_width, enigma::gui_height, 0);
 
     // Clear the depth buffer if hidden surface removal is on at the beginning of the draw step.
-    if (enigma::d3dMode)
+    if (enigma::render_state.d3dMode)
       d3d_clear_depth();
 
     draw_gui();

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.h
@@ -19,33 +19,22 @@
 #ifndef ENIGMA_GSSTDRAW_H
 #define ENIGMA_GSSTDRAW_H
 
+#include "GSd3d.h"
 #include "Universal_System/scalar.h"
 
 #include <list>
 
 namespace enigma {
 
-extern bool lineStippleEnable, msaaEnabled, alphaBlend, alphaTest;
-extern unsigned short lineStipplePattern;
-extern unsigned char alphaTestRef;
-extern float drawPointSize, drawLineWidth;
-extern int drawFillMode, lineStippleScale;
-
 void draw_set_state_dirty(bool dirty=true);
 bool draw_get_state_dirty();
 
-void graphics_state_flush();
+void graphics_state_flush(const RenderState& state=render_state);
 
 } // namespace enigma
 
 namespace enigma_user
 {
-  enum {
-    rs_point, // Render vertices as points
-    rs_line,  // Render in wireframe mode
-    rs_solid  // Normal render mode
-  };
-
   void draw_state_flush();
   void draw_set_fill_mode(int fill);
   void draw_set_line_width(float value);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.cpp
@@ -17,6 +17,7 @@
 **/
 
 #include "GStextures.h"
+#include "GSd3d.h"
 #include "GSstdraw.h"
 #include "GStextures_impl.h"
 #include "Graphics_Systems/graphics_mandatory.h"
@@ -41,7 +42,6 @@ inline unsigned int lgpp2(unsigned int x) { // Trailing zero count. lg for perfe
 namespace enigma {
 
 vector<Texture*> textures;
-Sampler samplers[8];
 
 int graphics_duplicate_texture(int tex, bool mipmap) {
   unsigned w = textures[tex]->width, h = textures[tex]->height,
@@ -168,19 +168,19 @@ gs_scalar texture_get_texel_height(int texid)
 }
 
 void texture_set_stage(int stage, int texid) {
-  if (enigma::samplers[stage].texture == texid) return;
+  if (enigma::render_state.samplers[stage].texture == texid) return;
   enigma::draw_set_state_dirty();
-  enigma::samplers[stage].texture = texid;
+  enigma::render_state.samplers[stage].texture = texid;
 }
 
 int texture_get_stage(int stage) {
-  return enigma::samplers[stage].texture;
+  return enigma::render_state.samplers[stage].texture;
 }
 
 void texture_reset() {
-  if (enigma::samplers[0].texture == -1) return;
+  if (enigma::render_state.samplers[0].texture == -1) return;
   enigma::draw_set_state_dirty();
-  enigma::samplers[0].texture = -1;
+  enigma::render_state.samplers[0].texture = -1;
 }
 
 void texture_set_enabled(bool enable){}
@@ -189,21 +189,21 @@ void texture_set_blending(bool enable){}
 
 void texture_set_interpolation_ext(int sampler, bool enable) {
   enigma::draw_set_state_dirty();
-  enigma::samplers[sampler].interpolate = enable;
+  enigma::render_state.samplers[sampler].interpolate = enable;
 }
 
 void texture_set_repeat_ext(int sampler, bool repeat) {
   enigma::draw_set_state_dirty();
-  enigma::samplers[sampler].wrapu = repeat;
-  enigma::samplers[sampler].wrapv = repeat;
-  enigma::samplers[sampler].wrapw = repeat;
+  enigma::render_state.samplers[sampler].wrapu = repeat;
+  enigma::render_state.samplers[sampler].wrapv = repeat;
+  enigma::render_state.samplers[sampler].wrapw = repeat;
 }
 
 void texture_set_wrap_ext(int sampler, bool wrapu, bool wrapv, bool wrapw) {
   enigma::draw_set_state_dirty();
-  enigma::samplers[sampler].wrapu = wrapu;
-  enigma::samplers[sampler].wrapv = wrapv;
-  enigma::samplers[sampler].wrapw = wrapw;
+  enigma::render_state.samplers[sampler].wrapu = wrapu;
+  enigma::render_state.samplers[sampler].wrapv = wrapv;
+  enigma::render_state.samplers[sampler].wrapw = wrapw;
 }
 
 void texture_set_border_ext(int sampler, int r, int g, int b, double a) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GStextures.h
@@ -30,18 +30,6 @@
 #include <string>
 using std::string;
 
-namespace enigma {
-
-struct Sampler {
-  int texture=-1; // GML texture id, NOT GL texture id!
-  bool wrapu=false, wrapv=false, wrapw=false;
-  bool interpolate=false;
-};
-
-extern Sampler samplers[8];
-
-} // namespace enigma
-
 namespace enigma_user {
   enum {
     tx_none,

--- a/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/None/fillin.cpp
@@ -66,7 +66,7 @@ namespace enigma
 	void graphics_push_texture_pixels(int texture, int x, int y, int width, int height, unsigned char* pxdata) {}
 	void graphics_push_texture_pixels(int texture, int width, int height, unsigned char* pxdata) {}
 
-	void graphics_state_flush() {}
+	void graphics_state_flush(const RenderState& state) {}
 
 	void graphics_delete_vertex_buffer_peer(int buffer) {}
 	void graphics_delete_index_buffer_peer(int buffer) {}

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/GL3vertex.cpp
@@ -176,12 +176,6 @@ void graphics_apply_vertex_format(int format, size_t offset) {
     offset += size * sizeof(enigma::VertexElement);
   }
 
-  glsl_uniformf_internal(shaderprograms[bound_shader]->uni_color,
-                         (float)currentcolor[0]/255.0f,
-                         (float)currentcolor[1]/255.0f,
-                         (float)currentcolor[2]/255.0f,
-                         (float)currentcolor[3]/255.0f);
-
   if (useTextCoords) {
     GLint boundTex;
     glActiveTexture(GL_TEXTURE0);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_fallback.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ParticleSystems/PS_particle_bridge_fallback.h
@@ -28,7 +28,7 @@
 #include "PS_particle_system.h"
 #include "PS_particle.h"
 
-#include "Graphics_Systems/General/GSblend.h"
+#include "Graphics_Systems/General/GSd3d.h"
 
 namespace enigma {
   namespace particle_bridge {
@@ -83,7 +83,7 @@ namespace enigma {
           const double x = it->x, y = it->y;
           const double xscale = pt->xscale*size, yscale = pt->yscale*size;
 
-          if (pt->blend_additive != enigma::blendMode[0]){
+          if (pt->blend_additive != enigma::render_state.blendMode[0]){
               if (pt->blend_additive) {
                 enigma_user::draw_set_blend_mode(enigma_user::bm_add);
               }
@@ -103,7 +103,7 @@ namespace enigma {
 
           int sprite_id = get_particle_actual_sprite(ps->shape);
 
-          if (pt->blend_additive != enigma::blendMode[0]){
+          if (pt->blend_additive != enigma::render_state.blendMode[0]){
               if (pt->blend_additive) {
                 draw_set_blend_mode(enigma_user::bm_add);
               } else {
@@ -122,7 +122,7 @@ namespace enigma {
         particle_sprite* ps = get_particle_sprite(pt_sh_pixel);
         if (ps == NULL) return; // NOTE: Skip to next particle.
 
-        if (enigma::blendMode[0] != 0){
+        if (enigma::render_state.blendMode[0] != 0){
             draw_set_blend_mode(enigma_user::bm_normal);
         }
 
@@ -144,8 +144,8 @@ namespace enigma {
         y_offset = a_y_offset;
 
         // Draw the particle system either from oldest to youngest or reverse.
-        int blend_src  = enigma::blendMode[0];
-        int blend_dest = enigma::blendMode[1];
+        int blend_src  = enigma::render_state.blendMode[0];
+        int blend_dest = enigma::render_state.blendMode[1];
 
         if (oldtonew) {
           const std::vector<particle_instance>::iterator end = pi_list.end();
@@ -161,7 +161,7 @@ namespace enigma {
           }
         }
 
-        if (enigma::blendMode[0] != blend_src || enigma::blendMode[1] != blend_dest){
+        if (enigma::render_state.blendMode[0] != blend_src || enigma::render_state.blendMode[1] != blend_dest){
           enigma_user::draw_set_blend_mode_ext(blend_src, blend_dest);
         }
     }


### PR DESCRIPTION
It should be very obvious what I am doing here. I am moving all of the namespace enigma:: scoped render state to a struct whose type is `RenderState` and whose members are public by default. This completes the first part of the work detailed in #1681 that is necessary to add dirty tracking. By having all of the render state encapsulated in a struct, we can do things like push and pop states as well as serialize the state to targets other than a GPU, such as including it in the `game_save` serialization.

I am not exactly sure of the performance implications of this change, but haven't noticed any degradation in any benchmarks. I have done extensive regression testing to ensure there's been no relapse in correctness either.

@JoshDreamland I think we also need to begin considering now what type of state belongs in this struct, and what type doesn't. For example, there is "render" state, such as circle precision, which is used by the general graphics functions, but does **NOT** need to be known by the GPU. However, it may still be useful to include in a `game_save` serialization and thus could still go into the new struct.