### PR TITLE
allow using relative paths for ini writing

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSfilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSfilemanip.cpp
@@ -44,7 +44,9 @@ namespace enigma_user
 
 void ini_open(std::string fname)
 {
-	iniFilename = fname;
+  char rpath[MAX_PATH];
+  GetFullPathName(fname.c_str(), MAX_PATH, rpath, NULL);
+  iniFilename = rpath;
 }
 
 void ini_close()

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSfilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSfilemanip.cpp
@@ -44,9 +44,9 @@ namespace enigma_user
 
 void ini_open(std::string fname)
 {
-  char rpath[MAX_PATH];
-  GetFullPathName(fname.c_str(), MAX_PATH, rpath, NULL);
-  iniFilename = rpath;
+	char rpath[MAX_PATH];
+	GetFullPathName(fname.c_str(), MAX_PATH, rpath, NULL);
+	iniFilename = rpath;
 }
 
 void ini_close()


### PR DESCRIPTION
For reference:
https://stackoverflow.com/questions/49620394/writeprivateprofilestring-works-in-main-but-not-in-function

"Also, if you read their documentation, you would see that you SHOULD NOT use a relative path for the INI file, or else the file will be relative to the Windows installation folder, not your app folder."

GetFullPathName fixes this issue because the whole purpose of that function is to automatically convert relative paths to absolute.