### PR TITLE
Fix using string as type/function.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/var4.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.h
@@ -262,9 +262,11 @@ enum {
 std::string toString(const void*);
 std::string toString(double);
 
-#ifdef INCLUDED_FROM_SHELLMAIN
+#if defined(INCLUDED_FROM_SHELLMAIN) && !defined(JUST_DEFINE_IT_RUN)
 #define string(...) toString(__VA_ARGS__)
 #endif
+
+using std::string;
 
 }
 


### PR DESCRIPTION
When we moved exclusively to namespace `enigma_user`, we didn't move toString there, so the function is no longer allowed in EDL. Problem is, `string()` was a macro to it, so that was necessarily broken.

The best option for now is to remove the macro and use just the type in EDL. EDL will not force the std::string constructor to succeed on objects passed to the method, so GCC can silently fix it in the preprocessor for the time being.