### PR TITLE
fix filename_ext when period in path to file

### DIFF
--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -199,6 +199,7 @@ gtest_expect_eq(filename_drive("/c/John/Doe/Smoe.txt"),"");
 gtest_expect_eq(filename_drive("Smoe.txt"),"");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.txt"),".txt");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile"),"");
+gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile.txt"),".txt");
 gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/Doe/Smoe.dingtwo");
 
 /// We're done!

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -1,5 +1,5 @@
 /// BINARY FILES
-var bin_path = "file_bin_test.bin"; 
+var bin_path = "file_bin_test.bin";
 
 // BINARY WRITE
 var bin_write;

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -200,7 +200,7 @@ gtest_expect_eq(filename_drive("Smoe.txt"),"");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.txt"),".txt");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile"),"");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile.txt"),".txt");
-gtest_expect_eq(filename_ext(filename_ext("archive.tar.gz"),".gz");
+gtest_expect_eq(filename_ext("archive.tar.gz"),".gz");
 gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/Doe/Smoe.dingtwo");
 
 /// We're done!

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -201,6 +201,8 @@ gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.txt"),".txt");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile"),"");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile.txt"),".txt");
 gtest_expect_eq(filename_ext("archive.tar.gz"),".gz");
+gtest_expect_eq(filename_ext("C:/John/Doe/Smoe/datafiles/archive.tar.gz"),".gz");
+gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/archive.tar.gz"),".gz");
 gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/Doe/Smoe.dingtwo");
 
 /// We're done!

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -198,6 +198,7 @@ gtest_expect_eq(filename_drive("C/John/Doe/Smoe.txt"),"");
 gtest_expect_eq(filename_drive("/c/John/Doe/Smoe.txt"),"");
 gtest_expect_eq(filename_drive("Smoe.txt"),"");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.txt"),".txt");
+gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile"),"");
 gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/Doe/Smoe.dingtwo");
 
 /// We're done!

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -200,6 +200,7 @@ gtest_expect_eq(filename_drive("Smoe.txt"),"");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.txt"),".txt");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile"),"");
 gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/Makefile.txt"),".txt");
+gtest_expect_eq(filename_ext(filename_ext("archive.tar.gz"),".gz");
 gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/Doe/Smoe.dingtwo");
 
 /// We're done!

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -1,5 +1,5 @@
 /// BINARY FILES
-var bin_path = "file_bin_test.bin";
+var bin_path = "file_bin_test.bin"; 
 
 // BINARY WRITE
 var bin_write;

--- a/ENIGMAsystem/SHELL/Universal_System/estring.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/estring.cpp
@@ -350,6 +350,7 @@ string filename_drive(string fname)
 
 string filename_ext(string fname)
 {
+  fname = filename_name(fname);
   size_t fp = fname.find_last_of(".");
   if (fp == string::npos)
     return "";


### PR DESCRIPTION
when there is a period in the path (and not and not in the file), it will return a non-empty string, when it should return an empty string.

This change fixes that issue.