### PR TITLE
Fix Empty Keyboard String Crashes

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -23,7 +23,7 @@ using std::map;
 #include <windows.h>
 //#include <winuser.h> // includes windows.h
 
-#include "Platforms/General/PFmain.h"
+#include "Platforms/General/PFmain.h" // for keyboard_string
 #include "Platforms/General/PFwindow.h" // For those damn vk_ constants.
 #include "Universal_System/Instances/instance_system.h"
 #include "Universal_System/Instances/instance.h"
@@ -35,10 +35,6 @@ using std::map;
 #endif
 
 namespace enigma_user {
-extern int keyboard_key;
-extern int keyboard_lastkey;
-extern string keyboard_lastchar;
-extern string keyboard_string;
 void draw_clear(int col);
 void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height);
 }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -23,9 +23,8 @@ using std::map;
 #include <windows.h>
 //#include <winuser.h> // includes windows.h
 
-#include "../General/PFwindow.h"
-
-#include "Platforms/General/PFmain.h" // For those damn vk_ constants.
+#include "Platforms/General/PFmain.h"
+#include "Platforms/General/PFwindow.h" // For those damn vk_ constants.
 #include "Universal_System/Instances/instance_system.h"
 #include "Universal_System/Instances/instance.h"
 
@@ -168,7 +167,7 @@ namespace enigma
       case WM_CHAR:
         keyboard_lastchar = string(1,wParam);
         if (keyboard_lastkey == enigma_user::vk_backspace) {
-          keyboard_string = keyboard_string.substr(0, keyboard_string.length() - 1);
+          if (!keyboard_string.empty()) keyboard_string.pop_back();
         } else {
           keyboard_string += keyboard_lastchar;
         }

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -71,8 +71,7 @@ int handleEvents() {
           if (len > 0) {
             enigma_user::keyboard_lastchar = string(1, str[0]);
             if (actualKey == enigma_user::vk_backspace) {
-              enigma_user::keyboard_string =
-                  enigma_user::keyboard_string.substr(0, enigma_user::keyboard_string.length() - 1);
+              if (!keyboard_string.empty()) keyboard_string.pop_back();
             } else {
               enigma_user::keyboard_string += enigma_user::keyboard_lastchar;
             }

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -71,7 +71,7 @@ int handleEvents() {
           if (len > 0) {
             enigma_user::keyboard_lastchar = string(1, str[0]);
             if (actualKey == enigma_user::vk_backspace) {
-              if (!keyboard_string.empty()) keyboard_string.pop_back();
+              if (!enigma_user::keyboard_string.empty()) enigma_user::keyboard_string.pop_back();
             } else {
               enigma_user::keyboard_string += enigma_user::keyboard_lastchar;
             }


### PR DESCRIPTION
This pull request fixes #1743 for Darkstar. Basically, we just needed to add a check if the `keyboard_string` was not empty before trying to remove a character from it. SDL did not have this problem as it seems it's already making that check. I am not bothering to add input tests right now, we can do that later. Let's just fix the crash for Darkstar right now. I confirm it fixed the crash for me and `keyboard_string` continues working just fine.