### PR TITLE
Fix Declaration Parsing Loop

### DIFF
--- a/CompilerSource/parser/collect_variables.cpp
+++ b/CompilerSource/parser/collect_variables.cpp
@@ -155,7 +155,6 @@ void collect_variables(language_adapter *lang, string &code, string &synt, parse
           {
             igstack[igpos]->ignore[dec_name] = pos;
             //pos++; //cout << "Added `" << dec_name << "' to ig\n";
-            continue;
           }
         }
         

--- a/CompilerSource/parser/collect_variables.cpp
+++ b/CompilerSource/parser/collect_variables.cpp
@@ -164,6 +164,7 @@ void collect_variables(language_adapter *lang, string &code, string &synt, parse
         dec_prefixes = dec_suffixes = "";
         dec_initializing = false;
         dec_name_givn = false;
+        continue;
       }
       if (!dec_initializing)
       {

--- a/CompilerSource/parser/collect_variables.cpp
+++ b/CompilerSource/parser/collect_variables.cpp
@@ -154,7 +154,8 @@ void collect_variables(language_adapter *lang, string &code, string &synt, parse
           else //Add to this scope
           {
             igstack[igpos]->ignore[dec_name] = pos;
-            pos++; //cout << "Added `" << dec_name << "' to ig\n";
+            //pos++; //cout << "Added `" << dec_name << "' to ig\n";
+            continue;
           }
         }
         


### PR DESCRIPTION
This addresses #1746 and fixes building of TKG's Key to Success using emake (though there is still some emake bugs to work out that make the game buggy). It also allows me to proceed with the same action scoping fix to the LGM plugin.