### PR TITLE
Make Windows Widgets Compatible w/ Other Platforms

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -124,27 +124,27 @@ namespace enigma_user {
     return queue_async_job(fnc);
   }
 
-  int get_string_async(string message, string def, string cap) {
+  int get_string_async(string message, string def) {
     auto fnc = [=] {
-      string result = get_string(message, def, cap);
+      string result = get_string(message, def);
       ds_map_overwrite(async_load, "status", true);
       ds_map_overwrite(async_load, "result", result);
     };
     return queue_async_job(fnc);
   }
 
-  int get_integer_async(string message, string def, string cap) {
+  int get_integer_async(string message, double def) {
     auto fnc = [=] {
-      int result = get_integer(message, def, cap);
+      int result = get_integer(message, def);
       ds_map_overwrite(async_load, "status", true);
       ds_map_overwrite(async_load, "result", result);
     };
     return queue_async_job(fnc);
   }
 
-  int get_login_async(string username, string password, string cap) {
+  int get_login_async(string username, string password) {
     auto fnc = [=] {
-      string result = get_login(username, password, cap);
+      string result = get_login(username, password);
       size_t end = result.find('\0', 0);
       string username, password;
       // must still check if the string is empty which is the case when the user cancels the dialog

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -145,7 +145,7 @@ namespace enigma_user {
   int get_login_async(string username, string password) {
     auto fnc = [=] {
       string result = get_login(username, password);
-      size_t end = result.find('\0', 0);
+      size_t end = result.find('\n', 0);
       string username, password;
       // must still check if the string is empty which is the case when the user cancels the dialog
       if (end != string::npos) {

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -124,7 +124,7 @@ namespace enigma_user {
     return queue_async_job(fnc);
   }
 
-  int get_string_async(string message, string def) {
+  int get_string_async(string str, string def) {
     auto fnc = [=] {
       string result = get_string(message, def);
       ds_map_overwrite(async_load, "status", true);
@@ -133,7 +133,7 @@ namespace enigma_user {
     return queue_async_job(fnc);
   }
 
-  int get_integer_async(string message, double def) {
+  int get_integer_async(string str, double def) {
     auto fnc = [=] {
       int result = get_integer(message, def);
       ds_map_overwrite(async_load, "status", true);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -135,7 +135,7 @@ namespace enigma_user {
 
   int get_integer_async(string str, double def) {
     auto fnc = [=] {
-      int result = get_integer(str, def);
+      double result = get_integer(str, def);
       ds_map_overwrite(async_load, "status", true);
       ds_map_overwrite(async_load, "result", result);
     };

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -126,7 +126,7 @@ namespace enigma_user {
 
   int get_string_async(string str, string def) {
     auto fnc = [=] {
-      string result = get_string(message, def);
+      string result = get_string(str, def);
       ds_map_overwrite(async_load, "status", true);
       ds_map_overwrite(async_load, "result", result);
     };
@@ -135,7 +135,7 @@ namespace enigma_user {
 
   int get_integer_async(string str, double def) {
     auto fnc = [=] {
-      int result = get_integer(message, def);
+      int result = get_integer(str, def);
       ds_map_overwrite(async_load, "status", true);
       ds_map_overwrite(async_load, "result", result);
     };

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -145,7 +145,7 @@ namespace enigma_user {
   int get_login_async(string username, string password) {
     auto fnc = [=] {
       string result = get_login(username, password);
-      size_t end = result.find('\n', 0);
+      size_t end = result.find('\0', 0);
       string username, password;
       // must still check if the string is empty which is the case when the user cancels the dialog
       if (end != string::npos) {

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.h
@@ -32,8 +32,8 @@ namespace enigma_user {
 
   int show_message_async(string str);
   int show_question_async(string str);
-  int get_string_async(string message, string def);
-  int get_integer_async(string message, double def);
+  int get_string_async(string str, string def);
+  int get_integer_async(string str, double def);
   int get_login_async(string username, string password);
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.h
@@ -32,9 +32,9 @@ namespace enigma_user {
 
   int show_message_async(string str);
   int show_question_async(string str);
-  int get_string_async(string message, string def, string cap="");
-  int get_integer_async(string message, string def, string cap="");
-  int get_login_async(string username, string password, string cap="");
+  int get_string_async(string message, string def);
+  int get_integer_async(string message, double def);
+  int get_login_async(string username, string password);
 }
 
 #endif // ENIGMA_ASYNCDIALOG_H

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -1,6 +1,6 @@
 /** Copyright (C) 2008 Josh Ventura
 *** Copyright (C) 2014 Robert B. Colton
-*** Copyright (C) 2019 Samuel Venable 
+*** Copyright (C) 2019 Samuel Venable
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -1,5 +1,6 @@
 /** Copyright (C) 2008 Josh Ventura
 *** Copyright (C) 2014 Robert B. Colton
+*** Copyright (C) 2019 Samuel Venable
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***
@@ -52,41 +53,37 @@ enum {
 };
 */
 
-    void message_alpha(double alpha);
-    void message_background(int back);
-    void message_button(int spr);
-    void message_button_font(string name, int size, int color, int style);
-    void message_caption(bool show, string str);
-    void message_input_color(int col);
-    void message_input_font(string name, int size, int color, int style);
-    void message_mouse_color(int col);
-    void message_position(int x, int y);
-    void message_size(int w, int h);
-    void message_text_font(string name, int size, int color, int style); 
-	void message_text_charset(int type, int charset); 
-	
-	int show_message_ext(string str, string but1, string but2, string but3);
-  
-	bool show_question(string str);
-	inline bool action_if_question(string str)
-	{
-		return show_question(str);
-	}
-	
-	// IMPLEMENTS from widgets_mandatory:
-	// void show_error(string errortext, const bool fatal);
+#include <string>
 
-	int get_color(int defcol, bool advanced = false);
-	
-	string get_open_filename(string filter, string fname, string caption="");
-	string get_save_filename(string filter, string fname, string caption="");
-	string get_directory(string dname, string caption="Select Folder");
-	string get_directory_alt(string message, string root, bool modern=false, string caption="Browse for Folder");
+    // void show_error(string errortext, const bool fatal);
+    // int show_message(string str);
+    int show_message_cancelable(string str);
+    int show_message_ext(string str, string but1, string but2, string but3);
+    bool show_question(string str);
+    int show_question_cancelable(string str);
+    int show_attempt(string str);
+    string get_string(string str, string def);
+    string get_password(string str, string def);
+    double get_integer(string str, double def);
+    double get_passcode(string str, double def);
+    string get_open_filename(string filter, string fname);
+    string get_open_filenames(string filter, string fname);
+    string get_save_filename(string filter, string fname);
+    string get_open_filename_ext(string filter, string fname, string dir, string title);
+    string get_open_filenames_ext(string filter, string fname, string dir, string title);
+    string get_save_filename_ext(string filter, string fname, string dir, string title);
+    string get_directory(string dname);
+    string get_directory_alt(string capt, string root);
+    int get_color(int defcol);
+    int get_color_ext(int defcol, string title);
+    string message_get_caption();
+    void message_set_caption(string str);
 
-	string get_login(string username, string password, string cap="");
-	string get_string(string message, string def, string cap="");
-	double get_number(string message, string def, string cap="");
-	int    get_integer(string message, string def, string cap="");
-	bool   get_string_canceled();
+    inline bool action_if_question(string str)
+    {
+        return show_question(str);
+    }
 
+    string get_login(string username, string password, string cap="");
+    bool   get_string_canceled();
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -55,35 +55,35 @@ enum {
 
 #include <string>
 
-    // void show_error(string errortext, const bool fatal);
-    // int show_message(string str);
-    int show_message_cancelable(string str);
-    int show_message_ext(string str, string but1, string but2, string but3);
-    bool show_question(string str);
-    int show_question_cancelable(string str);
-    int show_attempt(string str);
-    string get_string(string str, string def);
-    string get_password(string str, string def);
-    double get_integer(string str, double def);
-    double get_passcode(string str, double def);
-    string get_open_filename(string filter, string fname);
-    string get_open_filenames(string filter, string fname);
-    string get_save_filename(string filter, string fname);
-    string get_open_filename_ext(string filter, string fname, string dir, string title);
-    string get_open_filenames_ext(string filter, string fname, string dir, string title);
-    string get_save_filename_ext(string filter, string fname, string dir, string title);
-    string get_directory(string dname);
-    string get_directory_alt(string capt, string root);
-    int get_color(int defcol);
-    int get_color_ext(int defcol, string title);
-    string message_get_caption();
-    void message_set_caption(string str);
-
-    inline bool action_if_question(string str)
-    {
-        return show_question(str);
-    }
-
-    string get_login(string username, string password);
-    bool   get_string_canceled();
+	// void show_error(string errortext, const bool fatal);
+	// int show_message(string str);
+	int show_message_cancelable(string str);
+	int show_message_ext(string str, string but1, string but2, string but3);
+	bool show_question(string str);
+	int show_question_cancelable(string str);
+	int show_attempt(string str);
+	string get_string(string str, string def);
+	string get_password(string str, string def);
+	double get_integer(string str, double def);
+	double get_passcode(string str, double def);
+	string get_open_filename(string filter, string fname);
+	string get_open_filenames(string filter, string fname);
+	string get_save_filename(string filter, string fname);
+	string get_open_filename_ext(string filter, string fname, string dir, string title);
+	string get_open_filenames_ext(string filter, string fname, string dir, string title);
+	string get_save_filename_ext(string filter, string fname, string dir, string title);
+	string get_directory(string dname);
+	string get_directory_alt(string capt, string root);
+	int get_color(int defcol);
+	int get_color_ext(int defcol, string title);
+	string message_get_caption();
+	void message_set_caption(string str);
+	
+	inline bool action_if_question(string str)
+	{
+		return show_question(str);
+	}
+	
+	string get_login(string username, string password);
+	bool   get_string_canceled();
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -84,6 +84,6 @@ enum {
         return show_question(str);
     }
 
-    string get_login(string username, string password, string cap="");
+    string get_login(string username, string password);
     bool   get_string_canceled();
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -1,6 +1,6 @@
 /** Copyright (C) 2008 Josh Ventura
 *** Copyright (C) 2014 Robert B. Colton
-*** Copyright (C) 2019 Samuel Venable
+*** Copyright (C) 2019 Samuel Venable 
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***

--- a/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
@@ -117,8 +117,8 @@ bool show_question(string str) {
   return (answer == 'Y');
 }
 
-string get_login(string username, string password, string cap="") {
-  cout << cap << endl;
+string get_login(string username, string password) {
+  cout << c
   string input;
   cout << "Username: " << flush;
   cin >> input;
@@ -132,19 +132,19 @@ string get_login(string username, string password, string cap="") {
   return input;
 }
 
-string get_string(string message, string def, string cap="") {
-  printf("%s\n%s\n", cap.c_str(), message.c_str());
+string get_string(string str, string def) {
+  printf("%s\n", str.c_str());
   string input;
   cin >> input;
   return (input.empty()) ? def : input;
 }
 
-int get_integer(string message, string def, string cap="") {
-  printf("%s\n%s\n", cap.c_str(), message.c_str());
+double get_integer(string str, double def) {
+  printf("%s\n", str.c_str());
   string input;
   cin >> input;
-  if (input.empty()) input = def;
-  return stoi(input);
+  if (input.empty()) return def;
+  return strtod(input.c_str(), NULL);
 }
 
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/None/nowidget_impl.cpp
@@ -118,7 +118,6 @@ bool show_question(string str) {
 }
 
 string get_login(string username, string password) {
-  cout << c
   string input;
   cout << "Username: " << flush;
   cin >> input;

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -368,7 +368,7 @@ static inline string get_open_filenames_helper(string filter, string fname, stri
   ofn = get_filename_or_filenames_helper(filter, fname, dir, title, OFN_ALLOWMULTISELECT);
 
   if (GetOpenFileNameW(&ofn) != 0) {
-    tstring tstr_fname1 = wstr_fname1;
+    tstring tstr_fname1 = wstr_fname;
     tstr_fname1 += '\\';
 
     size_t pos = 0;

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -350,7 +350,7 @@ static inline OPENFILENAMEW get_filename_or_filenames_helper(string filter, stri
   ofn.lpstrInitialDir = tstr_dir.c_str();
   ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR | flags;
   
-  reutrn ofn;
+  return ofn;
 }
 
 static inline string get_open_filename_helper(string filter, string fname, string dir, string title) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -201,8 +201,8 @@ static INT_PTR CALLBACK GetLoginProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
     SetWindowTextW(hwndDlg, tstr_gs_cap.c_str());
     tstring tstr_gs_username = widen(gs_username);
     tstring tstr_gs_password = widen(gs_password);
-    SetDlgItemTextW(hwndDlg, 14, gs_username.c_str());
-    SetDlgItemTextW(hwndDlg, 15, gs_password.c_str());
+    SetDlgItemTextW(hwndDlg, 14, tstr_gs_username.c_str());
+    SetDlgItemTextW(hwndDlg, 15, tstr_gs_password.c_str());
     return true;
   }
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -746,7 +746,7 @@ double get_integer(string str, double def) {
   if (gs_str_submitted == "") return 0;
   puts(gs_str_submitted.c_str());
 
-  return stod(gs_str_submitted.c_str(), NULL);
+  return strtod(gs_str_submitted.c_str(), NULL);
 }
 
 double get_passcode(string str, double def) {
@@ -755,7 +755,7 @@ double get_passcode(string str, double def) {
   if (gs_str_submitted == "") return 0;
   puts(gs_str_submitted.c_str());
 
-  return stod(gs_str_submitted.c_str(), NULL);
+  return strtod(gs_str_submitted.c_str(), NULL);
 }
 
 bool get_string_canceled() {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -167,9 +167,13 @@ static INT_PTR CALLBACK ShowInfoProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
 static INT_PTR CALLBACK GetStrProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
   if (uMsg == WM_INITDIALOG) {
-    SetWindowText(hwndDlg, gs_cap.c_str());
-    SetDlgItemText(hwndDlg, 12, gs_def.c_str());
-    SetDlgItemText(hwndDlg, 13, gs_message.c_str());
+    CenterWindowToMonitor(hdlg, 0);
+    tstring tstr_gs_cap = widen(gs_cap);
+    tstring tstr_gs_def = widen(gs_def);
+    tstring tstr_gs_message = widen(gs_message);
+    SetWindowTextW(hwndDlg, tstr_gs_cap.c_str());
+    SetDlgItemTextW(hwndDlg, 12, tstr_gs_def.c_str());
+    SetDlgItemTextW(hwndDlg, 13, tstr_gs_message.c_str());
     return true;
   }
 
@@ -179,9 +183,9 @@ static INT_PTR CALLBACK GetStrProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
       gs_form_canceled = 1;
       EndDialog(hwndDlg, 1);
     } else if (wParam == 10) {
-      char strget[1024];
-      GetDlgItemText(hwndDlg, 12, strget, 1024);
-      gs_str_submitted = strget;
+      wchar_t strget[1024];
+      GetDlgItemTextW(hwndDlg, 12, strget, 1024);
+      gs_str_submitted = shorten(strget);
       gs_form_canceled = 0;
       EndDialog(hwndDlg, 2);
     }
@@ -193,9 +197,12 @@ static INT_PTR CALLBACK GetStrProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARA
 static INT_PTR CALLBACK GetLoginProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
   if (uMsg == WM_INITDIALOG) {
-    SetWindowText(hwndDlg, gs_cap.c_str());
-    SetDlgItemText(hwndDlg, 14, gs_username.c_str());
-    SetDlgItemText(hwndDlg, 15, gs_password.c_str());
+    tstring tstr_gs_cap = widen(gs_cap);
+    SetWindowTextW(hwndDlg, tstr_gs_cap.c_str());
+    tstring tstr_gs_username = widen(gs_username);
+    tstring tstr_gs_password = widen(gs_password);
+    SetDlgItemTextW(hwndDlg, 14, gs_username.c_str());
+    SetDlgItemTextW(hwndDlg, 15, gs_password.c_str());
     return true;
   }
 
@@ -205,11 +212,11 @@ static INT_PTR CALLBACK GetLoginProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
       gs_form_canceled = 1;
       EndDialog(hwndDlg, 1);
     } else if (wParam == 10) {
-      char strget[1024];
-      GetDlgItemText(hwndDlg, 14, strget, 1024);
-      gs_str_submitted = strget;
-      GetDlgItemText(hwndDlg, 15, strget, 1024);
-      gs_str_submitted += string(1, 0) + string(strget);
+      wchar_t strget[1024];
+      GetDlgItemTextW(hwndDlg, 14, strget, 1024);
+      gs_str_submitted = shorten(strget);
+      GetDlgItemTextW(hwndDlg, 15, strget, 1024);
+      gs_str_submitted += string(1, 0) + shorten(strget);
       gs_form_canceled = 0;
       EndDialog(hwndDlg, 2);
     }
@@ -221,11 +228,16 @@ static INT_PTR CALLBACK GetLoginProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
 static INT_PTR CALLBACK ShowMessageExtProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
   if (uMsg == WM_INITDIALOG) {
-    SetWindowText(hwndDlg,gs_cap.c_str());
-    SetDlgItemText(hwndDlg, 10, gs_message.c_str());
-    SetDlgItemText(hwndDlg, 11, gs_but1.c_str());
-    SetDlgItemText(hwndDlg, 12, gs_but2.c_str());
-    SetDlgItemText(hwndDlg, 13, gs_but3.c_str());
+    tstring tstr_gs_cap = widen(gs_cap);
+    tstring tstr_gs_message = widen(gs_message);
+    tstring tstr_gs_but1 = widen(gs_but1);
+    tstring tstr_gs_but2 = widen(gs_but2);
+    tstring tstr_gs_but3 = widen(gs_but3);
+    SetWindowTextW(hwndDlg, tstr_gs_cap.c_str());
+    SetDlgItemTextW(hwndDlg, 10, tstr_gs_message.c_str());
+    SetDlgItemTextW(hwndDlg, 11, tstr_gs_but1.c_str());
+    SetDlgItemTextW(hwndDlg, 12, tstr_gs_but2.c_str());
+    SetDlgItemTextW(hwndDlg, 13, tstr_gs_but3.c_str());
   }
 
   if (uMsg == WM_COMMAND) {
@@ -721,28 +733,28 @@ int show_message_ext(string msg, string but1, string but2, string but3) {
 
 string get_login(string username, string password) {
   gs_cap = message_get_caption(); gs_username = username; gs_password = password;
-  DialogBox(enigma::hInstance, "getlogindialog", enigma::hWnd, GetLoginProc);
+  DialogBoxW(enigma::hInstance, L"getlogindialog", enigma::hWnd, GetLoginProc);
 
   return gs_str_submitted;
 }
 
 string get_string(string str, string def) {
   gs_cap = message_get_caption(); gs_message = str; gs_def = def;
-  DialogBox(enigma::hInstance, "getstringdialog", enigma::hWnd, GetStrProc);
+  DialogBoxW(enigma::hInstance, L"getstringdialog", enigma::hWnd, GetStrProc);
 
   return gs_str_submitted;
 }
 
 string get_password(string str, string def) {
   gs_cap = message_get_caption(); gs_message = str; gs_def = def;
-  DialogBox(enigma::hInstance,"getpassworddialog",enigma::hWnd,GetStrProc);
+  DialogBoxW(enigma::hInstance, L"getpassworddialog", enigma::hWnd, GetStrProc);
 
   return gs_str_submitted;
 }
 
 double get_integer(string str, double def) {
   gs_cap = message_get_caption(); gs_message = str; gs_def = remove_trailing_zeros(def);
-  DialogBox(enigma::hInstance, "getstringdialog", enigma::hWnd, GetStrProc);
+  DialogBoxW(enigma::hInstance, L"getstringdialog", enigma::hWnd, GetStrProc);
   if (gs_str_submitted == "") return 0;
   puts(gs_str_submitted.c_str());
 
@@ -751,7 +763,7 @@ double get_integer(string str, double def) {
 
 double get_passcode(string str, double def) {
   gs_cap = message_get_caption(); gs_message = str; gs_def = remove_trailing_zeros(def);
-  DialogBox(enigma::hInstance, "getpassworddialog", enigma::hWnd, GetStrProc);
+  DialogBoxW(enigma::hInstance, L"getpassworddialog", enigma::hWnd, GetStrProc);
   if (gs_str_submitted == "") return 0;
   puts(gs_str_submitted.c_str());
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -167,7 +167,7 @@ static INT_PTR CALLBACK ShowInfoProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
 static INT_PTR CALLBACK GetStrProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
   if (uMsg == WM_INITDIALOG) {
-    CenterWindowToMonitor(hdlg, 0);
+    CenterWindowToMonitor(hwndDlg, 0);
     tstring tstr_gs_cap = widen(gs_cap);
     tstring tstr_gs_def = widen(gs_def);
     tstring tstr_gs_message = widen(gs_message);

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -63,7 +63,7 @@ static string str_gctitle;
 static tstring tstr_gctitle;
 
 // file dialog returns
-static wchar_t wstr_fname[MAX_PATH];
+static wchar_t wstr_fname[4096];
 
 using enigma_user::string_replace_all;
 
@@ -337,13 +337,13 @@ static inline OPENFILENAMEW get_filename_or_filenames_helper(string filter, stri
   tstring tstr_dir = widen(dir);
   tstring tstr_title = widen(title);
 
-  wcsncpy_s(wstr_fname, tstr_fname.c_str(), MAX_PATH);
+  wcsncpy_s(wstr_fname, tstr_fname.c_str(), 4096);
 
   ZeroMemory(&ofn, sizeof(ofn));
   ofn.lStructSize = sizeof(ofn);
   ofn.hwndOwner = enigma::hWnd;
   ofn.lpstrFile = wstr_fname;
-  ofn.nMaxFile = MAX_PATH;
+  ofn.nMaxFile = 4096;
   ofn.lpstrFilter = tstr_filter.c_str();
   ofn.nFilterIndex = 0;
   ofn.lpstrTitle = tstr_title.c_str();

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -322,7 +322,7 @@ static inline int show_question_helperfunc(string str) {
   return 0;
 }
 
-static inline string get_open_filename_helper(string filter, string fname, string dir, string title) {
+static inline OPENFILENAMEW get_filename_or_filenames_helper(string filter, string fname, string dir, string title, DWORD flags) {
   OPENFILENAMEW ofn;
 
   filter = filter.append("||");
@@ -346,7 +346,14 @@ static inline string get_open_filename_helper(string filter, string fname, strin
   ofn.nFilterIndex = 0;
   ofn.lpstrTitle = tstr_title.c_str();
   ofn.lpstrInitialDir = tstr_dir.c_str();
-  ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR;
+  ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR | flags;
+  
+  reutrn ofn;
+}
+
+static inline string get_open_filename_helper(string filter, string fname, string dir, string title) {
+  OPENFILENAMEW ofn;
+  ofn = get_filename_or_filenames_helper(filter, fname, dir, title, 0);
 
   if (GetOpenFileNameW(&ofn) != 0)
     return shorten(wstr_fname);
@@ -356,29 +363,7 @@ static inline string get_open_filename_helper(string filter, string fname, strin
 
 static inline string get_open_filenames_helper(string filter, string fname, string dir, string title) {
   OPENFILENAMEW ofn;
-
-  filter = string(filter).append("||");
-  fname = remove_slash(fname);
-
-  tstring tstr_filter = widen(filter);
-  replace(tstr_filter.begin(), tstr_filter.end(), '|', '\0');
-  tstring tstr_fname = widen(fname);
-  tstring tstr_dir = widen(dir);
-  tstring tstr_title = widen(title);
-
-  wchar_t wstr_fname1[4096];
-  wcsncpy_s(wstr_fname1, tstr_fname.c_str(), 4096);
-
-  ZeroMemory(&ofn, sizeof(ofn));
-  ofn.lStructSize = sizeof(ofn);
-  ofn.hwndOwner = enigma::hWnd;
-  ofn.lpstrFile = wstr_fname1;
-  ofn.nMaxFile = 4096;
-  ofn.lpstrFilter = tstr_filter.c_str();
-  ofn.nFilterIndex = 0;
-  ofn.lpstrTitle = tstr_title.c_str();
-  ofn.lpstrInitialDir = tstr_dir.c_str();
-  ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR | OFN_ALLOWMULTISELECT;
+  ofn = get_filename_or_filenames_helper(filter, fname, dir, title, OFN_ALLOWMULTISELECT);
 
   if (GetOpenFileNameW(&ofn) != 0) {
     tstring tstr_fname1 = wstr_fname1;
@@ -422,29 +407,7 @@ static inline string get_open_filenames_helper(string filter, string fname, stri
 
 static inline string get_save_filename_helper(string filter, string fname, string dir, string title) {
   OPENFILENAMEW ofn;
-
-  filter = string(filter).append("||");
-  fname = remove_slash(fname);
-
-  tstring tstr_filter = widen(filter);
-  replace(tstr_filter.begin(), tstr_filter.end(), '|', '\0');
-  tstring tstr_fname = widen(fname);
-  tstring tstr_dir = widen(dir);
-  tstring tstr_title = widen(title);
-
-  wchar_t wstr_fname[MAX_PATH];
-  wcsncpy_s(wstr_fname, tstr_fname.c_str(), MAX_PATH);
-
-  ZeroMemory(&ofn, sizeof(ofn));
-  ofn.lStructSize = sizeof(ofn);
-  ofn.hwndOwner = enigma::hWnd;
-  ofn.lpstrFile = wstr_fname;
-  ofn.nMaxFile = MAX_PATH;
-  ofn.lpstrFilter = tstr_filter.c_str();
-  ofn.nFilterIndex = 0;
-  ofn.lpstrTitle = tstr_title.c_str();
-  ofn.lpstrInitialDir = tstr_dir.c_str();
-  ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT | OFN_NOCHANGEDIR;
+  ofn = get_filename_or_filenames_helper(filter, fname, dir, title, 0);
 
   if (GetSaveFileNameW(&ofn) != 0)
     return shorten(wstr_fname);

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -373,18 +373,18 @@ static inline string get_open_filenames_helper(string filter, string fname, stri
 
     size_t pos = 0;
     size_t prevlen = pos;
-    size_t len = wcslen(wstr_fname1);
+    size_t len = wcslen(wstr_fname);
 
     while (pos < len) {
-      if (wstr_fname1[len - 1] != '\n' && wstr_fname1[len] == '\0')
-        wstr_fname1[len] = '\n';
+      if (wstr_fname[len - 1] != '\n' && wstr_fname[len] == '\0')
+        wstr_fname[len] = '\n';
 
       prevlen = len;
-      len = wcslen(wstr_fname1);
+      len = wcslen(wstr_fname);
       pos += (len - prevlen) + 1;
     }
 
-    tstring tstr_fname2 = wstr_fname1;
+    tstring tstr_fname2 = wstr_fname;
     if (tstr_fname2[len - 1] == '\n') tstr_fname2[len - 1] = '\0';
     if (tstr_fname2[len - 2] == '\\') tstr_fname2[len - 2] = '\0';
     tstr_fname2 = tstring_replace_all(tstr_fname2, L"\n", L"\n" + tstr_fname1);

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -1,5 +1,6 @@
 /** Copyright (C) 2011, 2017 Josh Ventura
 *** Copyright (C) 2014, 2017 Robert B. Colton
+*** Copyright (C) 2019 Samuel Venable
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***
@@ -26,6 +27,7 @@
 #include <richedit.h>
 #include <stdio.h>
 #include <string>
+#include <algorithm>
 
 using namespace std;
 #include "Widget_Systems/widgets_mandatory.h"
@@ -36,6 +38,8 @@ using namespace std;
 
 #include "Graphics_Systems/General/GScolor_macros.h"
 
+#define MONITOR_CENTER 0x0001
+
 static string gs_cap;
 static string gs_def;
 static string gs_message;
@@ -45,12 +49,29 @@ static bool   gs_form_canceled;
 static string gs_str_submitted;
 static string gs_but1, gs_but2, gs_but3;
 
+// message and error captions
+static string message_caption;
+static tstring dialog_caption = L"";
+static tstring error_caption = L"";
+
+// show cancel button?
+static bool message_cancel = false;
+static bool question_cancel = false;
+
+// get color
+static string str_gctitle;
+static tstring tstr_gctitle;
+
+using enigma_user::string_replace_all;
+
 #ifdef DEBUG_MODE
 #include "Universal_System/var4.h"
 #include "Universal_System/Resources/resource_data.h"
 #include "Universal_System/Object_Tiers/object.h"
 #include "Universal_System/debugscope.h"
 #endif
+
+string message_get_caption();
 
 static inline string add_slash(const string& dir) {
   if (dir.empty() || *dir.rbegin() != '\\') return dir + '\\';
@@ -65,10 +86,59 @@ HWND infore;
 
 }
 
-static inline string remove_slash(const string& dir) {
-  if (!dir.empty() && (dir.back() == '\\' || dir.back() == '/'))
-    return dir.substr(0, dir.length() - 1);
+static inline string remove_slash(string dir) {
+  while (!dir.empty() && (dir.back() == '\\' || dir.back() == '/'))
+    dir.pop_back();
   return dir;
+}
+
+static inline string remove_trailing_zeros(double numb) {
+  string strnumb = std::to_string(numb);
+
+  while (!strnumb.empty() && strnumb.find('.') != string::npos && (strnumb.back() == '.' || strnumb.back() == '0'))
+    strnumb.pop_back();
+
+  return strnumb;
+}
+
+static inline void CenterRectToMonitor(LPRECT prc, UINT flags) {
+  HMONITOR hMonitor;
+  MONITORINFO mi;
+  RECT        rc;
+  int         w = prc->right - prc->left;
+  int         h = prc->bottom - prc->top;
+
+  hMonitor = MonitorFromRect(prc, MONITOR_DEFAULTTONEAREST);
+
+  mi.cbSize = sizeof(mi);
+  GetMonitorInfo(hMonitor, &mi);
+  rc = mi.rcMonitor;
+
+  if (flags & MONITOR_CENTER) {
+    prc->left = rc.left + (rc.right - rc.left - w) / 2;
+    prc->top = rc.top + (rc.bottom - rc.top - h) / 2;
+    prc->right = prc->left + w;
+    prc->bottom = prc->top + h;
+  }
+  else {
+    prc->left = rc.left + (rc.right - rc.left - w) / 2;
+    prc->top = rc.top + (rc.bottom - rc.top - h) / 3;
+    prc->right = prc->left + w;
+    prc->bottom = prc->top + h;
+  }
+}
+
+// this is the correct way to center window on multi-monitor setups;
+// GetSystemMetrics() is discouraged by Microsoft for a good reason.
+static inline void CenterWindowToMonitor(HWND hwnd, UINT flags) {
+  RECT rc;
+  GetWindowRect(hwnd, &rc);
+  CenterRectToMonitor(&rc, flags);
+  SetWindowPos(hwnd, NULL, rc.left, rc.top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+static tstring tstring_replace_all(tstring str, tstring substr, tstring newstr) {
+  return widen(string_replace_all(shorten(str), shorten(substr), shorten(newstr)));
 }
 
 static INT_PTR CALLBACK ShowInfoProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
@@ -191,65 +261,254 @@ static INT_PTR CALLBACK ShowMessageExtProc(HWND hwndDlg, UINT uMsg, WPARAM wPara
   return 0;
 }
 
-static INT CALLBACK GetDirectoryAltProc(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM pData)
-{
-  if (uMsg == BFFM_INITIALIZED)
-    SetWindowText(hwnd, gs_cap.c_str());
+static UINT_PTR CALLBACK GetColorProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam) {
+  if (uiMsg == WM_INITDIALOG) {
+    CenterWindowToMonitor(hdlg, 0);
+    if (str_gctitle != "")
+      SetWindowTextW(hdlg, tstr_gctitle.c_str());
+    PostMessageW(hdlg, WM_SETFOCUS, 0, 0);
+  }
 
+  return false;
+}
+
+static inline int show_message_helperfunc(const string &str) {
+  tstring tstrStr = widen(str);
+
+  wchar_t wstrWindowCaption[512];
+  GetWindowTextW(enigma::hWnd, wstrWindowCaption, 512);
+
+  if (dialog_caption != L"")
+    wcsncpy_s(wstrWindowCaption, dialog_caption.c_str(), 512);
+
+  if (message_cancel) {
+    int result = MessageBoxW(enigma::hWnd, tstrStr.c_str(), wstrWindowCaption, MB_OKCANCEL | MB_ICONINFORMATION | MB_DEFBUTTON1 | MB_APPLMODAL);
+    if (result == IDOK) return 1; else return -1;
+  }
+
+  MessageBoxW(enigma::hWnd, tstrStr.c_str(), wstrWindowCaption, MB_OK | MB_ICONINFORMATION | MB_DEFBUTTON1 | MB_APPLMODAL);
+  return 1;
+}
+
+static inline int show_question_helperfunc(string str) {
+  tstring tstrStr = widen(str);
+
+  wchar_t wstrWindowCaption[512];
+  GetWindowTextW(enigma::hWnd, wstrWindowCaption, 512);
+
+  if (dialog_caption != L"")
+    wcsncpy_s(wstrWindowCaption, dialog_caption.c_str(), 512);
+
+  int result;
+  if (question_cancel) {
+    result = MessageBoxW(enigma::hWnd, tstrStr.c_str(), wstrWindowCaption, MB_YESNOCANCEL | MB_ICONQUESTION | MB_DEFBUTTON1 | MB_APPLMODAL);
+    if (result == IDYES) return 1; else if (result == IDNO) return 0; else return -1;
+  }
+
+  result = MessageBoxW(enigma::hWnd, tstrStr.c_str(), wstrWindowCaption, MB_YESNO | MB_ICONQUESTION | MB_DEFBUTTON1 | MB_APPLMODAL);
+  if (result == IDYES) return 1;
   return 0;
 }
 
+static inline string get_open_filename_helper(string filter, string fname, string dir, string title) {
+  OPENFILENAMEW ofn;
+
+  filter = filter.append("||");
+  fname = remove_slash(fname);
+
+  tstring tstr_filter = widen(filter);
+  replace(tstr_filter.begin(), tstr_filter.end(), '|', '\0');
+  tstring tstr_fname = widen(fname);
+  tstring tstr_dir = widen(dir);
+  tstring tstr_title = widen(title);
+
+  wchar_t wstr_fname[MAX_PATH];
+  wcsncpy_s(wstr_fname, tstr_fname.c_str(), MAX_PATH);
+
+  ZeroMemory(&ofn, sizeof(ofn));
+  ofn.lStructSize = sizeof(ofn);
+  ofn.hwndOwner = enigma::hWnd;
+  ofn.lpstrFile = wstr_fname;
+  ofn.nMaxFile = MAX_PATH;
+  ofn.lpstrFilter = tstr_filter.c_str();
+  ofn.nFilterIndex = 0;
+  ofn.lpstrTitle = tstr_title.c_str();
+  ofn.lpstrInitialDir = tstr_dir.c_str();
+  ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR;
+
+  if (GetOpenFileNameW(&ofn) != 0)
+    return shorten(wstr_fname);
+
+  return "";
+}
+
+static inline string get_open_filenames_helper(string filter, string fname, string dir, string title) {
+  OPENFILENAMEW ofn;
+
+  filter = string(filter).append("||");
+  fname = remove_slash(fname);
+
+  tstring tstr_filter = widen(filter);
+  replace(tstr_filter.begin(), tstr_filter.end(), '|', '\0');
+  tstring tstr_fname = widen(fname);
+  tstring tstr_dir = widen(dir);
+  tstring tstr_title = widen(title);
+
+  wchar_t wstr_fname1[4096];
+  wcsncpy_s(wstr_fname1, tstr_fname.c_str(), 4096);
+
+  ZeroMemory(&ofn, sizeof(ofn));
+  ofn.lStructSize = sizeof(ofn);
+  ofn.hwndOwner = enigma::hWnd;
+  ofn.lpstrFile = wstr_fname1;
+  ofn.nMaxFile = 4096;
+  ofn.lpstrFilter = tstr_filter.c_str();
+  ofn.nFilterIndex = 0;
+  ofn.lpstrTitle = tstr_title.c_str();
+  ofn.lpstrInitialDir = tstr_dir.c_str();
+  ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR | OFN_ALLOWMULTISELECT;
+
+  if (GetOpenFileNameW(&ofn) != 0) {
+    tstring tstr_fname1 = wstr_fname1;
+    tstr_fname1 += '\\';
+
+    size_t pos = 0;
+    size_t prevlen = pos;
+    size_t len = wcslen(wstr_fname1);
+
+    while (pos < len) {
+      if (wstr_fname1[len - 1] != '\n' && wstr_fname1[len] == '\0')
+        wstr_fname1[len] = '\n';
+
+      prevlen = len;
+      len = wcslen(wstr_fname1);
+      pos += (len - prevlen) + 1;
+    }
+
+    tstring tstr_fname2 = wstr_fname1;
+    if (tstr_fname2[len - 1] == '\n') tstr_fname2[len - 1] = '\0';
+    if (tstr_fname2[len - 2] == '\\') tstr_fname2[len - 2] = '\0';
+    tstr_fname2 = tstring_replace_all(tstr_fname2, L"\n", L"\n" + tstr_fname1);
+    size_t rm = tstr_fname2.find_first_of(L'\n');
+
+    if (rm != string::npos)
+      tstr_fname2 = tstr_fname2.substr(rm + 1, tstr_fname2.length() - (rm + 1));
+
+    tstr_fname2.append(L"\0");
+    if (tstr_fname2.length() >= 4095) {
+      tstr_fname2 = tstr_fname2.substr(0, 4095);
+      size_t end = tstr_fname2.find_last_of(L"\n");
+      tstr_fname2 = tstr_fname2.substr(0, end);
+      tstr_fname2.append(L"\0");
+    }
+
+    return string_replace_all(shorten(tstr_fname2), "\\\\", "\\");
+  }
+
+  return "";
+}
+
+static inline string get_save_filename_helper(string filter, string fname, string dir, string title) {
+  OPENFILENAMEW ofn;
+
+  filter = string(filter).append("||");
+  fname = remove_slash(fname);
+
+  tstring tstr_filter = widen(filter);
+  replace(tstr_filter.begin(), tstr_filter.end(), '|', '\0');
+  tstring tstr_fname = widen(fname);
+  tstring tstr_dir = widen(dir);
+  tstring tstr_title = widen(title);
+
+  wchar_t wstr_fname[MAX_PATH];
+  wcsncpy_s(wstr_fname, tstr_fname.c_str(), MAX_PATH);
+
+  ZeroMemory(&ofn, sizeof(ofn));
+  ofn.lStructSize = sizeof(ofn);
+  ofn.hwndOwner = enigma::hWnd;
+  ofn.lpstrFile = wstr_fname;
+  ofn.nMaxFile = MAX_PATH;
+  ofn.lpstrFilter = tstr_filter.c_str();
+  ofn.nFilterIndex = 0;
+  ofn.lpstrTitle = tstr_title.c_str();
+  ofn.lpstrInitialDir = tstr_dir.c_str();
+  ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT | OFN_NOCHANGEDIR;
+
+  if (GetSaveFileNameW(&ofn) != 0)
+    return shorten(wstr_fname);
+
+  return "";
+}
+
+static inline string get_directory_helper(string dname, string title) {
+  IFileDialog *selectDirectory;
+  CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&selectDirectory));
+
+  DWORD options;
+  selectDirectory->GetOptions(&options);
+  selectDirectory->SetOptions(options | FOS_PICKFOLDERS | FOS_NOCHANGEDIR | FOS_FORCEFILESYSTEM);
+
+  tstring tstr_dname = widen(dname);
+  LPWSTR szFilePath = (wchar_t *)tstr_dname.c_str();
+
+  IShellItem* pItem = nullptr;
+  HRESULT hr = ::SHCreateItemFromParsingName(szFilePath, nullptr, IID_PPV_ARGS(&pItem));
+
+  if (SUCCEEDED(hr)) {
+    LPWSTR szName = nullptr;
+    hr = pItem->GetDisplayName(SIGDN_NORMALDISPLAY, &szName);
+    if (SUCCEEDED(hr)) {
+      selectDirectory->SetFolder(pItem);
+      ::CoTaskMemFree(szName);
+    }
+    pItem->Release();
+  }
+
+  if (title == "") title = "Select Directory";
+  tstring tstr_capt = widen(title);
+
+  selectDirectory->SetOkButtonLabel(L"Select");
+  selectDirectory->SetTitle(tstr_capt.c_str());
+  selectDirectory->Show(enigma::hWnd);
+
+  pItem = nullptr;
+  hr = selectDirectory->GetResult(&pItem);
+
+  if (SUCCEEDED(hr)) {
+    LPWSTR wstr_result;
+    pItem->GetDisplayName(SIGDN_DESKTOPABSOLUTEPARSING, &wstr_result);
+    pItem->Release();
+
+    return add_slash(shorten(wstr_result));
+  }
+
+  return "";
+}
+
+static inline int get_color_helper(int defcol, string title) {
+  CHOOSECOLORW cc;
+
+  COLORREF DefColor = (int)defcol;
+  static COLORREF CustColors[16];
+
+  str_gctitle = title;
+  tstr_gctitle = widen(str_gctitle);
+
+  ZeroMemory(&cc, sizeof(cc));
+  cc.lStructSize = sizeof(CHOOSECOLORW);
+  cc.hwndOwner = enigma::hWnd;
+  cc.rgbResult = DefColor;
+  cc.lpCustColors = CustColors;
+  cc.Flags = CC_RGBINIT | CC_ENABLEHOOK;
+  cc.lpfnHook = GetColorProc;
+
+  if (ChooseColorW(&cc) != 0)
+    return (int)cc.rgbResult;
+
+  return -1;
+}
+
 namespace enigma_user {
-
-extern string window_get_caption();
-
-void message_alpha(double alpha) {
-
-}
-
-void message_background(int back) {
-
-}
-
-void message_button(int spr) {
-
-}
-
-void message_button_font(string name, int size, int color, int style) {
-
-}
-
-void message_caption(bool show, string str) {
-  gs_cap = str;
-}
-
-void message_input_color(int col) {
-
-}
-
-void message_input_font(string name, int size, int color, int style) {
-
-}
-
-void message_mouse_color(int col) {
-
-}
-
-void message_position(int x, int y) {
-
-}
-
-void message_size(int w, int h) {
-
-}
-
-void message_text_font(string name, int size, int color, int style) {
-
-}
-
-void message_text_charset(int type, int charset) {
-
-}
 
 void show_error(string errortext, const bool fatal)
 {
@@ -257,14 +516,17 @@ void show_error(string errortext, const bool fatal)
   errortext += "\n\n" + enigma::debug_scope::GetErrors();
   #endif
 
-  if (MessageBox(NULL,errortext.c_str(),"Error",MB_ABORTRETRYIGNORE | MB_ICONERROR)==IDABORT)
-    exit(0);
+  string strWindowCaption = "Error";
 
-  if (fatal)
-    printf("FATAL ERROR: %s\n",errortext.c_str()),
-    exit(0);
-  else
-    printf("ERROR: %s\n",errortext.c_str());
+  tstring tstrStr = widen(errortext);
+  tstring tstrWindowCaption = widen(strWindowCaption);
+
+  if (error_caption != L"")
+    tstrWindowCaption = error_caption;
+
+  int result;
+  result = MessageBoxW(enigma::hWnd, tstrStr.c_str(), tstrWindowCaption.c_str(), MB_ABORTRETRYIGNORE | MB_ICONERROR | MB_DEFBUTTON1 | MB_APPLMODAL);
+  if (result == IDABORT || fatal) exit(0);
 
   //ABORT_ON_ALL_ERRORS();
 }
@@ -414,238 +676,152 @@ void show_info(string info, int bgcolor, int left, int top, int width, int heigh
   */
 }
 
-int show_message(const string &str)
-{
-  //NOTE: This will not work with a fullscreen application, it is an issue with Windows
-  //this could be why GM8.1, unlike Studio, did not use native dialogs and custom
-  //rendered its own message boxes like most game engines.
-  //In Studio this function will cause the window to be minimized and the message shown, fullscreen will not be restored.
-  //A possible alternative is fake fullscreen for Win32, but who knows if we have to do that on XLIB or anywhere else.
-
-  tstring message = widen(str);
-  tstring caption = widen(window_get_caption());
-
-  MessageBoxW(enigma::hWnd, message.c_str(), caption.c_str(), MB_OK);
-
-  return 0;
+int show_message(const string &str) {
+  message_cancel = false;
+  return show_message_helperfunc(str);
 }
 
-int show_message_ext(string msg, string but1, string but2, string but3)
-{
-  gs_cap = window_get_caption();
+int show_message_cancelable(string str) {
+  message_cancel = true;
+  return show_message_helperfunc(str);
+}
+
+bool show_question(string str) {
+  question_cancel = false;
+  return (bool)show_question_helperfunc(str);
+}
+
+int show_question_cancelable(string str) {
+  question_cancel = true;
+  return show_question_helperfunc(str);
+}
+
+int show_attempt(string str) {
+  string strWindowCaption = "Error";
+
+  tstring tstrStr = widen(str);
+  tstring tstrWindowCaption = widen(strWindowCaption);
+
+  if (error_caption != L"")
+    tstrWindowCaption = error_caption;
+
+  int result;
+  result = MessageBoxW(enigma::hWnd, tstrStr.c_str(), tstrWindowCaption.c_str(), MB_RETRYCANCEL | MB_ICONERROR | MB_DEFBUTTON1 | MB_APPLMODAL);
+  if (result == IDRETRY) return 0;
+  return -1;
+}
+
+int show_message_ext(string msg, string but1, string but2, string but3) {
+  gs_cap = message_get_caption();
   gs_message = msg;
   gs_but1 = but1; gs_but2 = but2; gs_but3 = but3;
 
-  return DialogBox(enigma::hInstance,"showmessageext",enigma::hWnd,ShowMessageExtProc);
+  return DialogBox(enigma::hInstance, "showmessageext", enigma::hWnd, ShowMessageExtProc);
 }
 
-bool show_question(string str)
-{
-  return (MessageBox(enigma::hWnd, str.c_str(), window_get_caption().c_str(), MB_YESNO) == IDYES);
-}
-
-string get_login(string username, string password, string cap)
-{
-  gs_cap = cap; gs_username = username; gs_password = password;
-  DialogBox(enigma::hInstance,"getlogindialog",enigma::hWnd,GetLoginProc);
+string get_login(string username, string password) {
+  gs_cap = message_get_caption(); gs_username = username; gs_password = password;
+  DialogBox(enigma::hInstance, "getlogindialog", enigma::hWnd, GetLoginProc);
 
   return gs_str_submitted;
 }
 
-string get_string(string message,string def,string cap)
-{
-  gs_cap = cap; gs_message = message; gs_def = def;
-  DialogBox(enigma::hInstance,"getstringdialog",enigma::hWnd,GetStrProc);
+string get_string(string str, string def) {
+  gs_cap = message_get_caption(); gs_message = str; gs_def = def;
+  DialogBox(enigma::hInstance, "getstringdialog", enigma::hWnd, GetStrProc);
 
   return gs_str_submitted;
 }
 
-int get_integer(string message,string def,string cap)
-{
-  gs_cap = cap; gs_message = message; gs_def = def;
-  DialogBox(enigma::hInstance,"getstringdialog",enigma::hWnd,GetStrProc);
-  if (gs_str_submitted == "") return 0;
-  puts(gs_str_submitted.c_str());
+string get_password(string str, string def) {
+  gs_cap = message_get_caption(); gs_message = str; gs_def = def;
+  DialogBox(enigma::hInstance,"getpassworddialog",enigma::hWnd,GetStrProc);
 
-  return atol(gs_str_submitted.c_str());
+  return gs_str_submitted;
 }
 
-double get_number(string message,string def,string cap)
-{
-  gs_cap = cap; gs_message = message; gs_def = def;
-  DialogBox(enigma::hInstance,"getstringdialog",enigma::hWnd,GetStrProc);
+double get_integer(string str, double def) {
+  gs_cap = message_get_caption(); gs_message = str; gs_def = remove_trailing_zeros(def);
+  DialogBox(enigma::hInstance, "getstringdialog", enigma::hWnd, GetStrProc);
   if (gs_str_submitted == "") return 0;
   puts(gs_str_submitted.c_str());
 
-  return atof(gs_str_submitted.c_str());
+  return stod(gs_str_submitted.c_str(), NULL);
+}
+
+double get_passcode(string str, double def) {
+  gs_cap = message_get_caption(); gs_message = str; gs_def = remove_trailing_zeros(def);
+  DialogBox(enigma::hInstance, "getpassworddialog", enigma::hWnd, GetStrProc);
+  if (gs_str_submitted == "") return 0;
+  puts(gs_str_submitted.c_str());
+
+  return stod(gs_str_submitted.c_str(), NULL);
 }
 
 bool get_string_canceled() {
   return gs_form_canceled;
 }
 
-string get_open_filename(string filter,string filename,string caption)
-{
-  filter.append("||");
-  const unsigned int l = filter.length();
-  for (unsigned int i = 0; i < l; i++)
-    if (filter[i] == '|') filter[i] = 0;
-
-  char fn[MAX_PATH];
-  strcpy(fn, remove_slash(filename).c_str());
-
-  OPENFILENAME ofn;
-  ofn.lStructSize = sizeof(ofn); ofn.hwndOwner = enigma::hWnd; ofn.hInstance = NULL;
-  ofn.lpstrFilter = filter.c_str(); ofn.lpstrCustomFilter = NULL;
-  ofn.nMaxCustFilter = 0; ofn.nFilterIndex = 0;
-  ofn.lpstrFile = fn; ofn.nMaxFile = MAX_PATH;
-  ofn.lpstrFileTitle = NULL; ofn.nMaxFileTitle = 0;
-  ofn.lpstrInitialDir = NULL; ofn.lpstrTitle = caption.length() ? caption.c_str() : NULL;
-  ofn.Flags=OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR;
-  ofn.nFileOffset = 0; ofn.nFileExtension = 0;
-  ofn.lpstrDefExt = NULL; ofn.lCustData = 0;
-  ofn.lpfnHook = NULL; ofn.lpTemplateName = 0;
-
-  bool ret = GetOpenFileName(&ofn);
-  return ret == 0 ? "-1" : fn;
+string get_open_filename(string filter, string fname) {
+  return get_open_filename_helper(filter, fname, "", "");
 }
 
-string get_save_filename(string filter, string filename, string caption)
-{
-  filter.append("||");
-  const unsigned int l = filter.length();
-  for (unsigned int i = 0;i < l; i++)
-    if (filter[i] == '|')
-      filter[i] = 0;
-
-  char fn[MAX_PATH];
-  strcpy(fn, remove_slash(filename).c_str());
-
-  OPENFILENAME ofn;
-  ofn.lStructSize = sizeof(ofn); ofn.hwndOwner = enigma::hWnd; ofn.hInstance = NULL;
-  ofn.lpstrFilter = filter.c_str(); ofn.lpstrCustomFilter = NULL;
-  ofn.nMaxCustFilter = 0; ofn.nFilterIndex = 0;
-  ofn.lpstrFile = fn; ofn.nMaxFile = MAX_PATH;
-  ofn.lpstrFileTitle = NULL; ofn.nMaxFileTitle = 0;
-  ofn.lpstrInitialDir = NULL; ofn.lpstrTitle = caption.length() ? caption.c_str() : NULL;
-  ofn.Flags = OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
-  ofn.nFileOffset = 0; ofn.nFileExtension = 0;
-  ofn.lpstrDefExt = NULL; ofn.lCustData = 0;
-  ofn.lpfnHook = NULL; ofn.lpTemplateName = 0;
-
-  bool ret = GetSaveFileName(&ofn);
-  return ret == 0 ? "-1" : fn;
+string get_open_filename_ext(string filter, string fname, string dir, string title) {
+  return get_open_filename_helper(filter, fname, dir, title);
 }
 
-int get_color(int defcolor, bool advanced)
-{
-    COLORREF defc=(int)defcolor;
-    static COLORREF custcs[16];
-
-    CHOOSECOLOR gcol;
-    gcol.lStructSize=sizeof(CHOOSECOLOR);
-    gcol.hwndOwner=enigma::hWnd;
-    gcol.rgbResult=defc;
-    gcol.lpCustColors=custcs;
-  if (advanced) {
-    gcol.Flags= CC_FULLOPEN | CC_RGBINIT;
-  } else {
-    gcol.Flags= CC_RGBINIT;
-  }
-    gcol.lpTemplateName="";
-
-    if (ChooseColor(&gcol))
-      return (int)gcol.rgbResult;
-    else return defc;
+string get_open_filenames(string filter, string fname) {
+  return get_open_filenames_helper(filter, fname, "", "");
 }
 
-string get_directory(string dname, string caption) {
-  //NOTE: This uses the Windows Vista or later file chooser, which is different than the one used by GM8 and lower
-  //because I could not find out which one it uses, since IFileDialog is used by both wxWidgets and QtFramework
-  //and there doesn't appear to be a standard file picker for XP or lower in the Windows API except SHBrowseForFolder that is
-  //used by Game Maker for get_directory_alt
-  IFileDialog *selectDirectory;
-  CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&selectDirectory));
-
-  DWORD options;
-  selectDirectory->GetOptions(&options);
-  selectDirectory->SetOptions(options | FOS_PICKFOLDERS | FOS_NOCHANGEDIR | FOS_FORCEFILESYSTEM);
-
-  tstring tstr_dname = widen(dname);
-  LPWSTR szFilePath = (wchar_t *)tstr_dname.c_str();
-
-  IShellItem *pItem = nullptr;
-  HRESULT hr = ::SHCreateItemFromParsingName(szFilePath, nullptr, IID_PPV_ARGS(&pItem));
-
-  if (SUCCEEDED(hr)) {
-    LPWSTR szName = nullptr;
-    hr = pItem->GetDisplayName(SIGDN_NORMALDISPLAY, &szName);
-    if (SUCCEEDED(hr)) {
-      selectDirectory->SetFolder(pItem);
-      ::CoTaskMemFree(szName);
-    }
-    pItem->Release();
-  }
-
-  selectDirectory->SetTitle(std::wstring(caption.begin(), caption.end()).c_str());
-  selectDirectory->Show(enigma::hWnd);
-
-  pItem = nullptr;
-  hr = selectDirectory->GetResult(&pItem);
-
-  if (SUCCEEDED(hr)) {
-    LPWSTR wstr_result;
-    pItem->GetDisplayName(SIGDN_DESKTOPABSOLUTEPARSING, &wstr_result);
-    pItem->Release();
-
-    string str_result;
-    str_result = add_slash(shorten(wstr_result));
-    return str_result;
-  }
-
-  return "";
+string get_open_filenames_ext(string filter, string fname, string dir, string title) {
+  return get_open_filenames_helper(filter, fname, dir, title);
 }
 
-string get_directory_alt(string message, string root, bool modern, string caption) {
-  //standard use of the Shell API to browse for folders
-  bool f_selected = false;
+string get_save_filename(string filter, string fname) {
+  return get_save_filename_helper(filter, fname, "", "");
+}
 
-  char szDir [MAX_PATH];
-  BROWSEINFO bi;
-  LPITEMIDLIST pidl;
-  LPMALLOC pMalloc;
+string get_save_filename_ext(string filter, string fname, string dir, string title) {
+  return get_save_filename_helper(filter, fname, dir, title);
+}
 
-  if (SUCCEEDED (::SHGetMalloc (&pMalloc)))
-  {
-    ::ZeroMemory (&bi,sizeof(bi));
+int get_color(int defcol) {
+  return get_color_helper(defcol, "");
+}
 
-    bi.lpszTitle = message.c_str();
-    bi.hwndOwner = enigma::hWnd;
-    bi.pszDisplayName = 0;
-    bi.pidlRoot = 0;
-    bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_STATUSTEXT;
-    if (modern) {
-    bi.ulFlags |= BIF_EDITBOX | BIF_NEWDIALOGSTYLE;
-    }
-    gs_cap = caption;
-    bi.lpfn =  GetDirectoryAltProc;      //callback to set window caption
+int get_color_ext(int defcol, string title) {
+  return get_color_helper(defcol, title);
+}
 
-    pidl = ::SHBrowseForFolder(&bi);
-    if (pidl) {
-      if (::SHGetPathFromIDList(pidl, szDir)) {
-        f_selected = true;
-      }
+string get_directory(string dname) {
+  return get_directory_helper(dname, "");
+}
 
-      pMalloc->Free(pidl);
-      pMalloc->Release();
-    }
+string get_directory_alt(string capt, string root) {
+  return get_directory_helper(root, capt);
+}
+
+string message_get_caption() {
+  if (dialog_caption.empty()) {
+    wchar_t wstrWindowCaption[512];
+    GetWindowTextW(enigma::hWnd, wstrWindowCaption, 512);
+    return shorten(wstrWindowCaption);
   }
 
-  if (f_selected) {
-    return szDir;
-  } else {
+  if (error_caption.empty()) error_caption = L"Error";
+  if (dialog_caption.empty() && error_caption == L"Error")
     return "";
-  }
+
+  return shorten(dialog_caption);
 }
 
+void message_set_caption(string str) {
+  if (!str.empty()) dialog_caption = widen(str);
+  else dialog_caption = L"";
+
+  if (!str.empty()) error_caption = widen(str);
+  else error_caption = L"Error";
 }
+
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -62,6 +62,9 @@ static bool question_cancel = false;
 static string str_gctitle;
 static tstring tstr_gctitle;
 
+// file dialog returns
+static wchar_t wstr_fname[MAX_PATH];
+
 using enigma_user::string_replace_all;
 
 #ifdef DEBUG_MODE
@@ -334,7 +337,6 @@ static inline OPENFILENAMEW get_filename_or_filenames_helper(string filter, stri
   tstring tstr_dir = widen(dir);
   tstring tstr_title = widen(title);
 
-  wchar_t wstr_fname[MAX_PATH];
   wcsncpy_s(wstr_fname, tstr_fname.c_str(), MAX_PATH);
 
   ZeroMemory(&ofn, sizeof(ofn));

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -728,7 +728,7 @@ int show_message_ext(string msg, string but1, string but2, string but3) {
   gs_message = msg;
   gs_but1 = but1; gs_but2 = but2; gs_but3 = but3;
 
-  return DialogBox(enigma::hInstance, "showmessageext", enigma::hWnd, ShowMessageExtProc);
+  return DialogBoxW(enigma::hInstance, L"showmessageext", enigma::hWnd, ShowMessageExtProc);
 }
 
 string get_login(string username, string password) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/resources.rc
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/resources.rc
@@ -30,6 +30,19 @@ FONT 8, "Ms Shell Dlg 2"
   LTEXT           "Uninitialized message",13, 5, 5, 119, 33, SS_LEFT
 }
 
+/* --- get_password --- */
+getpassworddialog DIALOG 0, 0, 185, 63
+
+STYLE DS_3DLOOK | DS_CENTER | DS_MODALFRAME | DS_FIXEDSYS | WS_VISIBLE | WS_BORDER | WS_CAPTION | WS_DLGFRAME | WS_POPUP | WS_SYSMENU
+CAPTION "Prompt"
+FONT 8, "Ms Shell Dlg 2"
+{
+	EDITTEXT        12, 5, 43, 174, 15, ES_AUTOHSCROLL | ES_PASSWORD | ES_LEFT | WS_BORDER | WS_TABSTOP
+	DEFPUSHBUTTON   "OK", 10, 129, 5, 50, 14, BS_DEFPUSHBUTTON
+	PUSHBUTTON      "Cancel", 11, 129, 21, 50, 14, BS_PUSHBUTTON
+	LTEXT           "Uninitialized message", 13, 5, 5, 119, 33, SS_LEFT
+}
+
 /* --- show_message_ext --- */
 showmessageext DIALOG 0, 0, 185, 64
 


### PR DESCRIPTION
This is a complete re-write of Windows Widgets that adds UTF-8 support to most of the functions as well as adds all the functions that were always a part of the other system that were missing in Win32 to be a part of Windows Widgets as well. You may test this with the following demo EXE and GM81 source files: [Win32.zip](https://github.com/enigma-dev/enigma-dev/files/3296744/Win32.zip)


As a side note, I changed the get_directory() function to have "Select Directory" as the titlebar caption and the "OK" button label to say "Select" to match what YoYo Games did with the exact same dialog in the IDE:
![Untitled](https://user-images.githubusercontent.com/4379204/59562704-ea2fa680-8ffd-11e9-92ab-270ffefa2d8b.png)
Robert complained last time I changed that dialog to do this and I'm just explaining my reasoning for this.
