### PR TITLE
Add array_set function

### DIFF
--- a/CommandLine/testing/SimpleTests/math_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/math_test.sog/create.edl
@@ -218,6 +218,8 @@ gtest_assert_eq(user_array_same[1], 24);
 gtest_assert_eq(user_array_same[2], 24);
 gtest_assert_eq(user_array_same[3], 347);
 gtest_assert_eq(user_array_same[4], 555);
+array_set(user_array_smaller, 1, "Giorno Giovanna");
+gtest_assert_eq(user_array_smaller[1], "Giorno Giovanna");
 
 // Simple 2D array tests
 var user_array_2d = array_create_2d(3, 5, 256);

--- a/CommandLine/testing/SimpleTests/math_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/math_test.sog/create.edl
@@ -219,7 +219,11 @@ gtest_assert_eq(user_array_same[2], 24);
 gtest_assert_eq(user_array_same[3], 347);
 gtest_assert_eq(user_array_same[4], 555);
 array_set(user_array_smaller, 1, "Giorno Giovanna");
+array_set(user_array_smaller, 25, 10);
+array_set(user_array_smaller, 50, "Doppio");
 gtest_assert_eq(user_array_smaller[1], "Giorno Giovanna");
+gtest_assert_eq(user_array_smaller[25], 10);
+gtest_assert_eq(user_array_smaller[50], "Doppio");
 
 // Simple 2D array tests
 var user_array_2d = array_create_2d(3, 5, 256);

--- a/ENIGMAsystem/SHELL/Universal_System/var_array.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/var_array.cpp
@@ -47,6 +47,7 @@ void array_copy(var& dest, size_t dest_index, const var& src, size_t src_index, 
 int array_length_1d(const var& v) { return v.array_len(); }
 int array_length_2d(const var& v, int n) { return v.array_len(n); }
 int array_height_2d(const var& v) { return v.array_height(); }
+void array_set(var& v, int pos, variant value) { v[pos] = value; }
 bool is_array(const var& v) {
   //There is no way (currently) to downsize an array from >1 element, so this might not be accurate.
   return (v.array_height() > 1) || (v.array_len() > 1);

--- a/ENIGMAsystem/SHELL/Universal_System/var_array.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var_array.h
@@ -38,6 +38,7 @@ void array_copy(var& dest, size_t dest_index, const var& src, size_t src_index, 
 int array_length_1d(const var& v);
 int array_length_2d(const var& v, int n);
 int array_height_2d(const var& v);
+void array_set(var& v, int pos, variant value);
 bool is_array(const var& v);
 }  //namespace enigma_user
 


### PR DESCRIPTION
This pull request adds a simple function called `array_set`, so that you can pass arrays into scripts and modify them there (without needing to return the array). I believe there's no way to do so from EDL directly, so I'm making this pull request.