### PR TITLE
Fix Random Signed Overflow

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/random.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/random.cpp
@@ -135,7 +135,8 @@ namespace enigma_user
 
   ma_scalar random(ma_scalar n) // Do not fix:  Based off of Delphi PRNG.
   {
-    enigma::Random_Seed = enigma::Random_Seed * 0x8088405 + 1;
+    // signed overflow is undefined, so we use unsigned overflow
+    enigma::Random_Seed = (int)((unsigned int)enigma::Random_Seed * 0x8088405 + 1);
     return ((unsigned int)enigma::Random_Seed/(double)0x100000000) * n;
   }
 

--- a/ENIGMAsystem/SHELL/Universal_System/random.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/random.cpp
@@ -136,7 +136,7 @@ namespace enigma_user
   ma_scalar random(ma_scalar n) // Do not fix:  Based off of Delphi PRNG.
   {
     // signed overflow is undefined, so we use unsigned overflow
-    enigma::Random_Seed = (int)((unsigned int)enigma::Random_Seed * (unsigned int)0x8088405 + (unsigned int)1);
+    enigma::Random_Seed = (int)((unsigned int)enigma::Random_Seed * 0x8088405U + 1U);
     return ((unsigned int)enigma::Random_Seed/(double)0x100000000) * n;
   }
 

--- a/ENIGMAsystem/SHELL/Universal_System/random.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/random.cpp
@@ -136,7 +136,7 @@ namespace enigma_user
   ma_scalar random(ma_scalar n) // Do not fix:  Based off of Delphi PRNG.
   {
     // signed overflow is undefined, so we use unsigned overflow
-    enigma::Random_Seed = (int)((unsigned int)enigma::Random_Seed * 0x8088405 + 1);
+    enigma::Random_Seed = (int)((unsigned int)enigma::Random_Seed * (unsigned int)0x8088405 + (unsigned int)1);
     return ((unsigned int)enigma::Random_Seed/(double)0x100000000) * n;
   }
 


### PR DESCRIPTION
I noticed in the logs that we have signed overflow in the random.
`Universal_System/random.cpp:138:47: runtime error: signed integer overflow: 236732942 * 134775813 cannot be represented in type 'int'`

It was triggered with the following seed:
`random_set_seed(236732942);`

This pull request uses casting and unsigned literals so that we use unsigned overflow which is allowed rather than undefined.