### PR TITLE
Anonymize Cached Win32 Window Caption

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -33,6 +33,12 @@
 #include <string>
 using namespace std;
 
+namespace {
+
+std::string current_caption = "";
+
+} // anonymous namespace
+
 namespace enigma
 {
 

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -55,7 +55,6 @@ int room_last = 0;
 
 int room_persistent = 0;
 var room_caption = "";
-var current_caption = "";
 
 int background_color = 0xFFFFFF;
 int background_showcolor=1;

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.h
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.h
@@ -98,7 +98,6 @@ extern int room_first;
 extern int room_last;
 
 extern var room_caption;
-extern var current_caption;
 
 int room_count();
 #define room_count room_count()


### PR DESCRIPTION
So, I'm digging around trying to fix a crash in compile mode with regard to the caption. I started wondering, why do we have `current_caption` in user scope? Then I remembered that polygonz a couple of years ago (3359c9811602f2037d8691f1f1bd72da29423775) was trying to cache the window caption so that it wasn't redundantly changed since he claimed that was a performance bottleneck. The only variable GM ever had in user scope was `room_caption` and that's all we need too.

What I've done here is removed `current_caption` as a built-in global for the user and moved it to the Win32 source which still uses it. I decided not to get rid of it completely like the other platforms, because who knows if polygonz is actually correct about the bottleneck. I can say that I know `room_caption` is no longer a performance concern thanks to our newer cleanup of that (7b05efb1edd3d8c9d3e8ca3942472ccf953896dd).

Can confirm setting of the window caption is still working here. The room caption is still optional if empty as we had already decided. Everything looks good.


