### PR TITLE
Move Win32 INI Funcs to IniFileSystem Extension

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSfilemanip.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSfilemanip.cpp
@@ -37,75 +37,8 @@
 
 using namespace std;
 
-static std::string iniFilename = "";
-
 namespace enigma_user
 {
-
-void ini_open(std::string fname)
-{
-	char rpath[MAX_PATH];
-	GetFullPathName(fname.c_str(), MAX_PATH, rpath, NULL);
-	iniFilename = rpath;
-}
-
-void ini_close()
-{
-	iniFilename = "";
-}
-
-std::string ini_read_string(std::string section, std::string key, std::string defaultValue)
-{
-	char buffer[1024];
-	GetPrivateProfileString(section.c_str(), key.c_str(), defaultValue.c_str(), buffer, 1024, iniFilename.c_str());
-
-	return buffer;
-}
-
-float ini_read_real(std::string section, std::string key, float defaultValue)
-{
-	char res[255];
-	char def[255];
-	sprintf(def, "%f", defaultValue);
-	GetPrivateProfileString(section.c_str(), key.c_str(), def, res, 255, iniFilename.c_str());
-	return atof(res);
-	//return GetPrivateProfileInt(section.c_str(), key.c_str(), defaultValue, iniFilename.c_str());
-}
-
-void ini_write_string(std::string section, std::string key, std::string value)
-{
-	WritePrivateProfileString(section.c_str(), key.c_str(), value.c_str(), iniFilename.c_str());
-}
-
-void ini_write_real(std::string section, std::string key, float value)
-{
-	std::stringstream ss;
-	ss << value;
-
-	WritePrivateProfileString(section.c_str(), key.c_str(), ss.str().c_str(), iniFilename.c_str());
-}
-
-bool ini_key_exists(std::string section, std::string key)
-{
-	char buffer[1024];
-	return GetPrivateProfileString(section.c_str(), key.c_str(), "", buffer, 1024, iniFilename.c_str()) != 0;
-}
-
-bool ini_section_exists(std::string section)
-{
-	char buffer[1024];
-	return GetPrivateProfileSection(section.c_str(), buffer, 1024, iniFilename.c_str()) != 0;
-}
-
-void ini_key_delete(std::string section, std::string key)
-{
-	WritePrivateProfileString(section.c_str(), key.c_str(), NULL, iniFilename.c_str());
-}
-
-void ini_section_delete(std::string section)
-{
-  WritePrivateProfileString(section.c_str(), NULL, NULL, iniFilename.c_str());
-}
 
 /* OS Specific; should be moved */
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Makefile
@@ -1,1 +1,8 @@
-SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/*.cpp) 
+OS := $(shell uname -s)
+ifeq ($(OS), Linux)
+	SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/inifilesystem.cpp)
+else ifeq ($(OS), Darwin)
+	SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/inifilesystem.cpp)
+else
+	SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/Win32Ini.cpp)
+endif

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Makefile
@@ -1,7 +1,9 @@
 OS := $(shell uname -s)
 ifeq ($(OS), Linux)
+	SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/IniFileIndex.cpp)
 	SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/inifilesystem.cpp)
 else ifeq ($(OS), Darwin)
+	SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/IniFileIndex.cpp)
 	SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/inifilesystem.cpp)
 else
 	SOURCES += $(wildcard Universal_System/Extensions/IniFilesystem/Win32Ini.cpp)

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -57,7 +57,7 @@ string ini_read_string(string section, string key, string defaultValue) {
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
   tstring tstr_defaultValue = widen(defaultValue);
-  GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_defaultValue.c_str(), buffer, 1024, tstr_iniFilename.c_str());
+  GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_defaultValue.c_str(), buffer, 1024, iniFilename.c_str());
 
   return shorten(buffer);
 }
@@ -67,7 +67,7 @@ float ini_read_real(string section, string key, float defaultValue) {
   wchar_t def[255];
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), def, res, 255, tstr_iniFilename.c_str());
+  GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), def, res, 255, iniFilename.c_str());
   string result = shorten(res);
   return (float)atof(result.c_str());
 }
@@ -76,7 +76,7 @@ void ini_write_string(string section, string key, string value) {
   tstring tstr_value = widen(value);
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), tstr_iniFilename.c_str());
+  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), iniFilename.c_str());
 }
 
 void ini_write_real(string section, string key, float value) {
@@ -84,31 +84,31 @@ void ini_write_real(string section, string key, float value) {
   tstring tstr_value = widen(str_value);
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), tstr_iniFilename.c_str());
+  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), iniFilename.c_str());
 }
 
 bool ini_key_exists(string section, string key) {
   wchar_t buffer[1024];
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  return GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), L"", buffer, 1024, tstr_iniFilename.c_str()) != 0;
+  return GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), L"", buffer, 1024, iniFilename.c_str()) != 0;
 }
 
 bool ini_section_exists(string section) {
   wchar_t buffer[1024];
   tstring tstr_section = widen(section);
-  return GetPrivateProfileSectionW(tstr_section.c_str(), buffer, 1024, tstr_iniFilename.c_str()) != 0;
+  return GetPrivateProfileSectionW(tstr_section.c_str(), buffer, 1024, iniFilename.c_str()) != 0;
 }
 
 void ini_key_delete(string section, string key) {
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), NULL, tstr_iniFilename.c_str());
+  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), NULL, iniFilename.c_str());
 }
 
 void ini_section_delete(string section) {
   tstring tstr_section = widen(section);
-  WritePrivateProfileStringW(tstr_section.c_str(), NULL, NULL, tstr_iniFilename.c_str());
+  WritePrivateProfileStringW(tstr_section.c_str(), NULL, NULL, iniFilename.c_str());
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -83,12 +83,12 @@ void ini_write_string(string section, string key, string value) {
 }
 
 void ini_write_real(string section, string key, float value) {
-  string ss = to_string(value);
-  tstring tstr_ss = widen(ss);
+  string str_value = to_string(value);
+  tstring tstr_value = widen(str_value);
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
   tstring tstr_iniFilename = widen(iniFilename);
-  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_ss.c_str(), tstr_iniFilename.c_str());
+  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), tstr_iniFilename.c_str());
 }
 
 bool ini_key_exists(string section, string key) {

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -34,10 +34,10 @@
 using std::to_string;
 using std::string;
 
-static tstring iniFilename = L"";
-
 #include "Platforms/General/PFini.h"
 #include "Universal_System/estring.h"
+
+static tstring iniFilename = L"";
 
 namespace enigma_user {
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -1,0 +1,128 @@
+/********************************************************************************\
+**                                                                              **
+**  Copyright (C) 2012 Josh Ventura                                             **
+**  Copyright (C) 2014 Seth N. Hetu                                             **
+**                                                                              **
+**  This file is a part of the ENIGMA Development Environment.                  **
+**                                                                              **
+**                                                                              **
+**  ENIGMA is free software: you can redistribute it and/or modify it under the **
+**  terms of the GNU General Public License as published by the Free Software   **
+**  Foundation, version 3 of the license or any later version.                  **
+**                                                                              **
+**  This application and its source code is distributed AS-IS, WITHOUT ANY      **
+**  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS   **
+**  FOR A PARTICULAR PURPOSE. See the GNU General Public License for more       **
+**  details.                                                                    **
+**                                                                              **
+**  You should have recieved a copy of the GNU General Public License along     **
+**  with this code. If not, see <http://www.gnu.org/licenses/>                  **
+**                                                                              **
+**  ENIGMA is an environment designed to create games and other programs with a **
+**  high-level, fully compilable language. Developers of ENIGMA or anything     **
+**  associated with ENIGMA are in no way responsible for its users or           **
+**  applications created by its users, or damages caused by the environment     **
+**  or programs made in the environment.                                        **
+**                                                                              **
+\********************************************************************************/
+
+#include <windows.h>
+#include <cwchar>
+#include <cstdio>
+#include <vector>
+#include <string>
+
+using std::basic_string;
+using std::to_string;
+using std::string;
+using std::vector;
+
+static string iniFilename = "";
+
+#include "Universal_System/estring.h"
+#include "../General/PFini.h"
+
+namespace enigma_user
+{
+
+void ini_open(string fname) {
+	wchar_t rpath[MAX_PATH];
+	tstring tstr_fname = widen(fname);
+	GetFullPathNameW(tstr_fname.c_str(), MAX_PATH, rpath, NULL);
+	iniFilename = shorten(rpath);
+}
+
+void ini_close() {
+	iniFilename = "";
+}
+
+string ini_read_string(string section, string key, string defaultValue)
+{
+	wchar_t buffer[1024];
+	tstring tstr_section = widen(section);
+	tstring tstr_key = widen(key);
+	tstring tstr_iniFilename = widen(iniFilename);
+	tstring tstr_defaultValue = widen(defaultValue);
+	GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_defaultValue.c_str(), buffer, 1024, tstr_iniFilename.c_str());
+
+	return shorten(buffer);
+}
+
+float ini_read_real(string section, string key, float defaultValue) {
+	wchar_t res[255];
+	wchar_t def[255];
+	tstring tstr_section = widen(section);
+	tstring tstr_key = widen(key);
+	tstring tstr_iniFilename = widen(iniFilename);
+	GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), def, res, 255, tstr_iniFilename.c_str());
+	string result = shorten(res);
+	return (float)atof(result.c_str());
+}
+
+void ini_write_string(string section, string key, string value) {
+	tstring tstr_section = widen(section);
+	tstring tstr_key = widen(key);
+	tstring tstr_value = widen(value);
+	tstring tstr_iniFilename = widen(iniFilename);
+	WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), tstr_iniFilename.c_str());
+}
+
+void ini_write_real(string section, string key, float value) {
+	string ss = to_string(value);
+	tstring tstr_ss = widen(ss);
+	tstring tstr_section = widen(section);
+	tstring tstr_key = widen(key);
+	tstring tstr_iniFilename = widen(iniFilename);
+	WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_ss.c_str(), tstr_iniFilename.c_str());
+}
+
+bool ini_key_exists(string section, string key) {
+	wchar_t buffer[1024];
+	tstring tstr_section = widen(section);
+	tstring tstr_key = widen(key);
+	tstring tstr_iniFilename = widen(iniFilename);
+	return GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), L"", buffer, 1024, tstr_iniFilename.c_str()) != 0;
+}
+
+bool ini_section_exists(string section) {
+	wchar_t buffer[1024];
+	tstring tstr_section = widen(section);
+	tstring tstr_iniFilename = widen(iniFilename);
+	return GetPrivateProfileSectionW(tstr_section.c_str(), buffer, 1024, tstr_iniFilename.c_str()) != 0;
+}
+
+void ini_key_delete(string section, string key) {
+	tstring tstr_section = widen(section);
+	tstring tstr_key = widen(key);
+	tstring tstr_iniFilename = widen(iniFilename);
+	WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), NULL, tstr_iniFilename.c_str());
+}
+
+void ini_section_delete(string section) {
+	tstring tstr_section = widen(section);
+	tstring tstr_iniFilename = widen(iniFilename);
+	WritePrivateProfileStringW(tstr_section.c_str(), NULL, NULL, tstr_iniFilename.c_str());
+}
+
+} // namespace enigma_user
+

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -43,86 +43,84 @@ static string iniFilename = "";
 #include "Universal_System/estring.h"
 #include "../General/PFini.h"
 
-namespace enigma_user
-{
+namespace enigma_user {
 
 void ini_open(string fname) {
-	wchar_t rpath[MAX_PATH];
-	tstring tstr_fname = widen(fname);
-	GetFullPathNameW(tstr_fname.c_str(), MAX_PATH, rpath, NULL);
-	iniFilename = shorten(rpath);
+  wchar_t rpath[MAX_PATH];
+  tstring tstr_fname = widen(fname);
+  GetFullPathNameW(tstr_fname.c_str(), MAX_PATH, rpath, NULL);
+  iniFilename = shorten(rpath);
 }
 
 void ini_close() {
-	iniFilename = "";
+  iniFilename = "";
 }
 
-string ini_read_string(string section, string key, string defaultValue)
-{
-	wchar_t buffer[1024];
-	tstring tstr_section = widen(section);
-	tstring tstr_key = widen(key);
-	tstring tstr_iniFilename = widen(iniFilename);
-	tstring tstr_defaultValue = widen(defaultValue);
-	GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_defaultValue.c_str(), buffer, 1024, tstr_iniFilename.c_str());
+string ini_read_string(string section, string key, string defaultValue) {
+  wchar_t buffer[1024];
+  tstring tstr_section = widen(section);
+  tstring tstr_key = widen(key);
+  tstring tstr_iniFilename = widen(iniFilename);
+  tstring tstr_defaultValue = widen(defaultValue);
+  GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_defaultValue.c_str(), buffer, 1024, tstr_iniFilename.c_str());
 
-	return shorten(buffer);
+  return shorten(buffer);
 }
 
 float ini_read_real(string section, string key, float defaultValue) {
-	wchar_t res[255];
-	wchar_t def[255];
-	tstring tstr_section = widen(section);
-	tstring tstr_key = widen(key);
-	tstring tstr_iniFilename = widen(iniFilename);
-	GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), def, res, 255, tstr_iniFilename.c_str());
-	string result = shorten(res);
-	return (float)atof(result.c_str());
+  wchar_t res[255];
+  wchar_t def[255];
+  tstring tstr_section = widen(section);
+  tstring tstr_key = widen(key);
+  tstring tstr_iniFilename = widen(iniFilename);
+  GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), def, res, 255, tstr_iniFilename.c_str());
+  string result = shorten(res);
+  return (float)atof(result.c_str());
 }
 
 void ini_write_string(string section, string key, string value) {
-	tstring tstr_section = widen(section);
-	tstring tstr_key = widen(key);
-	tstring tstr_value = widen(value);
-	tstring tstr_iniFilename = widen(iniFilename);
-	WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), tstr_iniFilename.c_str());
+  tstring tstr_section = widen(section);
+  tstring tstr_key = widen(key);
+  tstring tstr_value = widen(value);
+  tstring tstr_iniFilename = widen(iniFilename);
+  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), tstr_iniFilename.c_str());
 }
 
 void ini_write_real(string section, string key, float value) {
-	string ss = to_string(value);
-	tstring tstr_ss = widen(ss);
-	tstring tstr_section = widen(section);
-	tstring tstr_key = widen(key);
-	tstring tstr_iniFilename = widen(iniFilename);
-	WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_ss.c_str(), tstr_iniFilename.c_str());
+  string ss = to_string(value);
+  tstring tstr_ss = widen(ss);
+  tstring tstr_section = widen(section);
+  tstring tstr_key = widen(key);
+  tstring tstr_iniFilename = widen(iniFilename);
+  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_ss.c_str(), tstr_iniFilename.c_str());
 }
 
 bool ini_key_exists(string section, string key) {
-	wchar_t buffer[1024];
-	tstring tstr_section = widen(section);
-	tstring tstr_key = widen(key);
-	tstring tstr_iniFilename = widen(iniFilename);
-	return GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), L"", buffer, 1024, tstr_iniFilename.c_str()) != 0;
+  wchar_t buffer[1024];
+  tstring tstr_section = widen(section);
+  tstring tstr_key = widen(key);
+  tstring tstr_iniFilename = widen(iniFilename);
+  return GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), L"", buffer, 1024, tstr_iniFilename.c_str()) != 0;
 }
 
 bool ini_section_exists(string section) {
-	wchar_t buffer[1024];
-	tstring tstr_section = widen(section);
-	tstring tstr_iniFilename = widen(iniFilename);
-	return GetPrivateProfileSectionW(tstr_section.c_str(), buffer, 1024, tstr_iniFilename.c_str()) != 0;
+  wchar_t buffer[1024];
+  tstring tstr_section = widen(section);
+  tstring tstr_iniFilename = widen(iniFilename);
+  return GetPrivateProfileSectionW(tstr_section.c_str(), buffer, 1024, tstr_iniFilename.c_str()) != 0;
 }
 
 void ini_key_delete(string section, string key) {
-	tstring tstr_section = widen(section);
-	tstring tstr_key = widen(key);
-	tstring tstr_iniFilename = widen(iniFilename);
-	WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), NULL, tstr_iniFilename.c_str());
+  tstring tstr_section = widen(section);
+  tstring tstr_key = widen(key);
+  tstring tstr_iniFilename = widen(iniFilename);
+  WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), NULL, tstr_iniFilename.c_str());
 }
 
 void ini_section_delete(string section) {
-	tstring tstr_section = widen(section);
-	tstring tstr_iniFilename = widen(iniFilename);
-	WritePrivateProfileStringW(tstr_section.c_str(), NULL, NULL, tstr_iniFilename.c_str());
+  tstring tstr_section = widen(section);
+  tstring tstr_iniFilename = widen(iniFilename);
+  WritePrivateProfileStringW(tstr_section.c_str(), NULL, NULL, tstr_iniFilename.c_str());
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -2,6 +2,7 @@
 **                                                                              **
 **  Copyright (C) 2012 Josh Ventura                                             **
 **  Copyright (C) 2014 Seth N. Hetu                                             **
+**  Copyright (C) 2019 Samuel Venable                                           **
 **                                                                              **
 **  This file is a part of the ENIGMA Development Environment.                  **
 **                                                                              **

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -29,13 +29,10 @@
 
 #include <windows.h>
 #include <cwchar>
-#include <cstdio>
-#include <vector>
 #include <string>
 
 using std::to_string;
 using std::string;
-using std::vector;
 
 static string iniFilename = "";
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -34,7 +34,7 @@
 using std::to_string;
 using std::string;
 
-static string iniFilename = "";
+static tstring iniFilename = L"";
 
 #include "Platforms/General/PFini.h"
 #include "Universal_System/estring.h"
@@ -45,18 +45,17 @@ void ini_open(string fname) {
   wchar_t rpath[MAX_PATH];
   tstring tstr_fname = widen(fname);
   GetFullPathNameW(tstr_fname.c_str(), MAX_PATH, rpath, NULL);
-  iniFilename = shorten(rpath);
+  iniFilename = rpath;
 }
 
 void ini_close() {
-  iniFilename = "";
+  iniFilename = L"";
 }
 
 string ini_read_string(string section, string key, string defaultValue) {
   wchar_t buffer[1024];
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  tstring tstr_iniFilename = widen(iniFilename);
   tstring tstr_defaultValue = widen(defaultValue);
   GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_defaultValue.c_str(), buffer, 1024, tstr_iniFilename.c_str());
 
@@ -68,17 +67,15 @@ float ini_read_real(string section, string key, float defaultValue) {
   wchar_t def[255];
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  tstring tstr_iniFilename = widen(iniFilename);
   GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), def, res, 255, tstr_iniFilename.c_str());
   string result = shorten(res);
   return (float)atof(result.c_str());
 }
 
 void ini_write_string(string section, string key, string value) {
+  tstring tstr_value = widen(value);
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  tstring tstr_value = widen(value);
-  tstring tstr_iniFilename = widen(iniFilename);
   WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), tstr_iniFilename.c_str());
 }
 
@@ -87,7 +84,6 @@ void ini_write_real(string section, string key, float value) {
   tstring tstr_value = widen(str_value);
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  tstring tstr_iniFilename = widen(iniFilename);
   WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), tstr_value.c_str(), tstr_iniFilename.c_str());
 }
 
@@ -95,27 +91,23 @@ bool ini_key_exists(string section, string key) {
   wchar_t buffer[1024];
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  tstring tstr_iniFilename = widen(iniFilename);
   return GetPrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), L"", buffer, 1024, tstr_iniFilename.c_str()) != 0;
 }
 
 bool ini_section_exists(string section) {
   wchar_t buffer[1024];
   tstring tstr_section = widen(section);
-  tstring tstr_iniFilename = widen(iniFilename);
   return GetPrivateProfileSectionW(tstr_section.c_str(), buffer, 1024, tstr_iniFilename.c_str()) != 0;
 }
 
 void ini_key_delete(string section, string key) {
   tstring tstr_section = widen(section);
   tstring tstr_key = widen(key);
-  tstring tstr_iniFilename = widen(iniFilename);
   WritePrivateProfileStringW(tstr_section.c_str(), tstr_key.c_str(), NULL, tstr_iniFilename.c_str());
 }
 
 void ini_section_delete(string section) {
   tstring tstr_section = widen(section);
-  tstring tstr_iniFilename = widen(iniFilename);
   WritePrivateProfileStringW(tstr_section.c_str(), NULL, NULL, tstr_iniFilename.c_str());
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -33,7 +33,6 @@
 #include <vector>
 #include <string>
 
-using std::basic_string;
 using std::to_string;
 using std::string;
 using std::vector;

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/Win32Ini.cpp
@@ -36,8 +36,8 @@ using std::string;
 
 static string iniFilename = "";
 
+#include "Platforms/General/PFini.h"
 #include "Universal_System/estring.h"
-#include "../General/PFini.h"
 
 namespace enigma_user {
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,7 @@ environment:
     - {EXTENSIONS: "XInput"}
     - {EXTENSIONS: "MediaControlInterface"}
     - {EXTENSIONS: "FileDropper"}
+    - {EXTENSIONS: "IniFileSystem"}
     - {EXTENSIONS: "Box2DPhysics", PACKAGES: "box2d:x"}
     - {EXTENSIONS: "StudioPhysics", PACKAGES: "box2d:x"}
     #TODO: Fix Bullet Physics on Windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ environment:
     - {EXTENSIONS: "XInput"}
     - {EXTENSIONS: "MediaControlInterface"}
     - {EXTENSIONS: "FileDropper"}
-    - {EXTENSIONS: "IniFileSystem"}
+    - {EXTENSIONS: "IniFilesystem"}
     - {EXTENSIONS: "Box2DPhysics", PACKAGES: "box2d:x"}
     - {EXTENSIONS: "StudioPhysics", PACKAGES: "box2d:x"}
     #TODO: Fix Bullet Physics on Windows


### PR DESCRIPTION
I'm doing this so that on all platforms users will consistently be expected to enable the extension in order to use the INI functions.

Additionally, UTF-8 support is added.