### PR TITLE
Path Extension Disabling Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Makefile
@@ -3,7 +3,7 @@ SOURCES += $(wildcard Universal_System/*.cpp)\
            $(wildcard Universal_System/Instances/*.cpp)\
            $(wildcard Universal_System/Resources/*.cpp)
 override LDLIBS += -lz
-CLEANDEPS += $(OBJDIR)/Universal_System/loading.o
+CLEANDEPS += $(OBJDIR)/Universal_System/Resources/loading.o
 
-Universal_System/Object_Tiers/planar_object.cpp: $(CODEGEN)/API_Switchboard.h
-Universal_System/loading.cpp: $(CODEGEN)/API_Switchboard.h
+$(OBJDIR)/Universal_System/Object_Tiers/planar_object.o: $(CODEGEN)/API_Switchboard.h
+$(OBJDIR)/Universal_System/Resources/loading.o: $(CODEGEN)/API_Switchboard.h

--- a/ENIGMAsystem/SHELL/Universal_System/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Makefile
@@ -4,3 +4,6 @@ SOURCES += $(wildcard Universal_System/*.cpp)\
            $(wildcard Universal_System/Resources/*.cpp)
 override LDLIBS += -lz
 CLEANDEPS += $(OBJDIR)/Universal_System/loading.o
+
+Universal_System/Object_Tiers/planar_object.cpp: $(CODEGEN)/API_Switchboard.h
+Universal_System/loading.cpp: $(CODEGEN)/API_Switchboard.h


### PR DESCRIPTION
So, I know this has been driving us all nuts for a while. I decided to take a close look at the extension and build system today with Rusky and reason about the problem of not being able to disable the path extension.

The decision I made was to have the sources which use `PATH_EXT_SET` have `API_Switchboard.h` as a dependency. Because the switchboard is generated, whenever the path extension is enabled or disabled, the switchboard will change. That means the appropriate sources can know when they need to be recompiled. The only problem with this I see is that switchboard is generated indiscriminately, and it may cause these sources to always be recompiled.

Regardless, this does fix issues with enabling and disabling the path extension.