### PR TITLE
call sound_add with sound_replace if !sound_exists

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/ALbasic.cpp
@@ -274,9 +274,10 @@ bool sound_replace(int sound, string fname, int kind, bool preload) {
   if (sound_resources.find(sound) != sound_resources.end() && sound_resources[sound]) {
     get_sound(snd, sound, false);
     alureDestroyStream(snd->stream, 0, 0);
+    return enigma::sound_replace_from_file(sound, fname);
   }
-
-  return enigma::sound_replace_from_file(sound, fname);
+  
+  return sound_add(fname, kind, preload);
 }
 
 void sound_3d_set_sound_cone(int sound, float x, float y, float z, double anglein, double angleout, long voloutside) {}


### PR DESCRIPTION
this issue was reported by hugar.

fixes sound_replace to not need a sound that exists in order to use. helps users who don't want to create "dummy" sound resources in advance.