### PR TITLE
Add functions environment_set_variable() and filename_absolute()

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -80,6 +80,7 @@ std::string execute_shell_for_output(const std::string &command);
 void execute_program(std::string fname, std::string args, bool wait);
 void execute_program(std::string operation, std::string fname, std::string args, bool wait);
 
+std::string filename_absolute(std::string fname);
 std::string environment_get_variable(std::string name);
 bool environment_set_variable(std::string name, std::string value);
 bool set_working_directory(std::string dname);

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -81,6 +81,7 @@ void execute_program(std::string fname, std::string args, bool wait);
 void execute_program(std::string operation, std::string fname, std::string args, bool wait);
 
 std::string environment_get_variable(std::string name);
+bool environment_set_variable(std::string name, std::string value);
 bool set_working_directory(std::string dname);
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -26,6 +26,14 @@ bool set_working_directory(string dname) {
   return false;
 }
 
+std::string filename_absolute(std::string fname) {
+  if (file_exists(fname) || directory_exists(fname)) {
+    char rpath1[PATH_MAX];
+    char *ptr = realpath((char *)fname.c_str(), rpath);
+    if (ptr != NULL) { return rpath; }
+  } return "";
+}
+
 string environment_get_variable(string name) {
   char *env = getenv((char *)name.c_str());
   return env ? env : "";

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -32,7 +32,7 @@ string environment_get_variable(string name) {
 
 // deletes the environment variable if set to empty string
 bool environment_set_variable(string name, string value) {
-  if (str2 == "") return (unsetenv(name.c_str()) == 0);
+  if (value == "") return (unsetenv(name.c_str()) == 0);
   return (setenv(name.c_str(), value.c_str(), 1) == 0);
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -26,15 +26,6 @@ bool set_working_directory(string dname) {
   return false;
 }
 
-string filename_absolute(string fname) {
-  if (file_exists(fname) || directory_exists(fname)) {
-    wchar_t rpath[MAX_PATH];
-    tstring tstr_fname = widen(fname);
-    GetFullPathNameW(tstr_fname.c_str(), MAX_PATH, rpath, NULL); 
-    return shorten(rpath);
-  } else { return ""; }
-}
-
 string environment_get_variable(string name) {
   char *env = getenv((char *)name.c_str());
   return env ? env : "";

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -1,4 +1,5 @@
 #include "Platforms/General/PFmain.h"
+#include "Platforms/General/PFfilemanip.h"
 
 #include <limits.h>
 #include <unistd.h>
@@ -23,6 +24,15 @@ bool set_working_directory(string dname) {
   }
 
   return false;
+}
+
+string filename_absolute(string fname) {
+  if (file_exists(fname) || directory_exists(fname)) {
+    wchar_t rpath[MAX_PATH];
+    tstring tstr_fname = widen(fname);
+    GetFullPathNameW(tstr_fname.c_str(), MAX_PATH, rpath, NULL); 
+    return shorten(rpath);
+  } else { return ""; }
 }
 
 string environment_get_variable(string name) {

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -31,7 +31,7 @@ string environment_get_variable(string name) {
 }
 
 // deletes the environment variable if set to empty string
-bool environment_set_variable(string name, string value) {
+bool environment_set_variable(const string &name, const string &value) {
   if (value == "") return (unsetenv(name.c_str()) == 0);
   return (setenv(name.c_str(), value.c_str(), 1) == 0);
 }

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -29,6 +29,7 @@ bool set_working_directory(string dname) {
   return false;
 }
 
+// converts a relative path to absolute if the path exists
 std::string filename_absolute(std::string fname) {
   if (file_exists(fname) || directory_exists(fname)) {
     char rpath[PATH_MAX];

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -28,14 +28,14 @@ bool set_working_directory(string dname) {
 
 std::string filename_absolute(std::string fname) {
   if (file_exists(fname) || directory_exists(fname)) {
-    char rpath1[PATH_MAX];
-    char *ptr = realpath((char *)fname.c_str(), rpath);
+    char rpath[PATH_MAX];
+    char *ptr = realpath(fname.c_str(), rpath);
     if (ptr != NULL) { return rpath; }
   } return "";
 }
 
 string environment_get_variable(string name) {
-  char *env = getenv((char *)name.c_str());
+  char *env = getenv(name.c_str());
   return env ? env : "";
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -30,4 +30,10 @@ string environment_get_variable(string name) {
   return env ? env : "";
 }
 
+// deletes the environment variable if set to empty string
+bool environment_set_variable(string name, string value) {
+  if (str2 == "") return (unsetenv(name.c_str()) == 0);
+  return (setenv(name.c_str(), value.c_str(), 1) == 0);
+}
+
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/POSIXdirectory.cpp
@@ -7,6 +7,9 @@
 
 using std::string;
 
+using enigma_user::file_exists;
+using enigma_user::directory_exists;
+
 static inline string add_slash(const string& dir) {
   if (dir.empty() || *dir.rbegin() != '/') return dir + '/';
   return dir;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -41,6 +41,9 @@
 using std::string;
 using std::vector;
 
+using enigma_user::file_exists;
+using enigma_user::directory_exists;
+
 namespace enigma_user {
 
 const int os_type = os_windows;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -21,6 +21,7 @@
 
 #include "Platforms/General/PFmain.h"
 #include "Platforms/General/PFwindow.h"
+#include "Platforms/General/PFfilemanip.h"
 #include "Platforms/platforms_mandatory.h"
 
 #include "Universal_System/mathnc.h" // enigma_user::clamp
@@ -457,11 +458,19 @@ void execute_program(std::string operation, std::string fname, std::string args,
 
 void execute_program(std::string fname, std::string args, bool wait) { execute_program("open", fname, args, wait); }
 
+std::string filename_absolute(std::string fname) {
+  if (file_exists(fname) || directory_exists(fname)) {
+    wchar_t rpath[MAX_PATH];
+    tstring tstr_fname = widen(fname);
+    GetFullPathNameW(tstr_fname.c_str(), MAX_PATH, rpath, NULL); 
+    return shorten(rpath);
+  } else { return ""; }
+}
+
 std::string environment_get_variable(std::string name) {
   WCHAR buffer[1024];
   tstring tstr_name = widen(name);
   GetEnvironmentVariableW(tstr_name.c_str(), (LPWSTR)&buffer, 1024);
-
   return shorten(buffer);
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -461,6 +461,7 @@ void execute_program(std::string operation, std::string fname, std::string args,
 
 void execute_program(std::string fname, std::string args, bool wait) { execute_program("open", fname, args, wait); }
 
+// converts a relative path to absolute if the path exists
 std::string filename_absolute(std::string fname) {
   if (file_exists(fname) || directory_exists(fname)) {
     wchar_t rpath[MAX_PATH];

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -465,6 +465,14 @@ std::string environment_get_variable(std::string name) {
   return shorten(buffer);
 }
 
+// deletes the environment variable if set to empty string
+bool environment_set_variable(const std::string &name, const std::string &value) {
+  tstring tstr_name = widen(name);
+  tstring tstr_value = widen(value);
+  if (value == "") return (SetEnvironmentVariableW(tstr_name.c_str(), NULL) != 0);
+  return (SetEnvironmentVariableW(tstr_name.c_str(), tstr_value.c_str()) != 0);
+}
+
 void action_webpage(const std::string &url) {
   tstring tstr_url = widen(url);
   tstring tstr_open = widen("open");


### PR DESCRIPTION
```
// win32

// converts a relative path to absolute if the path exists
string filename_absolute(string fname) {
  if (file_exists(fname) || directory_exists(fname)) {
    wchar_t rpath[MAX_PATH];
    tstring tstr_fname = widen(fname);
    GetFullPathNameW(tstr_fname.c_str(), MAX_PATH, rpath, NULL); 
    return shorten(rpath);
  } else { return ""; }
}

// deletes the environment variable if set to empty string
bool environment_set_variable(const string &name, const string &value) {
  tstring tstr_name = widen(name);
  tstring tstr_value = widen(value);
  if (value == "") return (SetEnvironmentVariableW(tstr_name.c_str(), NULL) != 0);
  return (SetEnvironmentVariableW(tstr_name.c_str(), tstr_value.c_str()) != 0);
}
```
```
// posix

// converts a relative path to absolute if the path exists
string filename_absolute(string fname) {
  if (file_exists(fname) || directory_exists(fname)) {
    char rpath[PATH_MAX];
    char *ptr = realpath(fname.c_str(), rpath);
    if (ptr != NULL) { return rpath; }
  } return "";
}

// deletes the environment variable if set to empty string
bool environment_set_variable(const string &name, const string &value) {
  if (value == "") return (unsetenv(name.c_str()) == 0);
  return (setenv(name.c_str(), value.c_str(), 1) == 0);
}
```