### PR TITLE
Enable INI Extension by Default

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/About.ey
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/IniFilesystem/About.ey
@@ -5,7 +5,7 @@ Name: Ini Filesystem
 Identifier: IniFilesystem
 Author: Seth N. Hetu
 Description: Provides a consistent, performant, cross-platform, GM-compliant API for manipulating INI files.
-Default: false
+Default: true
 Icon: inifilesystem.png
 
 Depends: None


### PR DESCRIPTION
Sam moved the Win32 INI functions over to the extension in #1755, but did not enable that extension by default. This is annoying for any project using INI that isn't converted to EGM, and people aren't converting to EGM because it's busted at the moment. Let's go ahead and enable the INI extension by default now.

He also probably should have moved the `PFini.h` to the extension `include.h` now to enable games to fail fast if they use ini functions. That is better than making them wait till link time for the compile to fail.