### PR TITLE
[win32, zenity] fix dialog icons, [kdialog] fix error message in file dialogs

### DIFF
--- a/ENIGMAsystem/SHELL/Widget_Systems/KDialog/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/KDialog/dialogs.cpp
@@ -300,7 +300,7 @@ string get_open_filename(string filter, string fname) {
 
   str_command = string("ans=$(kdialog ") +
   string("--attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--getopenfilename /") + pwd + add_escaping(kdialog_filter(filter), false, "") +
+  string("--getopenfilename ") + pwd + add_escaping(kdialog_filter(filter), false, "") +
   string(" --title \"") + str_title + string("\"") + string(");echo $ans");
 
   string result = shellscript_evaluate(str_command);
@@ -322,7 +322,7 @@ string get_open_filename_ext(string filter, string fname, string dir, string tit
 
   str_command = string("ans=$(kdialog ") +
   string("--attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--getopenfilename /") + pwd + add_escaping(kdialog_filter(filter), false, "") +
+  string("--getopenfilename ") + pwd + add_escaping(kdialog_filter(filter), false, "") +
   string(" --title \"") + str_title + string("\"") + string(");echo $ans");
 
   string result = shellscript_evaluate(str_command);
@@ -339,7 +339,7 @@ string get_open_filenames(string filter, string fname) {
 
   str_command = string("kdialog ") +
   string("--attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--getopenfilename /") + pwd + add_escaping(kdialog_filter(filter), false, "") +
+  string("--getopenfilename ") + pwd + add_escaping(kdialog_filter(filter), false, "") +
   string(" --multiple --separate-output --title \"") + str_title + string("\"");
 
   static string result;
@@ -370,7 +370,7 @@ string get_open_filenames_ext(string filter,string fname, string dir, string tit
 
   str_command = string("kdialog ") +
   string("--attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--getopenfilename /") + pwd + add_escaping(kdialog_filter(filter), false, "") +
+  string("--getopenfilename ") + pwd + add_escaping(kdialog_filter(filter), false, "") +
   string(" --multiple --separate-output --title \"") + str_title + string("\"");
 
   static string result;
@@ -396,7 +396,7 @@ string get_save_filename(string filter, string fname) {
 
   str_command = string("ans=$(kdialog ") +
   string("--attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--getsavefilename /") + pwd + add_escaping(kdialog_filter(filter), false, "") +
+  string("--getsavefilename ") + pwd + add_escaping(kdialog_filter(filter), false, "") +
   string(" --title \"") + str_title + string("\"") + string(");echo $ans");
 
   return shellscript_evaluate(str_command);
@@ -417,7 +417,7 @@ string get_save_filename_ext(string filter, string fname, string dir, string tit
 
   str_command = string("ans=$(kdialog ") +
   string("--attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--getsavefilename /") + pwd + add_escaping(kdialog_filter(filter), false, "") +
+  string("--getsavefilename ") + pwd + add_escaping(kdialog_filter(filter), false, "") +
   string(" --title \"") + str_title + string("\"") + string(");echo $ans");
 
   return shellscript_evaluate(str_command);
@@ -434,7 +434,7 @@ string get_directory(string dname) {
 
   str_command = string("ans=$(kdialog ") +
   string("--attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--getexistingdirectory /") + pwd + string(" --title \"") + str_title + str_end;
+  string("--getexistingdirectory ") + pwd + string(" --title \"") + str_title + str_end;
 
   return shellscript_evaluate(str_command);
 }
@@ -450,7 +450,7 @@ string get_directory_alt(string capt, string root) {
 
   str_command = string("ans=$(kdialog ") +
   string("--attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--getexistingdirectory /") + pwd + string(" --title \"") + str_title + str_end;
+  string("--getexistingdirectory ") + pwd + string(" --title \"") + str_title + str_end;
 
   return shellscript_evaluate(str_command);
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -299,7 +299,7 @@ static inline int show_message_helperfunc(const string &message) {
     wcsncpy_s(wstrWindowCaption, dialog_caption.c_str(), 512);
 
   if (message_cancel) {
-    int result = MessageBoxW(enigma::hWnd, tstrStr.c_str(), wstrWindowCaption, MB_OKCANCEL | MB_ICONINFORMATION | MB_DEFBUTTON1 | MB_APPLMODAL);
+    int result = MessageBoxW(enigma::hWnd, tstrStr.c_str(), wstrWindowCaption, MB_OKCANCEL | MB_ICONQUESTION | MB_DEFBUTTON1 | MB_APPLMODAL);
     if (result == IDOK) return 1; else return -1;
   }
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/Zenity/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Zenity/dialogs.cpp
@@ -108,23 +108,21 @@ static int show_message_helperfunc(string message) {
     dialog_caption = window_get_caption();
 
   string str_command;
-  string str_title;
-  string str_cancel;
+  string str_title = add_escaping(dialog_caption, true, " ");
+  string str_cancel = "--info --ok-label=OK ";
+  string str_icon = "\" --icon-name=dialog-information);";
   string str_echo = "echo 1";
 
-  if (message_cancel)
+  if (message_cancel) {
     str_echo = "if [ $? = 0 ] ;then echo 1;else echo -1;fi";
-
-  str_title = add_escaping(dialog_caption, true, " ");
-  str_cancel = "--info --ok-label=OK ";
-
-  if (message_cancel)
     str_cancel = "--question --ok-label=OK --cancel-label=Cancel ";
+    str_icon = "\" --icon-name=dialog-question);";
+  }
 
   str_command = string("ans=$(zenity ") +
   string("--attach=$(sleep .01;xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
   str_cancel + string("--title=\"") + str_title + string("\" --no-wrap --text=\"") +
-  add_escaping(message, false, "") + string("\" --icon-name=dialog-information);") + str_echo;
+  add_escaping(message, false, "") + str_icon + str_echo;
 
   string str_result = shellscript_evaluate(str_command);
   return (int)strtod(str_result.c_str(), NULL);
@@ -171,11 +169,11 @@ static inline void show_debug_message_helper(string errortext, MESSAGE_TYPE type
   #endif
 
   str_echo = (type == MESSAGE_TYPE::M_FATAL_ERROR || type == MESSAGE_TYPE::M_FATAL_USER_ERROR) ? "echo 1" :
-    "if [ $? = 0 ] ;then echo 1;elif [ $ans = \"Ignore\" ] ;then echo -1;elif [ $? = 2 ] ;then echo 0;fi";
+    "if [ $ans = \"Abort\" ] ;then echo 1;elif [ $ans = \"Ignore\" ] ;then echo -1;elif [ $ans = \"Retry\" ] ;then echo 0;fi";
 
   str_command = string("ans=$(zenity ") +
   string("--attach=$(sleep .01;xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--question --ok-label=Abort --cancel-label=Retry --extra-button=Ignore ") +
+  string("--error --ok-label=Ignore --extra-button=Retry --extra-button=Abort ") +
   string("--title=\"") + add_escaping(error_caption, true, "Error") + string("\" --no-wrap --text=\"") +
   add_escaping(errortext, false, "") + string("\" --icon-name=dialog-error);") + str_echo;
 
@@ -226,10 +224,10 @@ int show_attempt(string errortext) {
 
   str_command = string("ans=$(zenity ") +
   string("--attach=$(sleep .01;xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +
-  string("--question --ok-label=Retry --cancel-label=Cancel ") +  string("--title=\"") +
+  string("--error --ok-label=Cancel --extra-button=Retry ") +  string("--title=\"") +
   add_escaping(error_caption, true, "Error") + string("\" --no-wrap --text=\"") +
   add_escaping(errortext, false, "") +
-  string("\" --icon-name=dialog-error);if [ $? = 0 ] ;then echo 0;else echo -1;fi");
+  string("\" --icon-name=dialog-error);if [ $? = 0 ] ;then echo -1;else echo 0;fi");
 
   string str_result = shellscript_evaluate(str_command);
   return (int)strtod(str_result.c_str(), NULL);

--- a/ENIGMAsystem/SHELL/Widget_Systems/Zenity/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Zenity/dialogs.cpp
@@ -169,7 +169,7 @@ static inline void show_debug_message_helper(string errortext, MESSAGE_TYPE type
   #endif
 
   str_echo = (type == MESSAGE_TYPE::M_FATAL_ERROR || type == MESSAGE_TYPE::M_FATAL_USER_ERROR) ? "echo 1" :
-    "if [ $ans = \"Abort\" ] ;then echo 1;elif [ $ans = \"Ignore\" ] ;then echo -1;elif [ $ans = \"Retry\" ] ;then echo 0;fi";
+    "if [ $ans = \"Abort\" ] ;then echo 1;elif [ $ans = \"Retry\" ] ;then echo 0;else echo -1;fi";
 
   str_command = string("ans=$(zenity ") +
   string("--attach=$(sleep .01;xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2) ") +


### PR DESCRIPTION
makes win32 and zenity have the correct icons in the dialog and, in zenity's case, running in desktops using KDE, the title bar as well. OK/Cancel should have a question mark instead of "i" for information.

error happened with the default kdialog shipped with certain linux distro's (since disco dingo release), and not the one you would've installed from the now obsolete package kde-baseapps-bin. This fixes the issue.