### PR TITLE
center linux game on screen at startup

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -65,6 +65,13 @@ int enigma_main(int argc, char** argv) {
 
   // Call ENIGMA system initializers; sprites, audio, and what have you
   initialize_everything();
+  
+  // required for linux because x11 is retard 
+  int winw = enigma_user::window_get_width();
+  int winh = enigma_user::window_get_height();
+  int winx = (enigma_user::display_get_width() - winw) / 2;
+  int winy = (enigma_user::display_get_height() - winh) / 2;
+  enigma_user::window_set_rectangle(winx, winy, winw, winh);
 
   while (!game_isending) {
     if (!((std::string)enigma_user::room_caption).empty())


### PR DESCRIPTION
this effects all platforms and on windows and mac it is redundant, but oh well, it is required to initialize_everything() first, to determine game window size, before linux game can be centered properly, rather than opening in the corner of the screen or w/e.