### PR TITLE
center linux game on screen at startup

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -65,6 +65,9 @@ int enigma_main(int argc, char** argv) {
 
   // Call ENIGMA system initializers; sprites, audio, and what have you
   initialize_everything();
+  
+  // required for some WM's
+  enigma_user::window_center();
 
   while (!game_isending) {
     if (!((std::string)enigma_user::room_caption).empty())

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -194,7 +194,7 @@ void handleInput() {
 
 namespace enigma_user {
 
-int display_get_width() { return XWidthOfScreen(enigma::x11::screen); }
-int display_get_height() { return XHeightOfScreen(enigma::x11::screen); }
+int display_get_width() { return XWidthOfScreen(XDefaultScreenOfDisplay(enigma::x11::disp)); }
+int display_get_height() { return XHeightOfScreen(XDefaultScreenOfDisplay(enigma::x11::disp)); }
 
 }  // namespace enigma_user


### PR DESCRIPTION
this effects all platforms and on windows and mac it is redundant, but oh well, it is required to initialize_everything() first, to determine game window size, before linux game can be centered properly, rather than opening in the corner of the screen or w/e.