### PR TITLE
AssetArray Move Fixes

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -178,10 +178,9 @@ int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
   bufferDesc.guid3DAlgorithm = GUID_NULL;
   dsound->CreateSoundBuffer(&bufferDesc, &snd.soundBuffer, NULL);
 
+  auto sndBuf = snd.soundBuffer;
   LPVOID lpvWrite;
   DWORD dwLength;
-
-  IDirectSoundBuffer* sndBuf = snd.soundBuffer;
 
   if (DS_OK == sndBuf->Lock(0,                     // Offset at which to start lock.
                             waveHeader->dataSize,  // Size of lock; ignored because of flag.

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
@@ -19,12 +19,16 @@
 #define ENIGMA_SOUND_RESOURCE_H
 
 #include "Universal_System/Resources/AssetArray.h"
+
+#include <wrl/client.h> // ComPtr
+
 using enigma::AssetArray;
+using Microsoft::WRL::ComPtr;
 
 enum load_state { LOADSTATE_NONE, LOADSTATE_INDICATED, LOADSTATE_COMPLETE };
 
 struct Sound {
-  IDirectSoundBuffer *soundBuffer;
+  ComPtr<IDirectSoundBuffer> soundBuffer;
   void (*cleanup)(void *userdata);               // optional cleanup callback for streams
   void *userdata;                                // optional userdata for streams
   void (*seek)(void *userdata, float position);  // optional seeking
@@ -39,11 +43,7 @@ struct Sound {
   Sound() : soundBuffer(0), cleanup(0), userdata(0), seek(0), type(0), kind(0),
     loaded(LOADSTATE_NONE), idle(1), playing(0) {}
 
-  void destroy() {
-    if (soundBuffer) soundBuffer->Release();
-    soundBuffer = 0;
-  }
-
+  void destroy() { soundBuffer.Reset(); }
   bool isDestroyed() const { return soundBuffer; }
 
   static const char* getAssetTypeName() { return "sound"; }

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/SoundResource.h
@@ -38,10 +38,9 @@ struct Sound {
 
   Sound() : soundBuffer(0), cleanup(0), userdata(0), seek(0), type(0), kind(0),
     loaded(LOADSTATE_NONE), idle(1), playing(0) {}
-  ~Sound() { destroy(); }
 
   void destroy() {
-    soundBuffer->Release();
+    if (soundBuffer) soundBuffer->Release();
     soundBuffer = 0;
   }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/AssetArray.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/AssetArray.h
@@ -47,13 +47,13 @@ class AssetArray {
  public:
   AssetArray() {}
 
-  int add(const T&& asset) {
+  int add(T&& asset) {
     size_t id = size();
     assets_.emplace_back(std::move(asset));
     return (int)id;
   }
 
-  int assign(int id, const T&& asset) {
+  int assign(int id, T&& asset) {
     if (exists(id)) assets_[id].destroy();
     else {
       #ifdef DEBUG_MODE
@@ -74,7 +74,7 @@ class AssetArray {
     return assets_[id];
   }
 
-  int replace(int id, const T&& asset) {
+  int replace(int id, T&& asset) {
     CHECK_ID(id, -1);
     assets_[id].destroy();
     assets_[id] = std::move(asset);


### PR DESCRIPTION
After talking to Rusky I caught two problems in #1767.

First, it's not possible to move from a const rvalue reference and it just falls back to the copy constructor. So, I changed all the move methods of AssetArray to take a non-const rvalue reference.

>Beware of const! Const variables can not be moved from, since move constructors take a non-const (rvalue) reference. However the compiler will **silently fall-back to the copy constructor**. https://www.chromium.org/rvalue-references#TOC-8.-Move-constructors-will-only-bind-to-non-const-rvalues.

Second, the destructor I added for Sound actually causes a problem. Since we first allocate the Sound on the stack before we add it to the asset array, its destructor is called releasing the COM interface pointer for the DirectSound buffer. This means that the moved Sound no longer has a valid COM pointer. For now, I've simply deleted the destructor.

With these fixes the audio plays again for me.