### PR TITLE
Async Extension Copyright Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Asynchronous/ASYNCdialog.cpp
@@ -7,8 +7,7 @@
 *** Foundation, version 3 of the license or any later version.
 ***
 *** This application and its source code is distributed AS-IS, WITHOUT ANY
-*** WARRANTY {
-} without even the implied warranty of MERCHANTABILITY or FITNESS
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 *** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
 *** details.
 ***


### PR DESCRIPTION
At some point, I don't know when, the bottom half of the copyright header in the async extension got mutilated. This is just a small request to fix it.