### PR TITLE
Kill POSIX crap in Win32 execute_shell_for_output

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -433,12 +433,12 @@ std::string execute_shell_for_output(const std::string &command) {
   si.cb = sizeof(si);
   ZeroMemory(&pi, sizeof(pi));
   std::string str_output_file = temp_directory + string("ENIGMA-DEV-OUTPUT.TMP");
-  std::string str_command = string("CMD.EXE /C ") + command + string(" > \"") + str_output_file + string("\""); 
+  std::string str_command = string("cmd.exe /c chcp 65001 > nul & cmd.exe /c ") + command + string(" > \"") + str_output_file + string("\""); 
   tstring tstr_command = widen(str_command);
   tstr_command.resize(32767);
   if (CreateProcessW(NULL, (wchar_t *)tstr_command.c_str(), NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
-    // note if user uses "CMD.EXE" as the application to run, they must also use the "/C" flag to avoid endless wait
-    // calling "CMD.EXE /C " is done internally, so all they need to do is specify the command line arguments to CMD
+    // note if user uses "cmd.exe" as the application to run, they must also use the "/c" flag to avoid endless wait
+    // calling "cmd.exe /c " is done internally, so all they need to do is specify the command line arguments to cmd
     // CREATE_NO_WINDOW hides the command prompt to emulate the behavior of the Mac and Linux version of this method
     WaitForSingleObject(pi.hProcess, INFINITE);
     CloseHandle(pi.hProcess);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -428,7 +428,8 @@ void execute_shell(std::string operation, std::string fname, std::string args) {
 
 std::string execute_shell_for_output(const std::string &command) {
   tstring tstr_command = widen(command);
-  tstr_command.resize(32767);
+  wchar_t ctstr_command[32768];
+  wcsncpy_s(ctstr_command, tstr_command.c_str(), 32768);
   BOOL ok = TRUE;
   HANDLE hStdInPipeRead = NULL;
   HANDLE hStdInPipeWrite = NULL;
@@ -446,7 +447,7 @@ std::string execute_shell_for_output(const std::string &command) {
   si.hStdOutput = hStdOutPipeWrite;
   si.hStdInput = hStdInPipeRead;
   PROCESS_INFORMATION pi = { };
-  if (CreateProcessW(NULL, (wchar_t *)tstr_command.c_str(), NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
+  if (CreateProcessW(NULL, ctstr_command, NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
     while (WaitForSingleObject(pi.hThread, 0) == WAIT_TIMEOUT) {
       MSG msg;
       if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -26,6 +26,7 @@
 
 #include "Universal_System/mathnc.h" // enigma_user::clamp
 #include "Universal_System/estring.h"
+#include "Universal_System/fileio.h"
 #include "Universal_System/roomsystem.h"
 #include "Universal_System/var4.h"
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -437,9 +437,9 @@ std::string execute_shell_for_output(const std::string &command) {
   tstring tstr_command = widen(str_command);
   tstr_command.resize(32767);
   if (CreateProcessW(NULL, (wchar_t *)tstr_command.c_str(), NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
-	  // note if user uses "CMD.EXE" as the application to run, they must also use the "/C" flag to avoid endless wait
-	  // calling "CMD.EXE /C " is done internally, so all they need to do is specify the command line arguments to CMD
-	  // CREATE_NO_WINDOW hides the command prompt to emulate the behavior of the Mac and Linux version of this method
+    // note if user uses "CMD.EXE" as the application to run, they must also use the "/C" flag to avoid endless wait
+    // calling "CMD.EXE /C " is done internally, so all they need to do is specify the command line arguments to CMD
+    // CREATE_NO_WINDOW hides the command prompt to emulate the behavior of the Mac and Linux version of this method
     WaitForSingleObject(pi.hProcess, INFINITE);
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -429,7 +429,7 @@ void execute_shell(std::string operation, std::string fname, std::string args) {
 std::string execute_shell_for_output(const std::string &command) {
   tstring tstr_command = widen(command);
   wchar_t ctstr_command[32768];
-  wcsncpy_s(ctstr_command, tstr_command.c_str(), 32768);
+  wcsncpy(ctstr_command, tstr_command.c_str(), 32768);
   BOOL ok = TRUE;
   HANDLE hStdInPipeRead = NULL;
   HANDLE hStdInPipeWrite = NULL;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -432,7 +432,7 @@ std::string execute_shell_for_output(const std::string &command) {
   ZeroMemory(&si, sizeof(si));
   si.cb = sizeof(si);
   ZeroMemory(&pi, sizeof(pi));
-  std::string str_output_file = temp_directory + string("ENIGMA-DEV-OUTPUT.TMP");
+  std::string str_output_file = temp_directory + string("ENIGMA_DEV_OUTPUT.TMP");
   std::string str_command = string("cmd.exe /c chcp 65001 > nul & cmd.exe /c ") + command + string(" > \"") + str_output_file + string("\""); 
   tstring tstr_command = widen(str_command);
   tstr_command.resize(32767);
@@ -440,7 +440,13 @@ std::string execute_shell_for_output(const std::string &command) {
     // note if user uses "cmd.exe" as the application to run, they must also use the "/c" flag to avoid endless wait
     // calling "cmd.exe /c " is done internally, so all they need to do is specify the command line arguments to cmd
     // CREATE_NO_WINDOW hides the command prompt to emulate the behavior of the Mac and Linux version of this method
-    WaitForSingleObject(pi.hProcess, INFINITE);
+    while (WaitForSingleObject(pi.hThread, 0) == WAIT_TIMEOUT) {
+      MSG msg;
+      if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+      }
+    }
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
     int output_file = file_text_open_read(str_output_file);


### PR DESCRIPTION
I also intend to rewrite fileio.cpp for Win32 that doesn't use POSIX API calls and supports UTF-8, in a different pr.

`show_message(execute_shell_for_output('cmd /c dir c:\'));`

![Capture](https://user-images.githubusercontent.com/4379204/61423442-cfdb3800-a8dd-11e9-9ad3-8c712f165045.PNG)