### PR TITLE
Asset Exists Iterator

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/VirtualKeys/virtualkeys.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/VirtualKeys/virtualkeys.cpp
@@ -37,9 +37,8 @@ bool virtual_key_show_pressed = true;
 bool virtual_key_show_keyboard_pressed = false;
 
 void update_virtualkeys() {
-  for (int i = 0; size_t(i) < virtual_keys.size(); ++i) {
-    if (!virtual_keys.exists(i)) continue;
-    VirtualKey& vk = virtual_keys.get(i);
+  for (std::pair<int, VirtualKey&> vki : virtual_keys) {
+    VirtualKey& vk = vki.second;
     // always set it back to false in case of focus loss
     vk.pressed = false;
 
@@ -62,11 +61,9 @@ void update_virtualkeys() {
 }
 
 void draw_virtualkeys() {
-  for (int i = 0; size_t(i) < virtual_keys.size(); ++i) {
-    if (!virtual_keys.exists(i)) continue;
-    const VirtualKey& vk = virtual_keys.get(i);
-    if (!vk.visible) continue;
-    virtual_key_draw(i);
+  for (std::pair<int, VirtualKey&> vk : virtual_keys) {
+    if (!vk.second.visible) continue;
+    virtual_key_draw(vk.first);
   }
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/AssetArray.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/AssetArray.h
@@ -50,8 +50,7 @@ class AssetArray {
    public:
     iterator(AssetArray& assets, int ind): assets(assets), ind(ind) {}
     iterator operator++() {
-      do { ++ind; }
-      while (!assets.exists(ind) && size_t(ind) < assets.size());
+      while (!assets.exists(++ind) && size_t(ind) < assets.size());
       return *this;
     }
     bool operator!=(const iterator& other) const { return ind != other.ind; }
@@ -63,7 +62,10 @@ class AssetArray {
 
   AssetArray() {}
 
-  iterator begin() { return iterator(*this, 0); }
+  iterator begin() {
+    iterator it(*this, 0);
+    return (exists(0) ? it : ++it);
+  }
   iterator end() { return iterator(*this, size()); }
 
   int add(T&& asset) {

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/AssetArray.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/AssetArray.h
@@ -45,7 +45,26 @@ namespace enigma {
 template<typename T>
 class AssetArray {
  public:
+  // Custom iterator for looping over only the existing assets in the array.
+  class iterator {
+   public:
+    iterator(AssetArray& assets, int ind): assets(assets), ind(ind) {}
+    iterator operator++() {
+      do { ++ind; }
+      while (!assets.exists(ind) && size_t(ind) < assets.size());
+      return *this;
+    }
+    bool operator!=(const iterator& other) const { return ind != other.ind; }
+    std::pair<int, T&> operator*() const { return {ind, assets[ind]}; }
+   private:
+    AssetArray& assets;
+    int ind;
+  };
+
   AssetArray() {}
+
+  iterator begin() { return iterator(*this, 0); }
+  iterator end() { return iterator(*this, size()); }
 
   int add(T&& asset) {
     size_t id = size();
@@ -71,6 +90,13 @@ class AssetArray {
   T& get(int id) {
     static T sentinel;
     CHECK_ID(id,sentinel);
+    return assets_[id];
+  }
+
+  // NOTE: absolutely no bounds checking!
+  // only used in rare cases where you
+  // already know the asset exists
+  T& operator[](int id) {
     return assets_[id];
   }
 


### PR DESCRIPTION
This pull request attempts to implement what I described in #1807 as an essential feature of the AssetArray. It should be possible to iterate over only the existing assets in the array. For this, I am providing a custom exists iterator for AssetArray that works in range-based for loops.

In collusion with @rpjohnst we settled on an API where the iterator dereferences to a pair, allowing you to access the id of the resource. This was particularly needed in the Virtual Keys extension so the id of a virtual key could be passed to one of the virtual key functions. DirectSound will require it for similar reasons too, and the id is just something you generally want to know about when working with an asset.

I have _not_ implemented a skip list or segment tree because at this point we don't think it's worth it.