### PR TITLE
Empty Asset Array Iterator Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Resources/AssetArray.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/AssetArray.h
@@ -62,10 +62,7 @@ class AssetArray {
 
   AssetArray() {}
 
-  iterator begin() {
-    iterator it(*this, 0);
-    return (exists(0) ? it : ++it);
-  }
+  iterator begin() { return ++iterator(*this, -1); }
   iterator end() { return iterator(*this, size()); }
 
   int add(T&& asset) {


### PR DESCRIPTION
Well, there was a critical mistake in #1814 that's causing games not to build on master. The logic I am applying here to fix it is that it's illegal to advance past the end iterator. In this case, when we have an empty AssetArray, like Virtual Keys extension is at startup, our begin was advancing to 1 and our end was at 0 so they could never be equal making for loops never terminate. Since we always unconditionally advance by at least 1, I decided we should just always start begin at -1 to fix this.