### PR TITLE
DirectSound Asset Exists False Positive Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -54,9 +54,8 @@ bool sound_pause(int sound)  // Returns whether the sound was successfully pause
 }
 
 void sound_pause_all() {
-  for (std::pair<int, const Sound&> sndi : sounds) {
+  for (std::pair<int, const Sound&> sndi : sounds)
     sndi.second.soundBuffer->Stop();
-  }
 }
 
 void sound_stop(int sound) {
@@ -65,9 +64,8 @@ void sound_stop(int sound) {
 }
 
 void sound_stop_all() {
-  for (std::pair<int, const Sound&> sndi : sounds) {
+  for (std::pair<int, const Sound&> sndi : sounds)
     sndi.second.soundBuffer->Stop();
-  }
 }
 
 void sound_delete(int sound) {
@@ -90,9 +88,8 @@ bool sound_resume(int sound)  // Returns whether the sound is playing
 }
 
 void sound_resume_all() {
-  for (std::pair<int, const Sound&> sndi : sounds) {
+  for (std::pair<int, const Sound&> sndi : sounds)
     sndi.second.soundBuffer->Play(0, 0, 0);
-  }
 }
 
 bool sound_isplaying(int sound) {
@@ -144,9 +141,8 @@ void sound_seek(int sound, float position) {
 }
 
 void sound_seek_all(float position) {
-  for (std::pair<int, const Sound&> sndi : sounds) {
+  for (std::pair<int, const Sound&> sndi : sounds)
     sndi.second.soundBuffer->SetCurrentPosition(position);
-  }
 }
 
 void action_sound(int snd, bool loop) { (loop ? sound_loop : sound_play)(snd); }

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -54,9 +54,8 @@ bool sound_pause(int sound)  // Returns whether the sound was successfully pause
 }
 
 void sound_pause_all() {
-  for (size_t i = 0; i < sounds.size(); i++) {
-    const Sound& snd = sounds.get(i);
-    snd.soundBuffer->Stop();
+  for (std::pair<int, const Sound&> sndi : sounds) {
+    sndi.second.soundBuffer->Stop();
   }
 }
 
@@ -66,9 +65,8 @@ void sound_stop(int sound) {
 }
 
 void sound_stop_all() {
-  for (size_t i = 0; i < sounds.size(); i++) {
-    const Sound& snd = sounds.get(i);
-    snd.soundBuffer->Stop();
+  for (std::pair<int, const Sound&> sndi : sounds) {
+    sndi.second.soundBuffer->Stop();
   }
 }
 
@@ -92,9 +90,8 @@ bool sound_resume(int sound)  // Returns whether the sound is playing
 }
 
 void sound_resume_all() {
-  for (size_t i = 0; i < sounds.size(); i++) {
-    const Sound& snd = sounds.get(i);
-    snd.soundBuffer->Play(0, 0, 0);
+  for (std::pair<int, const Sound&> sndi : sounds) {
+    sndi.second.soundBuffer->Play(0, 0, 0);
   }
 }
 
@@ -147,9 +144,8 @@ void sound_seek(int sound, float position) {
 }
 
 void sound_seek_all(float position) {
-  for (size_t i = 0; i < sounds.size(); i++) {
-    const Sound& snd = sounds.get(i);
-    snd.soundBuffer->SetCurrentPosition(position);
+  for (std::pair<int, const Sound&> sndi : sounds) {
+    sndi.second.soundBuffer->SetCurrentPosition(position);
   }
 }
 


### PR DESCRIPTION
It seems the DirectSound functions that loop over all the existing sounds have had some issues for a while. Before AssetArray was introduced in #1767, they used a macro which actually caused them to abort on the first deleted sound. That was not correct at all as calling these functions should not be fatal. Now that #1814 gave us an exists iterator, we can use it to implement these functions correctly by looping over only the existing sound assets.

Here's a simple example that reproduces it on master. Just put the code in the create, create and load two sound resources, put the object in a room, and run.
```cpp
sound_play(snd_0);
sound_play(snd_1);
sound_delete(snd_1);
sound_stop_all();
```
![DirectSound Stop All False Positive](https://user-images.githubusercontent.com/3212801/61579013-599d2800-aacd-11e9-9bba-eb49acff8423.png)
