### PR TITLE
Fix New CI Test Harness Coverage

### DIFF
--- a/CI/solve_engine_deps.sh
+++ b/CI/solve_engine_deps.sh
@@ -2,7 +2,7 @@
 
 ###### Harness #######
 if [ "$TEST_HARNESS" == true ]; then
-  LINUX_DEPS="$LINUX_DEPS xfwm4 libgtest-dev wmctrl xdotool"
+  LINUX_DEPS="$LINUX_DEPS xfwm4 libgtest-dev wmctrl xdotool lcov"
 fi
 
 ###### Compilers #######


### PR DESCRIPTION
We were missing lcov because of #1792 apparently so this should fix #1810 and bring back coverage reports.