### PR TITLE
Draw Button Winding Order

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSstdraw.cpp
@@ -863,29 +863,33 @@ void draw_button(gs_scalar x1, gs_scalar y1,gs_scalar x2, gs_scalar y2, gs_scala
   float alpha = 0.5;
     if (up == true){ color = make_color_rgb(127,127,127); } else { color = make_color_rgb(255,255,255); }
 
+  // bottom
   draw_primitive_begin(pr_trianglestrip);
   draw_vertex_color(x1+border_width,y2-border_width,color,alpha);
-  draw_vertex_color(x2-border_width,y1-border_width,color,alpha);
+  draw_vertex_color(x2-border_width,y2-border_width,color,alpha);
   draw_vertex_color(x1,y2,color,alpha);
   draw_vertex_color(x2,y2,color,alpha);
   draw_primitive_end();
 
+  // right
   draw_primitive_begin(pr_trianglestrip);
   draw_vertex_color(x2-border_width,y1+border_width,color,alpha);
   draw_vertex_color(x2,y1,color,alpha);
-  draw_vertex_color(x1-border_width,y1-border_width,color,alpha);
+  draw_vertex_color(x2-border_width,y2-border_width,color,alpha);
   draw_vertex_color(x2,y2,color,alpha);
   draw_primitive_end();
 
   if (up == true){ color = make_color_rgb(255,255,255); } else { color = make_color_rgb(127,127,127); }
+
+  // top
   draw_primitive_begin(pr_trianglestrip);
   draw_vertex_color(x1,y1,color,alpha);
   draw_vertex_color(x2,y1,color,alpha);
   draw_vertex_color(x1+border_width,y1+border_width,color,alpha);
-  draw_vertex_color(x2-border_width,y2+border_width,color,alpha);
+  draw_vertex_color(x2-border_width,y1+border_width,color,alpha);
   draw_primitive_end();
 
-
+  // left
   draw_primitive_begin(pr_trianglestrip);
   draw_vertex_color(x1,y1,color,alpha);
   draw_vertex_color(x1+border_width,y1+border_width,color,alpha);


### PR DESCRIPTION
![Broken Draw Button Master](https://user-images.githubusercontent.com/3212801/61581841-b14d8a80-aaf1-11e9-9cfe-bd5969e25b01.png)![Fixed Draw Button Pull](https://user-images.githubusercontent.com/3212801/61581848-bdd1e300-aaf1-11e9-8e97-ebb8d09961ac.png)
(Left is master; right is this pull request)

I've been complaining about `draw_button` being screwed up on master and decided to investigate. I found that originally when I started Direct3D9 I had made some fixes to the `draw_button` I added there in 9a48e644000e2837842bbda68f2ce6e805e79e14, but not to the original one. The original one had some flaws too apparently but ultimately my fix made it worse. Then what happened was we deduplicated these functions to general in 03290669f7da08f8227481dce002af4bebff1c89 and I picked the Direct3D9 one.

Now I am sitting down, again, and making sure it's actually correct. I have fixed the winding order and added comments to easily discern which primitive is which side of the button.