### PR TITLE
Fix Parser Reinterpret Type Cast

### DIFF
--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -364,10 +364,16 @@ int parser_reinterpret(string &code,string &synt)
       synt[pos-1] = '0';
     else if (synt[pos] == 't')
     {
-      if (synt[pos-1] == '(')
-      {
+      pt rp = pos;
+      while (synt[++rp] == 't'); // find the right end
+
+      if (synt[rp] == '(') { // constructor e.g, string("test")
+        for (pt i = pos; i < rp; i++)
+          synt[i] = 'c';
+        pos = rp;
+      } else if (synt[pos-1] == '(') { // traditional cast e.g, (string)"test"
         const pt sp = pos-1;
-        while (synt[++pos] == 't');
+        pos = rp;
         if (synt[pos] == ')')
           for (pt i = sp; i <= pos; i++)
             synt[i] = 'c';


### PR DESCRIPTION
This fixes the regression mentioned in #1795 where locals are not being picked up inside constructors. Simple solution is to also look for the opening parenthesis of a type cast on the right side of the type, and treat the constructor as a cast. Then locals will be correctly prefixed with `ambi.` or `self.` for subsequent parsing and compiling stages. This fixes both SONIGMA and Wild Racing.

Caveat: C-style function pointers will temporarily regress as a result of this.