### PR TITLE
String Constructor Logical Equality Test

### DIFF
--- a/CommandLine/testing/SimpleTests/string_test.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/string_test.sog/create.edl
@@ -37,11 +37,13 @@ gtest_assert_eq(real("3.125"), 3.125);
 //gtest_assert_gt(real("1234567890123"), 1234567890000.);
 
 variant my_str = "hello, world";
+gtest_assert_eq(string(my_str), "hello, world");
 gtest_assert_eq(string_length("hello, world"), 12);
 gtest_assert_eq(string_length(my_str), 12);
 
 // String length operations use bytes unless otherwise directed.
 my_str = "hello, 🌎! 😀";
+gtest_assert_eq(string(my_str), "hello, 🌎! 😀");
 gtest_assert_eq(string_length("hello, 🌎! 😀"), 17);
 gtest_assert_eq(string_length(my_str), 17);
 gtest_assert_eq(string_length_utf8("hello, 🌎! 😀"), 11);


### PR DESCRIPTION
I realized that #1795 actually occurred in regular objects too and not just scripts. Since we patched it with #1820, I decided I want to add a test that will keep it from coming back. I have updated the CI strings test to validate the logical equality of the string constructor.

Edit: Apparently this doesn't actually test the thing we just fixed. It's only reproducible by passing an uninitialized var to the string constructor, which I don't want to do since that will error the test.

For now this can still be tested but what we could use later is an error suppression mechanism. Then we'd be able to test the actual thing we fixed.