### PR TITLE
[XLib] Get Primary Monitor Display Size like Windows/SDL

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -192,9 +192,39 @@ void handleInput() {
 
 }  // namespace enigma
 
+static inline int getScreenSize(int *w, int*h) {
+  Display* pdsp = NULL;
+  Screen* pscr = NULL;
+
+  pdsp = XOpenDisplay(NULL);
+  if (!pdsp) {
+    return -1;
+  }
+
+  pscr = DefaultScreenOfDisplay(pdsp);
+  if (!pscr) {
+    return -2;
+  }
+
+  *w = pscr->width;
+  *h = pscr->height;
+
+  XCloseDisplay(pdsp);
+  return 0;
+}
+
 namespace enigma_user {
 
-int display_get_width() { return XWidthOfScreen(enigma::x11::screen); }
-int display_get_height() { return XHeightOfScreen(enigma::x11::screen); }
+int display_get_width() {
+  int w, h;
+  getScreenSize(&w, &h);
+  return w;
+}
+
+int display_get_height() {
+  int w, h;
+  getScreenSize(&w, &h);
+  return h;
+}
 
 }  // namespace enigma_user


### PR DESCRIPTION
Just doing what the other platforms already do for consistency's sake. Will add optional enum argument to measure all monitors combined in a different pr. I need @JoshDreamland to test this on his monitors.
`draw_text(32, 32, string(display_get_width()) + "x" + string(display_get_height()));`
![Screenshot_20190721_061318](https://user-images.githubusercontent.com/4379204/61589896-a856ca80-ab7e-11e9-8c26-f7af13fa5afc.png)