### PR TITLE
Win32 Mouse Capture

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -223,12 +223,12 @@ namespace enigma
          hdeltadelta %= WHEEL_DELTA;
          return 0;
 
-      case WM_LBUTTONUP:   mousestatus[0]=0; return 0;
-      case WM_LBUTTONDOWN: mousestatus[0]=1; return 0;
-      case WM_RBUTTONUP:   mousestatus[1]=0; return 0;
-      case WM_RBUTTONDOWN: mousestatus[1]=1; return 0;
-      case WM_MBUTTONUP:   mousestatus[2]=0; return 0;
-      case WM_MBUTTONDOWN: mousestatus[2]=1; return 0;
+      case WM_LBUTTONUP:   ReleaseCapture(); mousestatus[0]=0; return 0;
+      case WM_LBUTTONDOWN: SetCapture(hWnd); mousestatus[0]=1; return 0;
+      case WM_RBUTTONUP:   ReleaseCapture(); mousestatus[1]=0; return 0;
+      case WM_RBUTTONDOWN: SetCapture(hWnd); mousestatus[1]=1; return 0;
+      case WM_MBUTTONUP:   ReleaseCapture(); mousestatus[2]=0; return 0;
+      case WM_MBUTTONDOWN: SetCapture(hWnd); mousestatus[2]=1; return 0;
 
       case WM_ERASEBKGND:
         RECT rc;


### PR DESCRIPTION
This pull request fixes #1823 and allows mouse release to be correctly detected outside the window. My testing indicates this is exactly what GM8.1 and GMSv1.4 do when receiving mouse down events. They capture the mouse until receiving a mouse release event.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setcapture

It seems there may be a minor anomaly yet though. While this is better, it's not perfect. Sometimes we don't detect a mouse down when switching to an ENIGMA game, while GM _always_ does. Perhaps this is a timing difference between ENIGMA and GM.