### PR TITLE
SDL Mouse Capture

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
@@ -245,6 +245,7 @@ void SDL_Event_Handler::textInput(const SDL_Event *event) {
 void SDL_Event_Handler::mouseButtonDown(const SDL_Event *event) {
   int btn = SDL_map_button_enum(event->button.button);
   if (btn < 0) return;
+  SDL_CaptureMouse(SDL_TRUE);
   enigma::last_mousestatus[btn] = enigma::mousestatus[btn];
   enigma::mousestatus[btn] = true;
 }
@@ -252,6 +253,7 @@ void SDL_Event_Handler::mouseButtonDown(const SDL_Event *event) {
 void SDL_Event_Handler::mouseButtonUp(const SDL_Event *event) {
   int btn = SDL_map_button_enum(event->button.button);
   if (btn < 0) return;
+  SDL_CaptureMouse(SDL_FALSE);
   enigma::last_mousestatus[btn] = enigma::mousestatus[btn];
   enigma::mousestatus[btn] = false;
 }


### PR DESCRIPTION
This pull request is a friend of #1824 that attempts to fix #1823 for the SDL platform. While this pull request improves the compatibility, there is still a difference in behavior from GMSv1.4 and GM8.1. That is that a mouse button press is not detected when switching focus from another Window to an ENIGMA game. That's not a regression, because it's not recognized on master either. So, I wonder what else it is that we are doing differently.

https://wiki.libsdl.org/SDL_CaptureMouse

I tried capturing also in mouse enter/leave and window focus gain/lost events, but that didn't seem to help. So, this is just like the other pull request, while it's better, it's still not perfect.