### PR TITLE
[XLib] Add Setting Window Min/Max, Fix Sizeable [Win32] Fix Maximize

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -22,7 +22,6 @@ int parameterc;
 int frames_count = 0;
 unsigned long current_time_mcs = 0;
 bool game_window_focused = true;
-bool initGame;
 
 int gameWait() {
   if (enigma_user::os_is_paused()) {
@@ -48,8 +47,6 @@ void set_program_args(int argc, char** argv) {
 }
 
 int enigma_main(int argc, char** argv) {
-  enigma::initGame = false;
-
   // Initialize directory globals
   initialize_directory_globals();
 

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -2,6 +2,7 @@
 
 #include "PFwindow.h"
 #include "PFsystem.h"
+#include "Graphics_Systems/graphics_mandatory.h"
 #include "Platforms/platforms_mandatory.h"
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Universal_System/roomsystem.h"
@@ -47,6 +48,9 @@ void initGame(unsigned started) {
     enigma_user::window_center();
     // required for global game setting fullscreen window
     enigma_user::window_set_fullscreen(isFullScreen);
+    // required for Draw GUI event
+    enigma_user::screen_init();
+    enigma_user::screen_refresh();
   }
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -23,14 +23,12 @@ int frames_count = 0;
 unsigned long current_time_mcs = 0;
 bool game_window_focused = true;
 
-void initGame(int step, bool sizeable, bool border, bool fullscreen) {
-  if (step < 15) {
-    enigma_user::window_set_sizeable(sizeable);
-    enigma_user::window_set_showborder(border);
-    enigma_user::window_set_fullscreen(fullscreen);
-    enigma_user::window_set_size(windowWidth, windowHeight);
-    enigma_user::window_center();
-  }
+void initGame() {
+  enigma_user::window_set_sizeable(isSizeable);
+  enigma_user::window_set_showborder(showBorder);
+  enigma_user::window_set_fullscreen(isFullScreen);
+  enigma_user::window_set_size(windowWidth, windowHeight);
+  enigma_user::window_center();
 }
 
 int gameWait() {
@@ -75,15 +73,11 @@ int enigma_main(int argc, char** argv) {
 
   // Call ENIGMA system initializers; sprites, audio, and what have you
   initialize_everything();
-  
-  int step = 0;
-  bool initSizeable = isSizeable;
-  bool initBorder = showBorder;
-  bool initFullScreen = isFullScreen;
 
+  unsigned step = 0;
   while (!game_isending) {
     if (step < 15) {
-      initGame(step, initSizeable, initBorder, initFullScreen);
+      initGame();
       step++;
     }
 

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -26,22 +26,14 @@ bool game_window_focused = true;
 void initGame(int step, bool sizeable, bool border, bool fullscreen) {
   // allow time for game to open for measuring titlebar
   // and border to calculate proper window positioning.
-  if (step == 2) {
-    // center window at start up
+  if (step < 15) {
     enigma_user::window_center();
-  } else if (step > 2 && step < 32) { // apply defaults
-    // required for global game setting resizeable window
     enigma_user::window_set_sizeable(false);
-    // required for global game setting borderless window
     enigma_user::window_set_showborder(true);
-    // required for global game setting fullscreen window
     enigma_user::window_set_fullscreen(false);
-  } else if (step == 32) { // apply global game settings
-    // required for global game setting resizeable window
+  } else if (step == 15) {
     enigma_user::window_set_sizeable(sizeable);
-    // required for global game setting borderless window
     enigma_user::window_set_showborder(border);
-    // required for global game setting fullscreen window
     enigma_user::window_set_fullscreen(fullscreen);
   }
 }
@@ -95,8 +87,10 @@ int enigma_main(int argc, char** argv) {
   bool initFullScreen = isFullScreen;
 
   while (!game_isending) {
-    initGame(step, initSizeable, initBorder, initFullScreen); 
-    if (step < 33) step++; // Jesus died at age 33.
+    if (step < 16) {
+      initGame(step, initSizeable, initBorder, initFullScreen);
+      step++;
+    }
 
     if (!((std::string)enigma_user::room_caption).empty())
       enigma_user::window_set_caption(enigma_user::room_caption);

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -23,19 +23,26 @@ int frames_count = 0;
 unsigned long current_time_mcs = 0;
 bool game_window_focused = true;
 
-void initGame(unsigned step) {
+void initGame(int step, bool sizeable, bool border, bool fullscreen) {
   // allow time for game to open for measuring titlebar
   // and border to calculate proper window positioning.
   if (step == 2) {
     // center window at start up
     enigma_user::window_center();
-  } else if (step == 10) {
+  } else if (step > 2 && step < 32) { // apply defaults
     // required for global game setting resizeable window
-    enigma_user::window_set_sizeable(isSizeable);
+    enigma_user::window_set_sizeable(false);
     // required for global game setting borderless window
-    enigma_user::window_set_showborder(showBorder);
+    enigma_user::window_set_showborder(true);
     // required for global game setting fullscreen window
-    enigma_user::window_set_fullscreen(isFullScreen);
+    enigma_user::window_set_fullscreen(false);
+  } else if (step == 32) { // apply global game settings
+    // required for global game setting resizeable window
+    enigma_user::window_set_sizeable(sizeable);
+    // required for global game setting borderless window
+    enigma_user::window_set_showborder(border);
+    // required for global game setting fullscreen window
+    enigma_user::window_set_fullscreen(fullscreen);
   }
 }
 
@@ -81,11 +88,15 @@ int enigma_main(int argc, char** argv) {
 
   // Call ENIGMA system initializers; sprites, audio, and what have you
   initialize_everything();
+  
+  int step = 0;
+  bool initSizeable = isSizeable;
+  bool initBorder = showBorder;
+  bool initFullScreen = isFullScreen;
 
-  unsigned step = 0;
   while (!game_isending) {
-    initGame(step); 
-    if (step < 11) step++;
+    initGame(step, initSizeable, initBorder, initFullScreen); 
+    if (step < 33) step++; // Jesus died at age 33.
 
     if (!((std::string)enigma_user::room_caption).empty())
       enigma_user::window_set_caption(enigma_user::room_caption);

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -26,7 +26,10 @@ bool game_window_focused = true;
 void initGame(unsigned step) {
   // allow time for game to open for measuring titlebar
   // and border to calculate proper window positioning.
-  if (step == 10) {
+  if (step == 2) {
+    // center window at start up
+    enigma_user::window_center();
+  } else if (step == 10) {
     // required for global game setting resizeable window
     enigma_user::window_set_sizeable(isSizeable);
     // required for global game setting borderless window

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -24,17 +24,12 @@ unsigned long current_time_mcs = 0;
 bool game_window_focused = true;
 
 void initGame(int step, bool sizeable, bool border, bool fullscreen) {
-  // allow time for game to open for measuring titlebar
-  // and border to calculate proper window positioning.
   if (step < 15) {
-    enigma_user::window_center();
-    enigma_user::window_set_sizeable(false);
-    enigma_user::window_set_showborder(true);
-    enigma_user::window_set_fullscreen(false);
-  } else if (step == 15) {
     enigma_user::window_set_sizeable(sizeable);
     enigma_user::window_set_showborder(border);
     enigma_user::window_set_fullscreen(fullscreen);
+    enigma_user::window_set_size(windowWidth, windowHeight);
+    enigma_user::window_center();
   }
 }
 
@@ -87,7 +82,7 @@ int enigma_main(int argc, char** argv) {
   bool initFullScreen = isFullScreen;
 
   while (!game_isending) {
-    if (step < 16) {
+    if (step < 15) {
       initGame(step, initSizeable, initBorder, initFullScreen);
       step++;
     }

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -2,7 +2,6 @@
 
 #include "PFwindow.h"
 #include "PFsystem.h"
-#include "Graphics_Systems/graphics_mandatory.h"
 #include "Platforms/platforms_mandatory.h"
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Universal_System/roomsystem.h"
@@ -24,33 +23,16 @@ int frames_count = 0;
 unsigned long current_time_mcs = 0;
 bool game_window_focused = true;
 
-void initGame(unsigned started) {
-  // game window will become visible at step zero when splash screen is turned
-  // on, and there will be a briefly running call to enigma_user::sleep(), and
-  // if splash is turned off, wait until step two to become visible w/o sleep.
-  // this is the exact behavior of GameMaker Studio. since this is executed at
-  // a time that is after rooms and views init, the window will be sized right
-  if (started == 2) {
-    // In pull request 1831, it was decided to adopt GMS behavior instead of GM8.
-    // The window is no longer moved, centered, or resized when switching rooms.
-    // This is always true, even if the room sizes are different.
-    enigma_user::window_default(false);
-    // window sized by first room, can make visible now
-    enigma_user::window_set_visible(true);
-    // allow time for game to open for measuring titlebar
-    // and border to calculate proper window positioning.
-  } else if (started == 10) {
+void initGame(unsigned step) {
+  // allow time for game to open for measuring titlebar
+  // and border to calculate proper window positioning.
+  if (step == 10) {
     // required for global game setting resizeable window
     enigma_user::window_set_sizeable(isSizeable);
     // required for global game setting borderless window
     enigma_user::window_set_showborder(showBorder);
-    // don't ask me why this is necessary, but it 100% is
-    enigma_user::window_center();
     // required for global game setting fullscreen window
     enigma_user::window_set_fullscreen(isFullScreen);
-    // required for Draw GUI event
-    enigma_user::screen_init();
-    enigma_user::screen_refresh();
   }
 }
 
@@ -97,10 +79,10 @@ int enigma_main(int argc, char** argv) {
   // Call ENIGMA system initializers; sprites, audio, and what have you
   initialize_everything();
 
-  unsigned started = 0;
+  unsigned step = 0;
   while (!game_isending) {
-    initGame(started); 
-    if (started < 11) started++;
+    initGame(step); 
+    if (step < 11) step++;
 
     if (!((std::string)enigma_user::room_caption).empty())
       enigma_user::window_set_caption(enigma_user::room_caption);

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -1,4 +1,4 @@
-#include "PFmain.h" 
+#include "PFmain.h"
 
 #include "PFwindow.h"
 #include "PFsystem.h"

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -1,4 +1,4 @@
-#include "PFmain.h"
+#include "PFmain.h" 
 
 #include "PFwindow.h"
 #include "PFsystem.h"

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -31,7 +31,6 @@ namespace enigma {
   extern int frames_count;
   extern unsigned long current_time_mcs;
   extern bool game_window_focused;
-  extern bool initGame;
 
   int enigma_main(int argc, char** argv);
   int game_ending();

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -18,271 +18,254 @@
 
 #include <map>
 #include <string>
-using std::map;
 using std::string;
+using std::map;
 #include <windows.h>
 //#include <winuser.h> // includes windows.h
 
-#include "Platforms/General/PFmain.h"    // for keyboard_string
-#include "Platforms/General/PFwindow.h"  // For those damn vk_ constants.
-#include "Universal_System/Instances/instance.h"
+#include "Platforms/General/PFmain.h" // for keyboard_string
+#include "Platforms/General/PFwindow.h" // For those damn vk_ constants.
 #include "Universal_System/Instances/instance_system.h"
+#include "Universal_System/Instances/instance.h"
 
 #include "Platforms/platforms_mandatory.h"
 
 #ifndef WM_MOUSEHWHEEL
-#define WM_MOUSEHWHEEL 0x020E
+  #define WM_MOUSEHWHEEL 0x020E
 #endif
 
 namespace enigma_user {
 void draw_clear(int col);
 void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height);
-}  // namespace enigma_user
+} // namespace enigma_user
 
-namespace enigma {
-extern HWND hWnd;
-extern HDC window_hDC;
+namespace enigma
+{
+  extern HWND hWnd;
+  extern HDC window_hDC;
 
-using enigma_user::keyboard_key;
-using enigma_user::keyboard_lastchar;
-using enigma_user::keyboard_lastkey;
-using enigma_user::keyboard_string;
+  using enigma_user::keyboard_key;
+  using enigma_user::keyboard_lastkey;
+  using enigma_user::keyboard_lastchar;
+  using enigma_user::keyboard_string;
 
-extern char mousestatus[3], last_mousestatus[3], keybdstatus[256], last_keybdstatus[256];
-extern int windowX, windowY, windowColor;
-extern HCURSOR currentCursor;
+  extern char mousestatus[3],last_mousestatus[3],keybdstatus[256],last_keybdstatus[256];
+  extern int windowX, windowY, windowColor;
+  extern HCURSOR currentCursor;
 
-static RECT tempWindow;
-static short hdeltadelta = 0, vdeltadelta = 0;
-static int tempLeft = 0, tempTop = 0, tempRight = 0, tempBottom = 0, tempWidth, tempHeight;
+  static RECT tempWindow;
+  static short hdeltadelta = 0, vdeltadelta = 0;
+  static int tempLeft = 0, tempTop = 0, tempRight = 0, tempBottom = 0, tempWidth, tempHeight;
 
-LRESULT(CALLBACK *touch_extension_callback)(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam);
-void (*WindowResizedCallback)();
+  LRESULT (CALLBACK *touch_extension_callback)(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam);
+  void (*WindowResizedCallback)();
 
-LRESULT CALLBACK WndProc(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam) {
-  switch (message) {
-    case WM_CREATE:
-      return 0;
-    case WM_SHOWWINDOW:
-      enigma::windowWidth = enigma_user::window_get_width();
-      enigma::windowHeight = enigma_user::window_get_height();
-      enigma::compute_window_scaling();
-      return 0;
-    case WM_CLOSE:
-      instance_event_iterator = &dummy_event_iterator;
-      for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
-        it->myevent_closebutton();
-      }
-      // Game Maker actually checks this first I am making the decision to check if after, since that is how it is expected to work
-      // so the user can execute something before the escape is processed, no sense in an override if user is going to call game_end() anyway.
-      // - Robert
-      if (treatCloseAsEscape) {
-        PostQuitMessage(0);
-      }
-      return 0;
-
-    case WM_DESTROY:
-      return 0;
-
-    case WM_SETFOCUS:
-      input_initialize();
-      game_window_focused = true;
-      pausedSteps = 0;
-      return 0;
-
-    case WM_KILLFOCUS:
-      for (int i = 0; i < 255; i++) {
-        last_keybdstatus[i] = keybdstatus[i];
-        keybdstatus[i] = 0;
-      }
-      for (int i = 0; i < 3; i++) {
-        last_mousestatus[i] = mousestatus[i];
-        mousestatus[i] = 0;
-      }
-      game_window_focused = false;
-      return 0;
-
-    case WM_SIZE:
-      // make sure window resized is only processed once per resize because there could possibly be child windows and handles, especially with widgets
-      if (hWndParameter == hWnd) {
-        if (WindowResizedCallback != NULL) {
-          WindowResizedCallback();
-          windowWidth = enigma_user::window_get_width();
-          windowHeight = enigma_user::window_get_height();
-          enigma::compute_window_scaling();
-        }
+  LRESULT CALLBACK WndProc (HWND hWndParameter, UINT message,WPARAM wParam, LPARAM lParam)
+  {
+    switch (message)
+    {
+      case WM_CREATE:
+        return 0;
+      case WM_SHOWWINDOW:
+        enigma::windowWidth = enigma_user::window_get_width();
+        enigma::windowHeight = enigma_user::window_get_height();
+        enigma::compute_window_scaling();
+        return 0;
+      case WM_CLOSE:
         instance_event_iterator = &dummy_event_iterator;
-        for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
-          ((object_graphics *)*it)->myevent_drawresize();
+        for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
+        {
+          it->myevent_closebutton();
         }
-      } else {
+        // Game Maker actually checks this first I am making the decision to check if after, since that is how it is expected to work
+        // so the user can execute something before the escape is processed, no sense in an override if user is going to call game_end() anyway.
+        // - Robert
+        if (treatCloseAsEscape) {
+          PostQuitMessage (0);
+        }
+        return 0;
+
+      case WM_DESTROY:
+        return 0;
+
+      case WM_SETFOCUS:
+        input_initialize();
+        game_window_focused = true;
+        pausedSteps = 0;
+        return 0;
+
+      case WM_KILLFOCUS:
+        for (int i = 0; i < 255; i++)
+        {
+            last_keybdstatus[i] = keybdstatus[i];
+            keybdstatus[i] = 0;
+        }
+        for(int i=0; i < 3; i++)
+        {
+            last_mousestatus[i] = mousestatus[i];
+            mousestatus[i] = 0;
+        }
+        game_window_focused = false;
+        return 0;
+
+      case WM_SIZE:
+        // make sure window resized is only processed once per resize because there could possibly be child windows and handles, especially with widgets
+        if (hWndParameter == hWnd) {
+          if (WindowResizedCallback != NULL) {
+            WindowResizedCallback();
+          }
+          instance_event_iterator = &dummy_event_iterator;
+          for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
+          {
+            ((object_graphics*)*it)->myevent_drawresize();
+          }
+        } else {
+          DefWindowProc(hWndParameter, message, wParam, lParam);
+        }
+        return 0;
+
+      case WM_ENTERSIZEMOVE:
+        GetWindowRect(hWndParameter,&tempWindow);
+        tempLeft = tempWindow.left;
+        tempTop = tempWindow.top;
+        tempRight = tempWindow.right;
+        tempBottom = tempWindow.bottom;
+        return 0;
+
+      case WM_EXITSIZEMOVE:
+        GetWindowRect(hWndParameter,&tempWindow);
+        tempWidth = windowWidth + (tempWindow.right - tempWindow.left) - (tempRight - tempLeft);
+        tempHeight = windowHeight + (tempWindow.bottom - tempWindow.top) - (tempBottom - tempTop);
+
+        windowX += tempWindow.left - tempLeft;
+        windowY += tempWindow.top - tempTop;
+        windowWidth = tempWidth;
+        windowHeight = tempHeight;
+        enigma::windowWidth = enigma_user::window_get_width();
+        enigma::windowHeight = enigma_user::window_get_height();
+        enigma::compute_window_scaling();
+        return 0;
+
+      case WM_GETMINMAXINFO: {
+        if (viewScale > 0) { //Fixed Scale, this is GM8.1 behaviour
+          RECT c;
+          c.left = 0; c.top = 0; c.right = scaledWidth; c.bottom = scaledHeight;
+          AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE), false);
+
+          LPMINMAXINFO lpMinMaxInfo = (LPMINMAXINFO) lParam;
+          lpMinMaxInfo->ptMinTrackSize.x = c.right-c.left;
+          lpMinMaxInfo->ptMinTrackSize.y = c.bottom-c.top;
+        }
+        break;
+      }
+
+      case WM_SETCURSOR:
+        // Set the user cursor if the mouse is in the client area of the window, otherwise let Windows handle setting the cursor
+        // since it knows how to set the gripper cursor for window resizing. This is exactly how GM handles it.
+        if (LOWORD(lParam) == HTCLIENT) {
+          SetCursor(currentCursor);
+          return TRUE;
+        }
+        break;
+      case WM_CHAR:
+        keyboard_lastchar = string(1,wParam);
+        if (keyboard_lastkey == enigma_user::vk_backspace) {
+          if (!keyboard_string.empty()) keyboard_string.pop_back();
+        } else {
+          keyboard_string += keyboard_lastchar;
+        }
+        return 0;
+
+      case WM_KEYDOWN: {
+        int key = enigma_user::keyboard_get_map(wParam);
+        keyboard_lastkey = key;
+        keyboard_key = key;
+        last_keybdstatus[key]=keybdstatus[key];
+        keybdstatus[key]=1;
+        return 0;
+      }
+      case WM_KEYUP: {
+        int key = enigma_user::keyboard_get_map(wParam);
+        keyboard_key = 0;
+        last_keybdstatus[key]=keybdstatus[key];
+        keybdstatus[key]=0;
+        return 0;
+      }
+      case WM_SYSKEYDOWN: {
+        int key = enigma_user::keyboard_get_map(wParam);
+        keyboard_lastkey = key;
+        keyboard_key = key;
+        last_keybdstatus[key]=keybdstatus[key];
+        keybdstatus[key]=1;
+        if (key!=18)
+        {
+          if ((lParam&(1<<29))>0)
+               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
+          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
+        }
+        return 0;
+      }
+      case WM_SYSKEYUP: {
+        int key = enigma_user::keyboard_get_map(wParam);
+        keyboard_key = 0;
+        last_keybdstatus[key]=keybdstatus[key];
+        keybdstatus[key]=0;
+        if (key!=(unsigned int)18)
+        {
+          if ((lParam&(1<<29))>0)
+               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
+          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
+        }
+        return 0;
+      }
+      case WM_MOUSEWHEEL:
+         vdeltadelta += (int)HIWORD(wParam);
+         enigma_user::mouse_vscrolls += vdeltadelta / WHEEL_DELTA;
+         vdeltadelta %= WHEEL_DELTA;
+         return 0;
+
+      case WM_MOUSEHWHEEL:
+         hdeltadelta += (int)HIWORD(wParam);
+         enigma_user::mouse_hscrolls += hdeltadelta / WHEEL_DELTA;
+         hdeltadelta %= WHEEL_DELTA;
+         return 0;
+
+      case WM_LBUTTONUP:   ReleaseCapture(); mousestatus[0]=0; return 0;
+      case WM_LBUTTONDOWN: SetCapture(hWnd); mousestatus[0]=1; return 0;
+      case WM_RBUTTONUP:   ReleaseCapture(); mousestatus[1]=0; return 0;
+      case WM_RBUTTONDOWN: SetCapture(hWnd); mousestatus[1]=1; return 0;
+      case WM_MBUTTONUP:   ReleaseCapture(); mousestatus[2]=0; return 0;
+      case WM_MBUTTONDOWN: SetCapture(hWnd); mousestatus[2]=1; return 0;
+
+      case WM_ERASEBKGND:
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+        FillRect((HDC) wParam, &rc, CreateSolidBrush(windowColor));
+        return 1L;
+
+      case WM_PAINT:
         DefWindowProc(hWndParameter, message, wParam, lParam);
+        return 0;
+
+      case WM_SYSCOMMAND: {
+        if (wParam == SC_MAXIMIZE) {
+          ShowWindow(hWnd, SW_MAXIMIZE);
+          enigma::windowWidth = enigma_user::window_get_width();
+          enigma::windowHeight = enigma_user::window_get_height();
+          enigma::compute_window_scaling();
+          break;
+        } else if (wParam == SC_RESTORE) {
+          ShowWindow(hWnd, SW_RESTORE);
+          enigma::windowWidth = enigma_user::window_get_width();
+          enigma::windowHeight = enigma_user::window_get_height();
+          enigma::compute_window_scaling();
+          break;
+        } else {
+          return DefWindowProc(hWndParameter, message, wParam, lParam);
+        }
+        return 0;
       }
-      return 0;
-
-    case WM_ENTERSIZEMOVE:
-      GetWindowRect(hWndParameter, &tempWindow);
-      tempLeft = tempWindow.left;
-      tempTop = tempWindow.top;
-      tempRight = tempWindow.right;
-      tempBottom = tempWindow.bottom;
-      return 0;
-
-    case WM_EXITSIZEMOVE:
-      GetWindowRect(hWndParameter, &tempWindow);
-      tempWidth = windowWidth + (tempWindow.right - tempWindow.left) - (tempRight - tempLeft);
-      tempHeight = windowHeight + (tempWindow.bottom - tempWindow.top) - (tempBottom - tempTop);
-
-      windowX += tempWindow.left - tempLeft;
-      windowY += tempWindow.top - tempTop;
-      windowWidth = tempWidth;
-      windowHeight = tempHeight;
-      enigma::windowWidth = enigma_user::window_get_width();
-      enigma::windowHeight = enigma_user::window_get_height();
-      enigma::compute_window_scaling();
-      return 0;
-
-    case WM_GETMINMAXINFO: {
-      if (viewScale > 0) {  //Fixed Scale, this is GM8.1 behaviour
-        RECT c;
-        c.left = 0;
-        c.top = 0;
-        c.right = scaledWidth;
-        c.bottom = scaledHeight;
-        AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE), false);
-
-        LPMINMAXINFO lpMinMaxInfo = (LPMINMAXINFO)lParam;
-        lpMinMaxInfo->ptMinTrackSize.x = c.right - c.left;
-        lpMinMaxInfo->ptMinTrackSize.y = c.bottom - c.top;
-      }
-      break;
     }
-
-    case WM_SETCURSOR:
-      // Set the user cursor if the mouse is in the client area of the window, otherwise let Windows handle setting the cursor
-      // since it knows how to set the gripper cursor for window resizing. This is exactly how GM handles it.
-      if (LOWORD(lParam) == HTCLIENT) {
-        SetCursor(currentCursor);
-        return TRUE;
-      }
-      break;
-    case WM_CHAR:
-      keyboard_lastchar = string(1, wParam);
-      if (keyboard_lastkey == enigma_user::vk_backspace) {
-        if (!keyboard_string.empty()) keyboard_string.pop_back();
-      } else {
-        keyboard_string += keyboard_lastchar;
-      }
-      return 0;
-
-    case WM_KEYDOWN: {
-      int key = enigma_user::keyboard_get_map(wParam);
-      keyboard_lastkey = key;
-      keyboard_key = key;
-      last_keybdstatus[key] = keybdstatus[key];
-      keybdstatus[key] = 1;
-      return 0;
-    }
-    case WM_KEYUP: {
-      int key = enigma_user::keyboard_get_map(wParam);
-      keyboard_key = 0;
-      last_keybdstatus[key] = keybdstatus[key];
-      keybdstatus[key] = 0;
-      return 0;
-    }
-    case WM_SYSKEYDOWN: {
-      int key = enigma_user::keyboard_get_map(wParam);
-      keyboard_lastkey = key;
-      keyboard_key = key;
-      last_keybdstatus[key] = keybdstatus[key];
-      keybdstatus[key] = 1;
-      if (key != 18) {
-        if ((lParam & (1 << 29)) > 0)
-          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 1;
-        else
-          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 0;
-      }
-      return 0;
-    }
-    case WM_SYSKEYUP: {
-      int key = enigma_user::keyboard_get_map(wParam);
-      keyboard_key = 0;
-      last_keybdstatus[key] = keybdstatus[key];
-      keybdstatus[key] = 0;
-      if (key != (unsigned int)18) {
-        if ((lParam & (1 << 29)) > 0)
-          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 0;
-        else
-          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 1;
-      }
-      return 0;
-    }
-    case WM_MOUSEWHEEL:
-      vdeltadelta += (int)HIWORD(wParam);
-      enigma_user::mouse_vscrolls += vdeltadelta / WHEEL_DELTA;
-      vdeltadelta %= WHEEL_DELTA;
-      return 0;
-
-    case WM_MOUSEHWHEEL:
-      hdeltadelta += (int)HIWORD(wParam);
-      enigma_user::mouse_hscrolls += hdeltadelta / WHEEL_DELTA;
-      hdeltadelta %= WHEEL_DELTA;
-      return 0;
-
-    case WM_LBUTTONUP:
-      ReleaseCapture();
-      mousestatus[0] = 0;
-      return 0;
-    case WM_LBUTTONDOWN:
-      SetCapture(hWnd);
-      mousestatus[0] = 1;
-      return 0;
-    case WM_RBUTTONUP:
-      ReleaseCapture();
-      mousestatus[1] = 0;
-      return 0;
-    case WM_RBUTTONDOWN:
-      SetCapture(hWnd);
-      mousestatus[1] = 1;
-      return 0;
-    case WM_MBUTTONUP:
-      ReleaseCapture();
-      mousestatus[2] = 0;
-      return 0;
-    case WM_MBUTTONDOWN:
-      SetCapture(hWnd);
-      mousestatus[2] = 1;
-      return 0;
-
-    case WM_ERASEBKGND:
-      RECT rc;
-      GetClientRect(hWnd, &rc);
-      FillRect((HDC)wParam, &rc, CreateSolidBrush(windowColor));
-      return 1L;
-
-    case WM_PAINT:
-      DefWindowProc(hWndParameter, message, wParam, lParam);
-      return 0;
-
-    case WM_SYSCOMMAND: {
-      if (wParam == SC_MAXIMIZE) {
-        ShowWindow(hWnd, SW_MAXIMIZE);
-        enigma::windowWidth = enigma_user::window_get_width();
-        enigma::windowHeight = enigma_user::window_get_height();
-        enigma::compute_window_scaling();
-        break;
-      } else if (wParam == SC_RESTORE) {
-        ShowWindow(hWnd, SW_RESTORE);
-        enigma::windowWidth = enigma_user::window_get_width();
-        enigma::windowHeight = enigma_user::window_get_height();
-        enigma::compute_window_scaling();
-        break;
-      } else {
-        return DefWindowProc(hWndParameter, message, wParam, lParam);
-      }
-      return 0;
-    }
+    return DefWindowProc (hWndParameter, message, wParam, lParam);
   }
-  return DefWindowProc(hWndParameter, message, wParam, lParam);
 }
-}  // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -257,12 +257,6 @@ namespace enigma
           enigma::windowHeight = enigma_user::window_get_height();
           enigma::compute_window_scaling();
           break;
-        } else if (wParam == SC_RESTORE) {
-          ShowWindow(hWnd, SW_RESTORE);
-          enigma::windowWidth = enigma_user::window_get_width();
-          enigma::windowHeight = enigma_user::window_get_height();
-          enigma::compute_window_scaling();
-          break;
         } else {
           return DefWindowProc(hWndParameter, message, wParam, lParam);
         }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -263,7 +263,8 @@ namespace enigma
         } else {
           return DefWindowProc(hWndParameter, message, wParam, lParam);
         }
-		return 0;
+        return 0;
+      }
     }
     return DefWindowProc (hWndParameter, message, wParam, lParam);
   }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -113,6 +113,9 @@ namespace enigma
         if (hWndParameter == hWnd) {
           if (WindowResizedCallback != NULL) {
             WindowResizedCallback();
+            windowWidth = enigma_user::window_get_width();
+            windowHeight = enigma_user::window_get_height();
+            enigma::compute_window_scaling();
           }
           instance_event_iterator = &dummy_event_iterator;
           for (enigma::iterator it = enigma::instance_list_first(); it; ++it)

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -18,268 +18,253 @@
 
 #include <map>
 #include <string>
-using std::map;
 using std::string;
+using std::map;
 #include <windows.h>
 //#include <winuser.h> // includes windows.h
 
-#include "Platforms/General/PFmain.h"    // for keyboard_string
-#include "Platforms/General/PFwindow.h"  // For those damn vk_ constants.
-#include "Universal_System/Instances/instance.h"
+#include "Platforms/General/PFmain.h" // for keyboard_string
+#include "Platforms/General/PFwindow.h" // For those damn vk_ constants.
 #include "Universal_System/Instances/instance_system.h"
+#include "Universal_System/Instances/instance.h"
 
 #include "Platforms/platforms_mandatory.h"
 
 #ifndef WM_MOUSEHWHEEL
-#define WM_MOUSEHWHEEL 0x020E
+  #define WM_MOUSEHWHEEL 0x020E
 #endif
 
 namespace enigma_user {
 void draw_clear(int col);
 void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height);
-}  // namespace enigma_user
+} // namespace enigma_user
 
-namespace enigma {
-extern HWND hWnd;
-extern HDC window_hDC;
+namespace enigma
+{
+  extern HWND hWnd;
+  extern HDC window_hDC;
 
-using enigma_user::keyboard_key;
-using enigma_user::keyboard_lastchar;
-using enigma_user::keyboard_lastkey;
-using enigma_user::keyboard_string;
+  using enigma_user::keyboard_key;
+  using enigma_user::keyboard_lastkey;
+  using enigma_user::keyboard_lastchar;
+  using enigma_user::keyboard_string;
 
-extern char mousestatus[3], last_mousestatus[3], keybdstatus[256], last_keybdstatus[256];
-extern int windowX, windowY, windowColor;
-extern HCURSOR currentCursor;
+  extern char mousestatus[3],last_mousestatus[3],keybdstatus[256],last_keybdstatus[256];
+  extern int windowX, windowY, windowColor;
+  extern HCURSOR currentCursor;
 
-static RECT tempWindow;
-static short hdeltadelta = 0, vdeltadelta = 0;
-static int tempLeft = 0, tempTop = 0, tempRight = 0, tempBottom = 0, tempWidth, tempHeight;
+  static RECT tempWindow;
+  static short hdeltadelta = 0, vdeltadelta = 0;
+  static int tempLeft = 0, tempTop = 0, tempRight = 0, tempBottom = 0, tempWidth, tempHeight;
 
-LRESULT(CALLBACK *touch_extension_callback)(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam);
-void (*WindowResizedCallback)();
+  LRESULT (CALLBACK *touch_extension_callback)(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam);
+  void (*WindowResizedCallback)();
 
-LRESULT CALLBACK WndProc(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam) {
-  switch (message) {
-    case WM_CREATE:
-      return 0;
-    case WM_SHOWWINDOW:
-      enigma::windowWidth = enigma_user::window_get_width();
-      enigma::windowHeight = enigma_user::window_get_height();
-      enigma::compute_window_scaling();
-      return 0;
-    case WM_CLOSE:
-      instance_event_iterator = &dummy_event_iterator;
-      for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
-        it->myevent_closebutton();
-      }
-      // Game Maker actually checks this first I am making the decision to check if after, since that is how it is expected to work
-      // so the user can execute something before the escape is processed, no sense in an override if user is going to call game_end() anyway.
-      // - Robert
-      if (treatCloseAsEscape) {
-        PostQuitMessage(0);
-      }
-      return 0;
-
-    case WM_DESTROY:
-      return 0;
-
-    case WM_SETFOCUS:
-      input_initialize();
-      game_window_focused = true;
-      pausedSteps = 0;
-      return 0;
-
-    case WM_KILLFOCUS:
-      for (int i = 0; i < 255; i++) {
-        last_keybdstatus[i] = keybdstatus[i];
-        keybdstatus[i] = 0;
-      }
-      for (int i = 0; i < 3; i++) {
-        last_mousestatus[i] = mousestatus[i];
-        mousestatus[i] = 0;
-      }
-      game_window_focused = false;
-      return 0;
-
-    case WM_SIZE:
-      // make sure window resized is only processed once per resize because there could possibly be child windows and handles, especially with widgets
-      if (hWndParameter == hWnd) {
-        if (WindowResizedCallback != NULL) {
-          WindowResizedCallback();
-        }
+  LRESULT CALLBACK WndProc (HWND hWndParameter, UINT message,WPARAM wParam, LPARAM lParam)
+  {
+    switch (message)
+    {
+      case WM_CREATE:
+        return 0;
+      case WM_SHOWWINDOW:
+        enigma::windowWidth = enigma_user::window_get_width();
+        enigma::windowHeight = enigma_user::window_get_height();
+        enigma::compute_window_scaling();
+        return 0;
+      case WM_CLOSE:
         instance_event_iterator = &dummy_event_iterator;
-        for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
-          ((object_graphics *)*it)->myevent_drawresize();
+        for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
+        {
+          it->myevent_closebutton();
         }
-      } else {
+        // Game Maker actually checks this first I am making the decision to check if after, since that is how it is expected to work
+        // so the user can execute something before the escape is processed, no sense in an override if user is going to call game_end() anyway.
+        // - Robert
+        if (treatCloseAsEscape) {
+          PostQuitMessage (0);
+        }
+        return 0;
+
+      case WM_DESTROY:
+        return 0;
+
+      case WM_SETFOCUS:
+        input_initialize();
+        game_window_focused = true;
+        pausedSteps = 0;
+        return 0;
+
+      case WM_KILLFOCUS:
+        for (int i = 0; i < 255; i++)
+        {
+            last_keybdstatus[i] = keybdstatus[i];
+            keybdstatus[i] = 0;
+        }
+        for(int i=0; i < 3; i++)
+        {
+            last_mousestatus[i] = mousestatus[i];
+            mousestatus[i] = 0;
+        }
+        game_window_focused = false;
+        return 0;
+
+      case WM_SIZE:
+        // make sure window resized is only processed once per resize because there could possibly be child windows and handles, especially with widgets
+        if (hWndParameter == hWnd) {
+          if (WindowResizedCallback != NULL) {
+            WindowResizedCallback();
+          }
+          instance_event_iterator = &dummy_event_iterator;
+          for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
+          {
+            ((object_graphics*)*it)->myevent_drawresize();
+          }
+        } else {
+          DefWindowProc(hWndParameter, message, wParam, lParam);
+        }
+        return 0;
+
+      case WM_ENTERSIZEMOVE:
+        GetWindowRect(hWndParameter,&tempWindow);
+        tempLeft = tempWindow.left;
+        tempTop = tempWindow.top;
+        tempRight = tempWindow.right;
+        tempBottom = tempWindow.bottom;
+        return 0;
+
+      case WM_EXITSIZEMOVE:
+        GetWindowRect(hWndParameter,&tempWindow);
+        tempWidth = windowWidth + (tempWindow.right - tempWindow.left) - (tempRight - tempLeft);
+        tempHeight = windowHeight + (tempWindow.bottom - tempWindow.top) - (tempBottom - tempTop);
+
+        windowX += tempWindow.left - tempLeft;
+        windowY += tempWindow.top - tempTop;
+        windowWidth = tempWidth;
+        windowHeight = tempHeight;
+        enigma::windowWidth = enigma_user::window_get_width();
+        enigma::windowHeight = enigma_user::window_get_height();
+        enigma::compute_window_scaling();
+        return 0;
+
+      case WM_GETMINMAXINFO: {
+        if (viewScale > 0) { //Fixed Scale, this is GM8.1 behaviour
+          RECT c;
+          c.left = 0; c.top = 0; c.right = scaledWidth; c.bottom = scaledHeight;
+          AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE), false);
+
+          LPMINMAXINFO lpMinMaxInfo = (LPMINMAXINFO) lParam;
+          lpMinMaxInfo->ptMinTrackSize.x = c.right-c.left;
+          lpMinMaxInfo->ptMinTrackSize.y = c.bottom-c.top;
+        }
+        break;
+      }
+
+      case WM_SETCURSOR:
+        // Set the user cursor if the mouse is in the client area of the window, otherwise let Windows handle setting the cursor
+        // since it knows how to set the gripper cursor for window resizing. This is exactly how GM handles it.
+        if (LOWORD(lParam) == HTCLIENT) {
+          SetCursor(currentCursor);
+          return TRUE;
+        }
+        break;
+      case WM_CHAR:
+        keyboard_lastchar = string(1,wParam);
+        if (keyboard_lastkey == enigma_user::vk_backspace) {
+          if (!keyboard_string.empty()) keyboard_string.pop_back();
+        } else {
+          keyboard_string += keyboard_lastchar;
+        }
+        return 0;
+
+      case WM_KEYDOWN: {
+        int key = enigma_user::keyboard_get_map(wParam);
+        keyboard_lastkey = key;
+        keyboard_key = key;
+        last_keybdstatus[key]=keybdstatus[key];
+        keybdstatus[key]=1;
+        return 0;
+      }
+      case WM_KEYUP: {
+        int key = enigma_user::keyboard_get_map(wParam);
+        keyboard_key = 0;
+        last_keybdstatus[key]=keybdstatus[key];
+        keybdstatus[key]=0;
+        return 0;
+      }
+      case WM_SYSKEYDOWN: {
+        int key = enigma_user::keyboard_get_map(wParam);
+        keyboard_lastkey = key;
+        keyboard_key = key;
+        last_keybdstatus[key]=keybdstatus[key];
+        keybdstatus[key]=1;
+        if (key!=18)
+        {
+          if ((lParam&(1<<29))>0)
+               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
+          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
+        }
+        return 0;
+      }
+      case WM_SYSKEYUP: {
+        int key = enigma_user::keyboard_get_map(wParam);
+        keyboard_key = 0;
+        last_keybdstatus[key]=keybdstatus[key];
+        keybdstatus[key]=0;
+        if (key!=(unsigned int)18)
+        {
+          if ((lParam&(1<<29))>0)
+               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
+          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
+        }
+        return 0;
+      }
+      case WM_MOUSEWHEEL:
+         vdeltadelta += (int)HIWORD(wParam);
+         enigma_user::mouse_vscrolls += vdeltadelta / WHEEL_DELTA;
+         vdeltadelta %= WHEEL_DELTA;
+         return 0;
+
+      case WM_MOUSEHWHEEL:
+         hdeltadelta += (int)HIWORD(wParam);
+         enigma_user::mouse_hscrolls += hdeltadelta / WHEEL_DELTA;
+         hdeltadelta %= WHEEL_DELTA;
+         return 0;
+
+      case WM_LBUTTONUP:   ReleaseCapture(); mousestatus[0]=0; return 0;
+      case WM_LBUTTONDOWN: SetCapture(hWnd); mousestatus[0]=1; return 0;
+      case WM_RBUTTONUP:   ReleaseCapture(); mousestatus[1]=0; return 0;
+      case WM_RBUTTONDOWN: SetCapture(hWnd); mousestatus[1]=1; return 0;
+      case WM_MBUTTONUP:   ReleaseCapture(); mousestatus[2]=0; return 0;
+      case WM_MBUTTONDOWN: SetCapture(hWnd); mousestatus[2]=1; return 0;
+
+      case WM_ERASEBKGND:
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+        FillRect((HDC) wParam, &rc, CreateSolidBrush(windowColor));
+        return 1L;
+
+      case WM_PAINT:
         DefWindowProc(hWndParameter, message, wParam, lParam);
-      }
-      return 0;
+        return 0;
 
-    case WM_ENTERSIZEMOVE:
-      GetWindowRect(hWndParameter, &tempWindow);
-      tempLeft = tempWindow.left;
-      tempTop = tempWindow.top;
-      tempRight = tempWindow.right;
-      tempBottom = tempWindow.bottom;
-      return 0;
-
-    case WM_EXITSIZEMOVE:
-      GetWindowRect(hWndParameter, &tempWindow);
-      tempWidth = windowWidth + (tempWindow.right - tempWindow.left) - (tempRight - tempLeft);
-      tempHeight = windowHeight + (tempWindow.bottom - tempWindow.top) - (tempBottom - tempTop);
-
-      windowX += tempWindow.left - tempLeft;
-      windowY += tempWindow.top - tempTop;
-      windowWidth = tempWidth;
-      windowHeight = tempHeight;
-      enigma::windowWidth = enigma_user::window_get_width();
-      enigma::windowHeight = enigma_user::window_get_height();
-      enigma::compute_window_scaling();
-      return 0;
-
-    case WM_GETMINMAXINFO: {
-      if (viewScale > 0) {  //Fixed Scale, this is GM8.1 behaviour
-        RECT c;
-        c.left = 0;
-        c.top = 0;
-        c.right = scaledWidth;
-        c.bottom = scaledHeight;
-        AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE), false);
-
-        LPMINMAXINFO lpMinMaxInfo = (LPMINMAXINFO)lParam;
-        lpMinMaxInfo->ptMinTrackSize.x = c.right - c.left;
-        lpMinMaxInfo->ptMinTrackSize.y = c.bottom - c.top;
-      }
-      break;
+      case WM_SYSCOMMAND: {
+        if (wParam == SC_MAXIMIZE) {
+          ShowWindow(hWnd, SW_MAXIMIZE);
+          enigma::windowWidth = enigma_user::window_get_width();
+          enigma::windowHeight = enigma_user::window_get_height();
+          enigma::compute_window_scaling();
+          break;
+        } else if (wParam == SC_RESTORE) {
+          ShowWindow(hWnd, SW_RESTORE);
+          enigma::windowWidth = enigma_user::window_get_width();
+          enigma::windowHeight = enigma_user::window_get_height();
+          enigma::compute_window_scaling();
+          break;
+        } else {
+          return DefWindowProc(hWndParameter, message, wParam, lParam);
+        }
+		return 0;
     }
-
-    case WM_SETCURSOR:
-      // Set the user cursor if the mouse is in the client area of the window, otherwise let Windows handle setting the cursor
-      // since it knows how to set the gripper cursor for window resizing. This is exactly how GM handles it.
-      if (LOWORD(lParam) == HTCLIENT) {
-        SetCursor(currentCursor);
-        return TRUE;
-      }
-      break;
-    case WM_CHAR:
-      keyboard_lastchar = string(1, wParam);
-      if (keyboard_lastkey == enigma_user::vk_backspace) {
-        if (!keyboard_string.empty()) keyboard_string.pop_back();
-      } else {
-        keyboard_string += keyboard_lastchar;
-      }
-      return 0;
-
-    case WM_KEYDOWN: {
-      int key = enigma_user::keyboard_get_map(wParam);
-      keyboard_lastkey = key;
-      keyboard_key = key;
-      last_keybdstatus[key] = keybdstatus[key];
-      keybdstatus[key] = 1;
-      return 0;
-    }
-    case WM_KEYUP: {
-      int key = enigma_user::keyboard_get_map(wParam);
-      keyboard_key = 0;
-      last_keybdstatus[key] = keybdstatus[key];
-      keybdstatus[key] = 0;
-      return 0;
-    }
-    case WM_SYSKEYDOWN: {
-      int key = enigma_user::keyboard_get_map(wParam);
-      keyboard_lastkey = key;
-      keyboard_key = key;
-      last_keybdstatus[key] = keybdstatus[key];
-      keybdstatus[key] = 1;
-      if (key != 18) {
-        if ((lParam & (1 << 29)) > 0)
-          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 1;
-        else
-          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 0;
-      }
-      return 0;
-    }
-    case WM_SYSKEYUP: {
-      int key = enigma_user::keyboard_get_map(wParam);
-      keyboard_key = 0;
-      last_keybdstatus[key] = keybdstatus[key];
-      keybdstatus[key] = 0;
-      if (key != (unsigned int)18) {
-        if ((lParam & (1 << 29)) > 0)
-          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 0;
-        else
-          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 1;
-      }
-      return 0;
-    }
-    case WM_MOUSEWHEEL:
-      vdeltadelta += (int)HIWORD(wParam);
-      enigma_user::mouse_vscrolls += vdeltadelta / WHEEL_DELTA;
-      vdeltadelta %= WHEEL_DELTA;
-      return 0;
-
-    case WM_MOUSEHWHEEL:
-      hdeltadelta += (int)HIWORD(wParam);
-      enigma_user::mouse_hscrolls += hdeltadelta / WHEEL_DELTA;
-      hdeltadelta %= WHEEL_DELTA;
-      return 0;
-
-    case WM_LBUTTONUP:
-      ReleaseCapture();
-      mousestatus[0] = 0;
-      return 0;
-    case WM_LBUTTONDOWN:
-      SetCapture(hWnd);
-      mousestatus[0] = 1;
-      return 0;
-    case WM_RBUTTONUP:
-      ReleaseCapture();
-      mousestatus[1] = 0;
-      return 0;
-    case WM_RBUTTONDOWN:
-      SetCapture(hWnd);
-      mousestatus[1] = 1;
-      return 0;
-    case WM_MBUTTONUP:
-      ReleaseCapture();
-      mousestatus[2] = 0;
-      return 0;
-    case WM_MBUTTONDOWN:
-      SetCapture(hWnd);
-      mousestatus[2] = 1;
-      return 0;
-
-    case WM_ERASEBKGND:
-      RECT rc;
-      GetClientRect(hWnd, &rc);
-      FillRect((HDC)wParam, &rc, CreateSolidBrush(windowColor));
-      return 1L;
-
-    case WM_PAINT:
-      DefWindowProc(hWndParameter, message, wParam, lParam);
-      return 0;
-
-	case WM_SYSCOMMAND: {
-      if (wParam == SC_MAXIMIZE) {
-        ShowWindow(hWnd, SW_MAXIMIZE);
-        enigma::windowWidth = enigma_user::window_get_width();
-        enigma::windowHeight = enigma_user::window_get_height();
-        enigma::compute_window_scaling();
-        break;
-      } else if (wParam == SC_RESTORE) {
-        ShowWindow(hWnd, SW_RESTORE);
-        enigma::windowWidth = enigma_user::window_get_width();
-        enigma::windowHeight = enigma_user::window_get_height();
-        enigma::compute_window_scaling();
-        break;
-      } else {
-        return DefWindowProc(hWndParameter, message, wParam, lParam);
-      }
-      return 0;
-    }
+    return DefWindowProc (hWndParameter, message, wParam, lParam);
   }
-  return DefWindowProc(hWndParameter, message, wParam, lParam);
 }
-}  // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -18,254 +18,271 @@
 
 #include <map>
 #include <string>
-using std::string;
 using std::map;
+using std::string;
 #include <windows.h>
 //#include <winuser.h> // includes windows.h
 
-#include "Platforms/General/PFmain.h" // for keyboard_string
-#include "Platforms/General/PFwindow.h" // For those damn vk_ constants.
-#include "Universal_System/Instances/instance_system.h"
+#include "Platforms/General/PFmain.h"    // for keyboard_string
+#include "Platforms/General/PFwindow.h"  // For those damn vk_ constants.
 #include "Universal_System/Instances/instance.h"
+#include "Universal_System/Instances/instance_system.h"
 
 #include "Platforms/platforms_mandatory.h"
 
 #ifndef WM_MOUSEHWHEEL
-  #define WM_MOUSEHWHEEL 0x020E
+#define WM_MOUSEHWHEEL 0x020E
 #endif
 
 namespace enigma_user {
 void draw_clear(int col);
 void screen_set_viewport(gs_scalar x, gs_scalar y, gs_scalar width, gs_scalar height);
-} // namespace enigma_user
+}  // namespace enigma_user
 
-namespace enigma
-{
-  extern HWND hWnd;
-  extern HDC window_hDC;
+namespace enigma {
+extern HWND hWnd;
+extern HDC window_hDC;
 
-  using enigma_user::keyboard_key;
-  using enigma_user::keyboard_lastkey;
-  using enigma_user::keyboard_lastchar;
-  using enigma_user::keyboard_string;
+using enigma_user::keyboard_key;
+using enigma_user::keyboard_lastchar;
+using enigma_user::keyboard_lastkey;
+using enigma_user::keyboard_string;
 
-  extern char mousestatus[3],last_mousestatus[3],keybdstatus[256],last_keybdstatus[256];
-  extern int windowX, windowY, windowColor;
-  extern HCURSOR currentCursor;
+extern char mousestatus[3], last_mousestatus[3], keybdstatus[256], last_keybdstatus[256];
+extern int windowX, windowY, windowColor;
+extern HCURSOR currentCursor;
 
-  static RECT tempWindow;
-  static short hdeltadelta = 0, vdeltadelta = 0;
-  static int tempLeft = 0, tempTop = 0, tempRight = 0, tempBottom = 0, tempWidth, tempHeight;
+static RECT tempWindow;
+static short hdeltadelta = 0, vdeltadelta = 0;
+static int tempLeft = 0, tempTop = 0, tempRight = 0, tempBottom = 0, tempWidth, tempHeight;
 
-  LRESULT (CALLBACK *touch_extension_callback)(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam);
-  void (*WindowResizedCallback)();
+LRESULT(CALLBACK *touch_extension_callback)(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam);
+void (*WindowResizedCallback)();
 
-  LRESULT CALLBACK WndProc (HWND hWndParameter, UINT message,WPARAM wParam, LPARAM lParam)
-  {
-    switch (message)
-    {
-      case WM_CREATE:
-        return 0;
-      case WM_SHOWWINDOW:
-        enigma::windowWidth = enigma_user::window_get_width();
-        enigma::windowHeight = enigma_user::window_get_height();
-        enigma::compute_window_scaling();
-        return 0;
-      case WM_CLOSE:
+LRESULT CALLBACK WndProc(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam) {
+  switch (message) {
+    case WM_CREATE:
+      return 0;
+    case WM_SHOWWINDOW:
+      enigma::windowWidth = enigma_user::window_get_width();
+      enigma::windowHeight = enigma_user::window_get_height();
+      enigma::compute_window_scaling();
+      return 0;
+    case WM_CLOSE:
+      instance_event_iterator = &dummy_event_iterator;
+      for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
+        it->myevent_closebutton();
+      }
+      // Game Maker actually checks this first I am making the decision to check if after, since that is how it is expected to work
+      // so the user can execute something before the escape is processed, no sense in an override if user is going to call game_end() anyway.
+      // - Robert
+      if (treatCloseAsEscape) {
+        PostQuitMessage(0);
+      }
+      return 0;
+
+    case WM_DESTROY:
+      return 0;
+
+    case WM_SETFOCUS:
+      input_initialize();
+      game_window_focused = true;
+      pausedSteps = 0;
+      return 0;
+
+    case WM_KILLFOCUS:
+      for (int i = 0; i < 255; i++) {
+        last_keybdstatus[i] = keybdstatus[i];
+        keybdstatus[i] = 0;
+      }
+      for (int i = 0; i < 3; i++) {
+        last_mousestatus[i] = mousestatus[i];
+        mousestatus[i] = 0;
+      }
+      game_window_focused = false;
+      return 0;
+
+    case WM_SIZE:
+      // make sure window resized is only processed once per resize because there could possibly be child windows and handles, especially with widgets
+      if (hWndParameter == hWnd) {
+        if (WindowResizedCallback != NULL) {
+          WindowResizedCallback();
+          windowWidth = enigma_user::window_get_width();
+          windowHeight = enigma_user::window_get_height();
+          enigma::compute_window_scaling();
+        }
         instance_event_iterator = &dummy_event_iterator;
-        for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
-        {
-          it->myevent_closebutton();
+        for (enigma::iterator it = enigma::instance_list_first(); it; ++it) {
+          ((object_graphics *)*it)->myevent_drawresize();
         }
-        // Game Maker actually checks this first I am making the decision to check if after, since that is how it is expected to work
-        // so the user can execute something before the escape is processed, no sense in an override if user is going to call game_end() anyway.
-        // - Robert
-        if (treatCloseAsEscape) {
-          PostQuitMessage (0);
-        }
-        return 0;
+      } else {
+        DefWindowProc(hWndParameter, message, wParam, lParam);
+      }
+      return 0;
 
-      case WM_DESTROY:
-        return 0;
+    case WM_ENTERSIZEMOVE:
+      GetWindowRect(hWndParameter, &tempWindow);
+      tempLeft = tempWindow.left;
+      tempTop = tempWindow.top;
+      tempRight = tempWindow.right;
+      tempBottom = tempWindow.bottom;
+      return 0;
 
-      case WM_SETFOCUS:
-        input_initialize();
-        game_window_focused = true;
-        pausedSteps = 0;
-        return 0;
+    case WM_EXITSIZEMOVE:
+      GetWindowRect(hWndParameter, &tempWindow);
+      tempWidth = windowWidth + (tempWindow.right - tempWindow.left) - (tempRight - tempLeft);
+      tempHeight = windowHeight + (tempWindow.bottom - tempWindow.top) - (tempBottom - tempTop);
 
-      case WM_KILLFOCUS:
-        for (int i = 0; i < 255; i++)
-        {
-            last_keybdstatus[i] = keybdstatus[i];
-            keybdstatus[i] = 0;
-        }
-        for(int i=0; i < 3; i++)
-        {
-            last_mousestatus[i] = mousestatus[i];
-            mousestatus[i] = 0;
-        }
-        game_window_focused = false;
-        return 0;
+      windowX += tempWindow.left - tempLeft;
+      windowY += tempWindow.top - tempTop;
+      windowWidth = tempWidth;
+      windowHeight = tempHeight;
+      enigma::windowWidth = enigma_user::window_get_width();
+      enigma::windowHeight = enigma_user::window_get_height();
+      enigma::compute_window_scaling();
+      return 0;
 
-      case WM_SIZE:
-        // make sure window resized is only processed once per resize because there could possibly be child windows and handles, especially with widgets
-        if (hWndParameter == hWnd) {
-          if (WindowResizedCallback != NULL) {
-            WindowResizedCallback();
-          }
-          instance_event_iterator = &dummy_event_iterator;
-          for (enigma::iterator it = enigma::instance_list_first(); it; ++it)
-          {
-            ((object_graphics*)*it)->myevent_drawresize();
-          }
-        } else {
-          DefWindowProc(hWndParameter, message, wParam, lParam);
-        }
-        return 0;
+    case WM_GETMINMAXINFO: {
+      if (viewScale > 0) {  //Fixed Scale, this is GM8.1 behaviour
+        RECT c;
+        c.left = 0;
+        c.top = 0;
+        c.right = scaledWidth;
+        c.bottom = scaledHeight;
+        AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE), false);
 
-      case WM_ENTERSIZEMOVE:
-        GetWindowRect(hWndParameter,&tempWindow);
-        tempLeft = tempWindow.left;
-        tempTop = tempWindow.top;
-        tempRight = tempWindow.right;
-        tempBottom = tempWindow.bottom;
-        return 0;
+        LPMINMAXINFO lpMinMaxInfo = (LPMINMAXINFO)lParam;
+        lpMinMaxInfo->ptMinTrackSize.x = c.right - c.left;
+        lpMinMaxInfo->ptMinTrackSize.y = c.bottom - c.top;
+      }
+      break;
+    }
 
-      case WM_EXITSIZEMOVE:
-        GetWindowRect(hWndParameter,&tempWindow);
-        tempWidth = windowWidth + (tempWindow.right - tempWindow.left) - (tempRight - tempLeft);
-        tempHeight = windowHeight + (tempWindow.bottom - tempWindow.top) - (tempBottom - tempTop);
+    case WM_SETCURSOR:
+      // Set the user cursor if the mouse is in the client area of the window, otherwise let Windows handle setting the cursor
+      // since it knows how to set the gripper cursor for window resizing. This is exactly how GM handles it.
+      if (LOWORD(lParam) == HTCLIENT) {
+        SetCursor(currentCursor);
+        return TRUE;
+      }
+      break;
+    case WM_CHAR:
+      keyboard_lastchar = string(1, wParam);
+      if (keyboard_lastkey == enigma_user::vk_backspace) {
+        if (!keyboard_string.empty()) keyboard_string.pop_back();
+      } else {
+        keyboard_string += keyboard_lastchar;
+      }
+      return 0;
 
-        windowX += tempWindow.left - tempLeft;
-        windowY += tempWindow.top - tempTop;
-        windowWidth = tempWidth;
-        windowHeight = tempHeight;
+    case WM_KEYDOWN: {
+      int key = enigma_user::keyboard_get_map(wParam);
+      keyboard_lastkey = key;
+      keyboard_key = key;
+      last_keybdstatus[key] = keybdstatus[key];
+      keybdstatus[key] = 1;
+      return 0;
+    }
+    case WM_KEYUP: {
+      int key = enigma_user::keyboard_get_map(wParam);
+      keyboard_key = 0;
+      last_keybdstatus[key] = keybdstatus[key];
+      keybdstatus[key] = 0;
+      return 0;
+    }
+    case WM_SYSKEYDOWN: {
+      int key = enigma_user::keyboard_get_map(wParam);
+      keyboard_lastkey = key;
+      keyboard_key = key;
+      last_keybdstatus[key] = keybdstatus[key];
+      keybdstatus[key] = 1;
+      if (key != 18) {
+        if ((lParam & (1 << 29)) > 0)
+          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 1;
+        else
+          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 0;
+      }
+      return 0;
+    }
+    case WM_SYSKEYUP: {
+      int key = enigma_user::keyboard_get_map(wParam);
+      keyboard_key = 0;
+      last_keybdstatus[key] = keybdstatus[key];
+      keybdstatus[key] = 0;
+      if (key != (unsigned int)18) {
+        if ((lParam & (1 << 29)) > 0)
+          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 0;
+        else
+          last_keybdstatus[18] = keybdstatus[18], keybdstatus[18] = 1;
+      }
+      return 0;
+    }
+    case WM_MOUSEWHEEL:
+      vdeltadelta += (int)HIWORD(wParam);
+      enigma_user::mouse_vscrolls += vdeltadelta / WHEEL_DELTA;
+      vdeltadelta %= WHEEL_DELTA;
+      return 0;
+
+    case WM_MOUSEHWHEEL:
+      hdeltadelta += (int)HIWORD(wParam);
+      enigma_user::mouse_hscrolls += hdeltadelta / WHEEL_DELTA;
+      hdeltadelta %= WHEEL_DELTA;
+      return 0;
+
+    case WM_LBUTTONUP:
+      ReleaseCapture();
+      mousestatus[0] = 0;
+      return 0;
+    case WM_LBUTTONDOWN:
+      SetCapture(hWnd);
+      mousestatus[0] = 1;
+      return 0;
+    case WM_RBUTTONUP:
+      ReleaseCapture();
+      mousestatus[1] = 0;
+      return 0;
+    case WM_RBUTTONDOWN:
+      SetCapture(hWnd);
+      mousestatus[1] = 1;
+      return 0;
+    case WM_MBUTTONUP:
+      ReleaseCapture();
+      mousestatus[2] = 0;
+      return 0;
+    case WM_MBUTTONDOWN:
+      SetCapture(hWnd);
+      mousestatus[2] = 1;
+      return 0;
+
+    case WM_ERASEBKGND:
+      RECT rc;
+      GetClientRect(hWnd, &rc);
+      FillRect((HDC)wParam, &rc, CreateSolidBrush(windowColor));
+      return 1L;
+
+    case WM_PAINT:
+      DefWindowProc(hWndParameter, message, wParam, lParam);
+      return 0;
+
+    case WM_SYSCOMMAND: {
+      if (wParam == SC_MAXIMIZE) {
+        ShowWindow(hWnd, SW_MAXIMIZE);
         enigma::windowWidth = enigma_user::window_get_width();
         enigma::windowHeight = enigma_user::window_get_height();
         enigma::compute_window_scaling();
-        return 0;
-
-      case WM_GETMINMAXINFO: {
-        if (viewScale > 0) { //Fixed Scale, this is GM8.1 behaviour
-          RECT c;
-          c.left = 0; c.top = 0; c.right = scaledWidth; c.bottom = scaledHeight;
-          AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE), false);
-
-          LPMINMAXINFO lpMinMaxInfo = (LPMINMAXINFO) lParam;
-          lpMinMaxInfo->ptMinTrackSize.x = c.right-c.left;
-          lpMinMaxInfo->ptMinTrackSize.y = c.bottom-c.top;
-        }
         break;
-      }
-
-      case WM_SETCURSOR:
-        // Set the user cursor if the mouse is in the client area of the window, otherwise let Windows handle setting the cursor
-        // since it knows how to set the gripper cursor for window resizing. This is exactly how GM handles it.
-        if (LOWORD(lParam) == HTCLIENT) {
-          SetCursor(currentCursor);
-          return TRUE;
-        }
+      } else if (wParam == SC_RESTORE) {
+        ShowWindow(hWnd, SW_RESTORE);
+        enigma::windowWidth = enigma_user::window_get_width();
+        enigma::windowHeight = enigma_user::window_get_height();
+        enigma::compute_window_scaling();
         break;
-      case WM_CHAR:
-        keyboard_lastchar = string(1,wParam);
-        if (keyboard_lastkey == enigma_user::vk_backspace) {
-          if (!keyboard_string.empty()) keyboard_string.pop_back();
-        } else {
-          keyboard_string += keyboard_lastchar;
-        }
-        return 0;
-
-      case WM_KEYDOWN: {
-        int key = enigma_user::keyboard_get_map(wParam);
-        keyboard_lastkey = key;
-        keyboard_key = key;
-        last_keybdstatus[key]=keybdstatus[key];
-        keybdstatus[key]=1;
-        return 0;
+      } else {
+        return DefWindowProc(hWndParameter, message, wParam, lParam);
       }
-      case WM_KEYUP: {
-        int key = enigma_user::keyboard_get_map(wParam);
-        keyboard_key = 0;
-        last_keybdstatus[key]=keybdstatus[key];
-        keybdstatus[key]=0;
-        return 0;
-      }
-      case WM_SYSKEYDOWN: {
-        int key = enigma_user::keyboard_get_map(wParam);
-        keyboard_lastkey = key;
-        keyboard_key = key;
-        last_keybdstatus[key]=keybdstatus[key];
-        keybdstatus[key]=1;
-        if (key!=18)
-        {
-          if ((lParam&(1<<29))>0)
-               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
-          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
-        }
-        return 0;
-      }
-      case WM_SYSKEYUP: {
-        int key = enigma_user::keyboard_get_map(wParam);
-        keyboard_key = 0;
-        last_keybdstatus[key]=keybdstatus[key];
-        keybdstatus[key]=0;
-        if (key!=(unsigned int)18)
-        {
-          if ((lParam&(1<<29))>0)
-               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
-          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
-        }
-        return 0;
-      }
-      case WM_MOUSEWHEEL:
-         vdeltadelta += (int)HIWORD(wParam);
-         enigma_user::mouse_vscrolls += vdeltadelta / WHEEL_DELTA;
-         vdeltadelta %= WHEEL_DELTA;
-         return 0;
-
-      case WM_MOUSEHWHEEL:
-         hdeltadelta += (int)HIWORD(wParam);
-         enigma_user::mouse_hscrolls += hdeltadelta / WHEEL_DELTA;
-         hdeltadelta %= WHEEL_DELTA;
-         return 0;
-
-      case WM_LBUTTONUP:   ReleaseCapture(); mousestatus[0]=0; return 0;
-      case WM_LBUTTONDOWN: SetCapture(hWnd); mousestatus[0]=1; return 0;
-      case WM_RBUTTONUP:   ReleaseCapture(); mousestatus[1]=0; return 0;
-      case WM_RBUTTONDOWN: SetCapture(hWnd); mousestatus[1]=1; return 0;
-      case WM_MBUTTONUP:   ReleaseCapture(); mousestatus[2]=0; return 0;
-      case WM_MBUTTONDOWN: SetCapture(hWnd); mousestatus[2]=1; return 0;
-
-      case WM_ERASEBKGND:
-        RECT rc;
-        GetClientRect(hWnd, &rc);
-        FillRect((HDC) wParam, &rc, CreateSolidBrush(windowColor));
-        return 1L;
-
-      case WM_PAINT:
-        DefWindowProc(hWndParameter, message, wParam, lParam);
-        return 0;
-
-      case WM_SYSCOMMAND: {
-        if (wParam == SC_MAXIMIZE) {
-          ShowWindow(hWnd, SW_MAXIMIZE);
-          enigma::windowWidth = enigma_user::window_get_width();
-          enigma::windowHeight = enigma_user::window_get_height();
-          enigma::compute_window_scaling();
-          break;
-        } else if (wParam == SC_RESTORE) {
-          ShowWindow(hWnd, SW_RESTORE);
-          enigma::windowWidth = enigma_user::window_get_width();
-          enigma::windowHeight = enigma_user::window_get_height();
-          enigma::compute_window_scaling();
-          break;
-        } else {
-          return DefWindowProc(hWndParameter, message, wParam, lParam);
-        }
-        return 0;
-      }
+      return 0;
     }
-    return DefWindowProc (hWndParameter, message, wParam, lParam);
   }
+  return DefWindowProc(hWndParameter, message, wParam, lParam);
 }
+}  // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -172,11 +172,13 @@ void window_set_rectangle(int x, int y, int width, int height) {
 }
 
 namespace {
-bool prefer_stayontop;
-bool prefer_sizeable = enigma::isSizeable;
+
 bool prefer_borderless = !enigma::showBorder;
+bool prefer_sizeable = enigma::isSizeable;
+bool prefer_stayontop;
 int tmpWidth = enigma::windowWidth;
 int tmpHeight = enigma::windowHeight;
+
 }  // anonymous namespace
 
 void window_set_fullscreen(bool full) {
@@ -187,6 +189,7 @@ void window_set_fullscreen(bool full) {
     prefer_borderless = !window_get_showborder();
     prefer_sizeable = window_get_sizeable();
     prefer_stayontop = window_get_stayontop();
+    window_set_maximized(false);
     tmpWidth = window_get_width();
     tmpHeight = window_get_height();
     window_set_stayontop(true);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -180,11 +180,13 @@ int tmpHeight = enigma::windowHeight;
 }  // anonymous namespace
 
 void window_set_fullscreen(bool full) {
-  prefer_stayontop = window_get_stayontop();
   if (window_get_fullscreen() == full) return;
   enigma::isFullScreen = full;
   // tweak the style first to remove or restore the window border
   if (full) {
+    prefer_borderless = !window_get_showborder();
+    prefer_sizeable = window_get_sizeable();
+    prefer_stayontop = window_get_stayontop();
     tmpWidth = window_get_width();
     tmpHeight = window_get_height();
     window_set_stayontop(true);
@@ -193,15 +195,14 @@ void window_set_fullscreen(bool full) {
     style |= WS_SIZEBOX;
     SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
     window_set_maximized(full);
-    enigma::compute_window_scaling();
   } else {
     window_set_maximized(full);
     window_set_showborder(!prefer_borderless);
     window_set_sizeable(prefer_sizeable);
     window_set_stayontop(prefer_stayontop);
     window_set_size(tmpWidth, tmpHeight);
-    enigma::compute_window_scaling();
   }
+  enigma::compute_window_scaling();
 }
 
 bool window_get_fullscreen() {
@@ -239,6 +240,7 @@ void window_set_showborder(bool show) {
   DWORD style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
   if (show) style |= WS_CAPTION | WS_BORDER | WS_MINIMIZEBOX;
   else style &= ~(WS_CAPTION | WS_BORDER);
+  if (show && prefer_sizeable) style |= WS_MAXIMIZEBOX;
   SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
   window_set_size(tmp2Width, tmp2Height);
 }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -149,6 +149,7 @@ double window_get_alpha() {
 
 void window_set_position(int x, int y)
 {
+  if (window_get_fullscreen()) return;
   enigma::windowX = x;
   enigma::windowY = y;
   SetWindowPos(enigma::hWnd, HWND_TOP, enigma::windowX, enigma::windowY, 0, 0, SWP_NOSIZE|SWP_NOACTIVATE);
@@ -156,12 +157,14 @@ void window_set_position(int x, int y)
 
 void window_set_size(unsigned int width, unsigned int height)
 {
+  if (window_get_fullscreen()) return;
   enigma::windowWidth = width;
   enigma::windowHeight = height;
   enigma::compute_window_size();
 }
 
 void window_set_rectangle(int x, int y, int width, int height) {
+  if (window_get_fullscreen()) return;
   RECT c;
   c.left = (enigma::windowX = x); c.top = (enigma::windowY = y); c.right = enigma::windowX + (enigma::windowWidth = width); c.bottom = enigma::windowY + (enigma::windowHeight = height);
   AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_STYLE), false);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -186,6 +186,7 @@ void window_set_fullscreen(bool full) {
     style |= WS_SIZEBOX;
     SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
     window_set_maximized(full);
+    enigma::compute_window_scaling();
   } else {
     window_set_maximized(full);
     window_set_showborder(!prefer_borderless);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -201,6 +201,8 @@ bool window_get_fullscreen() {
 }
 
 void window_set_sizeable(bool sizeable) {
+  if (window_get_maximized()) return;
+  if (window_get_fullscreen()) return;
   prefer_sizeable = sizeable;
   DWORD style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
   if (sizeable) style |= WS_SIZEBOX | WS_MAXIMIZEBOX;
@@ -215,6 +217,8 @@ bool window_get_sizeable() {
 }
 
 void window_set_showborder(bool show) {
+  if (window_get_maximized()) return;
+  if (window_get_fullscreen()) return;
   prefer_borderless = !show;
   DWORD style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
   if (show) style |= WS_CAPTION | WS_BORDER;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -17,19 +17,19 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "Platforms/General/PFmain.h"  // For those damn vk_ constants.
-#include "Platforms/General/PFwindow.h"
 #include "Platforms/platforms_mandatory.h"
+#include "Platforms/General/PFmain.h" // For those damn vk_ constants.
+#include "Platforms/General/PFwindow.h"
 
 #include "Widget_Systems/widgets_mandatory.h"
 
-#include "Universal_System/globalupdate.h"
-#include "Universal_System/roomsystem.h"  // room_caption
+#include "strings_util.h" // For string_replace_all
 #include "Universal_System/var4.h"
-#include "strings_util.h"  // For string_replace_all
+#include "Universal_System/roomsystem.h" // room_caption
+#include "Universal_System/globalupdate.h"
 
-#include <stdio.h>
 #include <windows.h>
+#include <stdio.h>
 #include <string>
 using namespace std;
 
@@ -37,14 +37,15 @@ namespace {
 
 std::string current_caption = "";
 
-}  // anonymous namespace
+} // anonymous namespace
 
-namespace enigma {
+namespace enigma
+{
 
 extern HWND hWnd;
 HCURSOR currentCursor = LoadCursor(NULL, IDC_ARROW);
 
-void configure_devmode(DEVMODE& devMode, int w, int h, int freq, int bitdepth) {
+void configure_devmode(DEVMODE &devMode, int w, int h, int freq, int bitdepth) {
   if (w != -1) {
     devMode.dmFields |= DM_PELSWIDTH;
     devMode.dmPelsWidth = w;
@@ -66,79 +67,95 @@ void configure_devmode(DEVMODE& devMode, int w, int h, int freq, int bitdepth) {
   }
 }
 
-}  // namespace enigma
+}
 
 namespace enigma_user {
 
 #if GM_COMPATIBILITY_VERSION <= 81
-unsigned long long window_handle() { return (unsigned long long)enigma::hWnd; }
+unsigned long long window_handle() {
+  return (unsigned long long)enigma::hWnd;
+}
 #else
-void* window_handle() { return enigma::hWnd; }
+void* window_handle() {
+  return enigma::hWnd;
+}
 #endif
 
 // GM8.1 Used its own internal variables for these functions and reported the regular window dimensions when minimized,
 // Studio uses the native functions and will tell you the dimensions of the window are 0 when it is minimized,
 // I have decided to go with the Studio method because it is still backwards compatible but also because it saves us some variables.
 // NOTE: X and Y are -32000 when the window is minimized.
-int window_get_x() {
+int window_get_x()
+{
   RECT rc;
   GetWindowRect(enigma::hWnd, &rc);
   return rc.left;
 }
 
-int window_get_y() {
+int window_get_y()
+{
   RECT rc;
   GetWindowRect(enigma::hWnd, &rc);
   return rc.top;
 }
 
-int window_get_width() {
+int window_get_width()
+{
   RECT rc;
   GetClientRect(enigma::hWnd, &rc);
-  return rc.right - rc.left;
+  return rc.right-rc.left;
 }
 
-int window_get_height() {
+int window_get_height()
+{
   RECT rc;
   GetClientRect(enigma::hWnd, &rc);
-  return rc.bottom - rc.top;
+  return rc.bottom-rc.top;
 }
 
-void window_set_caption(const string& caption) {
-  /*  if (caption == "")
+void window_set_caption(const string &caption)
+{
+/*  if (caption == "")
       if (score != 0)
         caption = "Score: " + string(score);  //GM does this but it's rather fucktarded */
 
-  if (caption != current_caption) {
-    SetWindowText(enigma::hWnd, (char*)caption.c_str());
-    current_caption = caption;
-  }
+    if (caption != current_caption)
+    {
+        SetWindowText(enigma::hWnd,(char*) caption.c_str());
+        current_caption = caption;
+    }
 }
 
-string window_get_caption() { return current_caption; }
+string window_get_caption()
+{
+  return current_caption;
+}
 
 void window_set_alpha(double alpha) {
   // Set WS_EX_LAYERED on this window
-  SetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE, GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+  SetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE,
+      GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
 
   // Make this window transparent
-  SetLayeredWindowAttributes(enigma::hWnd, 0, (unsigned char)(alpha * 255), LWA_ALPHA);
+  SetLayeredWindowAttributes(enigma::hWnd, 0, (unsigned char)(alpha*255), LWA_ALPHA);
 }
 
 double window_get_alpha() {
-  unsigned char alpha;
-  // Make this window transparent
-  GetLayeredWindowAttributes(enigma::hWnd, 0, &alpha, 0);
-  return alpha / 255;
+	unsigned char alpha;
+	// Make this window transparent
+	GetLayeredWindowAttributes(enigma::hWnd, 0, &alpha, 0);
+	return alpha/255;
 }
 
-void window_set_position(int x, int y) {
+void window_set_position(int x, int y)
+{
   enigma::windowX = x;
   enigma::windowY = y;
-  SetWindowPos(enigma::hWnd, HWND_TOP, enigma::windowX, enigma::windowY, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
+  SetWindowPos(enigma::hWnd, HWND_TOP, enigma::windowX, enigma::windowY, 0, 0, SWP_NOSIZE|SWP_NOACTIVATE);
 }
 
-void window_set_size(unsigned int width, unsigned int height) {
+void window_set_size(unsigned int width, unsigned int height)
+{
   enigma::windowWidth = width;
   enigma::windowHeight = height;
   enigma::compute_window_size();
@@ -146,21 +163,17 @@ void window_set_size(unsigned int width, unsigned int height) {
 
 void window_set_rectangle(int x, int y, int width, int height) {
   RECT c;
-  c.left = (enigma::windowX = x);
-  c.top = (enigma::windowY = y);
-  c.right = enigma::windowX + (enigma::windowWidth = width);
-  c.bottom = enigma::windowY + (enigma::windowHeight = height);
+  c.left = (enigma::windowX = x); c.top = (enigma::windowY = y); c.right = enigma::windowX + (enigma::windowWidth = width); c.bottom = enigma::windowY + (enigma::windowHeight = height);
   AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_STYLE), false);
-  SetWindowPos(enigma::hWnd, HWND_TOP, c.left, c.top, c.right - c.left, c.bottom - c.top,
-               SWP_NOZORDER | SWP_FRAMECHANGED);
+  SetWindowPos(enigma::hWnd, HWND_TOP, c.left, c.top, c.right-c.left, c.bottom-c.top, SWP_NOZORDER|SWP_FRAMECHANGED);
 }
 
 namespace {
-bool prefer_sizeable;
-bool prefer_borderless;
-bool get_fullscreen;
-bool get_stayontop;
-}  // namespace
+  bool prefer_sizeable;
+  bool prefer_borderless;
+  bool get_fullscreen;
+  bool get_stayontop;
+}
 
 void window_set_fullscreen(bool full) {
   get_fullscreen = full;
@@ -182,7 +195,9 @@ void window_set_fullscreen(bool full) {
   }
 }
 
-bool window_get_fullscreen() { return get_fullscreen; }
+bool window_get_fullscreen() {
+  return get_fullscreen;
+}
 
 void window_set_sizeable(bool sizeable) {
   prefer_sizeable = sizeable;
@@ -194,7 +209,9 @@ void window_set_sizeable(bool sizeable) {
   enigma::compute_window_size();
 }
 
-bool window_get_sizeable() { return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_THICKFRAME) == WS_THICKFRAME; }
+bool window_get_sizeable() {
+  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_THICKFRAME) == WS_THICKFRAME;
+}
 
 void window_set_showborder(bool show) {
   prefer_borderless = !show;
@@ -205,39 +222,56 @@ void window_set_showborder(bool show) {
   enigma::compute_window_size();
 }
 
-bool window_get_showborder() { return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_CAPTION) == WS_CAPTION; }
+bool window_get_showborder() {
+  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_CAPTION) == WS_CAPTION;
+}
 
 void window_set_showicons(bool show) {
-  SetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE, GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+  SetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE,
+      GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
 }
 
-bool window_get_showicons() { return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_THICKFRAME) == WS_THICKFRAME; }
-
-void window_set_visible(bool visible) { ShowWindow(enigma::hWnd, visible ? SW_SHOW : SW_HIDE); }
-
-int window_get_visible() { return IsWindowVisible(enigma::hWnd); }
-
-void window_set_minimized(bool minimized) { ShowWindow(enigma::hWnd, minimized ? SW_MINIMIZE : SW_RESTORE); }
-
-void window_set_maximized(bool maximized) { 
-  ShowWindow(enigma::hWnd, maximized ? SW_MAXIMIZE : SW_RESTORE);
-  enigma::compute_window_scaling();
+bool window_get_showicons() {
+  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_THICKFRAME) == WS_THICKFRAME;
 }
 
-bool window_get_minimized() { return IsIconic(enigma::hWnd); }
+void window_set_visible(bool visible) {
+  ShowWindow(enigma::hWnd, visible? SW_SHOW : SW_HIDE);
+}
 
-bool window_get_maximized() { return IsZoomed(enigma::hWnd); }
+int window_get_visible() {
+  return IsWindowVisible(enigma::hWnd);
+}
 
-void window_set_stayontop(bool stay) {
+void window_set_minimized(bool minimized) {
+  ShowWindow(enigma::hWnd, minimized? SW_MINIMIZE : SW_RESTORE);
+}
+
+void window_set_maximized(bool maximized) {
+  ShowWindow(enigma::hWnd, maximized? SW_MAXIMIZE : SW_RESTORE);
+}
+
+bool window_get_minimized() {
+  return IsIconic(enigma::hWnd);
+}
+
+bool window_get_maximized() {
+  return IsZoomed(enigma::hWnd);
+}
+
+void window_set_stayontop(bool stay)
+{
   if (stay) {
-    SetWindowPos(enigma::hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
+    SetWindowPos(enigma::hWnd,HWND_TOPMOST,0,0,0,0,SWP_NOSIZE|SWP_NOMOVE);
   } else {
-    SetWindowPos(enigma::hWnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
-    SetWindowPos(enigma::hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
+    SetWindowPos(enigma::hWnd,HWND_BOTTOM,0,0,0,0,SWP_NOSIZE|SWP_NOMOVE|SWP_NOACTIVATE);
+    SetWindowPos(enigma::hWnd,HWND_TOP,   0,0,0,0,SWP_NOSIZE|SWP_NOMOVE);
   }
 }
 
-bool window_get_stayontop() { return (GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) & WS_EX_TOPMOST) == WS_EX_TOPMOST; }
+bool window_get_stayontop() {
+    return (GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) & WS_EX_TOPMOST) == WS_EX_TOPMOST;
+}
 
 int display_mouse_get_x() {
   POINT mouse;
@@ -251,77 +285,105 @@ int display_mouse_get_y() {
   return mouse.y;
 }
 
-void display_mouse_set(int x, int y) { SetCursorPos(x, y); }
+void display_mouse_set(int x,int y) {
+    SetCursorPos(x,y);
+}
 
-int display_get_width() { return GetSystemMetrics(SM_CXSCREEN); }
+int display_get_width() {
+   return GetSystemMetrics(SM_CXSCREEN);
+}
 
-int display_get_height() { return GetSystemMetrics(SM_CYSCREEN); }
+int display_get_height() {
+   return GetSystemMetrics(SM_CYSCREEN);
+}
 
-int display_get_colordepth() { return GetDeviceCaps(GetDC(enigma::hWnd), BITSPIXEL); }
+int display_get_colordepth() {
+  return GetDeviceCaps(GetDC(enigma::hWnd), BITSPIXEL);
+}
 
-int display_get_frequency() { return GetDeviceCaps(GetDC(enigma::hWnd), VREFRESH); }
+int display_get_frequency() {
+  return GetDeviceCaps(GetDC(enigma::hWnd), VREFRESH);
+}
 
-unsigned display_get_dpi_x() { return GetDeviceCaps(GetDC(enigma::hWnd), LOGPIXELSX); }
+unsigned display_get_dpi_x() {
+  return GetDeviceCaps(GetDC(enigma::hWnd), LOGPIXELSX);
+}
 
-unsigned display_get_dpi_y() { return GetDeviceCaps(GetDC(enigma::hWnd), LOGPIXELSY); }
+unsigned display_get_dpi_y() {
+  return GetDeviceCaps(GetDC(enigma::hWnd), LOGPIXELSY);
+}
 
-void display_reset() { ChangeDisplaySettings(NULL, 0); }
+void display_reset()
+{
+	ChangeDisplaySettings(NULL, 0);
+}
 
-bool display_set_size(int w, int h) {
-  DEVMODE devMode;
+bool display_set_size(int w, int h)
+{
+	DEVMODE devMode;
 
-  if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode)) return false;
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return false;
 
-  devMode.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
-  devMode.dmPelsWidth = w;
-  devMode.dmPelsHeight = h;
+	devMode.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
+	devMode.dmPelsWidth = w;
+	devMode.dmPelsHeight = h;
+
+	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
+}
+
+bool display_set_frequency(int freq)
+{
+	DEVMODE devMode;
+
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return false;
+
+	devMode.dmFields = DM_DISPLAYFREQUENCY;
+	devMode.dmDisplayFrequency = freq;
+
+	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
+}
+
+bool display_set_colordepth(int depth)
+{
+	DEVMODE devMode;
+
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return true;
+
+	devMode.dmFields = DM_BITSPERPEL;
+	devMode.dmBitsPerPel = depth;
 
   return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
 }
 
-bool display_set_frequency(int freq) {
-  DEVMODE devMode;
+bool display_set_all(int w, int h, int freq, int bitdepth)
+{
+	DEVMODE devMode;
 
-  if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode)) return false;
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return false;
 
-  devMode.dmFields = DM_DISPLAYFREQUENCY;
-  devMode.dmDisplayFrequency = freq;
+	enigma::configure_devmode(devMode, w, h, freq, bitdepth);
 
-  return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
+	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
 }
 
-bool display_set_colordepth(int depth) {
-  DEVMODE devMode;
+bool display_test_all(int w, int h, int freq, int bitdepth)
+{
+	DEVMODE devMode;
 
-  if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode)) return true;
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return false;
 
-  devMode.dmFields = DM_BITSPERPEL;
-  devMode.dmBitsPerPel = depth;
+	enigma::configure_devmode(devMode, w, h, freq, bitdepth);
 
-  return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
+	return (ChangeDisplaySettings(&devMode, CDS_TEST) == DISP_CHANGE_SUCCESSFUL);
 }
 
-bool display_set_all(int w, int h, int freq, int bitdepth) {
-  DEVMODE devMode;
-
-  if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode)) return false;
-
-  enigma::configure_devmode(devMode, w, h, freq, bitdepth);
-
-  return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
-}
-
-bool display_test_all(int w, int h, int freq, int bitdepth) {
-  DEVMODE devMode;
-
-  if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode)) return false;
-
-  enigma::configure_devmode(devMode, w, h, freq, bitdepth);
-
-  return (ChangeDisplaySettings(&devMode, CDS_TEST) == DISP_CHANGE_SUCCESSFUL);
-}
-
-int window_mouse_get_x() {
+int window_mouse_get_x()
+{
   POINT mouse;
   GetCursorPos(&mouse);
   ScreenToClient(enigma::hWnd, &mouse);
@@ -329,7 +391,8 @@ int window_mouse_get_x() {
   return mouse.x;
 }
 
-int window_mouse_get_y() {
+int window_mouse_get_y()
+{
   POINT mouse;
   GetCursorPos(&mouse);
   ScreenToClient(enigma::hWnd, &mouse);
@@ -337,125 +400,137 @@ int window_mouse_get_y() {
   return mouse.y;
 }
 
-void window_mouse_set(int x, int y) {
+void window_mouse_set(int x, int y)
+{
   POINT pt;
-  pt.x = x;
-  pt.y = y;
+  pt.x=x;
+  pt.y=y;
   ClientToScreen(enigma::hWnd, &pt);
   SetCursorPos(pt.x, pt.y);
 }
 
-}  // namespace enigma_user
+}
 
-namespace enigma_user {
+namespace enigma_user
+{
 
-int window_set_cursor(int c) {
+int window_set_cursor(int c)
+{
   enigma::cursorInt = c;
   char* cursor = NULL;
   // this switch statement could be replaced with an array aligned to the constants
-  switch (c) {
-    case cr_default:
-    case cr_arrow:
-      cursor = IDC_ARROW;
-      break;
-    case cr_none:
-      cursor = NULL;
-      break;
-    case cr_cross:
-      cursor = IDC_CROSS;
-      break;
-    case cr_beam:
-      cursor = IDC_IBEAM;
-      break;
-    case cr_size_nesw:
-      cursor = IDC_SIZENESW;
-      break;
-    case cr_size_ns:
-      cursor = IDC_SIZENS;
-      break;
-    case cr_size_nwse:
-      cursor = IDC_SIZENWSE;
-      break;
-    case cr_size_we:
-      cursor = IDC_SIZEWE;
-      break;
-    case cr_uparrow:
-      cursor = IDC_UPARROW;
-      break;
-    case cr_hourglass:
-      cursor = IDC_WAIT;
-      break;
-    case cr_drag:
-      // Delphi-made?
-      cursor = IDC_HAND;
-      break;
-    case cr_nodrop:
-      cursor = IDC_NO;
-      break;
-    case cr_hsplit:
-      // Delphi-made?
-      cursor = IDC_SIZENS;
-      break;
-    case cr_vsplit:
-      // Delphi-made?
-      cursor = IDC_SIZEWE;
-      break;
-    case cr_multidrag:
-      cursor = IDC_SIZEALL;
-      break;
-    case cr_sqlwait:
-      // DEAR GOD WHY
-      cursor = IDC_WAIT;
-      break;
-    case cr_no:
-      cursor = IDC_NO;
-      break;
-    case cr_appstart:
-      cursor = IDC_APPSTARTING;
-      break;
-    case cr_help:
-      cursor = IDC_HELP;
-      break;
-    case cr_handpoint:
-      cursor = IDC_HAND;
-      break;
-    case cr_size_all:
-      cursor = IDC_SIZEALL;
-      break;
+  switch (c)
+  {
+      case cr_default:
+      case cr_arrow:
+          cursor = IDC_ARROW;
+          break;
+      case cr_none:
+          cursor = NULL;
+          break;
+      case cr_cross:
+          cursor = IDC_CROSS;
+          break;
+      case cr_beam:
+          cursor = IDC_IBEAM;
+          break;
+      case cr_size_nesw:
+          cursor = IDC_SIZENESW;
+          break;
+      case cr_size_ns:
+          cursor = IDC_SIZENS;
+          break;
+      case cr_size_nwse:
+          cursor = IDC_SIZENWSE;
+          break;
+      case cr_size_we:
+          cursor = IDC_SIZEWE;
+          break;
+      case cr_uparrow:
+          cursor = IDC_UPARROW;
+          break;
+      case cr_hourglass:
+          cursor = IDC_WAIT;
+          break;
+      case cr_drag:
+          // Delphi-made?
+          cursor = IDC_HAND;
+          break;
+      case cr_nodrop:
+          cursor = IDC_NO;
+          break;
+      case cr_hsplit:
+          // Delphi-made?
+          cursor = IDC_SIZENS;
+          break;
+      case cr_vsplit:
+          // Delphi-made?
+          cursor = IDC_SIZEWE;
+          break;
+      case cr_multidrag:
+          cursor = IDC_SIZEALL;
+          break;
+      case cr_sqlwait:
+          // DEAR GOD WHY
+          cursor = IDC_WAIT;
+          break;
+      case cr_no:
+          cursor = IDC_NO;
+          break;
+      case cr_appstart:
+          cursor = IDC_APPSTARTING;
+          break;
+      case cr_help:
+          cursor = IDC_HELP;
+          break;
+      case cr_handpoint:
+          cursor = IDC_HAND;
+          break;
+      case cr_size_all:
+          cursor = IDC_SIZEALL;
+          break;
   }
   enigma::currentCursor = LoadCursor(NULL, cursor);
   return SendMessage(enigma::hWnd, WM_SETCURSOR, (WPARAM)enigma::hWnd, MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
 }
 
-int window_get_cursor() { return enigma::cursorInt; }
+int window_get_cursor()
+{
+  return enigma::cursorInt;
+}
 
-void io_handle() {
+void io_handle()
+{
   MSG msg;
   enigma::input_push();
-  while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
-    TranslateMessage(&msg);
-    DispatchMessage(&msg);
+  while (PeekMessage (&msg, NULL, 0, 0, PM_REMOVE))
+  {
+    TranslateMessage (&msg);
+    DispatchMessage (&msg);
   }
   enigma::update_mouse_variables();
 }
 
-bool keyboard_check_direct(int key) {
-  BYTE keyState[256];
 
-  if (GetKeyboardState(keyState)) {
-    for (int x = 0; x < 256; x++) keyState[x] = (char)(GetKeyState(x) >> 8);
-  } else {
-    //TODO: print error message.
-    return 0;
-  }
+bool keyboard_check_direct(int key)
+{
+   BYTE keyState[256];
+
+   if ( GetKeyboardState( keyState ) )  {
+	  for (int x = 0; x < 256; x++)
+		keyState[x] = (char) (GetKeyState(x) >> 8);
+   } else {
+      //TODO: print error message.
+	  return 0;
+   }
 
   if (key == vk_anykey) {
-    for (int i = 0; i < 256; i++)
+    for(int i = 0; i < 256; i++)
       if (keyState[i] == 1) return 1;
     return 0;
   }
   if (key == vk_nokey) {
-    for (int i = 0; i < 256; i++)
+    for(int i = 0; i < 256; i++)
       if (keyState[i] == 1) return 0;
     return 1;
   }
@@ -468,7 +543,10 @@ void keyboard_key_press(int key) {
   GetKeyboardState((LPBYTE)&keyState);
 
   // Simulate a key press
-  keybd_event(key, keyState[key], KEYEVENTF_EXTENDEDKEY | 0, 0);
+  keybd_event( key,
+        keyState[key],
+        KEYEVENTF_EXTENDEDKEY | 0,
+        0 );
 }
 
 void keyboard_key_release(int key) {
@@ -477,26 +555,34 @@ void keyboard_key_release(int key) {
   GetKeyboardState((LPBYTE)&keyState);
 
   // Simulate a key release
-  keybd_event(key, keyState[key], KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+  keybd_event( key, keyState[key], KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
 }
 
-bool keyboard_get_capital() { return (((unsigned short)GetKeyState(0x14)) & 0xffff) != 0; }
+bool keyboard_get_capital() {
+	return (((unsigned short)GetKeyState(0x14)) & 0xffff) != 0;
+}
 
-bool keyboard_get_numlock() { return (((unsigned short)GetKeyState(0x90)) & 0xffff) != 0; }
+bool keyboard_get_numlock() {
+	return (((unsigned short)GetKeyState(0x90)) & 0xffff) != 0;
+}
 
-bool keyboard_get_scroll() { return (((unsigned short)GetKeyState(0x91)) & 0xffff) != 0; }
+bool keyboard_get_scroll() {
+	return (((unsigned short)GetKeyState(0x91)) & 0xffff) != 0;
+}
 
 void keyboard_set_capital(bool on) {
   BYTE keyState[256];
 
   GetKeyboardState((LPBYTE)&keyState);
 
-  if ((on && !(keyState[VK_CAPITAL] & 1)) || (!on && (keyState[VK_CAPITAL] & 1))) {
+  if( (on && !(keyState[VK_CAPITAL] & 1)) ||
+  (!on && (keyState[VK_CAPITAL] & 1)) )
+  {
     // Simulate a key press
-    keybd_event(VK_CAPITAL, 0x14, KEYEVENTF_EXTENDEDKEY | 0, 0);
+    keybd_event( VK_CAPITAL, 0x14, KEYEVENTF_EXTENDEDKEY | 0, 0 );
 
     // Simulate a key release
-    keybd_event(VK_CAPITAL, 0x14, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+    keybd_event( VK_CAPITAL, 0x14, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
   }
 }
 
@@ -505,12 +591,14 @@ void keyboard_set_numlock(bool on) {
 
   GetKeyboardState((LPBYTE)&keyState);
 
-  if ((on && !(keyState[VK_NUMLOCK] & 1)) || (!on && (keyState[VK_NUMLOCK] & 1))) {
+  if( (on && !(keyState[VK_NUMLOCK] & 1)) ||
+  (!on && (keyState[VK_NUMLOCK] & 1)) )
+  {
     // Simulate a key press
-    keybd_event(VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | 0, 0);
+    keybd_event( VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | 0, 0 );
 
     // Simulate a key release
-    keybd_event(VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+    keybd_event( VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
   }
 }
 
@@ -519,54 +607,63 @@ void keyboard_set_scroll(bool on) {
 
   GetKeyboardState((LPBYTE)&keyState);
 
-  if ((on && !(keyState[VK_SCROLL] & 1)) || (!on && (keyState[VK_SCROLL] & 1))) {
+  if( (on && !(keyState[VK_SCROLL] & 1)) ||
+  (!on && (keyState[VK_SCROLL] & 1)) )
+  {
     // Simulate a key press
-    keybd_event(VK_SCROLL, 0x91, KEYEVENTF_EXTENDEDKEY | 0, 0);
+    keybd_event( VK_SCROLL, 0x91, KEYEVENTF_EXTENDEDKEY | 0, 0 );
 
     // Simulate a key release
-    keybd_event(VK_SCROLL, 0x91, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+    keybd_event( VK_SCROLL, 0x91, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
   }
 }
 
-string clipboard_get_text() {
+string clipboard_get_text()
+{
   if (!OpenClipboard(enigma::hWnd)) return "";
-  unsigned int format = EnumClipboardFormats(0);
+  unsigned int format=EnumClipboardFormats(0);
   string res = "";
   while (format) {
-    if (format == CF_TEXT) {
+    if (format == CF_TEXT)
+    {
       HGLOBAL clip_data = GetClipboardData(format);
       char* clip_text = (char*)GlobalLock(clip_data);
-      if (clip_text) {
+      if (clip_text)
+      {
         unsigned long clip_size = GlobalSize(clip_data) - 1;
-        if (clip_size) res = string(clip_text, clip_size);
-        GlobalUnlock(clip_data);  //Give Windows back its clipdata
+        if (clip_size)
+          res = string(clip_text,clip_size);
+        GlobalUnlock(clip_data); //Give Windows back its clipdata
       }
     }
-    format = EnumClipboardFormats(format);  //Next
+    format=EnumClipboardFormats(format);  //Next
   }
   CloseClipboard();
   return res;
 }
 
-void clipboard_set_text(string text) {
-  text = string_replace_all(text, "\n", "\r\n");  //Otherwise newlines don't work
-  HGLOBAL hGlobal, hgBuffer;
-  if (!OpenClipboard(enigma::hWnd)) return;
-  EmptyClipboard();
-  hGlobal = GlobalAlloc(GMEM_DDESHARE, text.length() + 1);
-  hgBuffer = GlobalLock(hGlobal);
-  strcpy((char*)hgBuffer, text.c_str());
-  GlobalUnlock(hGlobal);
-  SetClipboardData(CF_TEXT, (HANDLE)hGlobal);
-  CloseClipboard();
+void clipboard_set_text(string text)
+{
+  text = string_replace_all(text, "\n", "\r\n"); //Otherwise newlines don't work
+	HGLOBAL hGlobal, hgBuffer;
+	if (!OpenClipboard(enigma::hWnd)) return;
+	EmptyClipboard();
+	hGlobal = GlobalAlloc(GMEM_DDESHARE, text.length() + 1);
+	hgBuffer = GlobalLock(hGlobal);
+    strcpy((char*)hgBuffer, text.c_str());
+    GlobalUnlock(hGlobal);
+	SetClipboardData(CF_TEXT, (HANDLE)hGlobal);
+	CloseClipboard();
 }
 
-bool clipboard_has_text() {
-  if (!OpenClipboard(enigma::hWnd)) return false;
+bool clipboard_has_text()
+{
+  if (!OpenClipboard(enigma::hWnd))
+      return false;
 
   bool value = GetClipboardData(CF_TEXT);
   CloseClipboard();
   return value;
 }
 
-}  // namespace enigma_user
+}

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -175,7 +175,8 @@ namespace {
 
 bool prefer_borderless = !enigma::showBorder;
 bool prefer_sizeable = enigma::isSizeable;
-bool prefer_stayontop;
+bool prefer_fullscreen = false;
+bool prefer_stayontop = false;
 int tmpWidth = enigma::windowWidth;
 int tmpHeight = enigma::windowHeight;
 
@@ -184,6 +185,7 @@ int tmpHeight = enigma::windowHeight;
 void window_set_fullscreen(bool full) {
   if (window_get_fullscreen() == full) return;
   enigma::isFullScreen = full;
+  prefer_fullscreen = full;
   // tweak the style first to remove or restore the window border
   if (full) {
     prefer_borderless = !window_get_showborder();
@@ -209,7 +211,7 @@ void window_set_fullscreen(bool full) {
 }
 
 bool window_get_fullscreen() {
-  return enigma::isFullScreen;
+  return prefer_fullscreen;
 }
 
 void window_set_sizeable(bool sizeable) {

--- a/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
+++ b/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
@@ -40,6 +40,8 @@ namespace enigma
   extern std::vector<std::function<void()> > extension_update_hooks;
   #endif
   
+  extern bool initGame;
+  
   bool initGameWindow();
 
   void destroyWindow();

--- a/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
+++ b/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
@@ -40,8 +40,6 @@ namespace enigma
   extern std::vector<std::function<void()> > extension_update_hooks;
   #endif
   
-  extern bool initGame;
-  
   bool initGameWindow();
 
   void destroyWindow();

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -47,23 +47,6 @@ const int os_type = os_linux;
 
 namespace enigma {
 
-int winEdgeX = windowX;
-int winEdgeY = windowY;
-
-static int getWindowDimension(int i) {
-  XFlush(disp);
-  XWindowAttributes wa;
-  XGetWindowAttributes(disp, win, &wa);
-  if (i == 2) return wa.width;
-  if (i == 3) return wa.height;
-  Window root, parent, *child;
-  uint children;
-  XQueryTree(disp, win, &root, &parent, &child, &children);
-  XWindowAttributes pwa;
-  XGetWindowAttributes(disp, parent, &pwa);
-  return i ? (i == 1 ? pwa.y + wa.y : -1) : pwa.x + wa.x;
-}
-
 void (*WindowResizedCallback)();
 void WindowResized();
 
@@ -161,18 +144,12 @@ int handleEvents() {
         continue;
       }
       case ConfigureNotify: {
-        if (showBorder && 
-          (windowX != e.xconfigure.x ||
-          windowY != e.xconfigure.y)) {
-          winEdgeX = getWindowDimension(0);
-          winEdgeY = getWindowDimension(1);
-        }
-        windowX = e.xconfigure.x;
-        windowY = e.xconfigure.y;
-        windowWidth = e.xconfigure.width;
-        windowHeight = e.xconfigure.height;
-        compute_window_scaling();
         if (WindowResizedCallback != NULL) {
+          windowX = e.xconfigure.x;
+          windowY = e.xconfigure.y;
+          windowWidth = e.xconfigure.width;
+          windowHeight = e.xconfigure.height;
+          compute_window_scaling();
           WindowResizedCallback();
         }
         continue;
@@ -219,7 +196,12 @@ void handleInput() {
 
 namespace enigma_user {
 
-int display_get_width() { return XWidthOfScreen(enigma::x11::screen); }
-int display_get_height() { return XHeightOfScreen(enigma::x11::screen); }
+int display_get_width() {
+  return XDisplayWidth(enigma::x11::disp, XDefaultScreen(enigma::x11::disp));
+}
+
+int display_get_height() { 
+  return XDisplayHeight(enigma::x11::disp, XDefaultScreen(enigma::x11::disp));
+}
 
 }  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -315,7 +315,6 @@ void window_set_max_height(int height) {
 bool window_get_sizeable() { return enigma::isSizeable; }
 
 void window_set_showborder(bool show) {
-  if (window_get_minimized()) return;
   if (show == window_get_showborder() && show) return;
   Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", False);
   enigma::showBorder = show;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -321,7 +321,7 @@ void window_set_showborder(bool show) {
   if (!show) {
     Hints hints;
     hints.flags = 2;        // Specify that we're changing the window decorations.
-    enigma::decorationsPrevious = hints.decorations; // Save current decorations before changing them.
+    enigma::decorationsPrevious = 1; // Save current decorations before changing them.
     hints.decorations = 0;  // 0 (false) means that window decorations should go bye-bye.
     enigma::decorationsCurrent = hints.decorations; // Save current decorations after changing them.
     XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -354,7 +354,7 @@ bool window_get_showborder() {
   Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", False);
   if (XGetWindowProperty(disp, win, property, 0, LONG_MAX, False, AnyPropertyType, &type, &format, &items, &bytes, &data) == Success && data != NULL) {
     Hints *hints = (Hints *)data;
-    ret = (hints->decorations || items == None);
+    ret = hints->decorations;
     XFree(data);
   }
   return ret;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -54,8 +54,8 @@ int tmpH = enigma::windowHeight;
 
 namespace {
 
-unsigned long decorationsPrevious = !showBorder;
-unsigned long decorationsCurrent = showBorder;
+unsigned long decorationsPrevious = !enigma::showBorder;
+unsigned long decorationsCurrent = enigma::showBorder;
 
 } // anonymous namespace
 
@@ -325,16 +325,16 @@ void window_set_showborder(bool show) {
   if (!show) {
     Hints hints;
     hints.flags = 2;        // Specify that we're changing the window decorations.
-    enigma::decorationsPrevious = 1; // Save current decorations before changing them.
+    decorationsPrevious = 1; // Save current decorations before changing them.
     hints.decorations = 0;  // 0 (false) means that window decorations should go bye-bye.
-    enigma::decorationsCurrent = hints.decorations; // Save current decorations after changing them.
+    decorationsCurrent = hints.decorations; // Save current decorations after changing them.
     XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);
     XMoveResizeWindow(disp, win, enigma::windowX, enigma::windowY, enigma::windowWidth, enigma::windowHeight);
   } else {
     Hints hints;
     hints.flags = 2;        // Specify that we're changing the window decorations.
-    hints.decorations = enigma::decorationsPrevious; // Set decorations back to the way they were.
-    enigma::decorationsCurrent = hints.decorations; // Save current decorations after changing them.
+    hints.decorations = decorationsPrevious; // Set decorations back to the way they were.
+    decorationsCurrent = hints.decorations; // Save current decorations after changing them.
     XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);
     XMoveResizeWindow(disp, win, enigma::windowX - enigma::winEdgeX, enigma::windowY - enigma::winEdgeY, enigma::windowWidth, enigma::windowHeight);
   }

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -325,14 +325,14 @@ void window_set_showborder(bool show) {
     hints.decorations = 0;  // 0 (false) means that window decorations should go bye-bye.
     enigma::decorationsCurrent = hints.decorations; // Save current decorations after changing them.
     XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);
-    XMoveWindow(disp, win, enigma::windowX, enigma::windowY);
+    XMoveResizeWindow(disp, win, enigma::windowX, enigma::windowY, enigma::windowWidth, enigma::windowHeight);
   } else {
     Hints hints;
     hints.flags = 2;        // Specify that we're changing the window decorations.
     hints.decorations = enigma::decorationsPrevious; // Set decorations back to the way they were.
     enigma::decorationsCurrent = hints.decorations; // Save current decorations after changing them.
     XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);
-    XMoveWindow(disp, win, enigma::windowX - enigma::winEdgeX, enigma::windowY - enigma::winEdgeY);
+    XMoveResizeWindow(disp, win, enigma::windowX - enigma::winEdgeX, enigma::windowY - enigma::winEdgeY, enigma::windowWidth, enigma::windowHeight);
   }
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -1,5 +1,5 @@
 /** Copyright (C) 2008-2017 Josh Ventura
-*** Copyright (C) 2013 Robert B. Colton
+*** Copyright (C) 2008-2011 IsmAvatar <cmagicj@nni.com>
 *** Copyright (C) 2014 Seth N. Hetu
 ***
 *** This file is a part of the ENIGMA Development Environment.
@@ -17,661 +17,692 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "Platforms/platforms_mandatory.h"
-#include "Platforms/General/PFmain.h" // For those damn vk_ constants.
-#include "Platforms/General/PFwindow.h"
-
+#include "Platforms/General/PFmain.h"       // For those damn vk_ constants, and io_clear().
+#include "Platforms/platforms_mandatory.h"  // For type insurance
 #include "Widget_Systems/widgets_mandatory.h"
-
-#include "strings_util.h" // For string_replace_all
-#include "Universal_System/var4.h"
-#include "Universal_System/roomsystem.h" // room_caption
 #include "Universal_System/globalupdate.h"
+#include "Universal_System/roomsystem.h"
 
-#include <windows.h>
-#include <stdio.h>
-#include <string>
-using namespace std;
+#include "GameSettings.h"  // ABORT_ON_ALL_ERRORS (MOVEME: this shouldn't be needed here)
+#include "XLIBmain.h"
+#include "XLIBwindow.h"  // Type insurance for non-mandatory functions
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <stdio.h>   //printf, NULL
+#include <stdlib.h>  //malloc
+#include <time.h>    //clock
+#include <unistd.h>  //usleep
+#include <climits>
+#include <map>
+#include <string>  //Return strings without needing a GC
+
+//////////
+// INIT //
+//////////
+
+Cursor NoCursor, DefCursor;
+
+using namespace enigma::x11;
+
+namespace tmpSize {
+    
+int tmpW = enigma::windowWidth;
+int tmpH = enigma::windowHeight;
+
+} // namespace tmpSize
 
 namespace {
 
-std::string current_caption = "";
+unsigned long decorationsPrevious = !enigma::showBorder;
+unsigned long decorationsCurrent = enigma::showBorder;
 
 } // anonymous namespace
 
-namespace enigma
+namespace enigma {
+
+namespace x11 {
+Display* disp;
+Screen* screen;
+Window win;
+Atom wm_delwin;
+
+void set_net_wm_pid(Window window) {
+  pid_t pid = getpid();
+  Atom cardinal = XInternAtom(disp, "CARDINAL", False);
+  Atom net_wm_pid = XInternAtom(disp, "_NET_WM_PID", False);
+  XChangeProperty(disp, window, net_wm_pid, cardinal, 32, PropModeReplace, (unsigned char*)&pid, sizeof(pid) / 4);
+}
+} // namespace x11;
+
+bool initGameWindow()
 {
-
-extern HWND hWnd;
-HCURSOR currentCursor = LoadCursor(NULL, IDC_ARROW);
-
-void configure_devmode(DEVMODE &devMode, int w, int h, int freq, int bitdepth) {
-  if (w != -1) {
-    devMode.dmFields |= DM_PELSWIDTH;
-    devMode.dmPelsWidth = w;
+  // Initiate display
+  disp = XOpenDisplay(NULL);
+  if (!disp) {
+    DEBUG_MESSAGE("Display failed", MESSAGE_TYPE::M_FATAL_ERROR);
+    return false;
   }
 
-  if (h != -1) {
-    devMode.dmFields |= DM_PELSHEIGHT;
-    devMode.dmPelsHeight = h;
+  // Identify components (close button, root pane)
+  wm_delwin = XInternAtom(disp, "WM_DELETE_WINDOW", False);
+  Window root = DefaultRootWindow(disp);
+
+  // Defined in the appropriate graphics bridge.
+  // Populates GLX attributes (or other graphics-system-specific properties).
+  XVisualInfo* vi = enigma::CreateVisualInfo();
+
+  // Window event listening and coloring
+  XSetWindowAttributes swa;
+  swa.border_pixel = 0;
+  swa.background_pixel = (enigma::windowColor & 0xFF000000) | ((enigma::windowColor & 0xFF0000) >> 16) |
+                         (enigma::windowColor & 0xFF00) | ((enigma::windowColor & 0xFF) << 16);
+  swa.colormap = XCreateColormap(disp, root, vi->visual, AllocNone);
+  swa.event_mask = ExposureMask | KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask |
+                   FocusChangeMask | StructureNotifyMask;
+  unsigned long valmask = CWColormap | CWEventMask | CWBackPixel;  // | CWBorderPixel;
+
+  // Prepare window for display (center, caption, etc)
+  screen = DefaultScreenOfDisplay(disp);
+  int winw = enigma_user::room_width;
+  int winh = enigma_user::room_height;
+  // By default, if the room is too big, limit the size of the window to the
+  // size of the screen. This is what 8.1 and Studio do; if the user wants to
+  // manually override this they can do so using views/screen_set_viewport or
+  // window_set_size/window_set_region_size.
+  if (winw > screen->width) winw = screen->width;
+  if (winh > screen->height) winh = screen->height;
+
+  // Make the window
+  win = XCreateWindow(disp, root, 0, 0, winw, winh, 0, vi->depth, InputOutput, vi->visual, valmask, &swa);
+  set_net_wm_pid(win);
+  XMoveWindow(disp, win, (screen->width - winw) / 2, (screen->height - winh) / 2);
+
+  //register CloseButton listener
+  Atom prots[] = {wm_delwin};
+  if (!XSetWMProtocols(disp, win, prots, 1)) {
+    DEBUG_MESSAGE("NoClose", MESSAGE_TYPE::M_ERROR);
+    return false;
   }
 
-  if (freq != -1) {
-    devMode.dmFields |= DM_DISPLAYFREQUENCY;
-    devMode.dmDisplayFrequency = freq;
+  //Default cursor
+  DefCursor = XCreateFontCursor(disp, 68);
+  //Blank cursor
+  XColor dummy;
+  Pixmap blank = XCreateBitmapFromData(disp, win, "", 1, 1);
+  if (blank == None) {  //out of memory
+    DEBUG_MESSAGE("Failed to create no cursor. lulz", MESSAGE_TYPE::M_ERROR);
+    NoCursor = DefCursor;
+  } else {
+    NoCursor = XCreatePixmapCursor(disp, blank, blank, &dummy, &dummy, 0, 0);
+    XFreePixmap(disp, blank);
   }
 
-  if (bitdepth != -1) {
-    devMode.dmFields |= DM_BITSPERPEL;
-    devMode.dmBitsPerPel = bitdepth;
+  return true;
+}
+
+void destroyWindow() {
+  XCloseDisplay(enigma::x11::disp);
+}
+
+}  //namespace enigma
+
+namespace enigma_user {
+
+void window_set_visible(bool visible) {
+  if (visible) {
+    XMapRaised(disp, win);
+  } else {
+    XUnmapWindow(disp, win);
   }
 }
 
+int window_get_visible() {
+  XWindowAttributes wa;
+  XGetWindowAttributes(disp, win, &wa);
+  return wa.map_state != IsUnmapped;
+}
+
+void window_set_caption(const string &caption) { XStoreName(disp, win, caption.c_str()); }
+
+string window_get_caption() {
+  char* caption;
+  XFetchName(disp, win, &caption);
+  if (!caption) return string();
+  string res = caption;
+  XFree(caption);
+  return res;
+}
+
+}  // namespace enigma_user
+
+inline int getMouse(int i) {
+  Window r1, r2;
+  int rx, ry, wx, wy;
+  unsigned int mask;
+  XQueryPointer(disp, win, &r1, &r2, &rx, &ry, &wx, &wy, &mask);
+  switch (i) {
+    case 0:
+      return rx;
+    case 1:
+      return ry;
+    case 2:
+      return wx;
+    case 3:
+      return wy;
+    default:
+      return -1;
+  }
+}
+
+enum { _NET_WM_STATE_REMOVE, _NET_WM_STATE_ADD, _NET_WM_STATE_TOGGLE };
+
+typedef struct {
+  unsigned long flags;
+  unsigned long functions;
+  unsigned long decorations;
+  long inputMode;
+  unsigned long status;
+} Hints;
+
+template <int count>
+static bool windowHasAtom(const Atom (&atom)[count]) {
+  bool res = false;
+  Atom wmState = XInternAtom(disp, "_NET_WM_STATE", False);
+
+  //Return types, not really used.
+  Atom actualType;
+  int actualFormat;
+  unsigned long bytesAfterReturn;
+
+  //These are used.
+  unsigned long numItems;
+  unsigned char* data = NULL;
+
+  if (XGetWindowProperty(disp, win, wmState, 0, LONG_MAX, False, AnyPropertyType, &actualType, &actualFormat, &numItems,
+                         &bytesAfterReturn, &data) == Success) {
+    for (unsigned long i = 0; i < numItems; ++i) {
+      for (int j = 0; j < count; ++j) {
+        if (atom[j] == reinterpret_cast<unsigned long*>(data)[i]) {
+          res = true;
+          break;
+        }
+      }
+    }
+  }
+
+  // Reclaim memory.
+  if (data) {
+    XFree(data);
+  }
+  return res;
 }
 
 namespace enigma_user {
 
-#if GM_COMPATIBILITY_VERSION <= 81
-unsigned long long window_handle() {
-  return (unsigned long long)enigma::hWnd;
-}
-#else
-void* window_handle() {
-  return enigma::hWnd;
-}
-#endif
+int display_mouse_get_x() { return getMouse(0); }
+int display_mouse_get_y() { return getMouse(1); }
+int window_mouse_get_x() { return getMouse(2); }
+int window_mouse_get_y() { return getMouse(3); }
 
-// GM8.1 Used its own internal variables for these functions and reported the regular window dimensions when minimized,
-// Studio uses the native functions and will tell you the dimensions of the window are 0 when it is minimized,
-// I have decided to go with the Studio method because it is still backwards compatible but also because it saves us some variables.
-// NOTE: X and Y are -32000 when the window is minimized.
-int window_get_x()
-{
-  RECT rc;
-  GetWindowRect(enigma::hWnd, &rc);
-  return rc.left;
-}
-
-int window_get_y()
-{
-  RECT rc;
-  GetWindowRect(enigma::hWnd, &rc);
-  return rc.top;
+void window_set_stayontop(bool stay) {
+  Atom wmState = XInternAtom(disp, "_NET_WM_STATE", False);
+  Atom aStay = XInternAtom(disp, "_NET_WM_STATE_ABOVE", False);
+  XEvent xev;
+  xev.xclient.type = ClientMessage;
+  xev.xclient.serial = 0;
+  xev.xclient.send_event = True;
+  xev.xclient.window = win;
+  xev.xclient.message_type = wmState;
+  xev.xclient.format = 32;
+  xev.xclient.data.l[0] = (stay ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE);
+  xev.xclient.data.l[1] = aStay;
+  xev.xclient.data.l[2] = 0;
+  XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
 }
 
-int window_get_width()
-{
-  RECT rc;
-  GetClientRect(enigma::hWnd, &rc);
-  return rc.right-rc.left;
-}
-
-int window_get_height()
-{
-  RECT rc;
-  GetClientRect(enigma::hWnd, &rc);
-  return rc.bottom-rc.top;
-}
-
-void window_set_caption(const string &caption)
-{
-/*  if (caption == "")
-      if (score != 0)
-        caption = "Score: " + string(score);  //GM does this but it's rather fucktarded */
-
-    if (caption != current_caption)
-    {
-        SetWindowText(enigma::hWnd,(char*) caption.c_str());
-        current_caption = caption;
-    }
-}
-
-string window_get_caption()
-{
-  return current_caption;
-}
-
-void window_set_alpha(double alpha) {
-  // Set WS_EX_LAYERED on this window
-  SetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE,
-      GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
-
-  // Make this window transparent
-  SetLayeredWindowAttributes(enigma::hWnd, 0, (unsigned char)(alpha*255), LWA_ALPHA);
-}
-
-double window_get_alpha() {
-	unsigned char alpha;
-	// Make this window transparent
-	GetLayeredWindowAttributes(enigma::hWnd, 0, &alpha, 0);
-	return alpha/255;
-}
-
-void window_set_position(int x, int y)
-{
-  enigma::windowX = x;
-  enigma::windowY = y;
-  if (window_get_fullscreen()) return;
-  SetWindowPos(enigma::hWnd, HWND_TOP, enigma::windowX, enigma::windowY, 0, 0, SWP_NOSIZE|SWP_NOACTIVATE);
-}
-
-void window_set_size(unsigned int width, unsigned int height)
-{
-  enigma::windowWidth = width;
-  enigma::windowHeight = height;
-  if (window_get_fullscreen()) return;
-  enigma::compute_window_size();
-}
-
-void window_set_rectangle(int x, int y, int width, int height) {
-  RECT c;
-  c.left = (enigma::windowX = x); c.top = (enigma::windowY = y); c.right = enigma::windowX + (enigma::windowWidth = width); c.bottom = enigma::windowY + (enigma::windowHeight = height);
-  if (window_get_fullscreen()) return;
-  AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_STYLE), false);
-  SetWindowPos(enigma::hWnd, HWND_TOP, c.left, c.top, c.right-c.left, c.bottom-c.top, SWP_NOZORDER|SWP_FRAMECHANGED);
-}
-
-namespace {
-  bool prefer_sizeable;
-  bool prefer_borderless;
-  bool get_fullscreen;
-  bool get_stayontop;
-}
-
-void window_set_fullscreen(bool full) {
-  get_fullscreen = full;
-  get_stayontop = window_get_stayontop();
-  // tweak the style first to remove or restore the window border
-  if (full) {
-    window_set_stayontop(true);
-    LONG_PTR style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
-    style &= ~(WS_CAPTION | WS_BORDER | WS_MAXIMIZEBOX | WS_MINIMIZEBOX);
-    style |= WS_SIZEBOX;
-    SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
-    window_set_maximized(full);
-    enigma::compute_window_scaling();
-  } else {
-    window_set_maximized(full);
-    window_set_showborder(!prefer_borderless);
-    window_set_sizeable(prefer_sizeable);
-    window_set_stayontop(get_stayontop);
-    enigma::compute_window_size();
-  }
-}
-
-bool window_get_fullscreen() {
-  return get_fullscreen;
+bool window_get_stayontop() {
+  Atom a[] = {XInternAtom(disp, "_NET_WM_STATE_ABOVE", False)};
+  return windowHasAtom(a);
 }
 
 void window_set_sizeable(bool sizeable) {
   if (window_get_maximized()) return;
   if (window_get_fullscreen()) return;
-  prefer_sizeable = sizeable;
-  DWORD style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
-  if (sizeable) style |= WS_SIZEBOX | WS_MAXIMIZEBOX;
-  else style &= ~(WS_SIZEBOX | WS_MAXIMIZEBOX);
-  style |= WS_MINIMIZEBOX;
-  SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
-  enigma::compute_window_size();
+  enigma::isSizeable = sizeable;
+  XSizeHints *sh = XAllocSizeHints();
+  sh->flags = PMinSize | PMaxSize;
+  
+  if (enigma::window_min_width == -1)
+    enigma::window_min_width = 1;
+  if (enigma::window_max_width == -1) 
+    enigma::window_max_width = INT_MAX;
+  if (enigma::window_min_height == -1) 
+    enigma::window_min_height = 1;
+  if (enigma::window_max_height == -1) 
+    enigma::window_max_height = INT_MAX;
+  
+  if (sizeable) {
+    sh->min_width = enigma::window_min_width;
+    sh->max_width = enigma::window_max_width;
+    sh->min_height = enigma::window_min_height;
+    sh->max_height = enigma::window_max_height;
+  } else {
+    sh->min_width = sh->max_width = window_get_width();
+    sh->min_height = sh->max_height = window_get_height();
+  }
+  XSetWMNormalHints(disp, win, sh);
+  XFree(sh);
+
+  XResizeWindow(disp, win, enigma::windowWidth, enigma::windowHeight);
 }
 
-bool window_get_sizeable() {
-  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_THICKFRAME) == WS_THICKFRAME;
+void window_set_min_width(int width) {
+  enigma::window_min_width = width;
+  window_set_sizeable(enigma::isSizeable);
 }
+
+void window_set_min_height(int height) {
+  enigma::window_min_height = height;
+  window_set_sizeable(enigma::isSizeable);
+}
+
+void window_set_max_width(int width) {
+  enigma::window_max_width = width;
+  window_set_sizeable(enigma::isSizeable);
+}
+
+void window_set_max_height(int height) {
+  enigma::window_max_height = height;
+  window_set_sizeable(enigma::isSizeable);
+}
+
+bool window_get_sizeable() { return enigma::isSizeable; }
 
 void window_set_showborder(bool show) {
   if (window_get_maximized()) return;
   if (window_get_fullscreen()) return;
-  prefer_borderless = !show;
-  DWORD style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
-  if (show) style |= WS_CAPTION | WS_BORDER;
-  else style &= ~(WS_CAPTION | WS_BORDER);
-  SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
-  enigma::compute_window_size();
+  if (show == window_get_showborder() && show) return;
+  Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", False);
+  enigma::showBorder = show;
+  if (!show) {
+    Hints hints;
+    hints.flags = 2;        // Specify that we're changing the window decorations.
+    decorationsPrevious = 1; // Save current decorations before changing them.
+    hints.decorations = 0;  // 0 (false) means that window decorations should go bye-bye.
+    decorationsCurrent = hints.decorations; // Save current decorations after changing them.
+    XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);
+    XMoveResizeWindow(disp, win, enigma::windowX, enigma::windowY, enigma::windowWidth, enigma::windowHeight);
+  } else {
+    Hints hints;
+    hints.flags = 2;        // Specify that we're changing the window decorations.
+    hints.decorations = decorationsPrevious; // Set decorations back to the way they were.
+    decorationsCurrent = hints.decorations; // Save current decorations after changing them.
+    XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);
+    XMoveResizeWindow(disp, win, enigma::windowX - enigma::winEdgeX, enigma::windowY - enigma::winEdgeY, enigma::windowWidth, enigma::windowHeight);
+  }
 }
 
 bool window_get_showborder() {
-  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_CAPTION) == WS_CAPTION;
+  return enigma::showBorder;
 }
 
 void window_set_showicons(bool show) {
-  SetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE,
-      GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+  if (enigma::showIcons == show) return;
+  enigma::showIcons = show;
+
+  Atom wmState = XInternAtom(disp, "_NET_WM_WINDOW_TYPE", False);
+  Atom aShow = XInternAtom(disp, "_NET_WM_WINDOW_TYPE_TOOLBAR", False);
+  XEvent xev;
+  xev.xclient.type = ClientMessage;
+  xev.xclient.serial = 0;
+  xev.xclient.send_event = True;
+  xev.xclient.window = win;
+  xev.xclient.message_type = wmState;
+  xev.xclient.format = 32;
+  xev.xclient.data.l[0] = (show ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE);
+  xev.xclient.data.l[1] = aShow;
+  xev.xclient.data.l[2] = 0;
+  XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
 }
 
-bool window_get_showicons() {
-  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_THICKFRAME) == WS_THICKFRAME;
-}
-
-void window_set_visible(bool visible) {
-  ShowWindow(enigma::hWnd, visible? SW_SHOW : SW_HIDE);
-}
-
-int window_get_visible() {
-  return IsWindowVisible(enigma::hWnd);
-}
+bool window_get_showicons() { return enigma::showIcons; }
 
 void window_set_minimized(bool minimized) {
-  ShowWindow(enigma::hWnd, minimized? SW_MINIMIZE : SW_RESTORE);
-}
+  XClientMessageEvent ev;
+  Atom prop;
 
-void window_set_maximized(bool maximized) {
-  ShowWindow(enigma::hWnd, maximized? SW_MAXIMIZE : SW_RESTORE);
+  prop = XInternAtom(disp, "WM_CHANGE_STATE", False);
+  if (prop == None) return;
+
+  // TODO: When restored after a minimize the window may not have focus.
+  ev.type = ClientMessage;
+  ev.window = win;
+  ev.message_type = prop;
+  ev.format = 32;
+  ev.data.l[0] = minimized ? IconicState : NormalState;
+  XSendEvent(disp, RootWindow(disp, 0), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*)&ev);
 }
 
 bool window_get_minimized() {
-  return IsIconic(enigma::hWnd);
+  Atom a[] = {XInternAtom(disp, "_NET_WM_STATE_HIDDEN", False)};
+  return windowHasAtom(a);
+}
+
+void window_set_maximized(bool maximized) {
+  XClientMessageEvent ev;
+
+  if (maximized) {
+    Atom wm_state, max_horz, max_vert;
+    wm_state = XInternAtom(disp, "_NET_WM_STATE", False);
+    if (wm_state == None) return;
+
+    max_horz = XInternAtom(disp, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
+    max_vert = XInternAtom(disp, "_NET_WM_STATE_MAXIMIZED_VERT", False);
+
+    // TODO: When restored after a minimize the window may not have focus.
+    ev.type = ClientMessage;
+    ev.window = win;
+    ev.message_type = wm_state;
+    ev.format = 32;
+    ev.data.l[0] = _NET_WM_STATE_ADD;
+    ev.data.l[1] = max_horz;
+    ev.data.l[2] = max_vert;
+    XSendEvent(disp, RootWindow(disp, 0), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*)&ev);
+  } else {
+    Atom prop;
+    prop = XInternAtom(disp, "WM_CHANGE_STATE", False);
+    if (prop == None) return;
+
+    // TODO: When restored after a minimize the window may not have focus.
+    ev.type = ClientMessage;
+    ev.window = win;
+    ev.message_type = prop;
+    ev.format = 32;
+    ev.data.l[0] = NormalState;
+    XSendEvent(disp, RootWindow(disp, 0), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*)&ev);
+  }
 }
 
 bool window_get_maximized() {
-  return IsZoomed(enigma::hWnd);
+  Atom maximized[] = {XInternAtom(disp, "_NET_WM_STATE_MAXIMIZED_VERT", False),
+                      XInternAtom(disp, "_NET_WM_STATE_MAXIMIZED_HORZ", False)};
+  return windowHasAtom(maximized);
 }
 
-void window_set_stayontop(bool stay)
-{
-  if (stay) {
-    SetWindowPos(enigma::hWnd,HWND_TOPMOST,0,0,0,0,SWP_NOSIZE|SWP_NOMOVE);
-  } else {
-    SetWindowPos(enigma::hWnd,HWND_BOTTOM,0,0,0,0,SWP_NOSIZE|SWP_NOMOVE|SWP_NOACTIVATE);
-    SetWindowPos(enigma::hWnd,HWND_TOP,   0,0,0,0,SWP_NOSIZE|SWP_NOMOVE);
+void window_mouse_set(int x, int y) { XWarpPointer(disp, None, win, 0, 0, 0, 0, (int)x, (int)y); }
+
+void display_mouse_set(int x, int y) { XWarpPointer(disp, None, DefaultRootWindow(disp), 0, 0, 0, 0, (int)x, (int)y); }
+
+////////////
+// WINDOW //
+////////////
+
+//Getters
+int window_get_x() { return enigma::windowX; }
+int window_get_y() { return enigma::windowY; }
+int window_get_width() { return enigma::windowWidth; }
+int window_get_height() { return enigma::windowHeight; }
+
+//Setters
+void window_set_position(int x, int y) {
+  if (window_get_fullscreen()) return;
+  enigma::windowX = x;
+  enigma::windowY = y;
+  XWindowAttributes wa;
+  XGetWindowAttributes(disp, win, &wa);
+  XMoveWindow(disp, win, (int)x - wa.x, (int)y - wa.y);
+}
+
+void window_set_size(unsigned int w, unsigned int h) {
+  if (window_get_fullscreen()) return;
+  enigma::windowWidth = w;
+  enigma::windowHeight = h;
+  enigma::compute_window_size();
+}
+
+void window_set_rectangle(int x, int y, int w, int h) {
+  if (window_get_fullscreen()) return;
+  enigma::windowX = x;
+  enigma::windowY = y;
+  enigma::windowWidth = w;
+  enigma::windowHeight = h;
+  XMoveResizeWindow(disp, win, x, y, w, h);
+}
+
+////////////////
+// FULLSCREEN //
+////////////////
+
+void window_set_fullscreen(bool full) {
+  if (enigma::isFullScreen == full && !full) return;
+  enigma::isFullScreen = full;
+  if (full) {
+    tmpSize::tmpW = enigma::windowWidth;
+    tmpSize::tmpH = enigma::windowHeight;
   }
+  Atom wmState = XInternAtom(disp, "_NET_WM_STATE", False);
+  Atom aFullScreen = XInternAtom(disp, "_NET_WM_STATE_FULLSCREEN", False);
+  XEvent xev;
+  xev.xclient.type = ClientMessage;
+  xev.xclient.serial = 0;
+  xev.xclient.send_event = True;
+  xev.xclient.window = win;
+  xev.xclient.message_type = wmState;
+  xev.xclient.format = 32;
+  xev.xclient.data.l[0] = (full ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE);
+  xev.xclient.data.l[1] = aFullScreen;
+  xev.xclient.data.l[2] = 0;
+  XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
+  if (!full) XResizeWindow(disp, win, tmpSize::tmpW, tmpSize::tmpH);
 }
 
-bool window_get_stayontop() {
-    return (GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) & WS_EX_TOPMOST) == WS_EX_TOPMOST;
+bool window_get_fullscreen() {
+  Atom fullscreen[] = {XInternAtom(disp, "_NET_WM_STATE_FULLSCREEN", False)};
+  return windowHasAtom(fullscreen);
 }
 
-int display_mouse_get_x() {
-  POINT mouse;
-  GetCursorPos(&mouse);
-  return mouse.x;
+}  // namespace enigma_user
+
+//default    +   -5   I    \    |    /    -    ^   ...  drg  no  -    |  drg3 ...  X  ...  ?   url  +
+short curs[] = {68, 68, 68, 130, 52, 152, 135, 116, 136, 108, 114, 150, 90, 68, 108, 116, 90, 150, 0, 150, 92, 60, 52};
+
+namespace enigma {
+std::map<int, int> keybdmap;
+
+inline unsigned short highbyte_allornothing(short x) { return x & 0xFF00 ? x | 0xFF00 : x; }
+
+unsigned char keymap[512];
+unsigned short keyrmap[256];
+void initkeymap() {
+  using namespace enigma_user;
+
+  for (size_t i = 0; i < 512; ++i) keymap[i] = 0;
+  for (size_t i = 0; i < 256; ++i) keyrmap[i] = 0;
+
+  // Pretend this part doesn't exist
+  keymap[0x151] = vk_left;
+  keymap[0x153] = vk_right;
+  keymap[0x152] = vk_up;
+  keymap[0x154] = vk_down;
+  keymap[0x1E3] = vk_control;
+  keymap[0x1E4] = vk_control;
+  keymap[0x1E9] = vk_alt;
+  keymap[0x1EA] = vk_alt;
+  keymap[0x1E1] = vk_shift;
+  keymap[0x1E2] = vk_shift;
+  keymap[0x10D] = vk_enter;
+  keymap[0x185] = vk_lsuper;
+  keymap[0x186] = vk_rsuper;
+  keymap[0x117] = vk_tab;
+  keymap[0x142] = vk_caps;
+  keymap[0x14E] = vk_scroll;
+  keymap[0x17F] = vk_pause;
+  keymap[0x19E] = vk_numpad0;
+  keymap[0x19C] = vk_numpad1;
+  keymap[0x199] = vk_numpad2;
+  keymap[0x19B] = vk_numpad3;
+  keymap[0x196] = vk_numpad4;
+  keymap[0x19D] = vk_numpad5;
+  keymap[0x198] = vk_numpad6;
+  keymap[0x195] = vk_numpad7;
+  keymap[0x197] = vk_numpad8;
+  keymap[0x19A] = vk_numpad9;
+  keymap[0x1AF] = vk_divide;
+  keymap[0x1AA] = vk_multiply;
+  keymap[0x1AD] = vk_subtract;
+  keymap[0x1AB] = vk_add;
+  keymap[0x19F] = vk_decimal;
+  keymap[0x1BE] = vk_f1;
+  keymap[0x1BF] = vk_f2;
+  keymap[0x1C0] = vk_f3;
+  keymap[0x1C1] = vk_f4;
+  keymap[0x1C2] = vk_f5;
+  keymap[0x1C3] = vk_f6;
+  keymap[0x1C4] = vk_f7;
+  keymap[0x1C5] = vk_f8;
+  keymap[0x1C6] = vk_f9;
+  keymap[0x1C7] = vk_f10;
+  keymap[0x1C8] = vk_f11;
+  keymap[0x1C9] = vk_f12;
+  keymap[0x108] = vk_backspace;
+  keymap[0x11B] = vk_escape;
+  keymap[0x150] = vk_home;
+  keymap[0x157] = vk_end;
+  keymap[0x155] = vk_pageup;
+  keymap[0x156] = vk_pagedown;
+  keymap[0x1FF] = vk_delete;
+  keymap[0x163] = vk_insert;
+
+  // Set up identity map...
+  //for (int i = 0; i < 255; i++)
+  //  usermap[i] = i;
+
+  for (int i = 0; i < 'a'; i++) keymap[i] = i;
+  for (int i = 'a'; i <= 'z'; i++)  // 'a' to 'z' wrap to 'A' to 'Z'
+    keymap[i] = i + 'A' - 'a';
+  for (int i = 'z' + 1; i < 255; i++) keymap[i] = i;
+
+  for (size_t i = 0; i < 512; ++i) keyrmap[keymap[i]] = highbyte_allornothing(i);
 }
+}  // namespace enigma
 
-int display_mouse_get_y() {
-  POINT mouse;
-  GetCursorPos(&mouse);
-  return mouse.y;
-}
+namespace enigma_user {
 
-void display_mouse_set(int x,int y) {
-    SetCursorPos(x,y);
-}
-
-int display_get_width() {
-   return GetSystemMetrics(SM_CXSCREEN);
-}
-
-int display_get_height() {
-   return GetSystemMetrics(SM_CYSCREEN);
-}
-
-int display_get_colordepth() {
-  return GetDeviceCaps(GetDC(enigma::hWnd), BITSPIXEL);
-}
-
-int display_get_frequency() {
-  return GetDeviceCaps(GetDC(enigma::hWnd), VREFRESH);
-}
-
-unsigned display_get_dpi_x() {
-  return GetDeviceCaps(GetDC(enigma::hWnd), LOGPIXELSX);
-}
-
-unsigned display_get_dpi_y() {
-  return GetDeviceCaps(GetDC(enigma::hWnd), LOGPIXELSY);
-}
-
-void display_reset()
-{
-	ChangeDisplaySettings(NULL, 0);
-}
-
-bool display_set_size(int w, int h)
-{
-	DEVMODE devMode;
-
-	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
-		return false;
-
-	devMode.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
-	devMode.dmPelsWidth = w;
-	devMode.dmPelsHeight = h;
-
-	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
-}
-
-bool display_set_frequency(int freq)
-{
-	DEVMODE devMode;
-
-	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
-		return false;
-
-	devMode.dmFields = DM_DISPLAYFREQUENCY;
-	devMode.dmDisplayFrequency = freq;
-
-	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
-}
-
-bool display_set_colordepth(int depth)
-{
-	DEVMODE devMode;
-
-	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
-		return true;
-
-	devMode.dmFields = DM_BITSPERPEL;
-	devMode.dmBitsPerPel = depth;
-
-  return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
-}
-
-bool display_set_all(int w, int h, int freq, int bitdepth)
-{
-	DEVMODE devMode;
-
-	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
-		return false;
-
-	enigma::configure_devmode(devMode, w, h, freq, bitdepth);
-
-	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
-}
-
-bool display_test_all(int w, int h, int freq, int bitdepth)
-{
-	DEVMODE devMode;
-
-	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
-		return false;
-
-	enigma::configure_devmode(devMode, w, h, freq, bitdepth);
-
-	return (ChangeDisplaySettings(&devMode, CDS_TEST) == DISP_CHANGE_SUCCESSFUL);
-}
-
-int window_mouse_get_x()
-{
-  POINT mouse;
-  GetCursorPos(&mouse);
-  ScreenToClient(enigma::hWnd, &mouse);
-
-  return mouse.x;
-}
-
-int window_mouse_get_y()
-{
-  POINT mouse;
-  GetCursorPos(&mouse);
-  ScreenToClient(enigma::hWnd, &mouse);
-
-  return mouse.y;
-}
-
-void window_mouse_set(int x, int y)
-{
-  POINT pt;
-  pt.x=x;
-  pt.y=y;
-  ClientToScreen(enigma::hWnd, &pt);
-  SetCursorPos(pt.x, pt.y);
-}
-
-}
-
-namespace enigma_user
-{
-
-int window_set_cursor(int c)
-{
-  enigma::cursorInt = c;
-  char* cursor = NULL;
-  // this switch statement could be replaced with an array aligned to the constants
-  switch (c)
-  {
-      case cr_default:
-      case cr_arrow:
-          cursor = IDC_ARROW;
-          break;
-      case cr_none:
-          cursor = NULL;
-          break;
-      case cr_cross:
-          cursor = IDC_CROSS;
-          break;
-      case cr_beam:
-          cursor = IDC_IBEAM;
-          break;
-      case cr_size_nesw:
-          cursor = IDC_SIZENESW;
-          break;
-      case cr_size_ns:
-          cursor = IDC_SIZENS;
-          break;
-      case cr_size_nwse:
-          cursor = IDC_SIZENWSE;
-          break;
-      case cr_size_we:
-          cursor = IDC_SIZEWE;
-          break;
-      case cr_uparrow:
-          cursor = IDC_UPARROW;
-          break;
-      case cr_hourglass:
-          cursor = IDC_WAIT;
-          break;
-      case cr_drag:
-          // Delphi-made?
-          cursor = IDC_HAND;
-          break;
-      case cr_nodrop:
-          cursor = IDC_NO;
-          break;
-      case cr_hsplit:
-          // Delphi-made?
-          cursor = IDC_SIZENS;
-          break;
-      case cr_vsplit:
-          // Delphi-made?
-          cursor = IDC_SIZEWE;
-          break;
-      case cr_multidrag:
-          cursor = IDC_SIZEALL;
-          break;
-      case cr_sqlwait:
-          // DEAR GOD WHY
-          cursor = IDC_WAIT;
-          break;
-      case cr_no:
-          cursor = IDC_NO;
-          break;
-      case cr_appstart:
-          cursor = IDC_APPSTARTING;
-          break;
-      case cr_help:
-          cursor = IDC_HELP;
-          break;
-      case cr_handpoint:
-          cursor = IDC_HAND;
-          break;
-      case cr_size_all:
-          cursor = IDC_SIZEALL;
-          break;
-  }
-  enigma::currentCursor = LoadCursor(NULL, cursor);
-  return SendMessage(enigma::hWnd, WM_SETCURSOR, (WPARAM)enigma::hWnd, MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
-}
-
-int window_get_cursor()
-{
-  return enigma::cursorInt;
-}
-
-void io_handle()
-{
-  MSG msg;
+void io_handle() {
   enigma::input_push();
-  while (PeekMessage (&msg, NULL, 0, 0, PM_REMOVE))
-  {
-    TranslateMessage (&msg);
-    DispatchMessage (&msg);
+  while (XQLength(disp)) {
+    DEBUG_MESSAGE("processing an event...", MESSAGE_TYPE::M_INFO);
+    if (enigma::handleEvents() > 0) exit(0);
   }
   enigma::update_mouse_variables();
 }
 
+int window_set_cursor(int c) {
+  enigma::cursorInt = c;
+  XUndefineCursor(disp, win);
+  XDefineCursor(disp, win, (c == -1) ? NoCursor : XCreateFontCursor(disp, curs[-c]));
+  return 0;
+}
 
-bool keyboard_check_direct(int key)
-{
-   BYTE keyState[256];
+int window_get_cursor() { return enigma::cursorInt; }
 
-   if ( GetKeyboardState( keyState ) )  {
-	  for (int x = 0; x < 256; x++)
-		keyState[x] = (char) (GetKeyState(x) >> 8);
-   } else {
-      //TODO: print error message.
-	  return 0;
-   }
+bool keyboard_check_direct(int key) {
+  char keyState[32];
+
+  if (XQueryKeymap(enigma::x11::disp, keyState)) {
+    //for (int x = 0; x < 32; x++)
+    //keyState[x] = 0;
+  } else {
+    //TODO: print error message.
+    return 0;
+  }
 
   if (key == vk_anykey) {
-    for(int i = 0; i < 256; i++)
-      if (keyState[i] == 1) return 1;
+    // next go through each member of keyState array
+    for (unsigned i = 0; i < 32; i++) {
+      const char& currentChar = keyState[i];
+
+      // iterate over each bit and check if the bit is set
+      for (unsigned j = 0; j < 8; j++) {
+        // AND current char with current bit we're interested in
+        bool isKeyPressed = ((1 << j) & currentChar) != 0;
+
+        if (isKeyPressed) {
+          return 1;
+        }
+      }
+    }
     return 0;
   }
   if (key == vk_nokey) {
-    for(int i = 0; i < 256; i++)
-      if (keyState[i] == 1) return 0;
-    return 1;
-  }
-  return keyState[key & 0xFF];
-}
+    // next go through each member of keyState array
+    for (unsigned i = 0; i < 32; i++) {
+      const char& currentChar = keyState[i];
 
-void keyboard_key_press(int key) {
-  BYTE keyState[256];
+      // iterate over each bit and check if the bit is set
+      for (unsigned j = 0; j < 8; j++) {
+        // AND current char with current bit we're interested in
+        bool isKeyPressed = ((1 << j) & currentChar) != 0;
 
-  GetKeyboardState((LPBYTE)&keyState);
-
-  // Simulate a key press
-  keybd_event( key,
-        keyState[key],
-        KEYEVENTF_EXTENDEDKEY | 0,
-        0 );
-}
-
-void keyboard_key_release(int key) {
-  BYTE keyState[256];
-
-  GetKeyboardState((LPBYTE)&keyState);
-
-  // Simulate a key release
-  keybd_event( key, keyState[key], KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
-}
-
-bool keyboard_get_capital() {
-	return (((unsigned short)GetKeyState(0x14)) & 0xffff) != 0;
-}
-
-bool keyboard_get_numlock() {
-	return (((unsigned short)GetKeyState(0x90)) & 0xffff) != 0;
-}
-
-bool keyboard_get_scroll() {
-	return (((unsigned short)GetKeyState(0x91)) & 0xffff) != 0;
-}
-
-void keyboard_set_capital(bool on) {
-  BYTE keyState[256];
-
-  GetKeyboardState((LPBYTE)&keyState);
-
-  if( (on && !(keyState[VK_CAPITAL] & 1)) ||
-  (!on && (keyState[VK_CAPITAL] & 1)) )
-  {
-    // Simulate a key press
-    keybd_event( VK_CAPITAL, 0x14, KEYEVENTF_EXTENDEDKEY | 0, 0 );
-
-    // Simulate a key release
-    keybd_event( VK_CAPITAL, 0x14, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
-  }
-}
-
-void keyboard_set_numlock(bool on) {
-  BYTE keyState[256];
-
-  GetKeyboardState((LPBYTE)&keyState);
-
-  if( (on && !(keyState[VK_NUMLOCK] & 1)) ||
-  (!on && (keyState[VK_NUMLOCK] & 1)) )
-  {
-    // Simulate a key press
-    keybd_event( VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | 0, 0 );
-
-    // Simulate a key release
-    keybd_event( VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
-  }
-}
-
-void keyboard_set_scroll(bool on) {
-  BYTE keyState[256];
-
-  GetKeyboardState((LPBYTE)&keyState);
-
-  if( (on && !(keyState[VK_SCROLL] & 1)) ||
-  (!on && (keyState[VK_SCROLL] & 1)) )
-  {
-    // Simulate a key press
-    keybd_event( VK_SCROLL, 0x91, KEYEVENTF_EXTENDEDKEY | 0, 0 );
-
-    // Simulate a key release
-    keybd_event( VK_SCROLL, 0x91, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
-  }
-}
-
-string clipboard_get_text()
-{
-  if (!OpenClipboard(enigma::hWnd)) return "";
-  unsigned int format=EnumClipboardFormats(0);
-  string res = "";
-  while (format) {
-    if (format == CF_TEXT)
-    {
-      HGLOBAL clip_data = GetClipboardData(format);
-      char* clip_text = (char*)GlobalLock(clip_data);
-      if (clip_text)
-      {
-        unsigned long clip_size = GlobalSize(clip_data) - 1;
-        if (clip_size)
-          res = string(clip_text,clip_size);
-        GlobalUnlock(clip_data); //Give Windows back its clipdata
+        if (isKeyPressed) {
+          return 0;
+        }
       }
     }
-    format=EnumClipboardFormats(format);  //Next
+    return 1;
   }
-  CloseClipboard();
-  return res;
+
+  key = XKeysymToKeycode(enigma::x11::disp, enigma::keyrmap[key]);
+  return (keyState[key >> 3] & (1 << (key & 7)));
 }
 
-void clipboard_set_text(string text)
-{
-  text = string_replace_all(text, "\n", "\r\n"); //Otherwise newlines don't work
-	HGLOBAL hGlobal, hgBuffer;
-	if (!OpenClipboard(enigma::hWnd)) return;
-	EmptyClipboard();
-	hGlobal = GlobalAlloc(GMEM_DDESHARE, text.length() + 1);
-	hgBuffer = GlobalLock(hGlobal);
-    strcpy((char*)hgBuffer, text.c_str());
-    GlobalUnlock(hGlobal);
-	SetClipboardData(CF_TEXT, (HANDLE)hGlobal);
-	CloseClipboard();
+void clipboard_set_text(string text) {
+  Atom XA_UTF8 = XInternAtom(disp, "UTF8", 0);
+  Atom XA_CLIPBOARD = XInternAtom(disp, "CLIPBOARD", False);
+  XChangeProperty(disp, RootWindow(disp, 0), XA_CLIPBOARD, XA_UTF8, 8, PropModeReplace,
+                  reinterpret_cast<unsigned char*>(const_cast<char*>(text.c_str())), text.length() + 1);
 }
 
-bool clipboard_has_text()
-{
-  if (!OpenClipboard(enigma::hWnd))
-      return false;
+string clipboard_get_text() {
+  Atom XA_UTF8 = XInternAtom(disp, "UTF8", 0);
+  Atom XA_CLIPBOARD = XInternAtom(disp, "CLIPBOARD", False);
+  //Atom XA_UNICODE = XInternAtom(disp, "UNICODE", 0);
+  Atom actual_type;
+  int actual_format;
+  unsigned long nitems, leftover;
+  unsigned char* buf;
 
-  bool value = GetClipboardData(CF_TEXT);
-  CloseClipboard();
-  return value;
+  if (XGetWindowProperty(disp, RootWindow(disp, 0), XA_CLIPBOARD, 0, 10000000L, False, XA_UTF8, &actual_type,
+                         &actual_format, &nitems, &leftover, &buf) == Success) {
+    ;
+    if (buf != NULL) {
+      //free(buf);
+      return string(reinterpret_cast<char*>(buf));
+    } else {
+      return "";
+    }
+  } else {
+    return "";
+  }
 }
 
+bool clipboard_has_text() {
+  Atom XA_UTF8 = XInternAtom(disp, "UTF8", 0);
+  Atom XA_CLIPBOARD = XInternAtom(disp, "CLIPBOARD", False);
+  //Atom XA_UNICODE = XInternAtom(disp, "UNICODE", 0);
+  Atom actual_type;
+  int actual_format;
+  unsigned long nitems, leftover;
+  unsigned char* buf;
+
+  if (XGetWindowProperty(disp, RootWindow(disp, 0), XA_CLIPBOARD, 0, 10000000L, False, XA_UTF8, &actual_type,
+                         &actual_format, &nitems, &leftover, &buf) == Success) {
+    ;
+    return buf != NULL;
+  } else {
+    return false;
+  }
 }
+
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -315,6 +315,7 @@ void window_set_max_height(int height) {
 bool window_get_sizeable() { return enigma::isSizeable; }
 
 void window_set_showborder(bool show) {
+  if (window_get_minimized()) return;
   if (show == window_get_showborder() && show) return;
   Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", False);
   enigma::showBorder = show;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -320,10 +320,10 @@ void window_set_showborder(bool show) {
   Atom aKWinRunning = XInternAtom(disp, "KWIN_RUNNING", True);
   bool bKWinRunning = (aKWinRunning != None);
   Hints hints;
-  Atom aProperty = XInternAtom(disp, "_MOTIF_WM_HINTS", True);
+  Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", False);
   hints.flags = 2;
   hints.decorations = show;
-  XChangeProperty(disp, win, aProperty, aProperty, 32, PropModeReplace, (unsigned char *)&hints, 5);
+  XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
   XWindowAttributes wa;
   XGetWindowAttributes(disp, win, &wa);
   Window root, parent, *child; uint children;
@@ -346,8 +346,8 @@ bool window_get_showborder() {
   unsigned long items;
   unsigned char *data = NULL;
   bool ret = true;
-  Atom aProperty = XInternAtom(disp, "_MOTIF_WM_HINTS", True);
-  if (XGetWindowProperty(disp, win, aProperty, 0, LONG_MAX, False, AnyPropertyType, &type, &format, &items, &bytes, &data) == Success && data != NULL) {
+  Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", False);
+  if (XGetWindowProperty(disp, win, property, 0, LONG_MAX, False, AnyPropertyType, &type, &format, &items, &bytes, &data) == Success && data != NULL) {
     Hints *hints = (Hints *)data;
     ret = hints->decorations;
     XFree(data);

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -1,5 +1,5 @@
 /** Copyright (C) 2008-2017 Josh Ventura
-*** Copyright (C) 2008-2011 IsmAvatar <cmagicj@nni.com>
+*** Copyright (C) 2013 Robert B. Colton
 *** Copyright (C) 2014 Seth N. Hetu
 ***
 *** This file is a part of the ENIGMA Development Environment.
@@ -17,692 +17,661 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "Platforms/General/PFmain.h"       // For those damn vk_ constants, and io_clear().
-#include "Platforms/platforms_mandatory.h"  // For type insurance
+#include "Platforms/platforms_mandatory.h"
+#include "Platforms/General/PFmain.h" // For those damn vk_ constants.
+#include "Platforms/General/PFwindow.h"
+
 #include "Widget_Systems/widgets_mandatory.h"
+
+#include "strings_util.h" // For string_replace_all
+#include "Universal_System/var4.h"
+#include "Universal_System/roomsystem.h" // room_caption
 #include "Universal_System/globalupdate.h"
-#include "Universal_System/roomsystem.h"
 
-#include "GameSettings.h"  // ABORT_ON_ALL_ERRORS (MOVEME: this shouldn't be needed here)
-#include "XLIBmain.h"
-#include "XLIBwindow.h"  // Type insurance for non-mandatory functions
-
-#include <X11/Xlib.h>
-#include <X11/Xutil.h>
-#include <stdio.h>   //printf, NULL
-#include <stdlib.h>  //malloc
-#include <time.h>    //clock
-#include <unistd.h>  //usleep
-#include <climits>
-#include <map>
-#include <string>  //Return strings without needing a GC
-
-//////////
-// INIT //
-//////////
-
-Cursor NoCursor, DefCursor;
-
-using namespace enigma::x11;
-
-namespace tmpSize {
-    
-int tmpW = enigma::windowWidth;
-int tmpH = enigma::windowHeight;
-
-} // namespace tmpSize
+#include <windows.h>
+#include <stdio.h>
+#include <string>
+using namespace std;
 
 namespace {
 
-unsigned long decorationsPrevious = !enigma::showBorder;
-unsigned long decorationsCurrent = enigma::showBorder;
+std::string current_caption = "";
 
 } // anonymous namespace
 
-namespace enigma {
-
-namespace x11 {
-Display* disp;
-Screen* screen;
-Window win;
-Atom wm_delwin;
-
-void set_net_wm_pid(Window window) {
-  pid_t pid = getpid();
-  Atom cardinal = XInternAtom(disp, "CARDINAL", False);
-  Atom net_wm_pid = XInternAtom(disp, "_NET_WM_PID", False);
-  XChangeProperty(disp, window, net_wm_pid, cardinal, 32, PropModeReplace, (unsigned char*)&pid, sizeof(pid) / 4);
-}
-} // namespace x11;
-
-bool initGameWindow()
+namespace enigma
 {
-  // Initiate display
-  disp = XOpenDisplay(NULL);
-  if (!disp) {
-    DEBUG_MESSAGE("Display failed", MESSAGE_TYPE::M_FATAL_ERROR);
-    return false;
+
+extern HWND hWnd;
+HCURSOR currentCursor = LoadCursor(NULL, IDC_ARROW);
+
+void configure_devmode(DEVMODE &devMode, int w, int h, int freq, int bitdepth) {
+  if (w != -1) {
+    devMode.dmFields |= DM_PELSWIDTH;
+    devMode.dmPelsWidth = w;
   }
 
-  // Identify components (close button, root pane)
-  wm_delwin = XInternAtom(disp, "WM_DELETE_WINDOW", False);
-  Window root = DefaultRootWindow(disp);
-
-  // Defined in the appropriate graphics bridge.
-  // Populates GLX attributes (or other graphics-system-specific properties).
-  XVisualInfo* vi = enigma::CreateVisualInfo();
-
-  // Window event listening and coloring
-  XSetWindowAttributes swa;
-  swa.border_pixel = 0;
-  swa.background_pixel = (enigma::windowColor & 0xFF000000) | ((enigma::windowColor & 0xFF0000) >> 16) |
-                         (enigma::windowColor & 0xFF00) | ((enigma::windowColor & 0xFF) << 16);
-  swa.colormap = XCreateColormap(disp, root, vi->visual, AllocNone);
-  swa.event_mask = ExposureMask | KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask |
-                   FocusChangeMask | StructureNotifyMask;
-  unsigned long valmask = CWColormap | CWEventMask | CWBackPixel;  // | CWBorderPixel;
-
-  // Prepare window for display (center, caption, etc)
-  screen = DefaultScreenOfDisplay(disp);
-  int winw = enigma_user::room_width;
-  int winh = enigma_user::room_height;
-  // By default, if the room is too big, limit the size of the window to the
-  // size of the screen. This is what 8.1 and Studio do; if the user wants to
-  // manually override this they can do so using views/screen_set_viewport or
-  // window_set_size/window_set_region_size.
-  if (winw > screen->width) winw = screen->width;
-  if (winh > screen->height) winh = screen->height;
-
-  // Make the window
-  win = XCreateWindow(disp, root, 0, 0, winw, winh, 0, vi->depth, InputOutput, vi->visual, valmask, &swa);
-  set_net_wm_pid(win);
-  XMoveWindow(disp, win, (screen->width - winw) / 2, (screen->height - winh) / 2);
-
-  //register CloseButton listener
-  Atom prots[] = {wm_delwin};
-  if (!XSetWMProtocols(disp, win, prots, 1)) {
-    DEBUG_MESSAGE("NoClose", MESSAGE_TYPE::M_ERROR);
-    return false;
+  if (h != -1) {
+    devMode.dmFields |= DM_PELSHEIGHT;
+    devMode.dmPelsHeight = h;
   }
 
-  //Default cursor
-  DefCursor = XCreateFontCursor(disp, 68);
-  //Blank cursor
-  XColor dummy;
-  Pixmap blank = XCreateBitmapFromData(disp, win, "", 1, 1);
-  if (blank == None) {  //out of memory
-    DEBUG_MESSAGE("Failed to create no cursor. lulz", MESSAGE_TYPE::M_ERROR);
-    NoCursor = DefCursor;
-  } else {
-    NoCursor = XCreatePixmapCursor(disp, blank, blank, &dummy, &dummy, 0, 0);
-    XFreePixmap(disp, blank);
+  if (freq != -1) {
+    devMode.dmFields |= DM_DISPLAYFREQUENCY;
+    devMode.dmDisplayFrequency = freq;
   }
 
-  return true;
+  if (bitdepth != -1) {
+    devMode.dmFields |= DM_BITSPERPEL;
+    devMode.dmBitsPerPel = bitdepth;
+  }
 }
 
-void destroyWindow() {
-  XCloseDisplay(enigma::x11::disp);
 }
-
-}  //namespace enigma
 
 namespace enigma_user {
 
-void window_set_visible(bool visible) {
-  if (visible) {
-    XMapRaised(disp, win);
-  } else {
-    XUnmapWindow(disp, win);
-  }
+#if GM_COMPATIBILITY_VERSION <= 81
+unsigned long long window_handle() {
+  return (unsigned long long)enigma::hWnd;
+}
+#else
+void* window_handle() {
+  return enigma::hWnd;
+}
+#endif
+
+// GM8.1 Used its own internal variables for these functions and reported the regular window dimensions when minimized,
+// Studio uses the native functions and will tell you the dimensions of the window are 0 when it is minimized,
+// I have decided to go with the Studio method because it is still backwards compatible but also because it saves us some variables.
+// NOTE: X and Y are -32000 when the window is minimized.
+int window_get_x()
+{
+  RECT rc;
+  GetWindowRect(enigma::hWnd, &rc);
+  return rc.left;
 }
 
-int window_get_visible() {
-  XWindowAttributes wa;
-  XGetWindowAttributes(disp, win, &wa);
-  return wa.map_state != IsUnmapped;
+int window_get_y()
+{
+  RECT rc;
+  GetWindowRect(enigma::hWnd, &rc);
+  return rc.top;
 }
 
-void window_set_caption(const string &caption) { XStoreName(disp, win, caption.c_str()); }
-
-string window_get_caption() {
-  char* caption;
-  XFetchName(disp, win, &caption);
-  if (!caption) return string();
-  string res = caption;
-  XFree(caption);
-  return res;
+int window_get_width()
+{
+  RECT rc;
+  GetClientRect(enigma::hWnd, &rc);
+  return rc.right-rc.left;
 }
 
-}  // namespace enigma_user
-
-inline int getMouse(int i) {
-  Window r1, r2;
-  int rx, ry, wx, wy;
-  unsigned int mask;
-  XQueryPointer(disp, win, &r1, &r2, &rx, &ry, &wx, &wy, &mask);
-  switch (i) {
-    case 0:
-      return rx;
-    case 1:
-      return ry;
-    case 2:
-      return wx;
-    case 3:
-      return wy;
-    default:
-      return -1;
-  }
+int window_get_height()
+{
+  RECT rc;
+  GetClientRect(enigma::hWnd, &rc);
+  return rc.bottom-rc.top;
 }
 
-enum { _NET_WM_STATE_REMOVE, _NET_WM_STATE_ADD, _NET_WM_STATE_TOGGLE };
+void window_set_caption(const string &caption)
+{
+/*  if (caption == "")
+      if (score != 0)
+        caption = "Score: " + string(score);  //GM does this but it's rather fucktarded */
 
-typedef struct {
-  unsigned long flags;
-  unsigned long functions;
-  unsigned long decorations;
-  long inputMode;
-  unsigned long status;
-} Hints;
-
-template <int count>
-static bool windowHasAtom(const Atom (&atom)[count]) {
-  bool res = false;
-  Atom wmState = XInternAtom(disp, "_NET_WM_STATE", False);
-
-  //Return types, not really used.
-  Atom actualType;
-  int actualFormat;
-  unsigned long bytesAfterReturn;
-
-  //These are used.
-  unsigned long numItems;
-  unsigned char* data = NULL;
-
-  if (XGetWindowProperty(disp, win, wmState, 0, LONG_MAX, False, AnyPropertyType, &actualType, &actualFormat, &numItems,
-                         &bytesAfterReturn, &data) == Success) {
-    for (unsigned long i = 0; i < numItems; ++i) {
-      for (int j = 0; j < count; ++j) {
-        if (atom[j] == reinterpret_cast<unsigned long*>(data)[i]) {
-          res = true;
-          break;
-        }
-      }
+    if (caption != current_caption)
+    {
+        SetWindowText(enigma::hWnd,(char*) caption.c_str());
+        current_caption = caption;
     }
-  }
-
-  // Reclaim memory.
-  if (data) {
-    XFree(data);
-  }
-  return res;
 }
 
-namespace enigma_user {
-
-int display_mouse_get_x() { return getMouse(0); }
-int display_mouse_get_y() { return getMouse(1); }
-int window_mouse_get_x() { return getMouse(2); }
-int window_mouse_get_y() { return getMouse(3); }
-
-void window_set_stayontop(bool stay) {
-  Atom wmState = XInternAtom(disp, "_NET_WM_STATE", False);
-  Atom aStay = XInternAtom(disp, "_NET_WM_STATE_ABOVE", False);
-  XEvent xev;
-  xev.xclient.type = ClientMessage;
-  xev.xclient.serial = 0;
-  xev.xclient.send_event = True;
-  xev.xclient.window = win;
-  xev.xclient.message_type = wmState;
-  xev.xclient.format = 32;
-  xev.xclient.data.l[0] = (stay ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE);
-  xev.xclient.data.l[1] = aStay;
-  xev.xclient.data.l[2] = 0;
-  XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
+string window_get_caption()
+{
+  return current_caption;
 }
 
-bool window_get_stayontop() {
-  Atom a[] = {XInternAtom(disp, "_NET_WM_STATE_ABOVE", False)};
-  return windowHasAtom(a);
+void window_set_alpha(double alpha) {
+  // Set WS_EX_LAYERED on this window
+  SetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE,
+      GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+
+  // Make this window transparent
+  SetLayeredWindowAttributes(enigma::hWnd, 0, (unsigned char)(alpha*255), LWA_ALPHA);
+}
+
+double window_get_alpha() {
+	unsigned char alpha;
+	// Make this window transparent
+	GetLayeredWindowAttributes(enigma::hWnd, 0, &alpha, 0);
+	return alpha/255;
+}
+
+void window_set_position(int x, int y)
+{
+  enigma::windowX = x;
+  enigma::windowY = y;
+  if (window_get_fullscreen()) return;
+  SetWindowPos(enigma::hWnd, HWND_TOP, enigma::windowX, enigma::windowY, 0, 0, SWP_NOSIZE|SWP_NOACTIVATE);
+}
+
+void window_set_size(unsigned int width, unsigned int height)
+{
+  enigma::windowWidth = width;
+  enigma::windowHeight = height;
+  if (window_get_fullscreen()) return;
+  enigma::compute_window_size();
+}
+
+void window_set_rectangle(int x, int y, int width, int height) {
+  RECT c;
+  c.left = (enigma::windowX = x); c.top = (enigma::windowY = y); c.right = enigma::windowX + (enigma::windowWidth = width); c.bottom = enigma::windowY + (enigma::windowHeight = height);
+  if (window_get_fullscreen()) return;
+  AdjustWindowRect(&c, GetWindowLongPtr(enigma::hWnd, GWL_STYLE), false);
+  SetWindowPos(enigma::hWnd, HWND_TOP, c.left, c.top, c.right-c.left, c.bottom-c.top, SWP_NOZORDER|SWP_FRAMECHANGED);
+}
+
+namespace {
+  bool prefer_sizeable;
+  bool prefer_borderless;
+  bool get_fullscreen;
+  bool get_stayontop;
+}
+
+void window_set_fullscreen(bool full) {
+  get_fullscreen = full;
+  get_stayontop = window_get_stayontop();
+  // tweak the style first to remove or restore the window border
+  if (full) {
+    window_set_stayontop(true);
+    LONG_PTR style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
+    style &= ~(WS_CAPTION | WS_BORDER | WS_MAXIMIZEBOX | WS_MINIMIZEBOX);
+    style |= WS_SIZEBOX;
+    SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
+    window_set_maximized(full);
+    enigma::compute_window_scaling();
+  } else {
+    window_set_maximized(full);
+    window_set_showborder(!prefer_borderless);
+    window_set_sizeable(prefer_sizeable);
+    window_set_stayontop(get_stayontop);
+    enigma::compute_window_size();
+  }
+}
+
+bool window_get_fullscreen() {
+  return get_fullscreen;
 }
 
 void window_set_sizeable(bool sizeable) {
   if (window_get_maximized()) return;
   if (window_get_fullscreen()) return;
-  enigma::isSizeable = sizeable;
-  XSizeHints *sh = XAllocSizeHints();
-  sh->flags = PMinSize | PMaxSize;
-  
-  if (enigma::window_min_width == -1)
-    enigma::window_min_width = 1;
-  if (enigma::window_max_width == -1) 
-    enigma::window_max_width = INT_MAX;
-  if (enigma::window_min_height == -1) 
-    enigma::window_min_height = 1;
-  if (enigma::window_max_height == -1) 
-    enigma::window_max_height = INT_MAX;
-  
-  if (sizeable) {
-    sh->min_width = enigma::window_min_width;
-    sh->max_width = enigma::window_max_width;
-    sh->min_height = enigma::window_min_height;
-    sh->max_height = enigma::window_max_height;
-  } else {
-    sh->min_width = sh->max_width = window_get_width();
-    sh->min_height = sh->max_height = window_get_height();
-  }
-  XSetWMNormalHints(disp, win, sh);
-  XFree(sh);
-
-  XResizeWindow(disp, win, enigma::windowWidth, enigma::windowHeight);
+  prefer_sizeable = sizeable;
+  DWORD style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
+  if (sizeable) style |= WS_SIZEBOX | WS_MAXIMIZEBOX;
+  else style &= ~(WS_SIZEBOX | WS_MAXIMIZEBOX);
+  style |= WS_MINIMIZEBOX;
+  SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
+  enigma::compute_window_size();
 }
 
-void window_set_min_width(int width) {
-  enigma::window_min_width = width;
-  window_set_sizeable(enigma::isSizeable);
+bool window_get_sizeable() {
+  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_THICKFRAME) == WS_THICKFRAME;
 }
-
-void window_set_min_height(int height) {
-  enigma::window_min_height = height;
-  window_set_sizeable(enigma::isSizeable);
-}
-
-void window_set_max_width(int width) {
-  enigma::window_max_width = width;
-  window_set_sizeable(enigma::isSizeable);
-}
-
-void window_set_max_height(int height) {
-  enigma::window_max_height = height;
-  window_set_sizeable(enigma::isSizeable);
-}
-
-bool window_get_sizeable() { return enigma::isSizeable; }
 
 void window_set_showborder(bool show) {
   if (window_get_maximized()) return;
   if (window_get_fullscreen()) return;
-  if (show == window_get_showborder() && show) return;
-  Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", False);
-  enigma::showBorder = show;
-  if (!show) {
-    Hints hints;
-    hints.flags = 2;        // Specify that we're changing the window decorations.
-    decorationsPrevious = 1; // Save current decorations before changing them.
-    hints.decorations = 0;  // 0 (false) means that window decorations should go bye-bye.
-    decorationsCurrent = hints.decorations; // Save current decorations after changing them.
-    XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);
-    XMoveResizeWindow(disp, win, enigma::windowX, enigma::windowY, enigma::windowWidth, enigma::windowHeight);
-  } else {
-    Hints hints;
-    hints.flags = 2;        // Specify that we're changing the window decorations.
-    hints.decorations = decorationsPrevious; // Set decorations back to the way they were.
-    decorationsCurrent = hints.decorations; // Save current decorations after changing them.
-    XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char*)&hints, 5);
-    XMoveResizeWindow(disp, win, enigma::windowX - enigma::winEdgeX, enigma::windowY - enigma::winEdgeY, enigma::windowWidth, enigma::windowHeight);
-  }
-}
-
-bool window_get_showborder() {
-  return enigma::showBorder;
-}
-
-void window_set_showicons(bool show) {
-  if (enigma::showIcons == show) return;
-  enigma::showIcons = show;
-
-  Atom wmState = XInternAtom(disp, "_NET_WM_WINDOW_TYPE", False);
-  Atom aShow = XInternAtom(disp, "_NET_WM_WINDOW_TYPE_TOOLBAR", False);
-  XEvent xev;
-  xev.xclient.type = ClientMessage;
-  xev.xclient.serial = 0;
-  xev.xclient.send_event = True;
-  xev.xclient.window = win;
-  xev.xclient.message_type = wmState;
-  xev.xclient.format = 32;
-  xev.xclient.data.l[0] = (show ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE);
-  xev.xclient.data.l[1] = aShow;
-  xev.xclient.data.l[2] = 0;
-  XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
-}
-
-bool window_get_showicons() { return enigma::showIcons; }
-
-void window_set_minimized(bool minimized) {
-  XClientMessageEvent ev;
-  Atom prop;
-
-  prop = XInternAtom(disp, "WM_CHANGE_STATE", False);
-  if (prop == None) return;
-
-  // TODO: When restored after a minimize the window may not have focus.
-  ev.type = ClientMessage;
-  ev.window = win;
-  ev.message_type = prop;
-  ev.format = 32;
-  ev.data.l[0] = minimized ? IconicState : NormalState;
-  XSendEvent(disp, RootWindow(disp, 0), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*)&ev);
-}
-
-bool window_get_minimized() {
-  Atom a[] = {XInternAtom(disp, "_NET_WM_STATE_HIDDEN", False)};
-  return windowHasAtom(a);
-}
-
-void window_set_maximized(bool maximized) {
-  XClientMessageEvent ev;
-
-  if (maximized) {
-    Atom wm_state, max_horz, max_vert;
-    wm_state = XInternAtom(disp, "_NET_WM_STATE", False);
-    if (wm_state == None) return;
-
-    max_horz = XInternAtom(disp, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
-    max_vert = XInternAtom(disp, "_NET_WM_STATE_MAXIMIZED_VERT", False);
-
-    // TODO: When restored after a minimize the window may not have focus.
-    ev.type = ClientMessage;
-    ev.window = win;
-    ev.message_type = wm_state;
-    ev.format = 32;
-    ev.data.l[0] = _NET_WM_STATE_ADD;
-    ev.data.l[1] = max_horz;
-    ev.data.l[2] = max_vert;
-    XSendEvent(disp, RootWindow(disp, 0), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*)&ev);
-  } else {
-    Atom prop;
-    prop = XInternAtom(disp, "WM_CHANGE_STATE", False);
-    if (prop == None) return;
-
-    // TODO: When restored after a minimize the window may not have focus.
-    ev.type = ClientMessage;
-    ev.window = win;
-    ev.message_type = prop;
-    ev.format = 32;
-    ev.data.l[0] = NormalState;
-    XSendEvent(disp, RootWindow(disp, 0), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*)&ev);
-  }
-}
-
-bool window_get_maximized() {
-  Atom maximized[] = {XInternAtom(disp, "_NET_WM_STATE_MAXIMIZED_VERT", False),
-                      XInternAtom(disp, "_NET_WM_STATE_MAXIMIZED_HORZ", False)};
-  return windowHasAtom(maximized);
-}
-
-void window_mouse_set(int x, int y) { XWarpPointer(disp, None, win, 0, 0, 0, 0, (int)x, (int)y); }
-
-void display_mouse_set(int x, int y) { XWarpPointer(disp, None, DefaultRootWindow(disp), 0, 0, 0, 0, (int)x, (int)y); }
-
-////////////
-// WINDOW //
-////////////
-
-//Getters
-int window_get_x() { return enigma::windowX; }
-int window_get_y() { return enigma::windowY; }
-int window_get_width() { return enigma::windowWidth; }
-int window_get_height() { return enigma::windowHeight; }
-
-//Setters
-void window_set_position(int x, int y) {
-  if (window_get_fullscreen()) return;
-  enigma::windowX = x;
-  enigma::windowY = y;
-  XWindowAttributes wa;
-  XGetWindowAttributes(disp, win, &wa);
-  XMoveWindow(disp, win, (int)x - wa.x, (int)y - wa.y);
-}
-
-void window_set_size(unsigned int w, unsigned int h) {
-  if (window_get_fullscreen()) return;
-  enigma::windowWidth = w;
-  enigma::windowHeight = h;
+  prefer_borderless = !show;
+  DWORD style = GetWindowLongPtr(enigma::hWnd, GWL_STYLE);
+  if (show) style |= WS_CAPTION | WS_BORDER;
+  else style &= ~(WS_CAPTION | WS_BORDER);
+  SetWindowLongPtr(enigma::hWnd, GWL_STYLE, style);
   enigma::compute_window_size();
 }
 
-void window_set_rectangle(int x, int y, int w, int h) {
-  if (window_get_fullscreen()) return;
-  enigma::windowX = x;
-  enigma::windowY = y;
-  enigma::windowWidth = w;
-  enigma::windowHeight = h;
-  XMoveResizeWindow(disp, win, x, y, w, h);
+bool window_get_showborder() {
+  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_CAPTION) == WS_CAPTION;
 }
 
-////////////////
-// FULLSCREEN //
-////////////////
+void window_set_showicons(bool show) {
+  SetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE,
+      GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+}
 
-void window_set_fullscreen(bool full) {
-  if (enigma::isFullScreen == full && !full) return;
-  enigma::isFullScreen = full;
-  if (full) {
-    tmpSize::tmpW = enigma::windowWidth;
-    tmpSize::tmpH = enigma::windowHeight;
+bool window_get_showicons() {
+  return (GetWindowLongPtr(enigma::hWnd, GWL_STYLE) & WS_THICKFRAME) == WS_THICKFRAME;
+}
+
+void window_set_visible(bool visible) {
+  ShowWindow(enigma::hWnd, visible? SW_SHOW : SW_HIDE);
+}
+
+int window_get_visible() {
+  return IsWindowVisible(enigma::hWnd);
+}
+
+void window_set_minimized(bool minimized) {
+  ShowWindow(enigma::hWnd, minimized? SW_MINIMIZE : SW_RESTORE);
+}
+
+void window_set_maximized(bool maximized) {
+  ShowWindow(enigma::hWnd, maximized? SW_MAXIMIZE : SW_RESTORE);
+}
+
+bool window_get_minimized() {
+  return IsIconic(enigma::hWnd);
+}
+
+bool window_get_maximized() {
+  return IsZoomed(enigma::hWnd);
+}
+
+void window_set_stayontop(bool stay)
+{
+  if (stay) {
+    SetWindowPos(enigma::hWnd,HWND_TOPMOST,0,0,0,0,SWP_NOSIZE|SWP_NOMOVE);
+  } else {
+    SetWindowPos(enigma::hWnd,HWND_BOTTOM,0,0,0,0,SWP_NOSIZE|SWP_NOMOVE|SWP_NOACTIVATE);
+    SetWindowPos(enigma::hWnd,HWND_TOP,   0,0,0,0,SWP_NOSIZE|SWP_NOMOVE);
   }
-  Atom wmState = XInternAtom(disp, "_NET_WM_STATE", False);
-  Atom aFullScreen = XInternAtom(disp, "_NET_WM_STATE_FULLSCREEN", False);
-  XEvent xev;
-  xev.xclient.type = ClientMessage;
-  xev.xclient.serial = 0;
-  xev.xclient.send_event = True;
-  xev.xclient.window = win;
-  xev.xclient.message_type = wmState;
-  xev.xclient.format = 32;
-  xev.xclient.data.l[0] = (full ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE);
-  xev.xclient.data.l[1] = aFullScreen;
-  xev.xclient.data.l[2] = 0;
-  XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
-  if (!full) XResizeWindow(disp, win, tmpSize::tmpW, tmpSize::tmpH);
 }
 
-bool window_get_fullscreen() {
-  Atom fullscreen[] = {XInternAtom(disp, "_NET_WM_STATE_FULLSCREEN", False)};
-  return windowHasAtom(fullscreen);
+bool window_get_stayontop() {
+    return (GetWindowLongPtr(enigma::hWnd, GWL_EXSTYLE) & WS_EX_TOPMOST) == WS_EX_TOPMOST;
 }
 
-}  // namespace enigma_user
-
-//default    +   -5   I    \    |    /    -    ^   ...  drg  no  -    |  drg3 ...  X  ...  ?   url  +
-short curs[] = {68, 68, 68, 130, 52, 152, 135, 116, 136, 108, 114, 150, 90, 68, 108, 116, 90, 150, 0, 150, 92, 60, 52};
-
-namespace enigma {
-std::map<int, int> keybdmap;
-
-inline unsigned short highbyte_allornothing(short x) { return x & 0xFF00 ? x | 0xFF00 : x; }
-
-unsigned char keymap[512];
-unsigned short keyrmap[256];
-void initkeymap() {
-  using namespace enigma_user;
-
-  for (size_t i = 0; i < 512; ++i) keymap[i] = 0;
-  for (size_t i = 0; i < 256; ++i) keyrmap[i] = 0;
-
-  // Pretend this part doesn't exist
-  keymap[0x151] = vk_left;
-  keymap[0x153] = vk_right;
-  keymap[0x152] = vk_up;
-  keymap[0x154] = vk_down;
-  keymap[0x1E3] = vk_control;
-  keymap[0x1E4] = vk_control;
-  keymap[0x1E9] = vk_alt;
-  keymap[0x1EA] = vk_alt;
-  keymap[0x1E1] = vk_shift;
-  keymap[0x1E2] = vk_shift;
-  keymap[0x10D] = vk_enter;
-  keymap[0x185] = vk_lsuper;
-  keymap[0x186] = vk_rsuper;
-  keymap[0x117] = vk_tab;
-  keymap[0x142] = vk_caps;
-  keymap[0x14E] = vk_scroll;
-  keymap[0x17F] = vk_pause;
-  keymap[0x19E] = vk_numpad0;
-  keymap[0x19C] = vk_numpad1;
-  keymap[0x199] = vk_numpad2;
-  keymap[0x19B] = vk_numpad3;
-  keymap[0x196] = vk_numpad4;
-  keymap[0x19D] = vk_numpad5;
-  keymap[0x198] = vk_numpad6;
-  keymap[0x195] = vk_numpad7;
-  keymap[0x197] = vk_numpad8;
-  keymap[0x19A] = vk_numpad9;
-  keymap[0x1AF] = vk_divide;
-  keymap[0x1AA] = vk_multiply;
-  keymap[0x1AD] = vk_subtract;
-  keymap[0x1AB] = vk_add;
-  keymap[0x19F] = vk_decimal;
-  keymap[0x1BE] = vk_f1;
-  keymap[0x1BF] = vk_f2;
-  keymap[0x1C0] = vk_f3;
-  keymap[0x1C1] = vk_f4;
-  keymap[0x1C2] = vk_f5;
-  keymap[0x1C3] = vk_f6;
-  keymap[0x1C4] = vk_f7;
-  keymap[0x1C5] = vk_f8;
-  keymap[0x1C6] = vk_f9;
-  keymap[0x1C7] = vk_f10;
-  keymap[0x1C8] = vk_f11;
-  keymap[0x1C9] = vk_f12;
-  keymap[0x108] = vk_backspace;
-  keymap[0x11B] = vk_escape;
-  keymap[0x150] = vk_home;
-  keymap[0x157] = vk_end;
-  keymap[0x155] = vk_pageup;
-  keymap[0x156] = vk_pagedown;
-  keymap[0x1FF] = vk_delete;
-  keymap[0x163] = vk_insert;
-
-  // Set up identity map...
-  //for (int i = 0; i < 255; i++)
-  //  usermap[i] = i;
-
-  for (int i = 0; i < 'a'; i++) keymap[i] = i;
-  for (int i = 'a'; i <= 'z'; i++)  // 'a' to 'z' wrap to 'A' to 'Z'
-    keymap[i] = i + 'A' - 'a';
-  for (int i = 'z' + 1; i < 255; i++) keymap[i] = i;
-
-  for (size_t i = 0; i < 512; ++i) keyrmap[keymap[i]] = highbyte_allornothing(i);
+int display_mouse_get_x() {
+  POINT mouse;
+  GetCursorPos(&mouse);
+  return mouse.x;
 }
-}  // namespace enigma
 
-namespace enigma_user {
+int display_mouse_get_y() {
+  POINT mouse;
+  GetCursorPos(&mouse);
+  return mouse.y;
+}
 
-void io_handle() {
+void display_mouse_set(int x,int y) {
+    SetCursorPos(x,y);
+}
+
+int display_get_width() {
+   return GetSystemMetrics(SM_CXSCREEN);
+}
+
+int display_get_height() {
+   return GetSystemMetrics(SM_CYSCREEN);
+}
+
+int display_get_colordepth() {
+  return GetDeviceCaps(GetDC(enigma::hWnd), BITSPIXEL);
+}
+
+int display_get_frequency() {
+  return GetDeviceCaps(GetDC(enigma::hWnd), VREFRESH);
+}
+
+unsigned display_get_dpi_x() {
+  return GetDeviceCaps(GetDC(enigma::hWnd), LOGPIXELSX);
+}
+
+unsigned display_get_dpi_y() {
+  return GetDeviceCaps(GetDC(enigma::hWnd), LOGPIXELSY);
+}
+
+void display_reset()
+{
+	ChangeDisplaySettings(NULL, 0);
+}
+
+bool display_set_size(int w, int h)
+{
+	DEVMODE devMode;
+
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return false;
+
+	devMode.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
+	devMode.dmPelsWidth = w;
+	devMode.dmPelsHeight = h;
+
+	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
+}
+
+bool display_set_frequency(int freq)
+{
+	DEVMODE devMode;
+
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return false;
+
+	devMode.dmFields = DM_DISPLAYFREQUENCY;
+	devMode.dmDisplayFrequency = freq;
+
+	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
+}
+
+bool display_set_colordepth(int depth)
+{
+	DEVMODE devMode;
+
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return true;
+
+	devMode.dmFields = DM_BITSPERPEL;
+	devMode.dmBitsPerPel = depth;
+
+  return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
+}
+
+bool display_set_all(int w, int h, int freq, int bitdepth)
+{
+	DEVMODE devMode;
+
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return false;
+
+	enigma::configure_devmode(devMode, w, h, freq, bitdepth);
+
+	return (ChangeDisplaySettings(&devMode, CDS_FULLSCREEN) == DISP_CHANGE_SUCCESSFUL);
+}
+
+bool display_test_all(int w, int h, int freq, int bitdepth)
+{
+	DEVMODE devMode;
+
+	if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &devMode))
+		return false;
+
+	enigma::configure_devmode(devMode, w, h, freq, bitdepth);
+
+	return (ChangeDisplaySettings(&devMode, CDS_TEST) == DISP_CHANGE_SUCCESSFUL);
+}
+
+int window_mouse_get_x()
+{
+  POINT mouse;
+  GetCursorPos(&mouse);
+  ScreenToClient(enigma::hWnd, &mouse);
+
+  return mouse.x;
+}
+
+int window_mouse_get_y()
+{
+  POINT mouse;
+  GetCursorPos(&mouse);
+  ScreenToClient(enigma::hWnd, &mouse);
+
+  return mouse.y;
+}
+
+void window_mouse_set(int x, int y)
+{
+  POINT pt;
+  pt.x=x;
+  pt.y=y;
+  ClientToScreen(enigma::hWnd, &pt);
+  SetCursorPos(pt.x, pt.y);
+}
+
+}
+
+namespace enigma_user
+{
+
+int window_set_cursor(int c)
+{
+  enigma::cursorInt = c;
+  char* cursor = NULL;
+  // this switch statement could be replaced with an array aligned to the constants
+  switch (c)
+  {
+      case cr_default:
+      case cr_arrow:
+          cursor = IDC_ARROW;
+          break;
+      case cr_none:
+          cursor = NULL;
+          break;
+      case cr_cross:
+          cursor = IDC_CROSS;
+          break;
+      case cr_beam:
+          cursor = IDC_IBEAM;
+          break;
+      case cr_size_nesw:
+          cursor = IDC_SIZENESW;
+          break;
+      case cr_size_ns:
+          cursor = IDC_SIZENS;
+          break;
+      case cr_size_nwse:
+          cursor = IDC_SIZENWSE;
+          break;
+      case cr_size_we:
+          cursor = IDC_SIZEWE;
+          break;
+      case cr_uparrow:
+          cursor = IDC_UPARROW;
+          break;
+      case cr_hourglass:
+          cursor = IDC_WAIT;
+          break;
+      case cr_drag:
+          // Delphi-made?
+          cursor = IDC_HAND;
+          break;
+      case cr_nodrop:
+          cursor = IDC_NO;
+          break;
+      case cr_hsplit:
+          // Delphi-made?
+          cursor = IDC_SIZENS;
+          break;
+      case cr_vsplit:
+          // Delphi-made?
+          cursor = IDC_SIZEWE;
+          break;
+      case cr_multidrag:
+          cursor = IDC_SIZEALL;
+          break;
+      case cr_sqlwait:
+          // DEAR GOD WHY
+          cursor = IDC_WAIT;
+          break;
+      case cr_no:
+          cursor = IDC_NO;
+          break;
+      case cr_appstart:
+          cursor = IDC_APPSTARTING;
+          break;
+      case cr_help:
+          cursor = IDC_HELP;
+          break;
+      case cr_handpoint:
+          cursor = IDC_HAND;
+          break;
+      case cr_size_all:
+          cursor = IDC_SIZEALL;
+          break;
+  }
+  enigma::currentCursor = LoadCursor(NULL, cursor);
+  return SendMessage(enigma::hWnd, WM_SETCURSOR, (WPARAM)enigma::hWnd, MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
+}
+
+int window_get_cursor()
+{
+  return enigma::cursorInt;
+}
+
+void io_handle()
+{
+  MSG msg;
   enigma::input_push();
-  while (XQLength(disp)) {
-    DEBUG_MESSAGE("processing an event...", MESSAGE_TYPE::M_INFO);
-    if (enigma::handleEvents() > 0) exit(0);
+  while (PeekMessage (&msg, NULL, 0, 0, PM_REMOVE))
+  {
+    TranslateMessage (&msg);
+    DispatchMessage (&msg);
   }
   enigma::update_mouse_variables();
 }
 
-int window_set_cursor(int c) {
-  enigma::cursorInt = c;
-  XUndefineCursor(disp, win);
-  XDefineCursor(disp, win, (c == -1) ? NoCursor : XCreateFontCursor(disp, curs[-c]));
-  return 0;
-}
 
-int window_get_cursor() { return enigma::cursorInt; }
+bool keyboard_check_direct(int key)
+{
+   BYTE keyState[256];
 
-bool keyboard_check_direct(int key) {
-  char keyState[32];
-
-  if (XQueryKeymap(enigma::x11::disp, keyState)) {
-    //for (int x = 0; x < 32; x++)
-    //keyState[x] = 0;
-  } else {
-    //TODO: print error message.
-    return 0;
-  }
+   if ( GetKeyboardState( keyState ) )  {
+	  for (int x = 0; x < 256; x++)
+		keyState[x] = (char) (GetKeyState(x) >> 8);
+   } else {
+      //TODO: print error message.
+	  return 0;
+   }
 
   if (key == vk_anykey) {
-    // next go through each member of keyState array
-    for (unsigned i = 0; i < 32; i++) {
-      const char& currentChar = keyState[i];
-
-      // iterate over each bit and check if the bit is set
-      for (unsigned j = 0; j < 8; j++) {
-        // AND current char with current bit we're interested in
-        bool isKeyPressed = ((1 << j) & currentChar) != 0;
-
-        if (isKeyPressed) {
-          return 1;
-        }
-      }
-    }
+    for(int i = 0; i < 256; i++)
+      if (keyState[i] == 1) return 1;
     return 0;
   }
   if (key == vk_nokey) {
-    // next go through each member of keyState array
-    for (unsigned i = 0; i < 32; i++) {
-      const char& currentChar = keyState[i];
-
-      // iterate over each bit and check if the bit is set
-      for (unsigned j = 0; j < 8; j++) {
-        // AND current char with current bit we're interested in
-        bool isKeyPressed = ((1 << j) & currentChar) != 0;
-
-        if (isKeyPressed) {
-          return 0;
-        }
-      }
-    }
+    for(int i = 0; i < 256; i++)
+      if (keyState[i] == 1) return 0;
     return 1;
   }
-
-  key = XKeysymToKeycode(enigma::x11::disp, enigma::keyrmap[key]);
-  return (keyState[key >> 3] & (1 << (key & 7)));
+  return keyState[key & 0xFF];
 }
 
-void clipboard_set_text(string text) {
-  Atom XA_UTF8 = XInternAtom(disp, "UTF8", 0);
-  Atom XA_CLIPBOARD = XInternAtom(disp, "CLIPBOARD", False);
-  XChangeProperty(disp, RootWindow(disp, 0), XA_CLIPBOARD, XA_UTF8, 8, PropModeReplace,
-                  reinterpret_cast<unsigned char*>(const_cast<char*>(text.c_str())), text.length() + 1);
+void keyboard_key_press(int key) {
+  BYTE keyState[256];
+
+  GetKeyboardState((LPBYTE)&keyState);
+
+  // Simulate a key press
+  keybd_event( key,
+        keyState[key],
+        KEYEVENTF_EXTENDEDKEY | 0,
+        0 );
 }
 
-string clipboard_get_text() {
-  Atom XA_UTF8 = XInternAtom(disp, "UTF8", 0);
-  Atom XA_CLIPBOARD = XInternAtom(disp, "CLIPBOARD", False);
-  //Atom XA_UNICODE = XInternAtom(disp, "UNICODE", 0);
-  Atom actual_type;
-  int actual_format;
-  unsigned long nitems, leftover;
-  unsigned char* buf;
+void keyboard_key_release(int key) {
+  BYTE keyState[256];
 
-  if (XGetWindowProperty(disp, RootWindow(disp, 0), XA_CLIPBOARD, 0, 10000000L, False, XA_UTF8, &actual_type,
-                         &actual_format, &nitems, &leftover, &buf) == Success) {
-    ;
-    if (buf != NULL) {
-      //free(buf);
-      return string(reinterpret_cast<char*>(buf));
-    } else {
-      return "";
+  GetKeyboardState((LPBYTE)&keyState);
+
+  // Simulate a key release
+  keybd_event( key, keyState[key], KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+}
+
+bool keyboard_get_capital() {
+	return (((unsigned short)GetKeyState(0x14)) & 0xffff) != 0;
+}
+
+bool keyboard_get_numlock() {
+	return (((unsigned short)GetKeyState(0x90)) & 0xffff) != 0;
+}
+
+bool keyboard_get_scroll() {
+	return (((unsigned short)GetKeyState(0x91)) & 0xffff) != 0;
+}
+
+void keyboard_set_capital(bool on) {
+  BYTE keyState[256];
+
+  GetKeyboardState((LPBYTE)&keyState);
+
+  if( (on && !(keyState[VK_CAPITAL] & 1)) ||
+  (!on && (keyState[VK_CAPITAL] & 1)) )
+  {
+    // Simulate a key press
+    keybd_event( VK_CAPITAL, 0x14, KEYEVENTF_EXTENDEDKEY | 0, 0 );
+
+    // Simulate a key release
+    keybd_event( VK_CAPITAL, 0x14, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+  }
+}
+
+void keyboard_set_numlock(bool on) {
+  BYTE keyState[256];
+
+  GetKeyboardState((LPBYTE)&keyState);
+
+  if( (on && !(keyState[VK_NUMLOCK] & 1)) ||
+  (!on && (keyState[VK_NUMLOCK] & 1)) )
+  {
+    // Simulate a key press
+    keybd_event( VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | 0, 0 );
+
+    // Simulate a key release
+    keybd_event( VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+  }
+}
+
+void keyboard_set_scroll(bool on) {
+  BYTE keyState[256];
+
+  GetKeyboardState((LPBYTE)&keyState);
+
+  if( (on && !(keyState[VK_SCROLL] & 1)) ||
+  (!on && (keyState[VK_SCROLL] & 1)) )
+  {
+    // Simulate a key press
+    keybd_event( VK_SCROLL, 0x91, KEYEVENTF_EXTENDEDKEY | 0, 0 );
+
+    // Simulate a key release
+    keybd_event( VK_SCROLL, 0x91, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+  }
+}
+
+string clipboard_get_text()
+{
+  if (!OpenClipboard(enigma::hWnd)) return "";
+  unsigned int format=EnumClipboardFormats(0);
+  string res = "";
+  while (format) {
+    if (format == CF_TEXT)
+    {
+      HGLOBAL clip_data = GetClipboardData(format);
+      char* clip_text = (char*)GlobalLock(clip_data);
+      if (clip_text)
+      {
+        unsigned long clip_size = GlobalSize(clip_data) - 1;
+        if (clip_size)
+          res = string(clip_text,clip_size);
+        GlobalUnlock(clip_data); //Give Windows back its clipdata
+      }
     }
-  } else {
-    return "";
+    format=EnumClipboardFormats(format);  //Next
   }
+  CloseClipboard();
+  return res;
 }
 
-bool clipboard_has_text() {
-  Atom XA_UTF8 = XInternAtom(disp, "UTF8", 0);
-  Atom XA_CLIPBOARD = XInternAtom(disp, "CLIPBOARD", False);
-  //Atom XA_UNICODE = XInternAtom(disp, "UNICODE", 0);
-  Atom actual_type;
-  int actual_format;
-  unsigned long nitems, leftover;
-  unsigned char* buf;
-
-  if (XGetWindowProperty(disp, RootWindow(disp, 0), XA_CLIPBOARD, 0, 10000000L, False, XA_UTF8, &actual_type,
-                         &actual_format, &nitems, &leftover, &buf) == Success) {
-    ;
-    return buf != NULL;
-  } else {
-    return false;
-  }
+void clipboard_set_text(string text)
+{
+  text = string_replace_all(text, "\n", "\r\n"); //Otherwise newlines don't work
+	HGLOBAL hGlobal, hgBuffer;
+	if (!OpenClipboard(enigma::hWnd)) return;
+	EmptyClipboard();
+	hGlobal = GlobalAlloc(GMEM_DDESHARE, text.length() + 1);
+	hgBuffer = GlobalLock(hGlobal);
+    strcpy((char*)hgBuffer, text.c_str());
+    GlobalUnlock(hGlobal);
+	SetClipboardData(CF_TEXT, (HANDLE)hGlobal);
+	CloseClipboard();
 }
 
-}  // namespace enigma_user
+bool clipboard_has_text()
+{
+  if (!OpenClipboard(enigma::hWnd))
+      return false;
+
+  bool value = GetClipboardData(CF_TEXT);
+  CloseClipboard();
+  return value;
+}
+
+}

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -335,7 +335,7 @@ void window_set_showborder(bool show) {
   int xpos = show ? enigma::windowX - xoffset : enigma::windowX;
   int ypos = show ? enigma::windowY - yoffset : enigma::windowY;
   XResizeWindow(disp, win, enigma::windowWidth + 1, enigma::windowHeight + 1); // trigger ConfigureNotify event
-  XResizeWindow(disp, win, enigma::windowWidth - 1, enigma::windowHeight - 1); // set window back to was it was
+  XResizeWindow(disp, win, enigma::windowWidth - 1, enigma::windowHeight - 1); // set window back to how it was
   XMoveResizeWindow(disp, win, xpos, ypos, bKWinRunning ? wa.width : wa.width + xoffset, bKWinRunning ? wa.height : wa.height + yoffset);
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -52,10 +52,14 @@ int tmpH = enigma::windowHeight;
 
 } // namespace tmpSize
 
-namespace enigma {
+namespace {
 
 unsigned long decorationsPrevious = !showBorder;
 unsigned long decorationsCurrent = showBorder;
+
+} // anonymous namespace
+
+namespace enigma {
 
 namespace x11 {
 Display* disp;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -268,6 +268,7 @@ bool window_get_stayontop() {
 
 void window_set_sizeable(bool sizeable) {
   if (window_get_maximized()) return;
+  if (window_get_fullscreen()) return;
   enigma::isSizeable = sizeable;
   XSizeHints *sh = XAllocSizeHints();
   sh->flags = PMinSize | PMaxSize;
@@ -319,6 +320,8 @@ void window_set_max_height(int height) {
 bool window_get_sizeable() { return enigma::isSizeable; }
 
 void window_set_showborder(bool show) {
+  if (window_get_maximized()) return;
+  if (window_get_fullscreen()) return;
   if (show == window_get_showborder() && show) return;
   Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", False);
   enigma::showBorder = show;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -320,10 +320,10 @@ void window_set_showborder(bool show) {
   Atom aKWinRunning = XInternAtom(disp, "KWIN_RUNNING", True);
   bool bKWinRunning = (aKWinRunning != None);
   Hints hints;
-  Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", True);
+  Atom aProperty = XInternAtom(disp, "_MOTIF_WM_HINTS", True);
   hints.flags = 2;
   hints.decorations = show;
-  XChangeProperty(disp, win, property, property, 32, PropModeReplace, (unsigned char *)&hints, 5);
+  XChangeProperty(disp, win, aProperty, aProperty, 32, PropModeReplace, (unsigned char *)&hints, 5);
   XWindowAttributes wa;
   XGetWindowAttributes(disp, win, &wa);
   Window root, parent, *child; uint children;
@@ -346,8 +346,8 @@ bool window_get_showborder() {
   unsigned long items;
   unsigned char *data = NULL;
   bool ret = true;
-  Atom property = XInternAtom(disp, "_MOTIF_WM_HINTS", True);
-  if (XGetWindowProperty(disp, win, property, 0, LONG_MAX, False, AnyPropertyType, &type, &format, &items, &bytes, &data) == Success && data != NULL) {
+  Atom aProperty = XInternAtom(disp, "_MOTIF_WM_HINTS", True);
+  if (XGetWindowProperty(disp, win, aProperty, 0, LONG_MAX, False, AnyPropertyType, &type, &format, &items, &bytes, &data) == Success && data != NULL) {
     Hints *hints = (Hints *)data;
     ret = hints->decorations;
     XFree(data);

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -53,13 +53,6 @@ int tmpH = enigma::windowHeight;
 
 } // namespace tmpSize
 
-namespace {
-
-unsigned long decorationsPrevious = !enigma::showBorder;
-unsigned long decorationsCurrent = enigma::showBorder;
-
-} // anonymous namespace
-
 namespace enigma {
 
 namespace x11 {

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -446,6 +446,7 @@ int window_get_height() { return enigma::windowHeight; }
 
 //Setters
 void window_set_position(int x, int y) {
+  if (window_get_fullscreen()) return;
   enigma::windowX = x;
   enigma::windowY = y;
   XWindowAttributes wa;
@@ -454,12 +455,14 @@ void window_set_position(int x, int y) {
 }
 
 void window_set_size(unsigned int w, unsigned int h) {
+  if (window_get_fullscreen()) return;
   enigma::windowWidth = w;
   enigma::windowHeight = h;
   enigma::compute_window_size();
 }
 
 void window_set_rectangle(int x, int y, int w, int h) {
+  if (window_get_fullscreen()) return;
   enigma::windowX = x;
   enigma::windowY = y;
   enigma::windowWidth = w;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.h
@@ -25,9 +25,6 @@
 
 namespace enigma {
 
-extern int winEdgeX;
-extern int winEdgeY;
-
 namespace x11 {
 extern Display* disp;
 extern Screen* screen;

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -41,6 +41,7 @@ namespace enigma_user
 
 namespace enigma
 {
+  bool initGame;
   extern const char* resource_file_path;
   extern int event_system_initialize(); //Leave this here until you can find a more brilliant way to include it; it's pretty much not-optional.
   extern void timeline_system_initialize();
@@ -50,6 +51,8 @@ namespace enigma
   //This is like main(), only cross-api
   int initialize_everything()
   {
+    initGame = false;
+
     time_t ss = time(0);
     enigma_user::random_set_seed(ss);
     enigma_user::mtrandom_seed(ss);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -130,7 +130,7 @@ namespace enigma
     if (enigma_user::room_count)
       enigma::game_start();
     else {
-      enigma_user::window_default(false);
+      enigma_user::window_default();
       enigma_user::window_set_visible(true);
     }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -139,6 +139,8 @@ namespace enigma
     enigma_user::window_set_showborder(showBorder);
     // required for global game setting fullscreen window
     enigma_user::window_set_fullscreen(isFullScreen);
+    // don't ask me why this is necessary, but it 100% is
+    enigma_user::window_set_rectangle(windowX, windowY, windowWidth, windowHeight);
 
     return 0;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -132,9 +132,6 @@ namespace enigma
       enigma_user::window_default();
       enigma_user::window_set_visible(true);
     }
-    
-    // center window at start up
-    enigma_user::window_center();
 
     return 0;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -141,6 +141,10 @@ namespace enigma
     enigma_user::window_set_fullscreen(isFullScreen);
     // don't ask me why this is necessary, but it 100% is
     enigma_user::window_set_rectangle(windowX, windowY, windowWidth, windowHeight);
+    
+    // needed for DrawGUI event
+    enigma_user::screen_init();
+    enigma_user::screen_refresh();
 
     return 0;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -140,10 +140,10 @@ namespace enigma
     enigma_user::window_set_sizeable(isSizeable);
     // required for global game setting borderless window
     enigma_user::window_set_showborder(showBorder);
-    // required for global game setting fullscreen window
-    enigma_user::window_set_fullscreen(isFullScreen);
     // don't ask me why this is necessary, but it 100% is
     enigma_user::window_set_rectangle(windowX, windowY, windowWidth, windowHeight);
+    // required for global game setting fullscreen window
+    enigma_user::window_set_fullscreen(isFullScreen);
     
     // needed for DrawGUI event
     enigma_user::screen_init();

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -41,7 +41,6 @@ namespace enigma_user
 
 namespace enigma
 {
-  bool initGame;
   extern const char* resource_file_path;
   extern int event_system_initialize(); //Leave this here until you can find a more brilliant way to include it; it's pretty much not-optional.
   extern void timeline_system_initialize();
@@ -51,8 +50,6 @@ namespace enigma
   //This is like main(), only cross-api
   int initialize_everything()
   {
-    initGame = false;
-
     time_t ss = time(0);
     enigma_user::random_set_seed(ss);
     enigma_user::mtrandom_seed(ss);
@@ -127,14 +124,21 @@ namespace enigma
 
     //Initialize extensions
     enigma::extensions_initialize();
+    
 
     //Go to the first room
     if (enigma_user::room_count)
       enigma::game_start();
-    else {
-      enigma_user::window_default();
-      enigma_user::window_set_visible(true);
-    }
+
+    enigma_user::window_default(false);
+    // window sized by first room, can make visible now
+    enigma_user::window_set_visible(true);
+    // required for global game setting resizeable window
+    enigma_user::window_set_sizeable(isSizeable);
+    // required for global game setting borderless window
+    enigma_user::window_set_showborder(showBorder);
+    // required for global game setting fullscreen window
+    enigma_user::window_set_fullscreen(isFullScreen);
 
     return 0;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -132,6 +132,9 @@ namespace enigma
       enigma_user::window_default();
       enigma_user::window_set_visible(true);
     }
+    
+    // center window at start up
+    enigma_user::window_center();
 
     return 0;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -124,7 +124,6 @@ namespace enigma
 
     //Initialize extensions
     enigma::extensions_initialize();
-    
 
     //Go to the first room
     if (enigma_user::room_count)

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -129,25 +129,10 @@ namespace enigma
     //Go to the first room
     if (enigma_user::room_count)
       enigma::game_start();
-
-    // In pull request 1831, it was decided to adopt GMS behavior instead of GM8.
-    // The window is no longer moved, centered, or resized when switching rooms.
-    // This is always true, even if the room sizes are different.
-    enigma_user::window_default(false);
-    // window sized by first room, can make visible now
-    enigma_user::window_set_visible(true);
-    // required for global game setting resizeable window
-    enigma_user::window_set_sizeable(isSizeable);
-    // required for global game setting borderless window
-    enigma_user::window_set_showborder(showBorder);
-    // don't ask me why this is necessary, but it 100% is
-    enigma_user::window_set_rectangle(windowX, windowY, windowWidth, windowHeight);
-    // required for global game setting fullscreen window
-    enigma_user::window_set_fullscreen(isFullScreen);
-    
-    // needed for DrawGUI event
-    enigma_user::screen_init();
-    enigma_user::screen_refresh();
+    else {
+      enigma_user::window_default(false);
+      enigma_user::window_set_visible(true);
+    }
 
     return 0;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -130,6 +130,9 @@ namespace enigma
     if (enigma_user::room_count)
       enigma::game_start();
 
+    // In pull request 1831, it was decided to adopt GMS behavior instead of GM8.
+    // The window is no longer moved, centered, or resized when switching rooms.
+    // This is always true, even if the room sizes are different.
     enigma_user::window_default(false);
     // window sized by first room, can make visible now
     enigma_user::window_set_visible(true);

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -232,10 +232,9 @@ namespace enigma
     //NOTE: window_default() always centers the Window, GM8 only recenters the window when switching rooms
     //if the window size changes.
     if (!enigma::initGame) {
-      compute_window_size(); // update window size detection
       // GMS doesn't do this every room init; only game init
-      // keep this false until xlib window_center() is fixed
       enigma_user::window_default(false);
+      compute_window_size(); // update window size detection
       // window sized by first room, can make visible now
       enigma_user::window_set_visible(true);
       // required for global game setting resizeable window

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -228,6 +228,14 @@ namespace enigma
       view_visible[i] = (bool)views[i].start_vis;
       view_angle[i] = 0;
     }
+    
+    // In pull request 1831, it was decided to adopt GMS behavior instead of GM8.
+    // The window is no longer moved, centered, or resized when switching rooms.
+    // This is always true, even if the room sizes are different.
+    enigma_user::window_default(false);
+    // window sized by first room, can make visible now
+    enigma_user::window_set_visible(true);
+    enigma_user::window_center();
 
     enigma_user::io_clear();
     // we only initialize the screen and clear the window color during game start

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -234,7 +234,6 @@ namespace enigma
     if (!enigma::initGame) {
       // GMS doesn't do this every room init; only game init
       enigma_user::window_default(false);
-      compute_window_size(); // update window size detection
       // window sized by first room, can make visible now
       enigma_user::window_set_visible(true);
       // required for global game setting resizeable window

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -229,21 +229,6 @@ namespace enigma
       view_angle[i] = 0;
     }
 
-    //NOTE: window_default() always centers the Window, GM8 only recenters the window when switching rooms
-    //if the window size changes.
-    if (!enigma::initGame) {
-      // GMS doesn't do this every room init; only game init
-      enigma_user::window_default(false);
-      // window sized by first room, can make visible now
-      enigma_user::window_set_visible(true);
-      // required for global game setting resizeable window
-      enigma_user::window_set_sizeable(enigma::isSizeable);
-      // required for global game setting borderless window
-      enigma_user::window_set_showborder(enigma::showBorder);
-      // required for global game setting fullscreen window
-      enigma_user::window_set_fullscreen(enigma::isFullScreen);
-      enigma::initGame = true;
-    }
     enigma_user::io_clear();
     // we only initialize the screen and clear the window color during game start
     // NOTE: no version of GM has EVER reset the drawing color or alpha during room transition

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -235,7 +235,6 @@ namespace enigma
     enigma_user::window_default(false);
     // window sized by first room, can make visible now
     enigma_user::window_set_visible(true);
-    enigma_user::window_center();
 
     enigma_user::io_clear();
     // we only initialize the screen and clear the window color during game start

--- a/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/roomsystem.cpp
@@ -235,7 +235,6 @@ namespace enigma
     enigma_user::window_default(false);
     // window sized by first room, can make visible now
     enigma_user::window_set_visible(true);
-
     enigma_user::io_clear();
     // we only initialize the screen and clear the window color during game start
     // NOTE: no version of GM has EVER reset the drawing color or alpha during room transition


### PR DESCRIPTION
Fixes the window_set_sizeable() to actually work, and the GML functions added since GMS 1.x - window_set_min/max_width()/height(). https://docs.yoyogames.com/source/dadiospice/002_reference/windows%20and%20views/the%20game%20window/window_set_max_width.html

Edit: this also fixes fullscreen and resizeable window bugs with the graphics not rendering scaled to the window size. All of that is no longer an issue! What can I say other than, "you're welcome!"

Edit2: Also fixed a bug with Win32 when trying to maximize the window, scaling is now handled correctly here, not just in xlib.

Edit3: also fixes get/set fullscreen switching. Global Game Settings for setting fullscreen, borderless mode, and resizeable window on both Win32 and XLib. You can now use dialogs in fullscreen with all graphics systems and platforms. Fixes borderless switching on Windows and setting to borderless on XLib. Fixes sizable switching on Wind32 and XLib.

Here's a demo linux exe (x64) and gmk that demonstrates a proper borderless toggle: [game.zip](https://github.com/enigma-dev/enigma-dev/files/3484633/game.zip)
