### PR TITLE
Mouse Clear Fix

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
@@ -229,7 +229,7 @@ bool mouse_check_button_released(int button) {
   }
 }
 
-void mouse_clear(const int button) { enigma::mousestatus[button] = enigma::last_mousestatus[button] = 0; }
+void mouse_clear(const int button) { enigma::mousestatus[button - 1] = enigma::last_mousestatus[button - 1] = 0; }
 
 void mouse_wait() {
   for (;;) {


### PR DESCRIPTION
This one is for hugar, since he would like to use this function. The bug was just a very simple mistake in this mouse function. As we can see, all of the other mouse functions offset the button index by one, because 0 is `mb_none` in ENIGMA and GM.

This does not appear to have been a regression, the blame tells me the function has always been bugged.
https://github.com/enigma-dev/enigma-dev/blame/34455a78bcbd5f5377472564785b69248361aeec/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp#L1008

I made a little test too. On this pr and GM8.1, my test means holding right down will prevent left showing a message. On ENIGMA master it doesn't stop the message from showing.
```cpp
if (mouse_check_button(mb_right))
    mouse_clear(mb_left);
if (mouse_check_button(mb_left))
    show_message("hello ding dong");
```