### PR TITLE
Virtual Keys Pressed/Released Tweak

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/VirtualKeys/virtualkeys.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/VirtualKeys/virtualkeys.cpp
@@ -39,24 +39,25 @@ bool virtual_key_show_keyboard_pressed = false;
 void update_virtualkeys() {
   for (std::pair<int, VirtualKey&> vki : virtual_keys) {
     VirtualKey& vk = vki.second;
-    // always set it back to false in case of focus loss
-    vk.pressed = false;
 
     // get the mouse with respect to the view
     int mx = window_mouse_get_x();
     int my = window_mouse_get_y();
-    // check if the mouse is inside the virtual key button
-    if (!point_in_rectangle(mx, my, vk.x, vk.y, vk.x + vk.width, vk.y + vk.height))
+    // continue if the left mouse button isn't down or the mouse arrow is not inside the virtual key
+    if (!point_in_rectangle(mx, my, vk.x, vk.y, vk.x + vk.width, vk.y + vk.height) || !mouse_check_button(mb_left)) {
+      if (vk.pressed) {
+        vk.pressed = false;
+        if (vk.keycode == -1) continue;
+        keyboard_key_release(vk.keycode);
+      }
       continue;
-
-    if (mouse_check_button(mb_left)) {
-      vk.pressed = true;
-      if (vk.keycode == -1) continue;
-      keyboard_key_press(vk.keycode);
-    } else if (mouse_check_button_released(mb_left)) {
-      if (vk.keycode == -1) continue;
-      keyboard_key_release(vk.keycode);
     }
+
+    // the left mouse button was down and in our rectangle
+    // classic example of De Morgan's laws
+    vk.pressed = true;
+    if (vk.keycode == -1) continue;
+    keyboard_key_press(vk.keycode);
   }
 }
 


### PR DESCRIPTION
This is a minor tweak to make the virtual keys behave more GMS like. In ENIGMA master, when you hold the left button and move off the virtual key, the keyboard event is still getting fired, even though the button no longer looks pressed. This is not the way GMSv1.4 behaves.

I applied De Morgan's law to my predicate logic in order to make ours behave the way GMSv1.4 does. That means that the virtual key does not need updated when the mouse is outside its rectangle or the left mouse button isn't down. When the virtual key doesn't need updated, it's possible to handle its release behavior, making the key no longer look pressed as well as firing a release event for its associated keycode. If the virtual key does need updated, then it's also being pressed, as it means the mouse is both inside its rectangle and the left button is held down.

Tested locally on my virtual keys example and seems to work pretty good. This makes the buttons much less annoying as they don't get stuck like they did before, especially when the mouse leaves the window altogether.