### PR TITLE
FreeType2 Extension Static Linking

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/Makefile
@@ -1,3 +1,3 @@
-SOURCES +=  $(wildcard Universal_System/Extensions/ttf/*.cpp) 
+SOURCES +=  $(wildcard Universal_System/Extensions/ttf/*.cpp)
 override CXXFLAGS += $(shell pkg-config --cflags freetype2)
-override LDLIBS += $(shell pkg-config --libs freetype2)
+override LDLIBS += $(shell pkg-config --libs --static freetype2) -lfreetype

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/include.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/include.h
@@ -1,4 +1,5 @@
-namespace enigma_user {
-  int font_add(string name, unsigned size, bool bold = false, bool italic = false, unsigned first = 32, unsigned last = 128);
-}
+#include <string>
 
+namespace enigma_user {
+  int font_add(std::string name, unsigned size, bool bold = false, bool italic = false, unsigned first = 32, unsigned last = 128);
+}

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp
@@ -54,7 +54,7 @@ namespace enigma_user {
     unsigned area;
   };
 
-  int font_add(std::string name, int size, bool bold, bool italic, unsigned first, unsigned last) {
+  int font_add(std::string name, unsigned size, bool bold, bool italic, unsigned first, unsigned last) {
 
     if (!enigma::FreeTypeAlive)
       return -1;


### PR DESCRIPTION
Just a few fixes pointed out to me by @time-killer-games which are necessary for me to even be able to use the extension now. We want to link FreeType statically to the game. We also want the `font_add` function signature declaration and definition to match.