### PR TITLE
Empty Vertex/Index Buffer Fixes

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11vertex.cpp
@@ -142,13 +142,13 @@ void graphics_prepare_buffer(const int buffer, const bool isIndex) {
   auto &bufferPeers = isIndex ? indexBufferPeers : vertexBufferPeers;
   const bool dirty = isIndex ? indexBuffers[buffer]->dirty : vertexBuffers[buffer]->dirty;
   const bool frozen = isIndex ? indexBuffers[buffer]->frozen : vertexBuffers[buffer]->frozen;
+  size_t size = isIndex ? enigma_user::index_get_buffer_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
   // if the contents of the buffer are dirty then we need to update our native "peer"
-  if (!dirty) return;
+  if (!dirty || !size) return;
 
   ID3D11Buffer* bufferPeer = NULL;
   auto it = bufferPeers.find(buffer);
-  size_t size = isIndex ? enigma_user::index_get_buffer_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
   // if we have already created a native "peer" for this user buffer,
   // then we have to release it if it isn't big enough to hold the new contents

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9vertex.cpp
@@ -54,14 +54,14 @@ void graphics_delete_index_buffer_peer(int buffer) {
 
 void graphics_prepare_vertex_buffer(const int buffer) {
   enigma::VertexBuffer* vertexBuffer = enigma::vertexBuffers[buffer];
+  size_t size = enigma_user::vertex_get_buffer_size(buffer);
 
   // if the contents of the vertex buffer are dirty then we need to update
   // our native vertex buffer object "peer"
-  if (!vertexBuffer->dirty) return;
+  if (!vertexBuffer->dirty || !size) return;
 
   LPDIRECT3DVERTEXBUFFER9 vertexBufferPeer = NULL;
   auto it = vertexBufferPeers.find(buffer);
-  size_t size = enigma_user::vertex_get_buffer_size(buffer);
 
   // if we have already created a native "peer" vbo for this user buffer,
   // then we have to release it if it isn't big enough to hold the new contents
@@ -103,14 +103,14 @@ void graphics_prepare_vertex_buffer(const int buffer) {
 
 void graphics_prepare_index_buffer(const int buffer) {
   enigma::IndexBuffer* indexBuffer = enigma::indexBuffers[buffer];
+  size_t size = enigma_user::index_get_buffer_size(buffer);
 
   // if the contents of the index buffer are dirty then we need to update
   // our native index buffer object "peer"
-  if (!indexBuffer->dirty) return;
+  if (!indexBuffer->dirty || !size) return;
 
   LPDIRECT3DINDEXBUFFER9 indexBufferPeer = NULL;
   auto it = indexBufferPeers.find(buffer);
-  size_t size = enigma_user::index_get_buffer_size(buffer);
 
   // if we have already created a native "peer" ibo for this user buffer,
   // then we have to release it if it isn't big enough to hold the new contents

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/vertex.cpp
@@ -74,10 +74,11 @@ void graphics_prepare_buffer(const int buffer, const bool isIndex) {
   GLuint bufferPeer;
   auto it = isIndex ? indexBufferPeers.find(buffer) : vertexBufferPeers.find(buffer);
   const GLenum target = isIndex ? GL_ELEMENT_ARRAY_BUFFER : GL_ARRAY_BUFFER;
+  size_t size = isIndex ? enigma_user::index_get_buffer_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
   // if the contents of the buffer are dirty then we need to update
   // our native buffer object "peer"
-  if (!dirty) {
+  if (!dirty || !size) {
     if (isIndex) {
       bind_element_buffer(it->second);
     } else {
@@ -85,8 +86,6 @@ void graphics_prepare_buffer(const int buffer, const bool isIndex) {
     }
     return;
   }
-
-  size_t size = isIndex ? enigma_user::index_get_buffer_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
   // if we haven't created a native "peer" for this buffer yet,
   // then we need to do so now

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/vertex.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/vertex.cpp
@@ -65,15 +65,14 @@ void graphics_prepare_buffer_peer(const int buffer, const bool isIndex) {
   GLuint bufferPeer;
   auto it = isIndex ? indexBufferPeers.find(buffer) : vertexBufferPeers.find(buffer);
   const GLenum target = isIndex ? GL_ELEMENT_ARRAY_BUFFER : GL_ARRAY_BUFFER;
+  size_t size = isIndex ? enigma_user::index_get_buffer_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
   // if the contents of the buffer are dirty then we need to update
   // our native buffer object "peer"
-  if (!dirty) {
+  if (!dirty || !size) {
     glBindBuffer(target, it->second);
     return;
   }
-
-  size_t size = isIndex ? enigma_user::index_get_buffer_size(buffer) : enigma_user::vertex_get_buffer_size(buffer);
 
   // if we haven't created a native "peer" for this buffer yet,
   // then we need to do so now


### PR DESCRIPTION
It has always been the case that Direct3D9 won't run the Minecraft example, this is not a new regression. The problem exhibited in that example is that it sometimes defines empty primitives on the model it uses to render the 3D world. We even have a debug message about that in the model class right now, which I am unsure of whether we should remove. Regardless, Direct3D9 breaks down because the API prevents you from allocating a vertex buffer of size 0 which is different from OpenGL.

>Size of the vertex buffer, in bytes. For FVF vertex buffers, Length must be large enough to contain at least one vertex, but it need not be a multiple of the vertex size. Length is not validated for non-FVF buffers. See Remarks.
https://docs.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9-createvertexbuffer

