### PR TITLE
Fix GTest Expect Exit Code Return

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -118,6 +118,10 @@ void game_end(int ret) {
   enigma::game_return = ret;
 }
 
+void game_end() {
+  enigma::game_isending = true;
+}
+
 void action_end_game() { return game_end(); }
 
 }  //namespace enigma_user

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -56,7 +56,8 @@ extern unsigned long delta_time;
 extern unsigned long current_time;
 
 void sleep(int ms);
-void game_end(int ret=0);
+void game_end();
+void game_end(int ret);
 void action_end_game();
 void url_open(std::string url,std::string target="_self",std::string options="");
 void url_open_ext(std::string url, std::string target);

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
@@ -263,5 +263,5 @@ void SDL_Event_Handler::mouseWheel(const SDL_Event *event) {
   enigma_user::mouse_vscrolls += event->wheel.y;
 }
 
-void SDL_Event_Handler::quit(const SDL_Event *event) { enigma_user::game_end(0); }
+void SDL_Event_Handler::quit(const SDL_Event *event) { enigma_user::game_end(); }
 }  // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -76,7 +76,7 @@ namespace enigma
         // so the user can execute something before the escape is processed, no sense in an override if user is going to call game_end() anyway.
         // - Robert
         if (treatCloseAsEscape) {
-          PostQuitMessage (0);
+          PostQuitMessage(game_return);
         }
         return 0;
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/GTest.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/GTest.cpp
@@ -1,4 +1,6 @@
 #include "include.h"
+#include "Platforms/General/PFmain.h"
+
 #include <gtest/gtest.h>
 #include <iostream>
 using std::string;
@@ -21,6 +23,7 @@ void gtest_binary(string expression, string left_value, string right_value,
       << right_value << ")."
       << (user_message.empty() ? "" : "\n" + user_message);
   if (assert) exit(42);
+  else game_return = 43;
 }
 
 void gtest_unary(string expression, string value, string expected_value,
@@ -35,6 +38,7 @@ void gtest_unary(string expression, string value, string expected_value,
       << "; it is actually " << value
       << (user_message.empty() ? "." : ".\n" + user_message);
   if (assert) exit(42);
+  else game_return = 43;
 }
 
 }  // namespace enigma

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/Makefile
@@ -1,2 +1,7 @@
 SOURCES += Universal_System/Extensions/GTest/GTest.cpp
-override LDLIBS += -lgtest
+
+ifeq ($(TARGET-PLATFORM), Windows)
+	override LDLIBS += -lgtest.dll
+else
+	override LDLIBS += -lgtest
+endif


### PR DESCRIPTION
This pull request addresses #1720 so that while gtest expect calls will not abort, they may fail the test when the game ends.

The first thing I had to do was get rid of the default parameter on `game_end` so that extensions are able to manipulate the game end return value. This circumvents having to update all of the existing tests to ask the gtest extension for an exit code to return or whether there was a failure. It may still be useful to provide that information later though.

I also had to tweak the Win32 and SDL platform's quit to just end the game rather than setting the exit code to 0, since that would preclude an extension being able to effect the game return code.

I tweaked the GTest Makefile in this too because I am tired of having to tweak it every time I want to run the extension on Windows. The package in MSYS2 only provides a dll, no static library, and thus the file extension is necessary for it to build.

Finally, I made the GTest extension set the game exit code to 43 if an expect fails (a non-assert, aka soft assert, failure). This will make it easy to quickly discern hard and soft assertion failures in the test harness.