### PR TITLE
Fix Screen Reading Test

### DIFF
--- a/CI/build_and_run_game.sh
+++ b/CI/build_and_run_game.sh
@@ -4,6 +4,7 @@ set -e
 
 if [ "$TEST_HARNESS" == true ]; then
   export ASAN_OPTIONS=detect_leaks=0;
+  export DISPLAY=:1
   xvfb-run ./ci-regression.sh "/tmp/enigma-master" 4
 else
   for mode in "Debug" "Run"; 

--- a/CI/build_and_run_game.sh
+++ b/CI/build_and_run_game.sh
@@ -4,7 +4,6 @@ set -e
 
 if [ "$TEST_HARNESS" == true ]; then
   export ASAN_OPTIONS=detect_leaks=0;
-  export DISPLAY=:1
   xvfb-run -s "-screen 0 1024x768x24" ./ci-regression.sh "/tmp/enigma-master" 4
 else
   for mode in "Debug" "Run"; 

--- a/CI/build_and_run_game.sh
+++ b/CI/build_and_run_game.sh
@@ -5,7 +5,7 @@ set -e
 if [ "$TEST_HARNESS" == true ]; then
   export ASAN_OPTIONS=detect_leaks=0;
   export DISPLAY=:1
-  xvfb-run ./ci-regression.sh "/tmp/enigma-master" 4
+  xvfb-run -s "-screen 0 1024x768x24" ./ci-regression.sh "/tmp/enigma-master" 4
 else
   for mode in "Debug" "Run"; 
   do


### PR DESCRIPTION
This pull request fixes the draw test regression caused by fundies in #1792 when he got rid of the screen size parameter for xvfb. Changing the screen size caused the `draw_getpixel` coordinates to be off and not return the correct value leading the expects to fail. The fact that the expects did not fail the overall test is an ongoing issue which #1844 covers.

The commit by me prior to fundies does not contain any failures:
https://travis-ci.org/enigma-dev/enigma-dev/jobs/557674696

His commit and every master commit since contains the same failures:
https://travis-ci.org/enigma-dev/enigma-dev/jobs/558269419#L1812

```
1812 EDL:1: Failure
1813 Failed
1814 Failure: Not true that draw_getpixel(surf_dupx + 2, surf_dupy + 2) (which is 16761666) is equal to c_red (which is 255).
1815 EDL:1: Failure
1816 Failed
1817 Failure: Not true that draw_getpixel(surf_dupx + 2, surf_dupy + 10) (which is 16761666) is equal to c_green (which is 32768).
1818 EDL:1: Failure
1819 Failed
1820 Failure: Not true that draw_getpixel(surf_dupx + 16, surf_dupy + 16) (which is 255) is equal to c_blue (which is 16711680).
```

This pull request contains no failures in its Test Harness job:
https://travis-ci.org/enigma-dev/enigma-dev/jobs/566714467