### PR TITLE
Test Harness Game Return

### DIFF
--- a/CI/build_and_run_game.sh
+++ b/CI/build_and_run_game.sh
@@ -4,9 +4,9 @@ set -e
 
 if [ "$TEST_HARNESS" == true ]; then
   export ASAN_OPTIONS=detect_leaks=0;
-  xvfb-run -s "-screen 0 1024x768x24" ./ci-regression.sh "/tmp/enigma-master" 4
+  xvfb-run ./ci-regression.sh "/tmp/enigma-master" 4
 else
-  for mode in "Debug" "Run"; 
+  for mode in "Debug" "Run";
   do
     MODE="$mode" ./ci-build.sh
     if [ "$COMPILER" == "MinGW64" ]; then

--- a/CI/build_and_run_game.sh
+++ b/CI/build_and_run_game.sh
@@ -4,9 +4,9 @@ set -e
 
 if [ "$TEST_HARNESS" == true ]; then
   export ASAN_OPTIONS=detect_leaks=0;
-  xvfb-run ./ci-regression.sh "/tmp/enigma-master" 4
+  xvfb-run -s "-screen 0 1024x768x24" ./ci-regression.sh "/tmp/enigma-master" 4
 else
-  for mode in "Debug" "Run";
+  for mode in "Debug" "Run"; 
   do
     MODE="$mode" ./ci-build.sh
     if [ "$COMPILER" == "MinGW64" ]; then

--- a/CommandLine/testing/Platform/TestHarness-X11.cpp
+++ b/CommandLine/testing/Platform/TestHarness-X11.cpp
@@ -133,6 +133,9 @@ class X11_TestHarness final: public TestHarness {
   void wait() final {
     usleep(1000000);
   }
+  int get_return() final {
+    return return_code;
+  }
   X11_TestHarness(Display *disp, pid_t game_pid, Window game_window,
                   const TestConfig &tc):
       pid(game_pid), window_id(game_window), display(disp), test_config(tc) {}

--- a/CommandLine/testing/TestHarness.hpp
+++ b/CommandLine/testing/TestHarness.hpp
@@ -47,6 +47,8 @@ class TestHarness {
   virtual void close_game() = 0;
   /// Check if the game process is still running.
   virtual bool game_is_running() = 0;
+  /// Check the game process's exit code.
+  virtual int get_return() = 0;
 
   virtual ~TestHarness() {}
 

--- a/CommandLine/testing/Tests/draw_3d_shapes_test.cpp
+++ b/CommandLine/testing/Tests/draw_3d_shapes_test.cpp
@@ -20,4 +20,6 @@ TEST(Regression, draw_3d_shapes_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
+  int game_return = test_harness->get_return();
+  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/draw_3d_shapes_test.cpp
+++ b/CommandLine/testing/Tests/draw_3d_shapes_test.cpp
@@ -20,6 +20,5 @@ TEST(Regression, draw_3d_shapes_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
-  int game_return = test_harness->get_return();
-  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
+  EXPECT_EQ(test_harness->get_return(), 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/draw_blend_test.cpp
+++ b/CommandLine/testing/Tests/draw_blend_test.cpp
@@ -22,6 +22,5 @@ TEST(Regression, draw_blend_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
-  int game_return = test_harness->get_return();
-  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
+  EXPECT_EQ(test_harness->get_return(), 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/draw_blend_test.cpp
+++ b/CommandLine/testing/Tests/draw_blend_test.cpp
@@ -22,4 +22,6 @@ TEST(Regression, draw_blend_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
+  int game_return = test_harness->get_return();
+  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/draw_test.cpp
+++ b/CommandLine/testing/Tests/draw_test.cpp
@@ -22,6 +22,5 @@ TEST(Regression, draw_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
-  int game_return = test_harness->get_return();
-  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
+  EXPECT_EQ(test_harness->get_return(), 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/draw_test.cpp
+++ b/CommandLine/testing/Tests/draw_test.cpp
@@ -22,4 +22,6 @@ TEST(Regression, draw_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
+  int game_return = test_harness->get_return();
+  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/draw_tiles_test.cpp
+++ b/CommandLine/testing/Tests/draw_tiles_test.cpp
@@ -22,6 +22,5 @@ TEST(Regression, draw_tiles_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
-  int game_return = test_harness->get_return();
-  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
+  EXPECT_EQ(test_harness->get_return(), 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/draw_tiles_test.cpp
+++ b/CommandLine/testing/Tests/draw_tiles_test.cpp
@@ -22,4 +22,6 @@ TEST(Regression, draw_tiles_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
+  int game_return = test_harness->get_return();
+  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/room_transition_test.cpp
+++ b/CommandLine/testing/Tests/room_transition_test.cpp
@@ -22,4 +22,6 @@ TEST(Regression, room_transition_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
+  int game_return = test_harness->get_return();
+  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/room_transition_test.cpp
+++ b/CommandLine/testing/Tests/room_transition_test.cpp
@@ -22,6 +22,5 @@ TEST(Regression, room_transition_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
-  int game_return = test_harness->get_return();
-  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
+  EXPECT_EQ(test_harness->get_return(), 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/window_test.cpp
+++ b/CommandLine/testing/Tests/window_test.cpp
@@ -22,6 +22,5 @@ TEST(Game, window_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
-  int game_return = test_harness->get_return();
-  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
+  EXPECT_EQ(test_harness->get_return(), 0) << "Game returned non-zero exit code!";
 }

--- a/CommandLine/testing/Tests/window_test.cpp
+++ b/CommandLine/testing/Tests/window_test.cpp
@@ -22,4 +22,6 @@ TEST(Game, window_test) {
     game_running = test_harness->game_is_running();
   }
   ASSERT_FALSE(game_running) << "Game did not exit after window was closed!";
+  int game_return = test_harness->get_return();
+  ASSERT_TRUE(game_return == 0) << "Game returned non-zero exit code!";
 }


### PR DESCRIPTION
This pull request addresses #1844 by having the regular CI tests assert the game's return code.

It seems to have worked, as I tested bringing back fundies regression I fixed yesterday, and it caused the test harness job to fail.
https://travis-ci.org/enigma-dev/enigma-dev/jobs/567212206#L1767

Sometime soon we should look at deduplicating these cpp files as they have quite a bit of redundancy.