### PR TITLE
Emake Fonts

### DIFF
--- a/CompilerSource/Makefile
+++ b/CompilerSource/Makefile
@@ -4,6 +4,7 @@ include $(SHARED_SRC_DIR)/Makefile
 include $(SHARED_SRC_DIR)/eyaml/Makefile
 include $(SHARED_SRC_DIR)/event_reader/Makefile
 include $(SHARED_SRC_DIR)/rectpacker/Makefile
+include $(SHARED_SRC_DIR)/fonts/Makefile
 
 #################
 # configuration #
@@ -14,11 +15,11 @@ BASE = compileEGMf
 OS := $(shell uname -s)
 ifeq ($(OS), Linux)
 	TARGET := ../lib$(BASE).so
-	CXXFLAGS += -fPIC
+	override CXXFLAGS += -fPIC
 	MKDIR := mkdir
 else ifeq ($(OS), Darwin)
 	TARGET := ../lib$(BASE).dylib
-	CXXFLAGS += -fPIC
+	override CXXFLAGS += -fPIC
 	MKDIR := mkdir
 else
 	TARGET := ../$(BASE).dll
@@ -31,9 +32,16 @@ endif
 ###########
 
 CXX := g++
-CXXFLAGS += -std=c++11 -Wall -O3 -g -I./JDI/src
+GCCVER := $(shell gcc -dumpversion | cut -c 1)
+ifeq ($(shell expr $(GCCVER) \>= 8), 1)
+	override CXXFLAGS += -std=c++17
+else
+	override CXXFLAGS += -std=c++11
+endif
+
+override CXXFLAGS += -Wall -O3 -g -I./JDI/src
 LDFLAGS += -shared -O3 -g -L../ -Wl,-rpath,./
-LDLIBS += -lProtocols -lprotobuf -lz -L$(SHARED_SRC_DIR)/libpng-util -lpng-util -lpng
+override LDLIBS += -lProtocols -lprotobuf -lz -L$(SHARED_SRC_DIR)/libpng-util -lpng-util -lpng
 
 # This implements a recursive wildcard allowing us to iterate in subdirs
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
@@ -43,7 +51,7 @@ OBJECTS := $(addprefix .eobjs/,$(SOURCES:.cpp=.o))
 DEPENDS := $(OBJECTS:.o=.d)
 PROTO_DIR := $(SHARED_SRC_DIR)/protos
 
-CXXFLAGS += -I$(SHARED_SRC_DIR) -I$(SHARED_SRC_DIR)/libpng-util -I$(PROTO_DIR)/.eobjs $(addprefix -I$(SHARED_SRC_DIR)/, $(SHARED_INCLUDES))
+override CXXFLAGS += -I$(SHARED_SRC_DIR) -I$(SHARED_SRC_DIR)/libpng-util -I$(PROTO_DIR)/.eobjs $(addprefix -I$(SHARED_SRC_DIR)/, $(SHARED_INCLUDES))
 SOURCES += $(addprefix $(SHARED_SRC_DIR),$(SHARED_SOURCES))
 OBJECTS += $(addprefix .eobjs/shared/,$(SHARED_SOURCES:.cpp=.o))
 DEPENDS += $(addprefix .eobjs/shared/,$(SHARED_SOURCES:.cpp=.d))

--- a/CompilerSource/Makefile
+++ b/CompilerSource/Makefile
@@ -39,8 +39,8 @@ else
 	override CXXFLAGS += -std=c++11
 endif
 
-override CXXFLAGS += -Wall -O3 -g -I./JDI/src
-LDFLAGS += -shared -O3 -g -L../ -Wl,-rpath,./
+override CXXFLAGS += -Wall -O0 -g -I./JDI/src
+LDFLAGS += -shared -O0 -g -L../ -Wl,-rpath,./
 override LDLIBS += -lProtocols -lprotobuf -lz -L$(SHARED_SRC_DIR)/libpng-util -lpng-util -lpng
 
 # This implements a recursive wildcard allowing us to iterate in subdirs

--- a/CompilerSource/backend/GameData.h
+++ b/CompilerSource/backend/GameData.h
@@ -18,6 +18,8 @@
 #include "project.pb.h"
 #include "GameInformation.pb.h"
 
+#include "fonts/fonts.h"
+
 struct ESLookup;
 
 template<class Proto> struct ProtoMessageInheritor {
@@ -45,7 +47,8 @@ struct ImageData {
   int width, height;
   // TODO: std::string filename;
   BinaryData pixels;
-
+  
+  ImageData() : width(0), height(0) {}
   ImageData(const ::Image &image);
   ImageData(int w, int h, const uint8_t *data, size_t size);
 };
@@ -80,24 +83,10 @@ struct BackgroundData : ProtoMessageInheritor<buffers::resources::Background> {
 
 struct FontData : ProtoMessageInheritor<buffers::resources::Font> {
   std::string name;
-  struct GlyphData : ImageData {
-    buffers::resources::Font::Glyph metrics;
+  ImageData image_data;
+  enigma::fonts::RawFont raw_font;
 
-    // TODO: Need to move the font packing logic to allow pre-packed sprite
-    // fonts; cannot construct image here in the meantime
-    GlyphData(const deprecated::JavaStruct::Glyph &glyph);
-  };
-  struct NormalizedRange {
-    int min, max;
-    std::vector<GlyphData> glyphs;
-    NormalizedRange(int min_, int max_): min(min_), max(max_) {
-      glyphs.reserve(max_ - min_ + 1);
-    }
-    NormalizedRange(const deprecated::JavaStruct::GlyphRange &range);
-  };
-  std::vector<NormalizedRange> normalized_ranges;
-
-  FontData(const BaseProtoClass &font, const std::string& name);
+  FontData(const BaseProtoClass &font, const std::string& name, const ImageData& image, const enigma::fonts::RawFont& raw_font);
   FontData(const deprecated::JavaStruct::Font &font);
 };
 

--- a/CompilerSource/compiler/components/module_write_fonts.cpp
+++ b/CompilerSource/compiler/components/module_write_fonts.cpp
@@ -55,9 +55,7 @@ int lang_CPP::module_write_fonts(const GameData &game, FILE *gameModule) {
   for (const auto &font : game.fonts) {
     cout << "Iterating included fonts..." << endl;
 
-    //writei(font.id(), gameModule);
     const ImageData& img = font.image_data;
-    std::cout << "size out: " << img.pixels.size() << std::endl;
     writei(img.pixels.size(), gameModule);
     fwrite(img.pixels.data(), 1, img.pixels.size(), gameModule);
 

--- a/CompilerSource/compiler/components/module_write_fonts.cpp
+++ b/CompilerSource/compiler/components/module_write_fonts.cpp
@@ -23,7 +23,6 @@
 
 using namespace std;
 
-
 #include "syntax/syncheck.h"
 #include "parser/parser.h"
 
@@ -32,8 +31,6 @@ using namespace std;
 #include "compiler/compile_common.h"
 
 #include "backend/ideprint.h"
-
-#include "rectpacker/rectpack.h"
 #include "languages/lang_CPP.h"
 
 inline void writei(int x, FILE *f) {
@@ -43,47 +40,7 @@ inline void writef(float x, FILE *f) {
   fwrite(&x,4,1,f);
 }
 
-using namespace enigma::rect_packer;
-
-struct GlyphTextureRect {
-  float x, y, x2, y2;
-};
-
-static inline void populate_texture(const FontData& font, pvrect* boxes,
-    GlyphTextureRect *glyphtexc, unsigned char* bigtex, int w, int h) {
-  for (int ii = 0; ii < w * h; ii++)
-    bigtex[ii] = 0;
-
-  size_t igt = 0;
-  for (const auto &range : font.normalized_ranges) {
-    for (const auto &glyph : range.glyphs) {
-      for (int yy = 0; yy < glyph.height; yy++)
-        for (int xx = 0; xx < glyph.width; xx++)
-          bigtex[w * (boxes[igt].y + yy) + boxes[igt].x + xx] =
-              glyph.pixels[yy * glyph.width + xx];
-
-      glyphtexc[igt].x  = boxes[igt].x / double(w);
-      glyphtexc[igt].y  = boxes[igt].y / double(h);
-      glyphtexc[igt].x2 = (boxes[igt].x + glyph.width) / double(w);
-      glyphtexc[igt].y2 = (boxes[igt].y + glyph.height) / double(h);
-      igt++;
-    }
-  }
-
-  /*cout << "Populated. Debugging..." << endl;
-  FILE* sex = fopen("/home/josh/Desktop/lol.txt","wb");
-  char grades[] = " =COBM";
-  for (int yy = 0; yy < h; yy++)
-  {
-    for (int xx = 0; xx < w; xx++)
-      fputc(grades[bigtex[(yy*w+xx)]*5/255],sex);
-    fputc('\n',sex);
-  }
-  fclose(sex);*/
-}
-
-int lang_CPP::module_write_fonts(const GameData &game, FILE *gameModule)
-{
+int lang_CPP::module_write_fonts(const GameData &game, FILE *gameModule) {
   // Now we're going to add backgrounds
   edbg << game.fonts.size() << " Adding Fonts to Game Module: " << flushl;
 
@@ -97,93 +54,14 @@ int lang_CPP::module_write_fonts(const GameData &game, FILE *gameModule)
   // For each included font
   for (const auto &font : game.fonts) {
     cout << "Iterating included fonts..." << endl;
-    // Simple allocations and initializations
-    int gc = font->glyphs().size();
 
-    pvrect* boxes = new pvrect[gc];
+    //writei(font.id(), gameModule);
+    const ImageData& img = font.image_data;
+    std::cout << "size out: " << img.pixels.size() << std::endl;
+    writei(img.pixels.size(), gameModule);
+    fwrite(img.pixels.data(), 1, img.pixels.size(), gameModule);
 
-    typedef pair<size_t, size_t> sizepair; // Gives glyph no by area of glyph (<area, gno>)
-    list<sizepair> box_order;
-    cout << "Allocated some font stuff" << endl;
-
-    // Copy our glyph metrics into it
-    size_t ib = 0;
-    for (const auto &glyph : font->glyphs()) {
-      boxes[ib].w = glyph.width(),
-      boxes[ib].h = glyph.height();
-      ib++;
-    }
-    cout << "Copied metrics" << endl;
-
-    // Sort our boxes from largest to smallest in area.
-    size_t glyphno = 0;
-    for (const auto &glyph : font->glyphs()) {
-      box_order.push_back(sizepair(glyph.width() * glyph.height(), glyphno++));
-    }
-    box_order.sort();
-    cout << "Sorted out some font stuff" << endl;
-
-    // Now we actually pack the mothers. We'll iterate our area-sorted list backwards (largest to smallest)
-    int w = 64, h = 64;
-    rectpnode *rectplane = new rectpnode(0,0,w,h);
-    for (list<sizepair>::reverse_iterator ii = box_order.rbegin(); ii != box_order.rend(); )
-    {
-      rectpnode *nn = rninsert(rectplane, ii->second, boxes);
-      if (nn)
-        rncopy(nn, boxes, ii->second),
-        ii++;
-      else
-      {
-        w > h ? h <<= 1 : w <<= 1,
-        rectplane = expand(rectplane, w, h);
-        printf("Expanded to %d by %d\n", w, h);
-        if (!w or !h) return -1;
-      }
-    }
-
-    cout << "Finished packing font stuff." << endl;
-
-    GlyphTextureRect *glyphtexc = new GlyphTextureRect[gc];
-
-    cout << "Generating font map and metrics..." << endl; {
-      unsigned char *bigtex = new unsigned char[w * h];
-
-      cout << "Allocated a big texture. Moving font into it..." << endl;
-      populate_texture(font, boxes, glyphtexc, bigtex, w, h);
-
-      writei(font.id(), gameModule);
-      writei(w,gameModule), writei(h, gameModule);
-      fwrite(bigtex, 1, w * h, gameModule);
-      fwrite("done", 1, 4, gameModule);
-
-      delete[] bigtex;
-    }
-
-    size_t igt = 0;
-    for (const auto &range : font.normalized_ranges) {
-      writei(range.min, gameModule);
-      unsigned rangeSize = range.max - range.min + 1;
-      writei(rangeSize, gameModule);
-      for (const auto &glyph : range.glyphs) {
-        writef(glyph.metrics.advance(),  gameModule);
-        writef(glyph.metrics.baseline(), gameModule);
-        writef(glyph.metrics.origin(),   gameModule);
-        writei(glyph.metrics.width(),    gameModule);
-        writei(glyph.metrics.height(),   gameModule);
-
-        writef(glyphtexc[igt].x,  gameModule),
-        writef(glyphtexc[igt].y,  gameModule),
-        writef(glyphtexc[igt].x2, gameModule),
-        writef(glyphtexc[igt].y2, gameModule);
-        igt++;
-      }
-    }
-
-
-    fwrite("endf",1,4,gameModule);
     cout << "Wrote all data for font " << font.id() << endl;
-    delete[] glyphtexc;
-    delete[] boxes;
   }
 
   edbg << "Done writing fonts." << flushl;

--- a/CompilerSource/compiler/components/write_font_info.cpp
+++ b/CompilerSource/compiler/components/write_font_info.cpp
@@ -47,14 +47,15 @@ int lang_CPP::compile_writeFontInfo(const GameData &game)
       << "#undef INCLUDED_FROM_SHELLMAIN" << endl
       << "#endif" << endl
       << "#include \"fonts/fonts.h\"" << endl
-      << "#include <unordered_map>" << endl
+      << "#include <map>" << endl
       << endl;
 
   int maxid = -1, rawfontcount = 0;
   wto << "namespace enigma {" << endl;
   wto << "namespace fonts {" << endl;
-  wto << "std::unordered_map<int, SpriteFont> exeFonts = {" << endl;
+  wto << "std::map<int, SpriteFont> exeFonts = {" << endl;
   for (auto font_it = game.fonts.begin(); font_it != game.fonts.end(); ++font_it) {
+   
     const auto& font = *font_it;
     wto << "    { " << font.id() << ", SpriteFont(\"" //begin font
         << font.name         << "\", \""  // string name;
@@ -64,11 +65,11 @@ int lang_CPP::compile_writeFontInfo(const GameData &game)
         << font->italic()    << ", ";     // bool italic;
 
         std::stringstream ranges;
-        //int ymin = 100, ymax = -100;
         ranges << "{ "; //begin glyph ranges
         //FIXME: should be has_image() but lgm writter bugged and always writes a image even if one doesnt exist
         if (font->glyphs_size() > 0)  { // font used pre-rendered texture
-         //todo: parse glyphs 
+         // TODO: this is where gmx with a pre-rendered texture should be handled
+         // iterate font.glyphs() and write them out to IDE_FONTS like below. I've already packed the texture
         } else { // we rendered the texture
           for (auto range = font.raw_font.ranges.begin(); range != font.raw_font.ranges.end(); ++range) {
             ranges << "GlyphRange(";
@@ -95,15 +96,15 @@ int lang_CPP::compile_writeFontInfo(const GameData &game)
               ranges << " ,";
           }
         }
-        //if (font.raw_font.lineHeight != 0 || font.raw_font.yOffset != 0) { // use lineHeight from ttf
-          wto << font.raw_font.lineHeight    << ", "
-              << font.raw_font.yOffset        << ", "
-              << font.image_data.width        << ", " 
-              << font.image_data.height  << ", " 
-              << "nullptr" << ", " 
-              << ranges.str()                << " }"; // end ranges
-        //}
-        wto << ") }"; // end SpriteFont
+          
+       wto << font.raw_font.lineHeight    << ", "
+           << font.raw_font.yOffset        << ", "
+           << font.image_data.width        << ", " 
+           << font.image_data.height  << ", " 
+           << "nullptr" << ", " 
+           << ranges.str()                << " }"; // end ranges
+
+        wto << ") }"; // end SpriteFont & end map index
         
         if (std::next(font_it) != game.fonts.end())
           wto << ",\n"; 

--- a/CompilerSource/compiler/components/write_font_info.cpp
+++ b/CompilerSource/compiler/components/write_font_info.cpp
@@ -35,6 +35,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <sstream>
 
 using namespace std;
 
@@ -45,30 +46,76 @@ int lang_CPP::compile_writeFontInfo(const GameData &game)
       << "#ifndef JUST_DEFINE_IT_RUN" << endl
       << "#undef INCLUDED_FROM_SHELLMAIN" << endl
       << "#endif" << endl
-      << "#include \"Universal_System/Resources/fonts_internal.h\"" << endl
+      << "#include \"fonts/fonts.h\"" << endl
+      << "#include <unordered_map>" << endl
       << endl;
 
   int maxid = -1, rawfontcount = 0;
   wto << "namespace enigma {" << endl;
-  wto << "  std::vector<rawfont> rawfontdata = {" << endl;
-  for (const auto &font : game.fonts) {
-    wto << "    {\""
-        << font.name        << "\", "     // string name;
-        << font->id()        << ", \""    // int id;
+  wto << "namespace fonts {" << endl;
+  wto << "std::unordered_map<int, SpriteFont> exeFonts = {" << endl;
+  for (auto font_it = game.fonts.begin(); font_it != game.fonts.end(); ++font_it) {
+    const auto& font = *font_it;
+    wto << "    { " << font.id() << ", SpriteFont(\"" //begin font
+        << font.name         << "\", \""  // string name;
         << font->font_name() << "\", "    // string fontName;
         << font->size()      << ", "      // int size;
         << font->bold()      << ", "      // bool bold;
-        << font->italic()    << ", "      // bool italic;
-        << font.normalized_ranges.size()  // int glyphRangeCount;
-        << "}," << endl;
+        << font->italic()    << ", ";     // bool italic;
+
+        std::stringstream ranges;
+        //int ymin = 100, ymax = -100;
+        ranges << "{ "; //begin glyph ranges
+        //FIXME: should be has_image() but lgm writter bugged and always writes a image even if one doesnt exist
+        if (font->glyphs_size() > 0)  { // font used pre-rendered texture
+         //todo: parse glyphs 
+        } else { // we rendered the texture
+          for (auto range = font.raw_font.ranges.begin(); range != font.raw_font.ranges.end(); ++range) {
+            ranges << "GlyphRange(";
+            ranges << range->start                 << ", ";
+            ranges << range->start + range->size() << ", { "; // begin glyphs
+            for (auto glyph = range->glyphs.begin(); glyph != range->glyphs.end(); ++glyph) {
+              ranges << "{ "; // begin glyph
+              ranges << glyph->x   << ", ";
+              ranges << glyph->y   << ", ";
+              ranges << glyph->x2  << ", ";
+              ranges << glyph->y2  << ", ";
+              ranges << glyph->tx  << ", ";
+              ranges << glyph->ty  << ", ";
+              ranges << glyph->tx2 << ", ";
+              ranges << glyph->ty2 << ", ";
+              ranges << glyph->xs;
+              ranges << "}"; // end glyph
+              if (std::next(glyph) != range->glyphs.end())
+                ranges << ", ";
+            }
+            ranges << " }"; // end glyphs
+            ranges << " )"; //end range
+            if (std::next(range) != font.raw_font.ranges.end())
+              ranges << " ,";
+          }
+        }
+        //if (font.raw_font.lineHeight != 0 || font.raw_font.yOffset != 0) { // use lineHeight from ttf
+          wto << font.raw_font.lineHeight    << ", "
+              << font.raw_font.yOffset        << ", "
+              << font.image_data.width        << ", " 
+              << font.image_data.height  << ", " 
+              << "nullptr" << ", " 
+              << ranges.str()                << " }"; // end ranges
+        //}
+        wto << ") }"; // end SpriteFont
+        
+        if (std::next(font_it) != game.fonts.end())
+          wto << ",\n"; 
 
     if (font.id() > maxid)
       maxid = font.id();
     rawfontcount++;
   }
-  wto << "  };" << endl;
-  wto << endl << "  int rawfontcount = " << rawfontcount << ", rawfontmaxid = " << maxid << ";" << endl;
-  wto << "}" << endl;
+  wto << "    \n};" << endl; // end fonts
+  wto << endl << "int exeFontsMaxID = " << maxid << ";" << endl;
+  wto << "}" << endl; //namespace fonts
+  wto << "}" << endl; //namespace enigma
   wto.close();
   return 0;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSfont.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSfont.cpp
@@ -34,6 +34,7 @@
 #include <stdint.h>
 
 using namespace std;
+using namespace enigma::fonts;
 
 namespace enigma {
   static int currentfont = -1;
@@ -89,17 +90,17 @@ unsigned draw_get_valign(){
 #ifdef DEBUG_MODE
   #include "Widget_Systems/widgets_mandatory.h"
   #define get_font(fnt,id,r) \
-    if (!enigma::sprite_fonts.exists(id)) { \
+    if (!sprite_fonts.exists(id)) { \
       DEBUG_MESSAGE("Cannot access font with id " + toString(id), MESSAGE_TYPE::M_USER_ERROR); \
       return r; \
     } SpriteFont& fnt = sprite_fonts[id];
   #define get_fontv(fnt,id) \
-    if (!enigma::sprite_fonts.exists(id)) { \
+    if (!sprite_fonts.exists(id)) { \
       DEBUG_MESSAGE("Cannot access font with id " + toString(id), MESSAGE_TYPE::M_USER_ERROR); \
       return; \
     } SpriteFont& fnt = sprite_fonts[id];
   #define get_font_null(fnt,id,r) \
-    if (!enigma::sprite_fonts.exists(id)) { \
+    if (!sprite_fonts.exists(id)) { \
       DEBUG_MESSAGE("Cannot access font with id " + toString(id), MESSAGE_TYPE::M_USER_ERROR); \
       return r; \
     } SpriteFont& fnt = sprite_fonts[id];
@@ -114,14 +115,14 @@ unsigned draw_get_valign(){
 
 namespace enigma {
   inline float get_space_width(const SpriteFont& fnt) {
-    fontglyph g = findGlyph(fnt, ' ');
+    GlyphMetrics g = findGlyph(fnt, ' ');
     // Use the width of the space glyph when available,
     // else use the backup.
     // FIXME: Find out why the width is not available on Linux.
     if (!g.empty()) {
-      return g.xs > 1 ? g.xs : fnt.height/3;
+      return g.xs > 1 ? g.xs : fnt.lineHeight/3;
     } else {
-      return fnt.height/3;
+      return fnt.lineHeight/3;
     }
   }
 }
@@ -139,7 +140,7 @@ double string_char_width(variant vstr)
   if (character == ' ') {
     return get_space_width(fnt);
   }
-  fontglyph g = findGlyph(fnt, character);
+  GlyphMetrics g = findGlyph(fnt, character);
   if (g.empty()) {
     return get_space_width(fnt);
   } else {
@@ -158,7 +159,7 @@ unsigned int string_width(variant vstr)
     if (character == '\r' or character == '\n') {
       tlen = 0;
     } else {
-      fontglyph g = findGlyph(fnt, character);
+      GlyphMetrics g = findGlyph(fnt, character);
       if (character == ' ' or g.empty()) {
         tlen += slen;
       } else {
@@ -174,10 +175,10 @@ unsigned int string_height(variant vstr)
 {
   string str = toString(vstr);
   get_font(fnt,currentfont,0);
-  float hgt = fnt.height;
+  float hgt = fnt.lineHeight;
   for (size_t i = 0; i < str.length(); i++)
     if (str[i] == '\r' or str[i] == '\n')
-      hgt += fnt.height;
+      hgt += fnt.lineHeight;
   return hgt;
 }
 
@@ -191,7 +192,7 @@ unsigned int string_width_ext(variant vstr, gs_scalar sep, gs_scalar w) //here s
   {
     uint32_t character = getUnicodeCharacter(str, i);
 
-    fontglyph g = findGlyph(fnt, character);
+    GlyphMetrics g = findGlyph(fnt, character);
     if (character == ' ' or g.empty()) {
         if (width >= w && w!=-1) {
           (width>maxwidth ? maxwidth=width, width = 0 : width = 0);
@@ -211,14 +212,14 @@ unsigned int string_height_ext(variant vstr, gs_scalar sep, gs_scalar w)
   string str = toString(vstr);
   get_font(fnt,currentfont,0);
 
-  float width = 0, tw = 0, height = fnt.height, slen = get_space_width(fnt);
+  float width = 0, tw = 0, height = fnt.lineHeight, slen = get_space_width(fnt);
   for (size_t i = 0; i < str.length(); i++)
   {
     uint32_t character = getUnicodeCharacter(str, i);
     if (character == '\r' or character == '\n') {
-      width = 0, height +=  (sep+2 ? fnt.height : sep);
+      width = 0, height +=  (sep+2 ? fnt.lineHeight : sep);
     } else {
-      fontglyph g = findGlyph(fnt, character);
+      GlyphMetrics g = findGlyph(fnt, character);
       if (character == ' ' or g.empty()) {
         width += slen;
       }
@@ -232,7 +233,7 @@ unsigned int string_height_ext(variant vstr, gs_scalar sep, gs_scalar w)
       }
 
       if (width+tw >= w && w != -1) {
-        height += (sep==-1 ? fnt.height : sep), width = 0, tw = 0;
+        height += (sep==-1 ? fnt.lineHeight : sep), width = 0, tw = 0;
       } else {
         width += g.xs;
       }
@@ -261,7 +262,7 @@ unsigned int string_width_line(variant vstr, int line)
       cl += 1;
       len = 0;
     } else {
-      fontglyph g = findGlyph(fnt, character);
+      GlyphMetrics g = findGlyph(fnt, character);
       if (character == ' ' or g.empty())
         len += slen;
       else {
@@ -287,7 +288,7 @@ unsigned int string_width_ext_line(variant vstr, gs_scalar w, int line)
     } else if (character == '\n') {
       if (cl == line) return ceil(width); else width = 0, cl +=1;
     } else {
-      fontglyph g = findGlyph(fnt, character);
+      GlyphMetrics g = findGlyph(fnt, character);
       if ((character == ' ' or g.empty()) && w != -1) {
         width += slen, tw = 0;
         for (size_t c = i+1; c < str.length(); c++)
@@ -295,7 +296,7 @@ unsigned int string_width_ext_line(variant vstr, gs_scalar w, int line)
           uint32_t ct = getUnicodeCharacter(str, c);
           if (ct == ' ' or ct == '\r' or ct == '\n')
             break;
-          fontglyph gt = findGlyph(fnt, ct);
+          GlyphMetrics gt = findGlyph(fnt, ct);
           tw += (!gt.empty() ? g.xs : slen);
         }
         if (width+tw >= w){
@@ -328,7 +329,7 @@ unsigned int string_width_ext_line_count(variant vstr, gs_scalar w)
     } else if (character == '\n') {
       width = 0, cl +=1;
     } else {
-      fontglyph g = findGlyph(fnt, character);
+      GlyphMetrics g = findGlyph(fnt, character);
       if ((character == ' ' or g.empty()) && w != -1){
         width += slen, tw = 0;
         for (size_t c = i+1; c < str.length(); c++)
@@ -336,7 +337,7 @@ unsigned int string_width_ext_line_count(variant vstr, gs_scalar w)
           uint32_t ct = getUnicodeCharacter(str, c);
           if (ct == ' ' or ct == '\r' or ct == '\n')
             break;
-          fontglyph gt = findGlyph(fnt, ct);
+          GlyphMetrics gt = findGlyph(fnt, ct);
           tw += (!gt.empty() ? g.xs : slen);
         }
         if (width+tw >= w)
@@ -360,7 +361,7 @@ void draw_text(gs_scalar x, gs_scalar y, variant vstr)
 {
   string str = toString(vstr);
   get_fontv(fnt,currentfont);
-  gs_scalar yy = valign == fa_top ? y+fnt.yoffset : valign == fa_middle ? y +fnt.yoffset - string_height(str)/2 : y + fnt.yoffset - string_height(str);
+  gs_scalar yy = valign == fa_top ? y+fnt.yOffset : valign == fa_middle ? y +fnt.yOffset - string_height(str)/2 : y + fnt.yOffset - string_height(str);
   float slen = get_space_width(fnt);
   if (halign == fa_left){
       gs_scalar xx = x;
@@ -369,15 +370,15 @@ void draw_text(gs_scalar x, gs_scalar y, variant vstr)
         uint32_t character = getUnicodeCharacter(str, i);
 
         if (character == '\r') {
-          xx = x, yy += fnt.height, i += str[i+1] == '\n';
+          xx = x, yy += fnt.lineHeight, i += str[i+1] == '\n';
         } else if (character == '\n') {
-          xx = x, yy += fnt.height;
+          xx = x, yy += fnt.lineHeight;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += slen;
           } else {
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture(xx + g.x,  yy + g.y, g.tx, g.ty);
             draw_vertex_texture(xx + g.x2, yy + g.y, g.tx2, g.ty);
             draw_vertex_texture(xx + g.x,  yy + g.y2, g.tx,  g.ty2);
@@ -394,17 +395,17 @@ void draw_text(gs_scalar x, gs_scalar y, variant vstr)
         uint32_t character = getUnicodeCharacter(str, i);
 
         if (character == '\r') {
-          line +=1, yy += fnt.height, i += str[i+1] == '\n';
+          line +=1, yy += fnt.lineHeight, i += str[i+1] == '\n';
           xx = halign == fa_center ? x-gs_scalar(string_width_line(str,line)/2) : x-gs_scalar(string_width_line(str,line));
         } else if (character == '\n') {
-          line +=1, yy += fnt.height;
+          line +=1, yy += fnt.lineHeight;
           xx = halign == fa_center ? x-gs_scalar(string_width_line(str,line)/2) : x-gs_scalar(string_width_line(str,line));
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += slen;
           } else {
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture(xx + g.x,  yy + g.y, g.tx, g.ty);
             draw_vertex_texture(xx + g.x2, yy + g.y, g.tx2, g.ty);
             draw_vertex_texture(xx + g.x,  yy + g.y2, g.tx,  g.ty2);
@@ -489,7 +490,7 @@ void draw_text_skewed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar top, gs_
 {
   string str = toString(vstr);
   get_fontv(fnt,currentfont);
-  gs_scalar yy = valign == fa_top ? y+fnt.yoffset : valign == fa_middle ? y +fnt.yoffset - string_height(str)/2 : y + fnt.yoffset - string_height(str);
+  gs_scalar yy = valign == fa_top ? y+fnt.yOffset : valign == fa_middle ? y +fnt.yOffset - string_height(str)/2 : y + fnt.yOffset - string_height(str);
   float slen = get_space_width(fnt);
   if (halign == fa_left){
     gs_scalar xx = x;
@@ -497,15 +498,15 @@ void draw_text_skewed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar top, gs_
     {
       uint32_t character = getUnicodeCharacter(str, i);
       if (character == '\r') {
-        xx = x, yy += fnt.height, i += str[i+1] == '\n';
+        xx = x, yy += fnt.lineHeight, i += str[i+1] == '\n';
       } else if (character == '\n') {
-        xx = x, yy += fnt.height;
+        xx = x, yy += fnt.lineHeight;
       } else {
-        fontglyph g = findGlyph(fnt, character);
+        GlyphMetrics g = findGlyph(fnt, character);
         if (character == ' ' or g.empty()) {
           xx += slen;
         } else {
-          draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+          draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
           draw_vertex_texture(xx + g.x + top,     yy + g.y + top, g.tx, g.ty);
           draw_vertex_texture(xx + g.x2 + top,    yy + g.y + top, g.tx2, g.ty);
           draw_vertex_texture(xx + g.x + bottom,  yy + g.y2 + bottom, g.tx,  g.ty2);
@@ -522,17 +523,17 @@ void draw_text_skewed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar top, gs_
     {
       uint32_t character = getUnicodeCharacter(str, i);
       if (character == '\r') {
-        line +=1, yy += fnt.height, i += str[i+1] == '\n';
+        line +=1, yy += fnt.lineHeight, i += str[i+1] == '\n';
         xx = halign == fa_center ? x-gs_scalar(string_width_line(str,line)/2) : x-gs_scalar(string_width_line(str,line));
       } else if (character == '\n') {
-        line +=1, yy += fnt.height;
+        line +=1, yy += fnt.lineHeight;
         xx = halign == fa_center ? x-gs_scalar(string_width_line(str,line)/2) : x-gs_scalar(string_width_line(str,line));
       } else {
-        fontglyph g = findGlyph(fnt, character);
+        GlyphMetrics g = findGlyph(fnt, character);
         if (character == ' ' or g.empty()) {
           xx += slen;
         } else {
-          draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+          draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
           draw_vertex_texture(xx + g.x + top,     yy + g.y + top, g.tx, g.ty);
           draw_vertex_texture(xx + g.x2 + top,    yy + g.y + top, g.tx2, g.ty);
           draw_vertex_texture(xx + g.x + bottom,  yy + g.y2 + bottom, g.tx,  g.ty2);
@@ -550,7 +551,7 @@ void draw_text_ext(gs_scalar x, gs_scalar y, variant vstr, gs_scalar sep, gs_sca
   string str = toString(vstr);
   get_fontv(fnt,currentfont);
 
-  gs_scalar yy = valign == fa_top ? y+fnt.yoffset : valign == fa_middle ? y + fnt.yoffset - string_height_ext(str,sep,w)/2 : y + fnt.yoffset - string_height_ext(str,sep,w);
+  gs_scalar yy = valign == fa_top ? y+fnt.yOffset : valign == fa_middle ? y + fnt.yOffset - string_height_ext(str,sep,w)/2 : y + fnt.yOffset - string_height_ext(str,sep,w);
   float slen = get_space_width(fnt);
   if (halign == fa_left){
     gs_scalar xx = x, width = 0, tw = 0;
@@ -558,11 +559,11 @@ void draw_text_ext(gs_scalar x, gs_scalar y, variant vstr, gs_scalar sep, gs_sca
     {
       uint32_t character = getUnicodeCharacter(str, i);
       if (character == '\r') {
-        xx = x, yy += (sep+2 ? fnt.height : sep), i += str[i+1] == '\n';
+        xx = x, yy += (sep+2 ? fnt.lineHeight : sep), i += str[i+1] == '\n';
       } else if (character == '\n') {
-            xx = x, yy += (sep+2 ? fnt.height : sep);
+            xx = x, yy += (sep+2 ? fnt.lineHeight : sep);
       } else {
-        fontglyph g = findGlyph(fnt, character);
+        GlyphMetrics g = findGlyph(fnt, character);
         if (character == ' ' or g.empty()) {
           xx += slen, width = xx-x;
           tw = 0;
@@ -575,9 +576,9 @@ void draw_text_ext(gs_scalar x, gs_scalar y, variant vstr, gs_scalar sep, gs_sca
             tw += (!g.empty()?g.xs:slen);
           }
           if (width+tw >= w && w != -1)
-          xx = x, yy += (sep==-1 ? fnt.height : sep), width = 0, tw = 0;
+          xx = x, yy += (sep==-1 ? fnt.lineHeight : sep), width = 0, tw = 0;
         } else {
-          draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+          draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
           draw_vertex_texture(xx + g.x,  yy + g.y, g.tx, g.ty);
           draw_vertex_texture(xx + g.x2, yy + g.y, g.tx2, g.ty);
           draw_vertex_texture(xx + g.x,  yy + g.y2, g.tx,  g.ty2);
@@ -593,11 +594,11 @@ void draw_text_ext(gs_scalar x, gs_scalar y, variant vstr, gs_scalar sep, gs_sca
     {
       uint32_t character = getUnicodeCharacter(str, i);
       if (character == '\r') {
-        line += 1, xx = halign == fa_center ? x-gs_scalar(string_width_ext_line(str,w,line)/2) : x-gs_scalar(string_width_ext_line(str,w,line)), yy += (sep+2 ? fnt.height : sep), i += str[i+1] == '\n', width = 0;
+        line += 1, xx = halign == fa_center ? x-gs_scalar(string_width_ext_line(str,w,line)/2) : x-gs_scalar(string_width_ext_line(str,w,line)), yy += (sep+2 ? fnt.lineHeight : sep), i += str[i+1] == '\n', width = 0;
       } else if (character == '\n') {
-        line += 1, xx = halign == fa_center ? x-gs_scalar(string_width_ext_line(str,w,line)/2) : x-gs_scalar(string_width_ext_line(str,w,line)), yy += (sep+2 ? fnt.height : sep), width = 0;
+        line += 1, xx = halign == fa_center ? x-gs_scalar(string_width_ext_line(str,w,line)/2) : x-gs_scalar(string_width_ext_line(str,w,line)), yy += (sep+2 ? fnt.lineHeight : sep), width = 0;
       } else {
-        fontglyph g = findGlyph(fnt, character);
+        GlyphMetrics g = findGlyph(fnt, character);
         if (character == ' ' or g.empty()) {
           xx += slen, width += slen, tw = 0;
           for (size_t c = i+1; c < str.length(); c++)
@@ -610,9 +611,9 @@ void draw_text_ext(gs_scalar x, gs_scalar y, variant vstr, gs_scalar sep, gs_sca
           }
 
           if (width+tw >= w && w != -1)
-            line += 1, xx = halign == fa_center ? x-gs_scalar(string_width_ext_line(str,w,line)/2) : x-gs_scalar(string_width_ext_line(str,w,line)), yy += (sep==-1 ? fnt.height : sep), width = 0, tw = 0;
+            line += 1, xx = halign == fa_center ? x-gs_scalar(string_width_ext_line(str,w,line)/2) : x-gs_scalar(string_width_ext_line(str,w,line)), yy += (sep==-1 ? fnt.lineHeight : sep), width = 0, tw = 0;
         } else {
-          draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+          draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
           draw_vertex_texture(xx + g.x,  yy + g.y, g.tx, g.ty);
           draw_vertex_texture(xx + g.x2, yy + g.y, g.tx2, g.ty);
           draw_vertex_texture(xx + g.x,  yy + g.y2, g.tx,  g.ty2);
@@ -635,16 +636,16 @@ void draw_text_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar xsc
 
   const gs_scalar sv = sin(rot), cv = cos(rot),
     svx = sv*xscale, cvx = cv*xscale, svy = sv * yscale,
-    cvy = cv*yscale, sw = get_space_width(fnt) * cvx, sh = fnt.height/3 * svx,
-    chi = fnt.height * cvy, shi = fnt.height * svy;
+    cvy = cv*yscale, sw = get_space_width(fnt) * cvx, sh = fnt.lineHeight/3 * svx,
+    chi = fnt.lineHeight * cvy, shi = fnt.lineHeight * svy;
 
   gs_scalar xx, yy, tmpx, tmpy, tmpsize;
   if (valign == fa_top)
-    yy = y + fnt.yoffset * cvy, xx = x + fnt.yoffset * svy;
+    yy = y + fnt.yOffset * cvy, xx = x + fnt.yOffset * svy;
   else if (valign == fa_middle)
-    tmpsize = string_height(str), yy = y + (fnt.yoffset - tmpsize/2) * cvy, xx = x + (fnt.yoffset - tmpsize/2) * svy;
+    tmpsize = string_height(str), yy = y + (fnt.yOffset - tmpsize/2) * cvy, xx = x + (fnt.yOffset - tmpsize/2) * svy;
   else
-    tmpsize = string_height(str), yy = y + (fnt.yoffset - tmpsize) * cvy, xx = x + (fnt.yoffset - tmpsize) * svy;
+    tmpsize = string_height(str), yy = y + (fnt.yOffset - tmpsize) * cvy, xx = x + (fnt.yOffset - tmpsize) * svy;
   tmpx = xx, tmpy = yy;
   if (halign == fa_left){
       int lines = 0, w;
@@ -656,7 +657,7 @@ void draw_text_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar xsc
         } else if (character == '\n') {
           lines += 1, xx = tmpx + lines * shi, yy = tmpy + lines * chi;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += sw,
             yy -= sh;
@@ -665,7 +666,7 @@ void draw_text_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar xsc
             const gs_scalar lx = xx + g.y * svy;
             const gs_scalar ly = yy + g.y * cvy;
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture(lx, ly, g.tx, g.ty);
             draw_vertex_texture(lx + w * cvx, ly - w * svx, g.tx2, g.ty);
             draw_vertex_texture(xx + g.y2 * svy,  yy + g.y2 * cvy, g.tx,  g.ty2);
@@ -700,7 +701,7 @@ void draw_text_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar xsc
           else
             xx = tmpx-tmpsize * cvx + lines * shi, yy = tmpy+tmpsize * svx + lines * chi;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
               xx += sw,
             yy -= sh;
@@ -709,7 +710,7 @@ void draw_text_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar xsc
             const gs_scalar lx = xx + g.y * svy;
             const gs_scalar ly = yy + g.y * cvy;
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture(lx, ly, g.tx, g.ty);
             draw_vertex_texture(lx + w * cvx, ly - w * svx, g.tx2, g.ty);
             draw_vertex_texture(xx + g.y2 * svy,  yy + g.y2 * cvy, g.tx,  g.ty2);
@@ -733,16 +734,16 @@ void draw_text_ext_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar
 
   const gs_scalar sv = sin(rot), cv = cos(rot),
     svx = sv*xscale, cvx = cv*xscale, svy = sv * yscale,
-    cvy = cv*yscale, sw = get_space_width(fnt) * cvx, sh = fnt.height/3 * svx,
-    chi = fnt.height * cvy, shi = fnt.height * svy;
+    cvy = cv*yscale, sw = get_space_width(fnt) * cvx, sh = fnt.lineHeight/3 * svx,
+    chi = fnt.lineHeight * cvy, shi = fnt.lineHeight * svy;
 
   gs_scalar xx, yy, tmpx, tmpy, wi, tmpsize;
   if (valign == fa_top)
-    yy = y + fnt.yoffset * cvy, xx = x + fnt.yoffset * svy;
+    yy = y + fnt.yOffset * cvy, xx = x + fnt.yOffset * svy;
   else if (valign == fa_middle)
-    tmpsize = string_height_ext(str,sep,w), yy = y + (fnt.yoffset - tmpsize/2) * cvy, xx = x + (fnt.yoffset - tmpsize/2) * svy;
+    tmpsize = string_height_ext(str,sep,w), yy = y + (fnt.yOffset - tmpsize/2) * cvy, xx = x + (fnt.yOffset - tmpsize/2) * svy;
   else
-    tmpsize = string_height_ext(str,sep,w), yy = y + (fnt.yoffset - tmpsize) * cvy, xx = x + (fnt.yoffset - tmpsize) * svy;
+    tmpsize = string_height_ext(str,sep,w), yy = y + (fnt.yOffset - tmpsize) * cvy, xx = x + (fnt.yOffset - tmpsize) * svy;
   tmpx = xx, tmpy = yy;
 
   if (halign == fa_left){
@@ -755,7 +756,7 @@ void draw_text_ext_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar
         } else if (character == '\n') {
           lines += 1, xx = tmpx + lines * shi, width = 0, yy = tmpy + lines * chi;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += sw,
             yy -= sh;
@@ -778,7 +779,7 @@ void draw_text_ext_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar
             const gs_scalar lx = xx + g.y * svy;
             const gs_scalar ly = yy + g.y * cvy;
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture(lx, ly, g.tx,  g.ty);
             draw_vertex_texture(lx + wi * cvx, ly - wi * svx, g.tx2, g.ty);
             draw_vertex_texture(xx + g.y2 * svy,  yy + g.y2 * cvy, g.tx,  g.ty2);
@@ -814,7 +815,7 @@ void draw_text_ext_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar
           else
             xx = tmpx-tmpsize * cvx + lines * shi, yy = tmpy+tmpsize * svx + lines * chi;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += sw,
             yy -= sh;
@@ -843,7 +844,7 @@ void draw_text_ext_transformed(gs_scalar x, gs_scalar y, variant vstr, gs_scalar
               const gs_scalar lx = xx + g.y * svy;
               const gs_scalar ly = yy + g.y * cvy;
 
-              draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+              draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
               draw_vertex_texture(lx, ly, g.tx,  g.ty);
               draw_vertex_texture(lx + wi * cvx, ly - wi * svx, g.tx2, g.ty);
               draw_vertex_texture(xx + g.y2 * svy,  yy + g.y2 * cvy, g.tx,  g.ty2);
@@ -868,17 +869,17 @@ void draw_text_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_scal
 
   const gs_scalar sv = sin(rot), cv = cos(rot),
     svx = sv*xscale, cvx = cv*xscale, svy = sv * yscale,
-    cvy = cv*yscale, sw = get_space_width(fnt) * cvx, sh = fnt.height/3 * svx,
-    chi = fnt.height * cvy, shi = fnt.height * svy;
+    cvy = cv*yscale, sw = get_space_width(fnt) * cvx, sh = fnt.lineHeight/3 * svx,
+    chi = fnt.lineHeight * cvy, shi = fnt.lineHeight * svy;
 
   gs_scalar xx, yy, tmpx, tmpy, tmpsize;
   int hcol1 = c1, hcol2 = c1, hcol3 = c3, hcol4 = c4, width = 0;
   if (valign == fa_top)
-    yy = y + fnt.yoffset * cvy, xx = x + fnt.yoffset * svy;
+    yy = y + fnt.yOffset * cvy, xx = x + fnt.yOffset * svy;
   else if (valign == fa_middle)
-    tmpsize = string_height(str), yy = y + (fnt.yoffset - tmpsize/2) * cvy, xx = x + (fnt.yoffset - tmpsize/2) * svy;
+    tmpsize = string_height(str), yy = y + (fnt.yOffset - tmpsize/2) * cvy, xx = x + (fnt.yOffset - tmpsize/2) * svy;
   else
-    tmpsize = string_height(str), yy = y + (fnt.yoffset - tmpsize) * cvy, xx = x + (fnt.yoffset - tmpsize) * svy;
+    tmpsize = string_height(str), yy = y + (fnt.yOffset - tmpsize) * cvy, xx = x + (fnt.yOffset - tmpsize) * svy;
   tmpx = xx, tmpy = yy;
   if (halign == fa_left){
       int lines = 0, w;
@@ -891,7 +892,7 @@ void draw_text_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_scal
         } else if (character == '\n') {
           lines += 1, width = 0, xx = tmpx + lines * shi, yy = tmpy + lines * chi, tmpsize = string_width_line(str,lines);
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += sw, yy -= sh,
             width += sw;
@@ -904,7 +905,7 @@ void draw_text_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_scal
             hcol3 = merge_color(c4,c3,(gs_scalar)(width)/tmpsize);
             hcol4 = merge_color(c4,c3,(gs_scalar)(width+g.xs)/tmpsize);
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture_color(lx, ly, g.tx,  g.ty, hcol1, a);
             draw_vertex_texture_color(lx + w * cvx, ly - w * svx, g.tx2, g.ty, hcol2, a);
             draw_vertex_texture_color(xx + g.y2 * svy,  yy + g.y2 * cvy, g.tx, g.ty2, hcol4, a);
@@ -940,7 +941,7 @@ void draw_text_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_scal
           else
             xx = tmpx-tmpsize * cvx + lines * shi, yy = tmpy+tmpsize * svx + lines * chi;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += sw, yy -= sh,
             width += sw;
@@ -953,7 +954,7 @@ void draw_text_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_scal
             hcol3 = merge_color(c4,c3,(gs_scalar)(width)/tmpsize);
             hcol4 = merge_color(c4,c3,(gs_scalar)(width+g.xs)/tmpsize);
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture_color(lx, ly, g.tx,  g.ty, hcol1, a);
             draw_vertex_texture_color(lx + w * cvx, ly - w * svx, g.tx2, g.ty, hcol2, a);
             draw_vertex_texture_color(xx + g.y2 * svy,  yy + g.y2 * cvy, g.tx, g.ty2, hcol4, a);
@@ -978,17 +979,17 @@ void draw_text_ext_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_
 
   const gs_scalar sv = sin(rot), cv = cos(rot),
     svx = sv*xscale, cvx = cv*xscale, svy = sv * yscale,
-    cvy = cv*yscale, sw = get_space_width(fnt) * cvx, sh = fnt.height/3 * svx,
-    chi = fnt.height * cvy, shi = fnt.height * svy;
+    cvy = cv*yscale, sw = get_space_width(fnt) * cvx, sh = fnt.lineHeight/3 * svx,
+    chi = fnt.lineHeight * cvy, shi = fnt.lineHeight * svy;
 
   gs_scalar xx, yy, tmpx, tmpy, tmpsize;
   int hcol1 = c1, hcol2 = c1, hcol3 = c3, hcol4 = c4, width = 0;
   if (valign == fa_top)
-    yy = y + fnt.yoffset * cvy, xx = x + fnt.yoffset * svy;
+    yy = y + fnt.yOffset * cvy, xx = x + fnt.yOffset * svy;
   else if (valign == fa_middle)
-    tmpsize = string_height_ext(str,sep,w), yy = y + (fnt.yoffset - tmpsize/2) * cvy, xx = x + (fnt.yoffset - tmpsize/2) * svy;
+    tmpsize = string_height_ext(str,sep,w), yy = y + (fnt.yOffset - tmpsize/2) * cvy, xx = x + (fnt.yOffset - tmpsize/2) * svy;
   else
-    tmpsize = string_height_ext(str,sep,w), yy = y + (fnt.yoffset - tmpsize) * cvy, xx = x + (fnt.yoffset - tmpsize) * svy;
+    tmpsize = string_height_ext(str,sep,w), yy = y + (fnt.yOffset - tmpsize) * cvy, xx = x + (fnt.yOffset - tmpsize) * svy;
   tmpx = xx, tmpy = yy;
   if (halign == fa_left){
       int lines = 0, tw = 0, wi;
@@ -1001,7 +1002,7 @@ void draw_text_ext_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_
         } else if (character == '\n') {
           lines += 1, width = 0, xx = tmpx + lines * shi, yy = tmpy + lines * chi, tmpsize = string_width_ext_line(str,w,lines);
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += sw, yy -= sh,
             width += sw;
@@ -1026,7 +1027,7 @@ void draw_text_ext_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_
             hcol3 = merge_color(c4,c3,(gs_scalar)(width)/tmpsize);
             hcol4 = merge_color(c4,c3,(gs_scalar)(width+g.xs)/tmpsize);
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture_color(lx, ly, g.tx,  g.ty, hcol1, a);
             draw_vertex_texture_color(lx + wi * cvx, ly - wi * svx, g.tx2, g.ty, hcol2, a);
             draw_vertex_texture_color(xx + g.y2 * svy,  yy + g.y2 * cvy, g.tx,  g.ty2, hcol4, a);
@@ -1063,7 +1064,7 @@ void draw_text_ext_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_
           else
             xx = tmpx-tmpsize * cvx + lines * shi, yy = tmpy+tmpsize * svx + lines * chi;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += sw, yy -= sh,
             width += sw;
@@ -1094,7 +1095,7 @@ void draw_text_ext_transformed_color(gs_scalar x, gs_scalar y, variant vstr, gs_
             hcol3 = merge_color(c4,c3,(gs_scalar)(width)/tmpsize);
             hcol4 = merge_color(c4,c3,(gs_scalar)(width+g.xs)/tmpsize);
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture_color(lx, ly, g.tx,  g.ty, hcol1, a);
             draw_vertex_texture_color(lx + wi * cvx, ly - wi * svx, g.tx2, g.ty, hcol2, a);
             draw_vertex_texture_color(xx + g.y2 * svy,  yy + g.y2 * cvy, g.tx,  g.ty2, hcol4, a);
@@ -1116,7 +1117,7 @@ void draw_text_color(gs_scalar x, gs_scalar y,variant vstr,int c1,int c2,int c3,
   get_fontv(fnt,currentfont);
 
   float slen = get_space_width(fnt);
-  gs_scalar yy = valign == fa_top ? y+fnt.yoffset : valign == fa_middle ? y +fnt.yoffset - string_height(str)/2 : y + fnt.yoffset - string_height(str);
+  gs_scalar yy = valign == fa_top ? y+fnt.yOffset : valign == fa_middle ? y +fnt.yOffset - string_height(str)/2 : y + fnt.yOffset - string_height(str);
   int hcol1 = c1, hcol2 = c1, hcol3 = c3, hcol4 = c4,  line = 0;
   gs_scalar tx1, tx2, sw = (gs_scalar)string_width_line(str, line);
   if (halign == fa_left){
@@ -1125,15 +1126,15 @@ void draw_text_color(gs_scalar x, gs_scalar y,variant vstr,int c1,int c2,int c3,
       {
         uint32_t character = getUnicodeCharacter(str, i);
         if (character == '\r') {
-          xx = x, yy += fnt.height, i += str[i+1] == '\n';
+          xx = x, yy += fnt.lineHeight, i += str[i+1] == '\n';
           line += 1;
           sw = (gs_scalar)string_width_line(str, line);
         } else if (character == '\n') {
-          xx = x, yy += fnt.height;
+          xx = x, yy += fnt.lineHeight;
           line += 1;
           sw = (gs_scalar)string_width_line(str, line);
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += slen;
           } else {
@@ -1143,7 +1144,7 @@ void draw_text_color(gs_scalar x, gs_scalar y,variant vstr,int c1,int c2,int c3,
             hcol3 = merge_color(c4,c3,tx1);
             hcol4 = merge_color(c4,c3,tx2);
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture_color(xx + g.x,  yy + g.y, g.tx, g.ty, hcol1, a);
             draw_vertex_texture_color(xx + g.x2, yy + g.y, g.tx2, g.ty, hcol2, a);
             draw_vertex_texture_color(xx + g.x,  yy + g.y2, g.tx,  g.ty2, hcol4, a);
@@ -1160,13 +1161,13 @@ void draw_text_color(gs_scalar x, gs_scalar y,variant vstr,int c1,int c2,int c3,
       {
         uint32_t character = getUnicodeCharacter(str, i);
         if (character == '\r') {
-          yy += fnt.height, i += str[i+1] == '\n', line += 1,
+          yy += fnt.lineHeight, i += str[i+1] == '\n', line += 1,
           sw = (gs_scalar)string_width_line(str, line), xx = halign == fa_center ? x-sw/2 : x-sw, tmpx = xx;
         } else if (character == '\n') {
-          yy += fnt.height, line += 1, sw = (gs_scalar)string_width_line(str, line),
+          yy += fnt.lineHeight, line += 1, sw = (gs_scalar)string_width_line(str, line),
           xx = halign == fa_center ? x-sw/2 : x-sw, tmpx = xx;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += slen;
           } else {
@@ -1176,7 +1177,7 @@ void draw_text_color(gs_scalar x, gs_scalar y,variant vstr,int c1,int c2,int c3,
             hcol3 = merge_color(c4,c3,tx1);
             hcol4 = merge_color(c4,c3,tx2);
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture_color(xx + g.x,  yy + g.y, g.tx, g.ty, hcol1, a);
             draw_vertex_texture_color(xx + g.x2, yy + g.y, g.tx2, g.ty, hcol2, a);
             draw_vertex_texture_color(xx + g.x,  yy + g.y2, g.tx,  g.ty2, hcol4, a);
@@ -1195,7 +1196,7 @@ void draw_text_ext_color(gs_scalar x, gs_scalar y,variant vstr,gs_scalar sep, gs
   string str = toString(vstr);
   get_fontv(fnt,currentfont);
 
-  gs_scalar yy = valign == fa_top ? y+fnt.yoffset : valign == fa_middle ? y + fnt.yoffset - string_height_ext(str,sep,w)/2 : y + fnt.yoffset - string_height_ext(str,sep,w);
+  gs_scalar yy = valign == fa_top ? y+fnt.yOffset : valign == fa_middle ? y + fnt.yOffset - string_height_ext(str,sep,w)/2 : y + fnt.yOffset - string_height_ext(str,sep,w);
   gs_scalar width = 0, tw = 0, line = 0, sw = string_width_ext_line(str, w, line);
   float slen = get_space_width(fnt);
   int hcol1 = c1, hcol2 = c1, hcol3 = c3, hcol4 = c4;
@@ -1205,11 +1206,11 @@ void draw_text_ext_color(gs_scalar x, gs_scalar y,variant vstr,gs_scalar sep, gs
       {
         uint32_t character = getUnicodeCharacter(str, i);
         if (character == '\r') {
-          xx = x, yy +=  (sep+2 ? fnt.height : sep), i += str[i+1] == '\n',  width = 0, line += 1, sw = string_width_ext_line(str, w, line);
+          xx = x, yy +=  (sep+2 ? fnt.lineHeight : sep), i += str[i+1] == '\n',  width = 0, line += 1, sw = string_width_ext_line(str, w, line);
         } else if (character == '\n') {
-          xx = x, yy += (sep+2 ? fnt.height : sep), width = 0, line += 1, sw = string_width_ext_line(str, w, line);
+          xx = x, yy += (sep+2 ? fnt.lineHeight : sep), width = 0, line += 1, sw = string_width_ext_line(str, w, line);
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += slen;
             width = xx-x;
@@ -1224,14 +1225,14 @@ void draw_text_ext_color(gs_scalar x, gs_scalar y,variant vstr,gs_scalar sep, gs
             }
 
             if (width+tw >= w && w != -1)
-            xx = x, yy += (sep==-1 ? fnt.height : sep), width = 0, line += 1, sw = string_width_ext_line(str, w, line);
+            xx = x, yy += (sep==-1 ? fnt.lineHeight : sep), width = 0, line += 1, sw = string_width_ext_line(str, w, line);
           } else {
             hcol1 = merge_color(c1,c2,(gs_scalar)(width)/sw);
             hcol2 = merge_color(c1,c2,(gs_scalar)(width+g.xs)/sw);
             hcol3 = merge_color(c4,c3,(gs_scalar)(width)/sw);
             hcol4 = merge_color(c4,c3,(gs_scalar)(width+g.xs)/sw);
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture_color(xx + g.x,  yy + g.y, g.tx, g.ty, hcol1, a);
             draw_vertex_texture_color(xx + g.x2, yy + g.y, g.tx2, g.ty, hcol2, a);
             draw_vertex_texture_color(xx + g.x,  yy + g.y2, g.tx,  g.ty2, hcol4, a);
@@ -1249,11 +1250,11 @@ void draw_text_ext_color(gs_scalar x, gs_scalar y,variant vstr,gs_scalar sep, gs
       {
         uint32_t character = getUnicodeCharacter(str, i);
         if (character == '\r') {
-          yy +=  (sep+2 ? fnt.height : sep), i += str[i+1] == '\n',  width = 0, line += 1, sw = string_width_ext_line(str, w, line), xx = halign == fa_center ? x-sw/2 : x-sw, tmpx = xx;
+          yy +=  (sep+2 ? fnt.lineHeight : sep), i += str[i+1] == '\n',  width = 0, line += 1, sw = string_width_ext_line(str, w, line), xx = halign == fa_center ? x-sw/2 : x-sw, tmpx = xx;
         } else if (character == '\n') {
-          yy += (sep+2 ? fnt.height : sep), width = 0, line += 1, sw = string_width_ext_line(str, w, line), xx = halign == fa_center ? x-sw/2 : x-sw, tmpx = xx;
+          yy += (sep+2 ? fnt.lineHeight : sep), width = 0, line += 1, sw = string_width_ext_line(str, w, line), xx = halign == fa_center ? x-sw/2 : x-sw, tmpx = xx;
         } else {
-          fontglyph g = findGlyph(fnt, character);
+          GlyphMetrics g = findGlyph(fnt, character);
           if (character == ' ' or g.empty()) {
             xx += slen, width = xx-tmpx, tw = 0;
             for (size_t c = i+1; c < str.length(); c++)
@@ -1265,14 +1266,14 @@ void draw_text_ext_color(gs_scalar x, gs_scalar y,variant vstr,gs_scalar sep, gs
               tw += (!g.empty() ? g.xs : slen);
             }
             if (width+tw >= w && w != -1)
-            yy += (sep==-1 ? fnt.height : sep), width = 0, line += 1, sw = string_width_ext_line(str, w, line), xx = halign == fa_center ? x-sw/2 : x-sw, tmpx = xx;
+            yy += (sep==-1 ? fnt.lineHeight : sep), width = 0, line += 1, sw = string_width_ext_line(str, w, line), xx = halign == fa_center ? x-sw/2 : x-sw, tmpx = xx;
           } else {
           hcol1 = merge_color(c1,c2,(gs_scalar)(width)/sw);
             hcol2 = merge_color(c1,c2,(gs_scalar)(width+g.xs)/sw);
             hcol3 = merge_color(c4,c3,(gs_scalar)(width)/sw);
             hcol4 = merge_color(c4,c3,(gs_scalar)(width+g.xs)/sw);
 
-            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture);
+            draw_primitive_begin_texture(pr_trianglestrip, fnt.texture.ID);
             draw_vertex_texture_color(xx + g.x,  yy + g.y, g.tx, g.ty, hcol1, a);
             draw_vertex_texture_color(xx + g.x2, yy + g.y, g.tx2, g.ty, hcol2, a);
             draw_vertex_texture_color(xx + g.x,  yy + g.y2, g.tx,  g.ty2, hcol4, a);
@@ -1289,22 +1290,22 @@ void draw_text_ext_color(gs_scalar x, gs_scalar y,variant vstr,gs_scalar sep, gs
 
 unsigned font_get_texture(int fnt) {
   get_font_null(f,fnt,-1);
-  return f.texture;
+  return f.texture.ID;
 }
 
 unsigned font_get_texture_width(int fnt) {
   get_font_null(f,fnt,-1);
-  return f.twid;
+  return f.texture.width;
 }
 
 unsigned font_get_texture_height(int fnt) {
   get_font_null(f,fnt,-1);
-  return f.thgt;
+  return f.texture.height;
 }
 
 unsigned font_height(int fnt) {
   get_font_null(f,fnt,-1);
-  return f.height;
+  return f.lineHeight;
 }
 
 void draw_set_font(int fnt) {

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/texture_atlas.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/texture_atlas.cpp
@@ -27,6 +27,7 @@
 #include "Universal_System/nlpo2.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "rectpacker/rectpack.h"
+#include "fonts/fonts.h"
 
 #ifdef DEBUG_MODE
   #include "libEGMstd.h"
@@ -43,6 +44,7 @@
 
 using std::unordered_map;
 using std::vector;
+using namespace enigma::fonts;
 
 namespace enigma {
   struct TextureAtlasRect{
@@ -72,9 +74,9 @@ namespace enigma {
         case 2: { //Add font glyps
           //We remove one as it's the font resource itself, but we only need glyps
           metrics.erase(metrics.begin());
-          enigma::SpriteFont *fnt = &enigma::sprite_fonts[textures[i].id];
-          for (size_t g = 0; g < fnt->glyphRanges.size(); g++) {
-            enigma::fontglyphrange& fgr = fnt->glyphRanges[g];
+          SpriteFont *fnt = &sprite_fonts[textures[i].id];
+          for (size_t g = 0; g < fnt->ranges.size(); g++) {
+            GlyphRange& fgr = fnt->ranges[g];
             for (size_t s = 0; s < fgr.glyphs.size(); s++){
               metrics.emplace_back();
             }
@@ -101,9 +103,9 @@ namespace enigma {
           counter++;
         } break;
         case 2: { //Metrics for font glyps
-          enigma::SpriteFont *fnt = &enigma::sprite_fonts[textures[i].id];
-          for (size_t g = 0; g < fnt->glyphRanges.size(); g++) {
-            enigma::fontglyphrange& fgr = fnt->glyphRanges[g];
+          SpriteFont *fnt = &sprite_fonts[textures[i].id];
+          for (size_t g = 0; g < fnt->ranges.size(); g++) {
+            GlyphRange& fgr = fnt->ranges[g];
             for (size_t s = 0; s < fgr.glyphs.size(); s++){
               metrics[counter].w = fgr.glyphs[s].x2-fgr.glyphs[s].x, metrics[counter].h = fgr.glyphs[s].y2-fgr.glyphs[s].y;
               counter++;
@@ -189,18 +191,18 @@ namespace enigma {
         } break;
         case 2: { //Copy textures for all font glyps
           ///This sometimes draws cut of letters - need to investigate!
-          enigma::SpriteFont *fnt = &enigma::sprite_fonts[textures[i].id];
-          for (size_t g = 0; g < fnt->glyphRanges.size(); g++) {
-            enigma::fontglyphrange& fgr = fnt->glyphRanges[g];
+          SpriteFont *fnt = &sprite_fonts[textures[i].id];
+          for (size_t g = 0; g < fnt->ranges.size(); g++) {
+            GlyphRange& fgr = fnt->ranges[g];
             for (size_t s = 0; s < fgr.glyphs.size(); s++){
               double tix, tiy; //Calculate texture position in image space (pixels) instead of normalized 0-1. We sadly don't hold this information, but maybe we should
-              tix = (double)fgr.glyphs[s].tx*(double)fnt->twid;
-              tiy = (double)fgr.glyphs[s].ty*(double)fnt->thgt;
+              tix = (double)fgr.glyphs[s].tx*(double)fnt->texture.width;
+              tiy = (double)fgr.glyphs[s].ty*(double)fnt->texture.height;
 
               int gw = fgr.glyphs[s].x2-fgr.glyphs[s].x;
               int gh = fgr.glyphs[s].y2-fgr.glyphs[s].y;
 
-              enigma::graphics_copy_texture_part(fnt->texture, enigma::texture_atlas_array[ta].texture, tix, tiy, gw, gh, metrics[counter].x, metrics[counter].y);
+              enigma::graphics_copy_texture_part(fnt->texture.ID, enigma::texture_atlas_array[ta].texture, tix, tiy, gw, gh, metrics[counter].x, metrics[counter].y);
 
               fgr.glyphs[s].tx = (double)metrics[counter].x/(double)(enigma::texture_atlas_array[ta].width);
               fgr.glyphs[s].ty = (double)metrics[counter].y/(double)(enigma::texture_atlas_array[ta].height);
@@ -212,9 +214,9 @@ namespace enigma {
             }
           }
           if (free_textures == true){
-            enigma::graphics_delete_texture(fnt->texture);
+            enigma::graphics_delete_texture(fnt->texture.ID);
           }
-          fnt->texture = enigma::texture_atlas_array[ta].texture;
+          fnt->texture.ID = enigma::texture_atlas_array[ta].texture;
         } break;
         default: break; //We do nothing for the rest
       }

--- a/ENIGMAsystem/SHELL/Makefile
+++ b/ENIGMAsystem/SHELL/Makefile
@@ -70,6 +70,7 @@ OBJDIR := $(WORKDIR).eobjs/$(COMPILEPATH)/$(GMODE)
 SHARED_SRC_DIR := ../../shared/
 include $(SHARED_SRC_DIR)/Makefile
 include $(SHARED_SRC_DIR)/rectpacker/Makefile
+include $(SHARED_SRC_DIR)/fonts/Makefile
 
 ###########
 # options #

--- a/ENIGMAsystem/SHELL/Makefile
+++ b/ENIGMAsystem/SHELL/Makefile
@@ -167,7 +167,7 @@ android_game: write_src_files
 
 compile_game: print_flags $(OBJECTS) $(RCFILES) $(RESOURCEBINARY) $(DEPENDENCIES)
 	@echo "Linking $(OUTPUTNAME)"
-	@$(CXX) $(LDFLAGS) -o "$(OUTPUTNAME)" $(OBJECTS) $(RESOURCEBINARY) $(LDLIBS)
+	@$(CXX) $(LDFLAGS) -o "$(OUTPUTNAME)" $(OBJECTS) $(RESOURCEBINARY) $(LDLIBS) -lpng
 	@echo Built to "$(OUTPUTNAME)"
 
 # GCC will figure out dependencies and write out makefile rules in %.d when they change

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp
@@ -1,47 +1,52 @@
+#include "fonts/fonts.h"
+#include "include.h"
 #include "Universal_System/Resources/fonts_internal.h"
-#include "Universal_System/Resources/sprites_internal.h"
-#include "Universal_System/Resources/sprites.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Widget_Systems/widgets_mandatory.h"
-#include "rectpacker/rectpack.h"
 
-#include <ft2build.h>
-#include FT_FREETYPE_H
+#include <string>
 
-#include <iostream>
-#include <algorithm>
+#if __cplusplus > 201402L
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#endif
 
+using enigma::GlyphRange;
+using enigma::RawFont;
 
-namespace enigma {
+namespace enigma_user {
 
-class FontManager {
-public:
-  static bool Init() {
-
-    FT_Error error = FT_Init_FreeType(&library);
-    if (error != 0)
-      DEBUG_MESSAGE("Error initializing freetype!", MESSAGE_TYPE::M_ERROR);
-
-    return (error == 0);
+int font_add(std::string name, unsigned size, bool bold, bool italic, unsigned first, unsigned last) {
+  if (last < first) {
+    DEBUG_MESSAGE("Freetype error invalid glyph range last < first", MESSAGE_TYPE::M_ERROR);
+    return -1;
   }
 
-  static const FT_Library& GetLibrary() {
-    return library;
+  unsigned w, h; // size of texture 
+  unsigned fontHeight = 0;
+  int yoffset;
+  
+  #if __cplusplus > 201402L
+  if (stringtolower(fs::path(name).extension()) != ".ttf") {
+    name = font_find(name, bold, italic, false);
+    if (name.empty()) return -1;
   }
+  #endif
 
-  ~FontManager() {
-    FT_Done_FreeType(library);
-  }
+  RawFont rawFont;
+  rawFont.ranges = {{GlyphRange(first, last)};
+  if (!enigma::font_load(name, size, bold, italic, &font)
+    return -1;
 
-private:
-  FontManager() = default;
-  static FT_Library library;
-};
+  unsigned char* pxdata = enigma::font_pack(rawFont, w, h, yoffset, fontHeight);
+  if (pxdata == nullptr)
+    return -1;
 
-FT_Library FontManager::library;
-static bool FreeTypeAlive = FontManager::Init();
-
+  enigma::SpriteFont fnt(name, size, bold, italic, rawFont.ranges, pxdata, w, h, yoffset, fontHeight);
+  fnt.init();
+  return sprite_fonts.add(fnt);
 }
+<<<<<<< HEAD
 
 namespace enigma_user {
 
@@ -186,4 +191,6 @@ namespace enigma_user {
 
     return fontid;
   }
+=======
+>>>>>>> a03fdbeb... broke ass fonts
 }

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ttf/ttf.cpp
@@ -11,186 +11,37 @@
   namespace fs = std::filesystem;
 #endif
 
-using enigma::GlyphRange;
-using enigma::RawFont;
+using namespace enigma::fonts;
 
 namespace enigma_user {
 
 int font_add(std::string name, unsigned size, bool bold, bool italic, unsigned first, unsigned last) {
   if (last < first) {
-    DEBUG_MESSAGE("Freetype error invalid glyph range last < first", MESSAGE_TYPE::M_ERROR);
+    DEBUG_MESSAGE("Freetype error invalid glyph range last < first", MESSAGE_TYPE::M_USER_ERROR);
     return -1;
   }
-
-  unsigned w, h; // size of texture 
-  unsigned fontHeight = 0;
-  int yoffset;
   
   #if __cplusplus > 201402L
-  if (stringtolower(fs::path(name).extension()) != ".ttf") {
+  if (!fs::path(name).extension().empty()) {
     name = font_find(name, bold, italic, false);
     if (name.empty()) return -1;
   }
   #endif
 
   RawFont rawFont;
-  rawFont.ranges = {{GlyphRange(first, last)};
-  if (!enigma::font_load(name, size, bold, italic, &font)
+  rawFont.ranges = {GlyphRange(first, last)};
+
+  if (!font_load(name, size, rawFont))
     return -1;
 
-  unsigned char* pxdata = enigma::font_pack(rawFont, w, h, yoffset, fontHeight);
+  unsigned w, h; // size of texture 
+  unsigned char* pxdata = font_pack(rawFont, w, h);
   if (pxdata == nullptr)
     return -1;
 
-  enigma::SpriteFont fnt(name, size, bold, italic, rawFont.ranges, pxdata, w, h, yoffset, fontHeight);
-  fnt.init();
-  return sprite_fonts.add(fnt);
+  SpriteFont fnt(name, rawFont.name, size, bold, italic, rawFont.lineHeight, rawFont.yOffset, w ,h, pxdata, rawFont.ranges);
+  fnt.texture.init();
+  return sprite_fonts.add(std::move(fnt));
 }
-<<<<<<< HEAD
 
-namespace enigma_user {
-
-  using enigma::rect_packer::pvrect;
-  using enigma::rect_packer::rectpnode;
-
-  struct GlyphPair {
-    GlyphPair(unsigned index = 0, unsigned area = 0) : index(index), area(area) {}
-    unsigned index;
-    unsigned area;
-  };
-
-  int font_add(std::string name, unsigned size, bool bold, bool italic, unsigned first, unsigned last) {
-
-    if (!enigma::FreeTypeAlive)
-      return -1;
-
-    FT_Face face;
-    FT_GlyphSlot slot;
-    FT_Error error;
-
-    error = FT_New_Face(enigma::FontManager::GetLibrary(), name.c_str(), 0, &face );
-
-    if (error != 0)
-      return -1;
-
-    // GameMaker has always generated fonts at 96 dpi, default Windows dpi since 1980s
-    error = FT_Set_Char_Size( face, size * 64, 0, 96, 0); // 96 dpi, 64 is 26.6 fixed point conversion
-
-    if (error != 0)
-      return -1;
-
-    slot = face->glyph;
-
-    unsigned gcount = last-first;
-    int fontid = enigma::font_new(first, gcount);
-
-    enigma::SpriteFont* fnt = &enigma::sprite_fonts[fontid];
-    fnt->name = name;
-    fnt->fontsize = size;
-    fnt->bold = bold;
-    fnt->italic = italic;
-    enigma::fontglyphrange fgr;
-    fgr.glyphstart = first;
-    fgr.glyphs.resize(gcount);
-
-    std::vector<pvrect> glyphmetrics(gcount);
-    std::vector<GlyphPair> glyphPairs(gcount);
-    for (unsigned c = first; c < last; ++c) {
-      error = FT_Load_Char(face, c, FT_LOAD_DEFAULT);
-
-      #ifdef DEBUG_MODE
-      if (error != 0)
-        DEBUG_MESSAGE("Freetype error loading metrics for char: " + std::to_string(static_cast<char>(c)), MESSAGE_TYPE::M_ERROR);
-      #endif
-
-      FT_Bitmap& charBitmap = slot->bitmap;
-
-      glyphmetrics[c-first] = pvrect(0, 0, charBitmap.width, charBitmap.rows, -1);
-      glyphPairs[c-first] = GlyphPair(c-first, charBitmap.width * charBitmap.rows);
-
-    }
-
-    std::sort(glyphPairs.begin(), glyphPairs.end(), [](const GlyphPair &a, const GlyphPair &b) {
-      return (a.area > b.area);
-    });
-
-    unsigned w = 64, h = 64; // starter size for our texture
-    rectpnode* rootNode = new rectpnode(0, 0, w, h);
-    for (std::vector<GlyphPair>::reverse_iterator ii = glyphPairs.rbegin(); ii != glyphPairs.rend();) {
-      rectpnode* node = rninsert(rootNode, ii->index, glyphmetrics.data());
-
-      if (node) {
-        rncopy(node, glyphmetrics.data(), ii->index);
-        ii++;
-      }
-      else {
-        w > h ? h <<= 1 : w <<= 1,
-        rootNode = expand(rootNode, w, h);
-        //printf("Expanded to %d by %d\n", w, h);
-        if (!w or !h) return -1;
-      }
-    }
-
-    unsigned char* pxdata = new unsigned char[w * h * 4];
-
-    for (unsigned y = 0; y < h; ++y) {
-      for (unsigned x = 0; x < w; ++x) {
-        unsigned index = y * w + x;
-        pxdata[index] = 255;
-      }
-    }
-
-    for (const GlyphPair &g : glyphPairs) {
-      error = FT_Load_Char(face, g.index + first, FT_LOAD_RENDER);
-
-      #ifdef DEBUG_MODE
-      if (error != 0) {
-        DEBUG_MESSAGE("Freetype error loading bitmap for char: " + std::to_string(static_cast<char>(g.index)), MESSAGE_TYPE::M_ERROR);
-        continue;
-      }
-      #endif
-
-      FT_Bitmap& charBitmap = slot->bitmap;
-      FT_Glyph_Metrics fftMetrics = face->glyph->metrics;
-
-      pvrect glyphInfo = glyphmetrics[g.index];
-
-      enigma::fontglyph glyph;
-      glyph.x = fftMetrics.horiBearingX / 64;
-      glyph.y = -fftMetrics.horiBearingY / 64;
-      glyph.x2 = fftMetrics.horiBearingX / 64 + charBitmap.width;
-      glyph.y2 = -fftMetrics.horiBearingY / 64 + charBitmap.rows;
-      glyph.tx = glyphInfo.x / double(w);
-      glyph.ty = glyphInfo.y / double(h);
-      glyph.tx2 = (glyphInfo.x +charBitmap.width) / double(w);
-      glyph.ty2 = (glyphInfo.y + charBitmap.rows) / double(h);
-      glyph.xs = face->glyph->linearHoriAdvance / 65536; // more fixed point conversion
-
-      fgr.glyphs[g.index] = glyph;
-
-      for (unsigned y = 0; y < charBitmap.rows; ++y) {
-        for (unsigned x = 0; x < charBitmap.width; ++x) {
-          unsigned index = (y * charBitmap.width + x);
-          unsigned index_out = ((y + glyphInfo.y) * w + (x + glyphInfo.x)) * 4;
-          pxdata[index_out] = pxdata[index_out + 1] = pxdata[index_out + 2] = 255;
-          pxdata[index_out + 3] =  charBitmap.buffer[index];
-        }
-      }
-    }
-
-    fnt->glyphRanges[0] = fgr;
-    fnt->texture = enigma::graphics_create_texture(w, h, w, h, pxdata, false);
-    fnt->twid = w;
-    fnt->thgt = h;
-    fnt->yoffset = face->glyph->linearVertAdvance / 65536;
-    fnt->height = face->glyph->linearVertAdvance / 65536;
-
-    delete rootNode;
-    delete[] pxdata;
-    FT_Done_Face(face);
-
-    return fontid;
-  }
-=======
->>>>>>> a03fdbeb... broke ass fonts
-}
+} //namespace enigma_user

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/fontinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/fontinit.cpp
@@ -31,122 +31,65 @@
 #include <cstdio>
 #include <string>
 
+#include <iostream>
+
 namespace enigma {
 
+using namespace fonts;
+
+unsigned char* exe_get_pxdata(FILE* exe, unsigned size) {
+  
+  unsigned int compressedSize;
+  if (!fread(&compressedSize, 4, 1, exe)) {};
+
+  std::cout << "size in: " << compressedSize << std::endl;
+  
+  unsigned char* cpxdata = new unsigned char[compressedSize];
+  if (!cpxdata) {
+    DEBUG_MESSAGE("Failed to load pixel data: Cannot allocate enough memory " + enigma_user::toString(compressedSize), MESSAGE_TYPE::M_ERROR);
+    return nullptr;
+  }
+  
+  unsigned int sz2 = fread(cpxdata, 1, compressedSize, exe);
+  if (compressedSize != sz2) {
+    DEBUG_MESSAGE("Failed to load pixel data: Data is truncated before exe end. Read " + 
+      enigma_user::toString(sz2) + " out of expected " + enigma_user::toString(compressedSize), MESSAGE_TYPE::M_ERROR);
+    delete[] cpxdata;
+    return nullptr;
+  }
+
+  unsigned char* pxdata=new unsigned char[size];
+  if (zlib_decompress(cpxdata, compressedSize, size, pxdata) != (int)size) {
+    DEBUG_MESSAGE("Failed to load pixel data: Data does not match expected size", MESSAGE_TYPE::M_ERROR);
+    delete[] cpxdata;
+    delete[] pxdata;
+    return nullptr;
+  }
+  
+  delete[] cpxdata;
+  return pxdata;
+}
+
 void exe_loadfonts(FILE* exe) {
-  int nullhere, fntid;
-  unsigned fontcount, twid, thgt, gwid, ghgt;
-  float advance, baseline, origin, gtx, gty, gtx2, gty2;
+  int nullhere;
+  unsigned fontcount;
 
   if (!fread(&nullhere, 4, 1, exe)) return;
   if (memcmp(&nullhere, "FNT ", sizeof(int)) != 0) return;
 
   if (!fread(&fontcount, 4, 1, exe)) return;
-  if ((int)fontcount != rawfontcount) {
+  if (fontcount != exeFonts.size()) {
     DEBUG_MESSAGE("Resource data does not match up with game metrics. Unable to improvise.", MESSAGE_TYPE::M_ERROR);
     return;
   }
 
-  sprite_fonts.resize(rawfontmaxid+1);
-
-  for (int rf = 0; rf < rawfontcount; rf++) {
-    // int unpacked;
-    if (!fread(&fntid, 4, 1, exe)) return;
-    if (!fread(&twid, 4, 1, exe)) return;
-    if (!fread(&thgt, 4, 1, exe)) return;
-
-    SpriteFont font;
-
-    font.name = rawfontdata[rf].name;
-    font.fontname = rawfontdata[rf].fontname;
-    font.fontsize = rawfontdata[rf].fontsize;
-    font.bold = rawfontdata[rf].bold;
-    font.italic = rawfontdata[rf].italic;
-
-    font.height = 0;
-
-    const unsigned int size = twid * thgt;
-
-    int* pixels =
-        new int[size + 1];  //FYI: This variable was once called "cpixels." When you do compress them, change it back.
-
-    unsigned int sz2;
-    for (sz2 = 0; !feof(exe) and sz2 < size; sz2++) {
-      pixels[sz2] = 0x00FFFFFF | ((unsigned char)fgetc(exe) << 24);
-      if (pixels[sz2] == 0x00FFFFFF) pixels[sz2] = 0;
-    }
-
-    if (size != sz2) {
-      DEBUG_MESSAGE("Failed to load font: Data is truncated before exe end. Read " + enigma_user::toString(sz2) +
-                     " out of expected " + enigma_user::toString(size), MESSAGE_TYPE::M_ERROR);
-      return;
-    }
-    if (!fread(&nullhere, 4, 1, exe)) return;
-    if (memcmp(&nullhere, "done", sizeof(int)) != 0) {
-      DEBUG_MESSAGE(std::string("Unexpected end; eof: ") + ((feof(exe) == 0) ? "true" : "false"), MESSAGE_TYPE::M_ERROR);
-      return;
-    }
-    //unpacked = width*height*4;
-    /*unsigned char* pixels=new unsigned char[unpacked+1];
-    if (zlib_decompress(cpixels,size,unpacked,pixels) != unpacked)
-    {
-      DEBUG_MESSAGE("Background load error: Background does not match expected size", MESSAGE_TYPE::M_ERROR);
-      continue;
-    }
-    delete[] cpixels;*/
-    int ymin = 100, ymax = -100;
-    for (size_t gri = 0; gri < rawfontdata[rf].glyphRangeCount; gri++) {
-      fontglyphrange fgr;
-
-      unsigned strt, cnt;
-      if (!fread(&strt, 4, 1, exe)) return;
-      if (!fread(&cnt, 4, 1, exe)) return;
-
-      fgr.glyphstart = strt;
-
-      for (unsigned gi = 0; gi < cnt; gi++) {
-        if (!fread(&advance, 4, 1, exe)) return;
-        if (!fread(&baseline, 4, 1, exe)) return;
-        if (!fread(&origin, 4, 1, exe)) return;
-        if (!fread(&gwid, 4, 1, exe)) return;
-        if (!fread(&ghgt, 4, 1, exe)) return;
-        if (!fread(&gtx, 4, 1, exe)) return;
-        if (!fread(&gty, 4, 1, exe)) return;
-        if (!fread(&gtx2, 4, 1, exe)) return;
-        if (!fread(&gty2, 4, 1, exe)) return;
-        fontglyph fg;
-
-        fg.x = int(origin + .5);
-        fg.y = int(baseline + .5);
-        fg.x2 = int(origin + .5) + gwid;
-        fg.y2 = int(baseline + .5) + ghgt;
-        fg.tx = gtx;
-        fg.ty = gty;
-        fg.tx2 = gtx2;
-        fg.ty2 = gty2;
-        fg.xs = advance + .5;
-
-        if (fg.y < ymin) ymin = fg.y;
-        if (fg.y2 > ymax) ymax = fg.y2;
-
-        fgr.glyphs.push_back(fg);
-      }
-
-      font.glyphRanges.push_back(std::move(fgr));
-    }
-
-    font.height = ymax - ymin + 2;
-    font.yoffset = -ymin + 1;
-
-    font.texture = graphics_create_texture(twid, thgt, twid, thgt, pixels, false);
-    font.twid = twid;
-    font.thgt = thgt;
-
-    delete[] pixels;
-    sprite_fonts[fntid] = std::move(font);
-
-    if (!fread(&nullhere, 4, 1, exe)) return;
-    if (memcmp(&nullhere, "endf", sizeof(int)) != 0) return;
+  sprite_fonts.resize(exeFontsMaxID + 1);
+  for (const std::pair<int, SpriteFont>& index : exeFonts) {
+    int id = index.first;
+    sprite_fonts[id] = index.second;
+    SpriteFont& font = sprite_fonts[id];
+    font.texture.pxdata = exe_get_pxdata(exe, font.texture.width * font.texture.height);
+    font.texture.init();
   }
 }
 }  //namespace enigma

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/fontinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/fontinit.cpp
@@ -37,12 +37,12 @@ namespace enigma {
 
 using namespace fonts;
 
-unsigned char* exe_get_pxdata(FILE* exe, unsigned size) {
+unsigned char* exe_get_pxdata(FILE* exe, unsigned expectedSize) {
   
   unsigned int compressedSize;
-  if (!fread(&compressedSize, 4, 1, exe)) {};
-
-  std::cout << "size in: " << compressedSize << std::endl;
+  if (!fread(&compressedSize, 4, 1, exe)) {
+    DEBUG_MESSAGE("Failed to load size of compressed pixel data", MESSAGE_TYPE::M_ERROR);
+  }
   
   unsigned char* cpxdata = new unsigned char[compressedSize];
   if (!cpxdata) {
@@ -58,8 +58,8 @@ unsigned char* exe_get_pxdata(FILE* exe, unsigned size) {
     return nullptr;
   }
 
-  unsigned char* pxdata=new unsigned char[size];
-  if (zlib_decompress(cpxdata, compressedSize, size, pxdata) != (int)size) {
+  unsigned char* pxdata=new unsigned char[expectedSize];
+  if (zlib_decompress(cpxdata, compressedSize, expectedSize, pxdata) != (int)expectedSize) {
     DEBUG_MESSAGE("Failed to load pixel data: Data does not match expected size", MESSAGE_TYPE::M_ERROR);
     delete[] cpxdata;
     delete[] pxdata;

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/fonts_internal.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/fonts_internal.h
@@ -25,71 +25,21 @@
 #ifndef ENIGMA_FONTS_INTERNAL_H
 #define ENIGMA_FONTS_INTERNAL_H
 
+#include "fonts/fonts.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "AssetArray.h"
 
 #include <string>
 #include <vector>
-#include <stdint.h>
+#include <unordered_map>
 
-namespace enigma
-{
-  struct fontglyph
-  {
-    fontglyph() : x(0), y(0), x2(0), y2(0), tx(0), ty(0), tx2(0), ty2(0), xs(0) {}
-    bool empty();
-    int   x,  y,  x2,  y2; // Draw coordinates, relative to the top-left corner of a full glyph. Added to xx and yy for draw.
-    float tx, ty, tx2, ty2; // Texture coords: used to locate glyph on bound font texture
-    float xs; // Spacing: used to increment xx
-  };
-  struct fontglyphrange {
-    fontglyphrange() : glyphstart(0) {}
-    unsigned int glyphstart;
-    std::vector<fontglyph> glyphs;
-  };
-  class SpriteFont
-  {
-   public:
-     SpriteFont() : name(""), fontname(""), fontsize(0),
-       bold(false), italic(false), height(0), yoffset(0), texture(-1),
-       twid(0), thgt(0) {}
-    // Trivia
-    std::string name, fontname;
-    int fontsize; 
-    bool bold, italic;
-
-    // Metrics and such
-    std::vector<fontglyphrange> glyphRanges;
-    unsigned int height, yoffset;
-
-    // Texture layer
-    int texture;
-    int twid, thgt;
-
-    void destroy() { 
-      glyphRanges.clear();
-      if (texture >= 0) graphics_delete_texture(texture);
-      texture = -1;
-    }
-    bool isDestroyed() const { return texture == -1 || glyphRanges.empty(); }
-
-    static const char* getAssetTypeName() { return "font"; }
-  };
-  struct rawfont {
-    std::string name;
-    int id;
-
-    std::string fontname;
-    int fontsize; bool bold, italic;
-    unsigned int glyphRangeCount;
-  };
-  extern std::vector<rawfont> rawfontdata;
-  extern AssetArray<SpriteFont, -1> sprite_fonts;
-
-  extern int rawfontcount, rawfontmaxid;
-  int font_new(uint32_t gs, uint32_t gc); // Creates a new font, allocating 'gc' glyphs
-  int font_pack(SpriteFont *font, int spr, uint32_t gcount, bool prop, int sep);
-  fontglyph findGlyph(const SpriteFont& fnt, uint32_t character);
+namespace enigma {
+namespace fonts {
+  GlyphMetrics findGlyph(const fonts::SpriteFont& fnt, uint32_t character);
+  extern AssetArray<fonts::SpriteFont, -1> sprite_fonts;
+  extern std::unordered_map<int, SpriteFont> exeFonts;
+  extern int exeFontsMaxID;
+} // namespace fonts  
 } //namespace enigma
 
 #endif //ENIGMA_FONTS_INTERNAL_H

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/fonts_internal.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/fonts_internal.h
@@ -31,13 +31,13 @@
 
 #include <string>
 #include <vector>
-#include <unordered_map>
+#include <map>
 
 namespace enigma {
 namespace fonts {
   GlyphMetrics findGlyph(const fonts::SpriteFont& fnt, uint32_t character);
   extern AssetArray<fonts::SpriteFont, -1> sprite_fonts;
-  extern std::unordered_map<int, SpriteFont> exeFonts;
+  extern std::map<int, SpriteFont> exeFonts;
   extern int exeFontsMaxID;
 } // namespace fonts  
 } //namespace enigma

--- a/shared/fonts/Makefile
+++ b/shared/fonts/Makefile
@@ -1,0 +1,3 @@
+SHARED_SOURCES := $(SHARED_SOURCES) $(addprefix fonts/,$(call relative_wildcard,*.cpp))
+override CXXFLAGS += $(shell pkg-config --cflags freetype2)
+override LDLIBS += $(shell pkg-config --libs freetype2)

--- a/shared/fonts/fonts.cpp
+++ b/shared/fonts/fonts.cpp
@@ -13,7 +13,9 @@
 #include FT_TRUETYPE_IDS_H
 #include FT_SFNT_NAMES_H
 
-#include <map>
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>
 #include <iostream>
 #include <algorithm>
 #include <numeric>
@@ -28,8 +30,23 @@ using namespace enigma::rect_packer;
 
 namespace enigma {
 namespace fonts {
+
 static std::vector<std::string> fontSearchPaths;
-static std::map<std::string, std::string> fontNames;
+static std::unordered_map<std::string, std::string> fontNames;
+static std::unordered_map<std::string, std::string> fontFamilies;
+
+// FreeType supports a few more obscure font types but I'm not sure to what extent so I put what looked like main ones
+// https://www.freetype.org/freetype2/docs/index.html for full list of supported fomats
+static const std::unordered_set<std::string> supportedExtensions = {
+  ".ttf",  // truetype font
+  ".ttc",  // truetype collection
+  ".otf",  // opentype font
+  ".otc",  // opentype collection
+  ".fnt",  // windows font
+  ".woff", // web open font format
+  ".woff2",
+};
+
 void init_font_search_dirs() {
 
   std::vector<std::string> intialPaths = {
@@ -91,6 +108,10 @@ bool font_load(std::string fName, unsigned size, RawFont& rawFont) {
   if (error != 0)
     return false;
 
+  FT_SfntName name;
+  FT_Get_Sfnt_Name(face, TT_NAME_ID_FULL_NAME, &name);
+  rawFont.name = std::string(reinterpret_cast<char*>(name.string), name.string_len);
+
   // GameMaker has always generated fonts at 96 dpi, default Windows dpi since 1980s
   error = FT_Set_Char_Size( face, size * 64, 0, 96, 0); // 96 dpi, 64 is 26.6 fixed point conversion
 
@@ -98,7 +119,6 @@ bool font_load(std::string fName, unsigned size, RawFont& rawFont) {
     return false;
 
   slot = face->glyph;
-  rawFont.lineHeight = face->size->metrics.height / 64;
 
   // sum of all glyphs in all ranges
   size_t gcount = 0;
@@ -107,8 +127,8 @@ bool font_load(std::string fName, unsigned size, RawFont& rawFont) {
   // vector of all (raw) glyphs used later for sorting
   rawFont.glyphs.resize(gcount);
    
-  size_t currOffset = 0; // our location in the glyphInfo vector
   // loop over all ranges
+  size_t currOffset = 0;
   for (GlyphRange& range : rawFont.ranges) {
     // loop over each character per range
     for (size_t c = 0; c < range.size(); ++c) {
@@ -125,27 +145,31 @@ bool font_load(std::string fName, unsigned size, RawFont& rawFont) {
 
        RawGlyph rg;
        rg.character = range.start + c;
-       rg.index = currOffset + c;
        rg.dimensions = pvrect(0, 0, charBitmap.width, charBitmap.rows, -1);
        rg.range = &range;
        rg.horiBearingX = fftMetrics.horiBearingX / 64;
        rg.horiBearingY = fftMetrics.horiBearingY / 64;
        rg.linearHoriAdvance = face->glyph->linearHoriAdvance / 65536; // more fixed point conversion
-       rg.pxdata = new unsigned char[charBitmap.width * charBitmap.rows /* 4*/];
+
+       if (charBitmap.width > 0 && charBitmap.rows > 0) {
+         rg.pxdata = new unsigned char[charBitmap.width * charBitmap.rows];
        
-       // copy glyph to texture
-       for (unsigned y = 0; y < charBitmap.rows; ++y) {
-         for (unsigned x = 0; x < charBitmap.width; ++x) {
-           unsigned index = (y * charBitmap.width + x);
-           rg.pxdata[index] = charBitmap.buffer[index];
+         // copy glyph to texture
+         for (unsigned y = 0; y < charBitmap.rows; ++y) {
+           for (unsigned x = 0; x < charBitmap.width; ++x) {
+             unsigned index = (y * charBitmap.pitch + x);
+             rg.pxdata[index] = charBitmap.buffer[index];
+            }
           }
-        }
+       }
        
-       rawFont.glyphs[currOffset + c] = rg;
+       rawFont.glyphs[currOffset++] = rg;
     }
-    // done with one range so update offset
-    currOffset += range.size();
   }
+
+  // FIXME: idk how GM calculates the line height 
+  // this produces similar results for me but freetype docs recommends face->size->metrics.height / 64 but thats way off compared to GM
+  rawFont.lineHeight = rawFont.yOffset = face->glyph->linearVertAdvance / 65536;
 
   FT_Done_Face(face);
   
@@ -153,47 +177,16 @@ bool font_load(std::string fName, unsigned size, RawFont& rawFont) {
 }
 
 unsigned char* font_pack(RawFont& font, unsigned& textureW, unsigned& textureH) {
-
-  // sort all glyphs by area
-  std::sort(font.glyphs.begin(), font.glyphs.end(), [](const RawGlyph &a, const RawGlyph &b) {
-    return (a.area() > b.area());
-  });
-
-  // Josh's rectpacker code needs access to an array so we copy all pvrects into one here 
-  std::vector<pvrect> dimensions(font.glyphs.size());
-  size_t currIndex = 0;
-  for (RawGlyph& rg : font.glyphs) {
-    dimensions[currIndex++] = rg.dimensions;
-  }
-
-  // insert the metrics and calculate a minimum (power of 2) texture size
-  textureW = 64, textureH = 64; // starter size for our texture
-  rectpnode* rootNode = new rectpnode(0, 0, textureW, textureH);
-  for (std::vector<RawGlyph>::reverse_iterator ii = font.glyphs.rbegin(); ii != font.glyphs.rend();) {
-    rectpnode* node = rninsert(rootNode, ii->index, dimensions.data());
-
-    if (node) {
-      rncopy(node, dimensions.data(), ii->index);
-      ii++;
-    } else {
-      textureW > textureH ? textureH <<= 1 : textureW <<= 1,
-      rootNode = expand(rootNode, textureW, textureH);
-      if (!textureW or !textureH) return nullptr;
-    }
-  }
-
-  // Copy our updated pvrects back to our glyphs
-  currIndex = 0;
-  for (RawGlyph& rg : font.glyphs) {
-     rg.dimensions = dimensions[currIndex++];
-  }
+ 
+  if (!pack_rectangles(font.glyphs, textureW, textureH))
+    return nullptr;
 
   // intialize blank image (the caller is responisible for deleting pxdata)
   unsigned char* pxdata = new unsigned char[textureW * textureH];
   for (unsigned y = 0; y < textureH; ++y) {
     for (unsigned x = 0; x < textureW; ++x) {
       unsigned index = y * textureW + x;
-      pxdata[index] = 255;
+      pxdata[index] = 0;
     }
   }
 
@@ -224,8 +217,6 @@ unsigned char* font_pack(RawFont& font, unsigned& textureW, unsigned& textureH) 
     }
   }
 
-
-  delete rootNode;
   return pxdata;
 }
 
@@ -236,9 +227,12 @@ using namespace enigma::fonts;
 
 namespace enigma_user {
 
+
 #if __cplusplus > 201402L
 static inline void font_add_search_path_helper(const fs::path& p) {
-  if (stringtolower(p.extension()) == ".ttf") {
+   
+  auto it = supportedExtensions.find(stringtolower(p.extension()));
+  if (it != supportedExtensions.end()) {
     FT_Face face;
     FT_Error error;
     error = FT_New_Face(enigma::fonts::FontManager::GetLibrary(), p.c_str(), 0, &face );
@@ -250,12 +244,19 @@ static inline void font_add_search_path_helper(const fs::path& p) {
      FT_Get_Sfnt_Name(face, TT_NAME_ID_FULL_NAME, &name);
      std::string fontName(reinterpret_cast<char*>(name.string), name.string_len);
      fontNames[fontName] = p;
+
+     FT_SfntName family;
+     FT_Get_Sfnt_Name(face, TT_NAME_ID_FONT_FAMILY, &family);
+     std::string fontFamily(reinterpret_cast<char*>(family.string), family.string_len);
+     fontFamilies[fontFamily] = p;
+
+     std::cout << fontFamily << std::endl;
   }
 }
 #endif
 
 void font_add_search_path(std::string path, bool recursive) {
-  fontSearchPaths.push_back(path);
+  fontSearchPaths.emplace_back(path); // TODO: disallow duplicate paths?
   #if __cplusplus > 201402L
   if (fs::exists(path)) {
     if (recursive) {
@@ -275,10 +276,19 @@ std::string font_find(std::string name, bool bold, bool italic, bool exact_match
   if (fontNames.count(fullName) > 0) {
      return fontNames[fullName];
   } else if (!exact_match) {
-    // search for base name (not italics / bold)
-    if (fontNames.count(name) > 0) return fontNames[name]; 
+    // search for name by font family
+    if (fontFamilies.count(name) > 0) return fontFamilies[name]; 
   }
-  // TODO: return a default font?
+
+  // LGM default font
+  if (name == "Dialog.plain") {
+    // GM's default is Arial
+    std::string arial = font_find("Arial", false, false, false);
+    if (!arial.empty()) return arial;
+    else return fontNames.begin()->second; // Couldn't find arial. Guess well try to give it some kind of font
+  }
+  
+  // TODO: include and return a default font?
   return "";
 }
 

--- a/shared/fonts/fonts.cpp
+++ b/shared/fonts/fonts.cpp
@@ -1,0 +1,285 @@
+#include "strings_util.h"
+#include "fonts.h"
+
+#ifdef ENIGMA_GAME
+#include "Widget_Systems/widgets_mandatory.h"
+#else 
+#include <iostream>
+#define DEBUG_MESSAGE(msg, severity) std::cerr << msg << std::endl;
+#endif
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_TRUETYPE_IDS_H
+#include FT_SFNT_NAMES_H
+
+#include <map>
+#include <iostream>
+#include <algorithm>
+#include <numeric>
+#include <cstdlib>
+
+#if __cplusplus > 201402L
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#endif
+
+using namespace enigma::rect_packer;
+
+namespace enigma {
+namespace fonts {
+static std::vector<std::string> fontSearchPaths;
+static std::map<std::string, std::string> fontNames;
+void init_font_search_dirs() {
+
+  std::vector<std::string> intialPaths = {
+    #ifdef WIN32
+    std::string(std::getenv("windir")) + "/Fonts",
+    std::string(std::getenv("windir")) + "/boot/Fonts",
+    #else
+    std::string(std::getenv("HOME")) + "/.local/share/fonts",
+    std::string(std::getenv("HOME")) + "/.fonts",
+    "/usr/share/fonts/",
+    #endif
+  };
+  
+  for (std::string& p : intialPaths) {
+    enigma_user::font_add_search_path(p, true);
+  }
+}
+
+class FontManager {
+public:
+  static bool Init() {
+
+    FT_Error error = FT_Init_FreeType(&library);
+    if (error != 0)
+      DEBUG_MESSAGE("Error initializing freetype!", MESSAGE_TYPE::M_ERROR);
+
+   init_font_search_dirs();
+
+    return (error == 0);
+  }
+
+  static const FT_Library& GetLibrary() {
+    return library;
+  }
+
+  ~FontManager() {
+    FT_Done_FreeType(library);
+  }
+
+private:
+  FontManager() = default;
+  static FT_Library library;
+};
+
+FT_Library FontManager::library;
+static bool FreeTypeAlive = FontManager::Init();
+
+bool font_load(std::string fName, unsigned size, RawFont& rawFont) {
+
+  if (!enigma::fonts::FreeTypeAlive)
+    return false;
+
+  FT_Face face;
+  FT_GlyphSlot slot;
+  FT_Error error;
+
+  error = FT_New_Face(enigma::fonts::FontManager::GetLibrary(), fName.c_str(), 0, &face );
+
+  if (error != 0)
+    return false;
+
+  // GameMaker has always generated fonts at 96 dpi, default Windows dpi since 1980s
+  error = FT_Set_Char_Size( face, size * 64, 0, 96, 0); // 96 dpi, 64 is 26.6 fixed point conversion
+
+  if (error != 0)
+    return false;
+
+  slot = face->glyph;
+  rawFont.lineHeight = face->size->metrics.height / 64;
+
+  // sum of all glyphs in all ranges
+  size_t gcount = 0;
+  for (const GlyphRange& range : rawFont.ranges) gcount += range.glyphs.size();
+ 
+  // vector of all (raw) glyphs used later for sorting
+  rawFont.glyphs.resize(gcount);
+   
+  size_t currOffset = 0; // our location in the glyphInfo vector
+  // loop over all ranges
+  for (GlyphRange& range : rawFont.ranges) {
+    // loop over each character per range
+    for (size_t c = 0; c < range.size(); ++c) {
+      // open character to get metrics and pixel data
+      error = FT_Load_Char(face, range.start + c, FT_LOAD_RENDER);
+
+      #if defined(DEBUG_MODE) || !defined(ENIGMA_GAME)
+      if (error != 0)
+        DEBUG_MESSAGE("Freetype error loading char: " + std::to_string(range.start + c), MESSAGE_TYPE::M_ERROR);
+      #endif
+      
+       FT_Bitmap& charBitmap = slot->bitmap;
+       FT_Glyph_Metrics fftMetrics = face->glyph->metrics;
+
+       RawGlyph rg;
+       rg.character = range.start + c;
+       rg.index = currOffset + c;
+       rg.dimensions = pvrect(0, 0, charBitmap.width, charBitmap.rows, -1);
+       rg.range = &range;
+       rg.horiBearingX = fftMetrics.horiBearingX / 64;
+       rg.horiBearingY = fftMetrics.horiBearingY / 64;
+       rg.linearHoriAdvance = face->glyph->linearHoriAdvance / 65536; // more fixed point conversion
+       rg.pxdata = new unsigned char[charBitmap.width * charBitmap.rows /* 4*/];
+       
+       // copy glyph to texture
+       for (unsigned y = 0; y < charBitmap.rows; ++y) {
+         for (unsigned x = 0; x < charBitmap.width; ++x) {
+           unsigned index = (y * charBitmap.width + x);
+           rg.pxdata[index] = charBitmap.buffer[index];
+          }
+        }
+       
+       rawFont.glyphs[currOffset + c] = rg;
+    }
+    // done with one range so update offset
+    currOffset += range.size();
+  }
+
+  FT_Done_Face(face);
+  
+  return true;
+}
+
+unsigned char* font_pack(RawFont& font, unsigned& textureW, unsigned& textureH) {
+
+  // sort all glyphs by area
+  std::sort(font.glyphs.begin(), font.glyphs.end(), [](const RawGlyph &a, const RawGlyph &b) {
+    return (a.area() > b.area());
+  });
+
+  // Josh's rectpacker code needs access to an array so we copy all pvrects into one here 
+  std::vector<pvrect> dimensions(font.glyphs.size());
+  size_t currIndex = 0;
+  for (RawGlyph& rg : font.glyphs) {
+    dimensions[currIndex++] = rg.dimensions;
+  }
+
+  // insert the metrics and calculate a minimum (power of 2) texture size
+  textureW = 64, textureH = 64; // starter size for our texture
+  rectpnode* rootNode = new rectpnode(0, 0, textureW, textureH);
+  for (std::vector<RawGlyph>::reverse_iterator ii = font.glyphs.rbegin(); ii != font.glyphs.rend();) {
+    rectpnode* node = rninsert(rootNode, ii->index, dimensions.data());
+
+    if (node) {
+      rncopy(node, dimensions.data(), ii->index);
+      ii++;
+    } else {
+      textureW > textureH ? textureH <<= 1 : textureW <<= 1,
+      rootNode = expand(rootNode, textureW, textureH);
+      if (!textureW or !textureH) return nullptr;
+    }
+  }
+
+  // Copy our updated pvrects back to our glyphs
+  currIndex = 0;
+  for (RawGlyph& rg : font.glyphs) {
+     rg.dimensions = dimensions[currIndex++];
+  }
+
+  // intialize blank image (the caller is responisible for deleting pxdata)
+  unsigned char* pxdata = new unsigned char[textureW * textureH];
+  for (unsigned y = 0; y < textureH; ++y) {
+    for (unsigned x = 0; x < textureW; ++x) {
+      unsigned index = y * textureW + x;
+      pxdata[index] = 255;
+    }
+  }
+
+  // now we can copy all our glyphs onto single texture
+  for (RawGlyph& rg : font.glyphs) {
+
+    GlyphMetrics glyph;
+    glyph.x = rg.horiBearingX;
+    glyph.y = -rg.horiBearingY;
+    glyph.x2 = rg.horiBearingX + rg.w();
+    glyph.y2 = -rg.horiBearingY + rg.h();
+    glyph.tx = rg.x() / double(textureW);
+    glyph.ty = rg.y() / double(textureH);
+    glyph.tx2 = (rg.x() + rg.w()) / double(textureW);
+    glyph.ty2 = (rg.y() + rg.h()) / double(textureH);
+    glyph.xs = rg.linearHoriAdvance;
+
+    // insert our glyph into the glyph range
+    rg.range->glyphs[rg.character - rg.range->start] = glyph;
+
+    // write glyph pixel data to the texture
+    for (unsigned y = 0; y < rg.h(); ++y) {
+      for (unsigned x = 0; x < rg.w(); ++x) {
+        unsigned index = (y * rg.w() + x);
+        unsigned index_out = ((y + rg.y()) * textureW + (x + rg.x()));
+        pxdata[index_out] = rg.pxdata[index];
+      }
+    }
+  }
+
+
+  delete rootNode;
+  return pxdata;
+}
+
+} // namespace fonts
+} // namespace enigma
+
+using namespace enigma::fonts;
+
+namespace enigma_user {
+
+#if __cplusplus > 201402L
+static inline void font_add_search_path_helper(const fs::path& p) {
+  if (stringtolower(p.extension()) == ".ttf") {
+    FT_Face face;
+    FT_Error error;
+    error = FT_New_Face(enigma::fonts::FontManager::GetLibrary(), p.c_str(), 0, &face );
+
+    if (error != 0)
+      DEBUG_MESSAGE("Error opening font: " + p.string(), MESSAGE_TYPE::M_ERROR);
+    
+     FT_SfntName name;
+     FT_Get_Sfnt_Name(face, TT_NAME_ID_FULL_NAME, &name);
+     std::string fontName(reinterpret_cast<char*>(name.string), name.string_len);
+     fontNames[fontName] = p;
+  }
+}
+#endif
+
+void font_add_search_path(std::string path, bool recursive) {
+  fontSearchPaths.push_back(path);
+  #if __cplusplus > 201402L
+  if (fs::exists(path)) {
+    if (recursive) {
+      for (auto& p: fs::recursive_directory_iterator(fs::path(path)))
+        font_add_search_path_helper(p.path());
+    } else {
+      for (auto& p: fs::directory_iterator(fs::path(path)))
+        font_add_search_path_helper(p.path());
+    }
+  } else DEBUG_MESSAGE("Freetype warning searching non-existing directory: " + path, MESSAGE_TYPE::M_WARNING);
+  
+  #endif
+}
+
+std::string font_find(std::string name, bool bold, bool italic, bool exact_match) {
+  std::string fullName = name + ((bold) ? " Bold" : "") + ((italic) ? " Italic" : "");
+  if (fontNames.count(fullName) > 0) {
+     return fontNames[fullName];
+  } else if (!exact_match) {
+    // search for base name (not italics / bold)
+    if (fontNames.count(name) > 0) return fontNames[name]; 
+  }
+  // TODO: return a default font?
+  return "";
+}
+
+} //namespace enigma_user

--- a/shared/fonts/fonts.h
+++ b/shared/fonts/fonts.h
@@ -33,13 +33,11 @@ struct GlyphRange {
 
 /// Struct holding the pixel data and dimensions for individual glyphs
 struct RawGlyph {
-  RawGlyph() : character(0), pxdata(nullptr), index(0), dimensions(0,0,0,0,-1), horiBearingX(0), horiBearingY(0), range(nullptr) {}
-  ~RawGlyph() { /*delete[] pxdata;*/ }
+  RawGlyph() : character(0), pxdata(nullptr), dimensions(0,0,0,0,-1), horiBearingX(0), horiBearingY(0), range(nullptr) {}
+  void destroy() { delete[] pxdata; }
   unsigned character; // the letter/character we want to render
   unsigned char* pxdata; // raw pixel data of glyph
-  size_t index; // our index in vector
   rect_packer::pvrect dimensions; // rectange(x,y,w,h) holding the dimensions of our glyph in pixels
-  unsigned area() const { return dimensions.w * dimensions.h; }
   int x() const { return dimensions.x; }
   int y() const { return dimensions.y; }
   unsigned w() const { return dimensions.w; }
@@ -52,7 +50,8 @@ struct RawGlyph {
 
 /// Ready to be packed font data
 struct RawFont {
-  RawFont() : lineHeight(0), yOffset(0) {}
+  RawFont() : name(""), lineHeight(0), yOffset(0) {}
+  std::string name;
   unsigned lineHeight; // space between lines
   int yOffset;
   std::vector<RawGlyph> glyphs;

--- a/shared/fonts/fonts.h
+++ b/shared/fonts/fonts.h
@@ -1,0 +1,108 @@
+#ifndef ENIGMA_SHARED_FONTS_H
+#define ENIGMA_SHARED_FONTS_H
+
+#include "rectpacker/rectpack.h" // pvrect
+#include "texture.h"
+
+#include <vector>
+#include <string>
+
+namespace enigma {
+
+namespace fonts {
+
+/// Struct holding the location of Glyph on packed texture
+struct GlyphMetrics {
+  GlyphMetrics(int x = 0, int y = 0, int x2 = 0, int y2 = 0, float tx = 0, float ty = 0, float tx2 = 0, float ty2 = 0, float xs = 0) : 
+    x(x), y(y), x2(x2), y2(y2), tx(tx), ty(ty), tx2(tx2), ty2(ty2), xs(xs) {}
+  bool empty() {  return !(std::abs(x2-x) > 0 && std::abs(y2-y) > 0); }
+  int   x,  y,  x2,  y2; // Draw coordinates, relative to the top-left corner of a full glyph. Added to xx and yy for draw.
+  float tx, ty, tx2, ty2; // Texture coords: used to locate glyph on bound font texture
+  float xs; // Spacing: used to increment xx
+};
+
+/// Range of characters (eg: a-z)
+struct GlyphRange {
+  GlyphRange() : start(0) {}
+  GlyphRange(unsigned first, unsigned last) : start(first) { glyphs.resize(last-first+1); }
+  GlyphRange(unsigned first, unsigned last, std::initializer_list<GlyphMetrics> glyphs) : start(first), glyphs(glyphs) {}
+  unsigned int start;
+  size_t size() const { return glyphs.size(); }
+  std::vector<GlyphMetrics> glyphs;
+};
+
+/// Struct holding the pixel data and dimensions for individual glyphs
+struct RawGlyph {
+  RawGlyph() : character(0), pxdata(nullptr), index(0), dimensions(0,0,0,0,-1), horiBearingX(0), horiBearingY(0), range(nullptr) {}
+  ~RawGlyph() { /*delete[] pxdata;*/ }
+  unsigned character; // the letter/character we want to render
+  unsigned char* pxdata; // raw pixel data of glyph
+  size_t index; // our index in vector
+  rect_packer::pvrect dimensions; // rectange(x,y,w,h) holding the dimensions of our glyph in pixels
+  unsigned area() const { return dimensions.w * dimensions.h; }
+  int x() const { return dimensions.x; }
+  int y() const { return dimensions.y; }
+  unsigned w() const { return dimensions.w; }
+  unsigned h() const { return dimensions.h; }
+  double horiBearingX; // left side bearing for horizontal layout
+  double horiBearingY; // top side bearing for horizontal layout
+  double linearHoriAdvance; // the advance width of the unhinted glyph
+  GlyphRange* range; // range that owns the glyph
+};
+
+/// Ready to be packed font data
+struct RawFont {
+  RawFont() : lineHeight(0), yOffset(0) {}
+  unsigned lineHeight; // space between lines
+  int yOffset;
+  std::vector<RawGlyph> glyphs;
+  std::vector<GlyphRange> ranges;
+};
+
+/// Font with a packed texture of all glyphs (this is the one used throughout most the engine)
+struct SpriteFont {
+  SpriteFont(std::string name, std::string fontName, unsigned fontSize, bool bold, 
+    bool italic, unsigned lineHeight, int yOffset, unsigned textureW, unsigned textureH,
+    unsigned char* pxdata, std::initializer_list<GlyphRange> ranges) :
+     name(name), fontName(fontName), fontSize(fontSize), bold(bold), italic(italic), lineHeight(lineHeight), 
+     yOffset(yOffset), texture(textureW, textureH, pxdata), ranges(ranges) {}
+
+  SpriteFont(std::string name = "", std::string fontName = "", unsigned fontSize = 0, bool bold = false, 
+    bool italic = false, unsigned lineHeight = 0, int yOffset = 0, unsigned textureW = 0, unsigned textureH = 0,
+    unsigned char* pxdata = nullptr, std::vector<GlyphRange> ranges = {}) :
+     name(name), fontName(fontName), fontSize(fontSize), bold(bold), italic(italic), lineHeight(lineHeight), 
+     yOffset(yOffset), texture(textureW, textureH, pxdata), ranges(ranges) {}
+
+  // The folowing functions are for use & implemented exclusively in the engine
+  //void init(); // loads our pixel data into memory and deletes it
+  void destroy(); // deletes the texture
+  bool isDestroyed() const;
+  static const char* getAssetTypeName();
+
+  std::string name;  // name of asset 
+  std::string fontName; // name of font (typically derived from the ttf)
+  unsigned fontSize; // point size of font
+  bool bold, italic;
+  unsigned lineHeight; // height of text line in pixels
+  int yOffset; // idk?
+  Texture texture;
+  std::vector<GlyphRange> ranges; // range of characters (eg: a-z)
+};
+
+/// Loads a ttf file into a RawFont
+bool font_load(std::string fName, unsigned size, RawFont& font);
+
+/// Packs a vector of RawGlyph(s) on to a single texture and returns that texture
+unsigned char* font_pack(RawFont& font, unsigned& textureW, unsigned& textureH);
+
+} //namespace fonts
+} //namespace enigma
+
+namespace enigma_user {
+  /// Searches and indexes all ttf files by name in the given path 
+  void font_add_search_path(std::string path, bool recursive = false);
+  
+  /// Returns a ttf file based on the given font name
+  std::string font_find(std::string name, bool bold, bool italic, bool exact_match = false);
+}
+#endif

--- a/shared/rectpacker/rectpack.h
+++ b/shared/rectpacker/rectpack.h
@@ -18,14 +18,51 @@
 #ifndef ENIGMA_RECT_PACT_H
 #define ENIGMA_RECT_PACT_H
 
+#include <vector>
+#include <algorithm>
+
 namespace enigma {
 
 namespace rect_packer {
+
 struct pvrect {
-  int x, y, w, h, placed;
-  pvrect();
-  pvrect(int a, int b, int c, int d, int e);
+  pvrect(int x = 0, int y = 0, unsigned w = 0, unsigned h = 0, int placed = -1) :  
+    x(x), y(y), w(w), h(h), placed(placed) {}
+  int x, y;
+  unsigned w, h;
+  int placed;
+  unsigned area() const { return w * h; };
 };
+
+bool pack_rectangles(std::vector<pvrect>& rects, unsigned& width, unsigned &height);
+
+template <class T>
+bool pack_rectangles(std::vector<T>& vec, unsigned& width, unsigned &height) {
+
+  // sort our vector by area
+  std::sort(vec.begin(), vec.end(), [](const T& a, const T& b) {
+    return (a.dimensions.area() > b.dimensions.area());
+  });
+
+  std::vector<pvrect> copy(vec.size());
+  size_t currIndex = 0;
+  for (auto& i : vec) {
+    copy[currIndex++] = i.dimensions;
+  }
+
+  pack_rectangles(copy, width, height);
+
+  // Copy our updated positions back to our array
+  currIndex = 0;
+  for (pvrect& rect : copy) {
+    vec[currIndex].dimensions.x = rect.x;
+    vec[currIndex].dimensions.y = rect.y;
+    currIndex++;
+  }
+
+  return true;
+}
+
 
 struct rectpnode {
   rectpnode* child[2];

--- a/shared/strings_util.h
+++ b/shared/strings_util.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <algorithm>
 
 inline std::string string_replace_all(std::string str, std::string substr, std::string nstr) {
   size_t pos = 0;
@@ -26,5 +27,11 @@ inline std::vector<std::string> split_string(const std::string &str, char delimi
         return vec;
 }
 
+inline std::string stringtolower(const std::string str) {
+std::string ret = str;
+ std::transform(ret.begin(), ret.end(), ret.begin(),
+    [](unsigned char c){ return std::tolower(c); });
+ return ret;
+}
 
 #endif

--- a/shared/texture.h
+++ b/shared/texture.h
@@ -3,12 +3,13 @@
 
 namespace enigma {
 struct Texture {
-  Texture() : width(0), height(0), ID(-1), pxdata(nullptr) {}
-  Texture(unsigned width, unsigned height, unsigned char* pxdata) : width(width), height(height), pxdata(pxdata) {}
-  Texture(unsigned width, unsigned height, int ID) : width(width), height(height), ID(ID) {}
+  Texture() : width(0), height(0), channels(1), ID(-1), pxdata(nullptr) {}
+  Texture(unsigned width, unsigned height, unsigned char* pxdata) : width(width), height(height), channels(1), pxdata(pxdata) {}
+  Texture(unsigned width, unsigned height, int ID) : width(width), height(height), channels(1), ID(ID) {}
   void init(); // loads a texture and deletes pxdata (engine only)
   unsigned width;
   unsigned height;
+  unsigned channels;
   int ID;
   unsigned char* pxdata;
 };

--- a/shared/texture.h
+++ b/shared/texture.h
@@ -1,0 +1,17 @@
+#ifndef ENIGMA_SHARED_TEXTURE_H
+#define  ENIGMA_SHARED_TEXTURE_H
+
+namespace enigma {
+struct Texture {
+  Texture() : width(0), height(0), ID(-1), pxdata(nullptr) {}
+  Texture(unsigned width, unsigned height, unsigned char* pxdata) : width(width), height(height), pxdata(pxdata) {}
+  Texture(unsigned width, unsigned height, int ID) : width(width), height(height), ID(ID) {}
+  void init(); // loads a texture and deletes pxdata (engine only)
+  unsigned width;
+  unsigned height;
+  int ID;
+  unsigned char* pxdata;
+};
+} //namespace enigma
+
+#endif


### PR DESCRIPTION
This PR adds support for emake fonts.

DONE:

*  emake can now load fonts
* All fonts now go through the same code path regardless of if they're from the gmx, or added later using font_add / font_add_sprite
* LGM also now uses the same path as emake in-order to keep consistent rendering between builds
* I've fixed a regression where enigma was no longer compressing the font data
* All font data (excluding image data) is now written to source instead of tacked on the exe

TODO:
* I've added font finding functions but they depend on c++17 and could use more rigorous testing 
* I've put a framework in place to load gmx fonts with pre-rendered texture atlases but I have no idea how the gmx attributes translate to our GlyphMetrics struct 
* font_add() and font_add_sprite() are completely untested and likely broken
* I've added a generic interface to the rect_packer that should be applied in texture_atlas.cpp
*  We should be able to use one generic function for loading all compressed data on exe. I started one in fontinit.cpp but perhaps that can be continued in another PR
* We probably want to include some font to use as a default as only windows users are likely to have arial.  We can grab it via install.sh or whatever.
* It seems my lastest changes to AssetArray have broken the default font

NOTE: 
The compiler is now dependent on freetype and c++17 in-order to load fonts properly