### PR TITLE
Bitmap reader rennovation.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -49,6 +49,7 @@ int image_save(std::string filename, const unsigned char* data, std::string form
 int image_save(std::string filename, const unsigned char* data, unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, bool flipped);
 
 unsigned char* image_load_bmp(std::string filename, unsigned int* width, unsigned int* height, unsigned int* fullwidth, unsigned int* fullheight, bool flipped);
+unsigned char* image_decode_bmp(const std::string &image_data, unsigned int* width, unsigned int* height, unsigned int* fullwidth, unsigned int* fullheight, bool flipped);
 unsigned char* image_load_gif(std::string filename, unsigned int* width, unsigned int* height, unsigned int* fullwidth, unsigned int* fullheight, int* imgnumb, bool flipped);
 int image_save_bmp(std::string filename, const unsigned char* data, unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, bool flipped);
 


### PR DESCRIPTION
The old bitmap reader was difficult to reuse or extend. This new approach trades the single-copy reader approach for the ability to pass in arbitrary blocks of memory to decode. We could technically accomplish the same thing by just using a stringstream under the hood, but I'm not in the mood.

Also plugs in actual bitmap headers instead of trying to do everything in terms of hard-coded offsets in the file. This is in the interest of extending the reader with support for compression schemes (eg, RLE).