### PR TITLE
c++17 for the CI

### DIFF
--- a/CI/build_and_run_game.sh
+++ b/CI/build_and_run_game.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 set -e
 

--- a/CI/build_and_run_game.sh
+++ b/CI/build_and_run_game.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 set -e
 

--- a/CI/install_emake_deps.sh
+++ b/CI/install_emake_deps.sh
@@ -9,12 +9,12 @@ if [ "$TRAVIS_OS_NAME" != "osx" ]; then
   # new gcc 
   sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
-  # new lcov
-  sudo add-apt-repository -y ppa:cheeseboy16/travis-backports
-
   # new boost for old travis
   if [ "$COMPILER" == "Android" ]; then
     sudo add-apt-repository -y ppa:mhier/libboost-latest;
+  else
+    # new lcov
+    sudo add-apt-repository -y ppa:cheeseboy16/travis-backports
   fi
 
   sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60";

--- a/CI/install_emake_deps.sh
+++ b/CI/install_emake_deps.sh
@@ -2,20 +2,43 @@
 
 set -e
 
-sudo add-apt-repository -y ppa:maarten-fonville/protobuf;
+if [ "$TRAVIS_OS_NAME" != "osx" ]; then
+  # new protobuf
+  sudo add-apt-repository -y ppa:maarten-fonville/protobuf;
+
+  # new gcc 
+  sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+
+  # new lcov
+  sudo add-apt-repository -y ppa:cheeseboy16/travis-backports
+
+  # new boost for old travis
+  if [ "$COMPILER" == "Android" ]; then
+    sudo add-apt-repository -y ppa:mhier/libboost-latest;
+  fi
+
+  sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60";
+  sudo apt-get -y install gcc-9 g++-9 cpp-9 build-essential libprotobuf-dev protobuf-compiler zlib1g-dev libglm-dev libpng-dev
+
+  sudo update-alternatives --remove-all cpp;
+  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 \
+              15 \
+              --slave   /usr/bin/g++ g++ /usr/bin/g++-9 \
+              --slave   /usr/bin/gcov gcov /usr/bin/gcov-9 \
+              --slave   /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-9 \
+              --slave   /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-9 \
+              --slave   /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-9 \
+              --slave   /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-9 \
+              --slave   /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-9;
+
+  g++ --version
+fi
 
 if [ "$COMPILER" == "Android" ]; then
-  sudo add-apt-repository -y ppa:mhier/libboost-latest;
-  sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60";
-  sudo apt-get -y install build-essential zlib1g-dev libboost1.67-dev\
-        libprotobuf-dev protobuf-compiler libglm-dev libpng-dev;
+  sudo apt-get -y install libboost1.67-dev
 elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
-  sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60";
-  sudo apt-get -y install build-essential zlib1g-dev libboost-dev\
-    libboost-filesystem-dev libboost-system-dev libboost-program-options-dev\
-    libboost-iostreams-dev libprotobuf-dev protobuf-compiler libglm-dev libpng-dev\
-    pulseaudio libpugixml-dev libyaml-cpp-dev rapidjson-dev
+  sudo apt-get -y install libboost-program-options-dev pulseaudio libpugixml-dev libyaml-cpp-dev rapidjson-dev
 elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
   brew upgrade gcc || brew install gcc || brew link --overwrite gcc;
-  brew install protobuf pugixml
+  brew install protobuf pugixml yaml-cpp rapidjson
 fi

--- a/CI/solve_engine_deps.sh
+++ b/CI/solve_engine_deps.sh
@@ -12,7 +12,7 @@ if [ "$COMPILER" == "gcc32" ] || [ "$COMPILER" == "clang32" ]; then
     libgl1-mesa-dev:i386 lib32z1-dev libxrandr-dev:i386 libxinerama-dev:i386\
     gcc-multilib g++-multilib libc++abi-dev:i386 libpng-dev:i386"
 elif [ "$COMPILER" == "MinGW64" ] || [ "$COMPILER" == "MinGW32" ]; then
-  LINUX_DEPS="$LINUX_DEPS mingw-w64 wine64 wine32 wine-stable"
+  LINUX_DEPS="$LINUX_DEPS mingw-w64 wine64 wine32 wine-stable libgl1-mesa-glx:i386"
 fi
 
 ###### Platforms #######

--- a/CI/split_jobs.sh
+++ b/CI/split_jobs.sh
@@ -20,10 +20,10 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   JOBS[15]='COLLISION=BBox EXTENSIONS="Alarms,Timelines,DataStructures,Asynchronous,BasicGUI,DateTime,GM5Compat,IniFilesystem,Json,XRandR,Paths,MotionPlanning,ttf,Box2DPhysics,StudioPhysics,BulletDynamics"'
   JOBS[16]='COMPILER=MinGW32 PLATFORM=Win32 Widgets=Win32 AUDIO=DirectSound EXTENSIONS="DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper" OUTPUT="/tmp/test.exe"'
   JOBS[17]='COMPILER=MinGW64 PLATFORM=Win32 Widgets=Win32 AUDIO=DirectSound EXTENSIONS="DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper" OUTPUT="/tmp/test.exe"'
-  JOBS[18]='COMPILER=gcc32'
-  JOBS[19]='COMPILER=clang'
-  JOBS[20]='COMPILER=clang32'
-  JOB_COUNT=21
+  JOBS[18]='COMPILER=clang'
+  #JOBS[18]='COMPILER=gcc32'
+  #JOBS[20]='COMPILER=clang32'
+  JOB_COUNT=19
   TRAVIS_WORKERS=4
 elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
   JOBS[0]='COMPILER=gcc PLATFORM=None'

--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -4,7 +4,9 @@
 #include "OS_Switchboard.h"
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-#	include <windows.h>
+# define byte __windows_byte_workaround
+# include <windows.h>
+# undef byte
 #	include <process.h>
 #else
 #	include <pthread.h>

--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -15,7 +15,8 @@
 #include "yyp.h"
 #endif
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
+namespace fs = std::filesystem;
 
 #include <fstream>
 #include <iostream>
@@ -124,7 +125,7 @@ int main(int argc, char* argv[])
     game.SetOutputFile(input_file);
 
   if (input_file.size()) {
-    if (!boost::filesystem::exists(input_file)) {
+    if (!fs::exists(input_file)) {
       std::cerr << "Input file does not exist: " << input_file << std::endl;
       return OPTIONS_ERROR;
     }
@@ -141,8 +142,8 @@ int main(int argc, char* argv[])
       if (!(project = gmk::LoadGMK(input_file))) return 1;
       return plugin.BuildGame(project->mutable_game(), mode, output_file.c_str());
     } else if (ext == "gmx") {
-      boost::filesystem::path p = input_file;
-      if (boost::filesystem::is_directory(p)) {
+      fs::path p = input_file;
+      if (fs::is_directory(p)) {
         input_file += "/" + p.filename().stem().string() + ".project.gmx";
       }
 

--- a/CommandLine/emake/Makefile
+++ b/CommandLine/emake/Makefile
@@ -8,11 +8,11 @@ include $(SHARED_SRC_DIR)/event_reader/Makefile
 PROTO_DIR := $(SHARED_SRC_DIR)/protos/.eobjs
 
 ifeq ($(OS), Linux)
-	OS_LIBS=-lboost_system -Wl,--no-as-needed -Wl,-rpath,./ -lboost_program_options -lboost_iostreams -lboost_filesystem -lboost_system -lpthread -ldl
+	OS_LIBS=-lboost_program_options -Wl,--no-as-needed -Wl,-rpath,./ -lpthread -ldl
 else ifeq ($(OS), Darwin)
-	OS_LIBS=-lboost_system -lboost_program_options -lboost_iostreams -lboost_filesystem -lboost_system -lpthread -ldl
+	OS_LIBS=-lboost_program_options -lpthread -ldl
 else
-	OS_LIBS=-lboost_system-mt -Wl,--no-as-needed -Wl,-rpath,./ -lboost_program_options-mt -lboost_iostreams-mt -lboost_filesystem-mt -lboost_system-mt -lpthread
+	OS_LIBS=-lboost_system-mt -Wl,--no-as-needed -Wl,-rpath,./ -lboost_program_options-mt -lpthread
 endif
 
 CXXFLAGS  += -I../../CompilerSource -I$(PROTO_DIR)

--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -2,18 +2,14 @@
 #include "Main.hpp"
 
 #include "eyaml/eyaml.h"
+#include "strings_util.h"
 #include "OS_Switchboard.h"
 
-#include <boost/filesystem.hpp>
-#include <boost/foreach.hpp>
-#include <boost/iostreams/device/mapped_file.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/exception/diagnostic_information.hpp>
+#include <filesystem>
+namespace fs = std::filesystem;
 
 #include <iostream>
 #include <cctype> // std::ispace
-
-namespace fs = boost::filesystem;
 
 inline std::string word_wrap(std::string text, unsigned per_line)
 {
@@ -222,8 +218,8 @@ std::string OptionsParser::APIyaml(const buffers::resources::Settings* currentCo
               widgets = _rawArgs["widgets"].as<std::string>(),
               collision = _rawArgs["collision"].as<std::string>(),
               network = _rawArgs["network"].as<std::string>(),
-              eobjs_directory = boost::filesystem::absolute(_rawArgs["workdir"].as<std::string>()).string(),
-              codegen_directory = boost::filesystem::absolute(_rawArgs["codegen"].as<std::string>()).string();
+              eobjs_directory = fs::absolute(_rawArgs["workdir"].as<std::string>()).string(),
+              codegen_directory = fs::absolute(_rawArgs["codegen"].as<std::string>()).string();
 
   int inherit_strings = 0,
       inherit_escapes = 0,
@@ -287,11 +283,12 @@ std::string OptionsParser::APIyaml(const buffers::resources::Settings* currentCo
 
 int OptionsParser::find_ey(const char* dir)
 {
-  boost::filesystem::path targetDir(dir);
-  boost::filesystem::recursive_directory_iterator iter(targetDir), eod;
+  fs::path targetDir(dir);
+  fs::recursive_directory_iterator iter(targetDir);
 
-  BOOST_FOREACH(boost::filesystem::path const& i, std::make_pair(iter, eod))
+  for(auto& p : iter)
   {
+    fs::path i = p.path();
     if (is_regular_file(i))
     {
       auto ey = i.string().find(".ey");
@@ -350,7 +347,7 @@ int OptionsParser::printInfo(const std::string &api)
           id = about.get("id"); // allow alias
         if (id.empty()) {
           // compilers use filename minus ext as id
-          boost::filesystem::path ey(p);
+          fs::path ey(p);
           id = ey.stem().string();
         }
 
@@ -452,7 +449,7 @@ int OptionsParser::searchCompilers(const std::string &target)
 {
   auto it = std::find_if(std::begin(_api["Compilers"]), std::end(_api["Compilers"]), [target](std::string &a)
   {
-    boost::filesystem::path ey(a);
+    fs::path ey(a);
     return ey.stem().string() == target;
   });
 
@@ -483,8 +480,7 @@ int OptionsParser::searchAPI(const std::string &api, const std::string &target)
   if (it != std::end(_api[api]))
   {
     //set api
-    std::string lower = api;
-    boost::algorithm::to_lower(lower);
+    std::string lower = tolower(api);
 
     if (lower == "extensions")
     {

--- a/CommandLine/emake/SOG.cpp
+++ b/CommandLine/emake/SOG.cpp
@@ -2,8 +2,9 @@
 #include "Main.hpp"
 #include "event_reader/event_parser.h"
 
-#include <boost/filesystem.hpp>
-#include <boost/foreach.hpp>
+#include <filesystem>
+namespace fs = std::filesystem;
+
 #include <fstream>
 #include <iostream>
 
@@ -24,9 +25,10 @@ bool ReadSOG(const std::string &input_file, Game *game) {
   }
 
   map<evpair, string> events;
-  boost::filesystem::path targetDir(input_file);
-  boost::filesystem::recursive_directory_iterator iter(targetDir), eod;
-  BOOST_FOREACH(boost::filesystem::path const& i, std::make_pair(iter, eod)) {
+  fs::path targetDir(input_file);
+  fs::recursive_directory_iterator iter(targetDir);
+  for(auto& p : iter) {
+    fs::path i = p.path();
     if (is_regular_file(i)) {
       auto find = event_filenames.find(i.filename().string());
       if (find == event_filenames.end())  {

--- a/CommandLine/gm2egm/main.cpp
+++ b/CommandLine/gm2egm/main.cpp
@@ -3,16 +3,10 @@
 #include "yyp.h"
 #include "egm.h"
 
+#include "strings_util.h"
+
 #include <iostream>
 #include <string>
-
-static std::string tolower(const std::string &str) {
-  std::string res = str;
-  for (size_t i = 0; i < res.length(); ++i) {
-    if (res[i] >= 'A' && res[i] <= 'Z') res[i] += 'a' - 'A';
-  }
-  return res;
-}
 
 int main(int argc, char *argv[])
 {

--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -5,21 +5,8 @@ SOURCES := $(call rwildcard,$(SRC_DIR),*.cpp)
 SHARED_SRC_DIR := ../../shared
 PROTO_DIR := $(SHARED_SRC_DIR)/protos/.eobjs
 
-#if gcc >= 8 use std::filesystem instead of boost
-ifeq ($(OS), Darwin)
-	CXXFLAGS += -std=c++17
-else ifeq ($(shell expr $(GCCVER) \>= 8), 1)
-	CXXFLAGS += -std=c++17
+ifeq ($(OS), Linux)
 	FS_LIBS=-lstdc++fs
-else
-	CXXFLAGS += -std=c++14 -DUSE_BOOST_FS
-	ifeq ($(OS), Linux)
-		FS_LIBS=-lboost_system -lboost_filesystem
-	else ifeq ($(OS), Darwin)
-		FS_LIBS=-lboost_system -lboost_filesystem
-	else
-		FS_LIBS=-lboost_system-mt -lboost_filesystem-mt
-	endif
 endif
 
 CXXFLAGS += -I../ $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR) -I$(SHARED_SRC_DIR) -I$(SHARED_SRC_DIR)/libpng-util -fPIC

--- a/CommandLine/libEGM/Makefile
+++ b/CommandLine/libEGM/Makefile
@@ -6,7 +6,9 @@ SHARED_SRC_DIR := ../../shared
 PROTO_DIR := $(SHARED_SRC_DIR)/protos/.eobjs
 
 #if gcc >= 8 use std::filesystem instead of boost
-ifeq ($(shell expr $(GCCVER) \>= 8), 1)
+ifeq ($(OS), Darwin)
+	CXXFLAGS += -std=c++17
+else ifeq ($(shell expr $(GCCVER) \>= 8), 1)
 	CXXFLAGS += -std=c++17
 	FS_LIBS=-lstdc++fs
 else
@@ -21,6 +23,6 @@ else
 endif
 
 CXXFLAGS += -I../ $(shell pkg-config --cflags pugixml) -I$(PROTO_DIR) -I$(SHARED_SRC_DIR) -I$(SHARED_SRC_DIR)/libpng-util -fPIC
-LDFLAGS += -shared -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -lstdc++fs -L$(SHARED_SRC_DIR)/libpng-util -lpng-util -lpng $(FS_LIBS)
+LDFLAGS += -shared -lz $(shell pkg-config --libs-only-L pugixml) -lpugixml -lyaml-cpp -L../../ -lProtocols -lprotobuf -L$(SHARED_SRC_DIR)/libpng-util -lpng-util -lpng $(FS_LIBS)
 
 include ../../Default.mk

--- a/CommandLine/libEGM/filesystem.cpp
+++ b/CommandLine/libEGM/filesystem.cpp
@@ -37,14 +37,10 @@ fs::path InternalizeFile(const fs::path &file,
   }
   fs::path relative = data/StripPath(file.string());
 
-  #ifdef USE_BOOST_FS
-    fs::copy_file(file, directory/relative);
-  #else
-    if (!fs::copy_file(file, directory/relative)) {
-      std::cerr << "Failed to copy \"" << file << "\" into EGM." << std::endl;
-      return "";
-    }
-  #endif
+  if (!fs::copy_file(file, directory/relative)) {
+    std::cerr << "Failed to copy \"" << file << "\" into EGM." << std::endl;
+    return "";
+  }
 
   return relative;
 }
@@ -64,10 +60,5 @@ string TempFileName(const string &pattern) {
 }
 
 void DeleteFile(const string &fName) {
-#ifdef USE_BOOST_FS
-  fs::remove(fName.c_str());
-#else
   std::remove(fName.c_str());
-#endif
-
 }

--- a/CommandLine/libEGM/filesystem.h
+++ b/CommandLine/libEGM/filesystem.h
@@ -1,24 +1,6 @@
-#ifdef USE_BOOST_FS
-  #include <boost/filesystem.hpp>
-  #include <boost/system/error_code.hpp>
-  namespace fs = boost::filesystem;
-  using errc = boost::system::error_code;
-  namespace boost {
-    template<class ForwardIt>
-    ForwardIt next(
-        ForwardIt it,
-        typename std::iterator_traits<ForwardIt>::difference_type n = 1);
-  }  // namespace boost
-#else 
-  #ifdef __APPLE__
-    #include <experimental/filesystem>
-    namespace fs = std::experimental::filesystem;
-  #else
-    #include <filesystem>
-    namespace fs = std::filesystem;
-  #endif
-  using errc = std::error_code;
-#endif
+#include <filesystem>
+namespace fs = std::filesystem;
+using errc = std::error_code;
 
 using std::string;
 

--- a/CommandLine/testing/Makefile
+++ b/CommandLine/testing/Makefile
@@ -5,13 +5,11 @@ TESTCASES_DIR := $(SRC_DIR)/Tests
 
 ifeq ($(OS), Linux)
 	OS_SRCS=$(wildcard ./Platform/*-X11.cpp)
-	OS_LIBS=-lX11 -lboost_filesystem -lboost_system
+	OS_LIBS=-lX11 -lstdc++fs
 else ifeq ($(OS), Darwin)
 	OS_SRCS=./Platform/TestHarness-Cocoa.cpp
-	OS_LIBS=-lboost_filesystem -lboost_system
 else
 	OS_SRCS=./Platform/TestHarness-Win32.cpp
-	OS_LIBS=-lboost_filesystem-mt -lboost_system-mt
 endif
 
 SOURCES := $(wildcard $(SRC_DIR)/*.cpp) $(wildcard $(TESTCASES_DIR)/*.cpp) $(OS_SRCS)

--- a/CommandLine/testing/SmallTests.cpp
+++ b/CommandLine/testing/SmallTests.cpp
@@ -1,12 +1,14 @@
-#include <boost/filesystem.hpp>
-#include <boost/foreach.hpp>
+#include "TestHarness.hpp"
+
 #include <gtest/gtest.h>
+
+#include <filesystem>
+namespace fs = std::filesystem;
+
 #include <iostream>
 #include <map>
 #include <string>
 #include <vector>
-
-#include "TestHarness.hpp"
 
 namespace {
 
@@ -21,9 +23,10 @@ const char *const kDrivenTestDirectory = "CommandLine/testing/Tests";
 
 void read_files(string directory,
                 NameMap *games, NameMap *sources, NameMap *others) {
-  boost::filesystem::path targetDir(directory);
-  boost::filesystem::directory_iterator iter(targetDir), eod;
-  BOOST_FOREACH(boost::filesystem::path const& i, std::make_pair(iter, eod)) {
+  fs::path targetDir(directory);
+  fs::directory_iterator iter(targetDir);
+  for(auto& p : iter) {
+    fs::path i = p.path();
     string fullname = i.filename().string();
     string filename = i.filename().stem().string();
     string ext = i.filename().extension().string();

--- a/CompilerSource/filesystem/file_find.cpp
+++ b/CompilerSource/filesystem/file_find.cpp
@@ -32,7 +32,9 @@ using namespace std;
 #include "file_find.h"
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-  #include <windows.h>
+   #define byte __windows_byte_workaround
+   #include <windows.h>
+   #undef byte
 
   static int ff_attribs=0;
   static HANDLE current_find = INVALID_HANDLE_VALUE;

--- a/CompilerSource/frontend.cpp
+++ b/CompilerSource/frontend.cpp
@@ -48,7 +48,9 @@ string fc(const char* fn);
 int m_prog_loop_cfp();
 
 #ifdef _WIN32
+ #define byte __windows_byte_workaround
  #include <windows.h>
+ #undef byte
  #define dllexport extern "C" __declspec(dllexport)
 #else
  #define dllexport extern "C"

--- a/CompilerSource/gcc_interface/gcc_backend.cpp
+++ b/CompilerSource/gcc_interface/gcc_backend.cpp
@@ -36,7 +36,9 @@
 #include <cstdlib>
 
 #ifdef _WIN32
- #include <windows.h>
+  #define byte __windows_byte_workaround
+  #include <windows.h>
+  #undef byte
  #define dllexport extern "C" __declspec(dllexport)
 #else
  #define dllexport extern "C"

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -100,7 +100,9 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 }
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
+    #define byte __windows_byte_workaround
     #include <windows.h>
+    #undef byte
 
     int e_exec(const char* fcmd, const char* *Cenviron)
     {

--- a/CompilerSource/languages/lang_CPP.cpp
+++ b/CompilerSource/languages/lang_CPP.cpp
@@ -52,7 +52,9 @@ void lang_CPP::load_extension_locals() {
 }
 
 #ifdef _WIN32
+ #define byte __windows_byte_workaround
  #include <windows.h>
+ #undef byte
  #define dllexport extern "C" __declspec(dllexport)
    #define DECLARE_TIME_TYPE clock_t
    #define CURRENT_TIME(t) t = clock()

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -39,12 +39,14 @@ int m_prog_loop_cfp();
 #include <sys/time.h>
 
 #ifdef _WIN32
+ #define byte __windows_byte_workaround
  #include <windows.h>
  #define dllexport extern "C" __declspec(dllexport)
    #define DECLARE_TIME() clock_t cs, ce
    #define START_TIME() cs = clock()
    #define STOP_TIME() ce = clock()
    #define PRINT_TIME() (((ce - cs) * 1000)/CLOCKS_PER_SEC)
+  #undef byte
 #else
  #define dllexport extern "C"
  #include <cstdio>

--- a/CompilerSource/makedir.cpp
+++ b/CompilerSource/makedir.cpp
@@ -18,16 +18,19 @@
 #include "makedir.h"
 
 #include <iostream>
+using namespace std;
 
 // Only include the headers for mkdir() if we are not on Windows; on Windows we use CreateDirectory() from windows.h
 #if CURRENT_PLATFORM_ID != OS_WINDOWS
 #include <sys/stat.h>
 #include <unistd.h>
 #else
+#define byte __windows_byte_workaround
 #include <windows.h>
+#undef byte
 #endif
 
-std::string myReplace(std::string str, const std::string& oldStr, const std::string& newStr)
+string myReplace(string str, const string& oldStr, const string& newStr)
 {
   std::string nstr = str;
   size_t pos = 0;
@@ -39,15 +42,15 @@ std::string myReplace(std::string str, const std::string& oldStr, const std::str
   return nstr;
 }
 
-std::string escapeEnv(std::string str, std::string env) {
+string escapeEnv(string str, string env) {
 	char* val = getenv(env.c_str());
 	if (val != NULL)
 		return myReplace(str, "%" + env + "%", val);
 	return str;
 }
 
-std::string escapeEnv(std::string str) {
-	std::string escaped = escapeEnv(str, "LOCALAPPDATA");
+string escapeEnv(string str) {
+	string escaped = escapeEnv(str, "LOCALAPPDATA");
 	escaped = escapeEnv(escaped, "APPDATA");
 	escaped = escapeEnv(escaped, "PROGRAMDATA");
 	escaped = escapeEnv(escaped, "ALLUSERSPROFILE");

--- a/CompilerSource/makedir.cpp
+++ b/CompilerSource/makedir.cpp
@@ -18,7 +18,6 @@
 #include "makedir.h"
 
 #include <iostream>
-using namespace std;
 
 // Only include the headers for mkdir() if we are not on Windows; on Windows we use CreateDirectory() from windows.h
 #if CURRENT_PLATFORM_ID != OS_WINDOWS
@@ -28,7 +27,7 @@ using namespace std;
 #include <windows.h>
 #endif
 
-string myReplace(string str, const string& oldStr, const string& newStr)
+std::string myReplace(std::string str, const std::string& oldStr, const std::string& newStr)
 {
   std::string nstr = str;
   size_t pos = 0;
@@ -40,15 +39,15 @@ string myReplace(string str, const string& oldStr, const string& newStr)
   return nstr;
 }
 
-string escapeEnv(string str, string env) {
+std::string escapeEnv(std::string str, std::string env) {
 	char* val = getenv(env.c_str());
 	if (val != NULL)
 		return myReplace(str, "%" + env + "%", val);
 	return str;
 }
 
-string escapeEnv(string str) {
-	string escaped = escapeEnv(str, "LOCALAPPDATA");
+std::string escapeEnv(std::string str) {
+	std::string escaped = escapeEnv(str, "LOCALAPPDATA");
 	escaped = escapeEnv(escaped, "APPDATA");
 	escaped = escapeEnv(escaped, "PROGRAMDATA");
 	escaped = escapeEnv(escaped, "ALLUSERSPROFILE");

--- a/Config.mk
+++ b/Config.mk
@@ -13,15 +13,8 @@ else
 endif
 
 # Global g++ flags
-CXXFLAGS := -Wall -Wextra -Wpedantic -g -I.
+CXXFLAGS := -std=c++17 -Wall -Wextra -Wpedantic -g -I.
 LDFLAGS := -g
-
-# For older travis instances
-ifeq ($(shell expr $(GCCVER) \<= 6), 1)
-	ifneq ($(OS), Darwin)
-		CXXFLAGS += -std=c++11
-	endif
-endif
 
 # These will be relative to the file that includes this Makefile
 SRC_DIR := .

--- a/Config.mk
+++ b/Config.mk
@@ -18,7 +18,9 @@ LDFLAGS := -g
 
 # For older travis instances
 ifeq ($(shell expr $(GCCVER) \<= 6), 1)
-  CXXFLAGS += -std=c++11
+	ifneq ($(OS), Darwin)
+		CXXFLAGS += -std=c++11
+	endif
 endif
 
 # These will be relative to the file that includes this Makefile

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +x
+#!/bin/bash -x
 
 set -e  # exit if any command fails
 
@@ -71,6 +71,10 @@ if [[ "${PWD}" == "${TEST_HARNESS_MASTER_DIR}" ]]; then
     git checkout master
   fi
   git clean -f -d
+
+  # re-install deps incase they've changed
+  echo "Reinstalling deps"
+  ./CI/install_emake_deps.sh && ./CI/split_jobs.sh install
 
   echo "Rebuilding plugin and harness from last commit..."
   make all -j$MAKE_JOBS

--- a/ci-regression.sh
+++ b/ci-regression.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash +x
 
 set -e  # exit if any command fails
 

--- a/shared/strings_util.h
+++ b/shared/strings_util.h
@@ -26,5 +26,12 @@ inline std::vector<std::string> split_string(const std::string &str, char delimi
         return vec;
 }
 
+inline std::string tolower(const std::string &str) {
+  std::string res = str;
+  for (size_t i = 0; i < res.length(); ++i) {
+    if (res[i] >= 'A' && res[i] <= 'Z') res[i] += 'a' - 'A';
+  }
+  return res;
+}
 
 #endif


### PR DESCRIPTION
This PR brings the CI up to c++17 but it comes with some good and bad

Good:
* Brings the ci up to gcc-9 and in turn c++17
* Removes our dep on boost filesystem
* Fixed small bug in regression script that caused it to fail when deps changed between commits

Bad:
* "windows.h" has a conflict with std::byte so anywhere it's included I had to wrap it in a macro to fix the conflict.
* Ubuntu's ppa for newest gcc don't have multilib gccs so I had to disable our 64->32bit builds but this is a very uncommon scenario.
* Our current JDI isn't c++17 compliant but only clang on osx seems to care and that job was already broken.

Note: emake still depends on boost options but that can be addressed in a separate PR 