### PR TITLE
[Win32] implement proper display_get_x/y() funcs

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -318,11 +318,13 @@ void display_mouse_set(int x,int y) {
 }
 
 int display_get_x() {
-  return 0; // TODO
+  RECT rc; GetWindowRect(GetDesktopWindow(), &rc);
+  return rc.left;
 }
 
 int display_get_y() {
-  return 0; // TODO
+  RECT rc; GetWindowRect(GetDesktopWindow(), &rc);
+  return rc.top;
 }
 
 int display_get_width() {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -318,13 +318,13 @@ void display_mouse_set(int x,int y) {
 }
 
 int display_get_x() {
-  RECT rc; GetWindowRect(GetDesktopWindow(), &rc);
-  return rc.left;
+  // Windows is different than our Unix-like platforms in that this value is always zero...
+  return 0;
 }
 
 int display_get_y() {
-  RECT rc; GetWindowRect(GetDesktopWindow(), &rc);
-  return rc.top;
+  // Windows is different than our Unix-like platforms in that this value is always zero...
+  return 0;
 }
 
 int display_get_width() {


### PR DESCRIPTION
Just like our X11/Xlib implementation, this gets the x/y values for the primary monitor, except this time for Windows. More info here: https://docs.microsoft.com/en-us/windows/win32/gdi/multiple-monitor-system-metrics