### PR TITLE
[FileDropper] Keep Window Focus After File Dropped

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
@@ -65,8 +65,9 @@ LRESULT CALLBACK HookWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       DragQueryFileW(hDrop, i, fName.data(), fName.size());
       dropped_files.insert(shorten({fName.data(), fName.size() - 1}));
     }
-    DragFinish(hDrop);
-    AllowSetForegroundWindow(GetWindowThreadProcessId(enigma::hWnd, NULL));
+    DragFinish(hDrop); DWORD ProcessId;
+    GetWindowThreadProcessId(enigma::hWnd, &ProcessId)
+    AllowSetForegroundWindow(ProcessId);
     SetForegroundWindow(enigma::hWnd);
     SetActiveWindow(enigma::hWnd);
     SetFocus(enigma::hWnd);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
@@ -1,4 +1,4 @@
-/** Copyright (C) 2019-2020 Samuel Venable
+/** Copyright (C) 2019 Samuel Venable
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
@@ -66,7 +66,7 @@ LRESULT CALLBACK HookWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       dropped_files.insert(shorten({fName.data(), fName.size() - 1}));
     }
     DragFinish(hDrop); DWORD dwProcessId;
-    GetWindowThreadProcessId(enigma::hWnd, &dwProcessId)
+    GetWindowThreadProcessId(enigma::hWnd, &dwProcessId);
     AllowSetForegroundWindow(dwProcessId);
     SetForegroundWindow(enigma::hWnd);
     SetActiveWindow(enigma::hWnd);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
@@ -65,7 +65,12 @@ LRESULT CALLBACK HookWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       DragQueryFileW(hDrop, i, fName.data(), fName.size());
       dropped_files.insert(shorten({fName.data(), fName.size() - 1}));
     }
-    DragFinish(hDrop);
+    DragFinish(hDrop); DWORD dwProcessId;
+    GetWindowThreadProcessId(enigma::hWnd, &dwProcessId);
+    AllowSetForegroundWindow(dwProcessId);
+    SetForegroundWindow(enigma::hWnd);
+    SetActiveWindow(enigma::hWnd);
+    SetFocus(enigma::hWnd);
     return 0;
   }
   return rc;

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
@@ -65,9 +65,9 @@ LRESULT CALLBACK HookWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       DragQueryFileW(hDrop, i, fName.data(), fName.size());
       dropped_files.insert(shorten({fName.data(), fName.size() - 1}));
     }
-    DragFinish(hDrop); DWORD ProcessId;
-    GetWindowThreadProcessId(enigma::hWnd, &ProcessId)
-    AllowSetForegroundWindow(ProcessId);
+    DragFinish(hDrop); DWORD dwProcessId;
+    GetWindowThreadProcessId(enigma::hWnd, &dwProcessId)
+    AllowSetForegroundWindow(dwProcessId);
     SetForegroundWindow(enigma::hWnd);
     SetActiveWindow(enigma::hWnd);
     SetFocus(enigma::hWnd);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.cpp
@@ -1,4 +1,4 @@
-/** Copyright (C) 2020 Samuel Venable
+/** Copyright (C) 2019-2020 Samuel Venable
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***
@@ -65,12 +65,8 @@ LRESULT CALLBACK HookWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       DragQueryFileW(hDrop, i, fName.data(), fName.size());
       dropped_files.insert(shorten({fName.data(), fName.size() - 1}));
     }
-    DragFinish(hDrop); DWORD dwProcessId;
-    GetWindowThreadProcessId(enigma::hWnd, &dwProcessId);
-    AllowSetForegroundWindow(dwProcessId);
-    SetForegroundWindow(enigma::hWnd);
-    SetActiveWindow(enigma::hWnd);
-    SetFocus(enigma::hWnd);
+    DragFinish(hDrop);
+    return 0;
   }
   return rc;
 }

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.h
@@ -1,4 +1,4 @@
-/** Copyright (C) 2019-2020 Samuel Venable
+/** Copyright (C) 2019 Samuel Venable
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.h
@@ -1,4 +1,4 @@
-/** Copyright (C) 2020 Samuel Venable
+/** Copyright (C) 2019-2020 Samuel Venable
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/FileDropper/FileDropper.h
@@ -1,4 +1,4 @@
-/** Copyright (C) 2019 Samuel Venable
+/** Copyright (C) 2020 Samuel Venable
 ***
 *** This file is a part of the ENIGMA Development Environment.
 ***


### PR DESCRIPTION
I had a user from the GMC complain the window doesn't keep focus after a DND operation, so yeah...

I really want to add a macOS version of this ENIGMA extension, as I have already written it, and verified it works in an empty Xcode project, but it will have to wait until my icon pr gets merged because it relies on those changes, (more specifically the window_handle-related stuff in that pr)...

rip