### PR TITLE
Fix GRPC Server Compile Game Crashes

### DIFF
--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -125,7 +125,9 @@ int EnigmaPlugin::BuildGame(buffers::Game* data, GameMode mode, const char* fpat
 {
   buffers::Project proj;
   proj.set_allocated_game(data);
-  return plugin_CompileProto(&proj, fpath, mode);
+  int ret = plugin_CompileProto(&proj, fpath, mode);
+  proj.release_game();
+  return ret;
 }
 
 const char* EnigmaPlugin::NextResource() {

--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -4,9 +4,7 @@
 #include "OS_Switchboard.h"
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-# define byte __windows_byte_workaround
-# include <windows.h>
-# undef byte
+#	include <windows.h>
 #	include <process.h>
 #else
 #	include <pthread.h>
@@ -121,10 +119,10 @@ int EnigmaPlugin::BuildGame(deprecated::JavaStruct::EnigmaStruct* data,
   return plugin_CompileEGM(data, fpath, mode);
 }
 
-int EnigmaPlugin::BuildGame(const buffers::Game* data, GameMode mode, const char* fpath)
+int EnigmaPlugin::BuildGame(const buffers::Game& data, GameMode mode, const char* fpath)
 {
   buffers::Project proj;
-  proj.mutable_game()->CopyFrom(*data);
+  proj.mutable_game()->CopyFrom(data);
   return plugin_CompileProto(&proj, fpath, mode);
 }
 

--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -121,13 +121,11 @@ int EnigmaPlugin::BuildGame(deprecated::JavaStruct::EnigmaStruct* data,
   return plugin_CompileEGM(data, fpath, mode);
 }
 
-int EnigmaPlugin::BuildGame(buffers::Game* data, GameMode mode, const char* fpath)
+int EnigmaPlugin::BuildGame(const buffers::Game* data, GameMode mode, const char* fpath)
 {
   buffers::Project proj;
-  proj.set_allocated_game(data);
-  int ret = plugin_CompileProto(&proj, fpath, mode);
-  proj.release_game();
-  return ret;
+  proj.mutable_game()->CopyFrom(*data);
+  return plugin_CompileProto(&proj, fpath, mode);
 }
 
 const char* EnigmaPlugin::NextResource() {

--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -4,7 +4,9 @@
 #include "OS_Switchboard.h"
 
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-#	include <windows.h>
+# define byte __windows_byte_workaround
+# include <windows.h>
+# undef byte
 #	include <process.h>
 #else
 #	include <pthread.h>

--- a/CommandLine/emake/EnigmaPlugin.hpp
+++ b/CommandLine/emake/EnigmaPlugin.hpp
@@ -38,7 +38,7 @@ public:
   void HandleGameLaunch();
   void LogMakeToConsole();
   int BuildGame(deprecated::JavaStruct::EnigmaStruct* data, GameMode mode, const char* fpath);
-  int BuildGame(buffers::Game* data, GameMode mode, const char* fpath);
+  int BuildGame(const buffers::Game& data, GameMode mode, const char* fpath);
   const char* NextResource();
   const char* FirstResource();
   bool ResourceIsFunction();

--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -15,7 +15,8 @@
 #include "yyp.h"
 #endif
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
+namespace fs = std::filesystem;
 
 #include <fstream>
 #include <iostream>
@@ -124,7 +125,7 @@ int main(int argc, char* argv[])
     game.SetOutputFile(input_file);
 
   if (input_file.size()) {
-    if (!boost::filesystem::exists(input_file)) {
+    if (!fs::exists(input_file)) {
       std::cerr << "Input file does not exist: " << input_file << std::endl;
       return OPTIONS_ERROR;
     }
@@ -141,8 +142,8 @@ int main(int argc, char* argv[])
       if (!(project = gmk::LoadGMK(input_file))) return 1;
       return plugin.BuildGame(project->game(), mode, output_file.c_str());
     } else if (ext == "gmx") {
-      boost::filesystem::path p = input_file;
-      if (boost::filesystem::is_directory(p)) {
+      fs::path p = input_file;
+      if (fs::is_directory(p)) {
         input_file += "/" + p.filename().stem().string() + ".project.gmx";
       }
 

--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -15,8 +15,7 @@
 #include "yyp.h"
 #endif
 
-#include <filesystem>
-namespace fs = std::filesystem;
+#include <boost/filesystem.hpp>
 
 #include <fstream>
 #include <iostream>
@@ -125,7 +124,7 @@ int main(int argc, char* argv[])
     game.SetOutputFile(input_file);
 
   if (input_file.size()) {
-    if (!fs::exists(input_file)) {
+    if (!boost::filesystem::exists(input_file)) {
       std::cerr << "Input file does not exist: " << input_file << std::endl;
       return OPTIONS_ERROR;
     }
@@ -140,20 +139,20 @@ int main(int argc, char* argv[])
     } else if (ext == "gm81" || ext == "gmk" || ext == "gm6" || ext == "gmd") {
       buffers::Project* project;
       if (!(project = gmk::LoadGMK(input_file))) return 1;
-      return plugin.BuildGame(project->mutable_game(), mode, output_file.c_str());
+      return plugin.BuildGame(project->game(), mode, output_file.c_str());
     } else if (ext == "gmx") {
-      fs::path p = input_file;
-      if (fs::is_directory(p)) {
+      boost::filesystem::path p = input_file;
+      if (boost::filesystem::is_directory(p)) {
         input_file += "/" + p.filename().stem().string() + ".project.gmx";
       }
 
       buffers::Project* project;
       if (!(project = gmx::LoadGMX(input_file))) return 1;
-      return plugin.BuildGame(project->mutable_game(), mode, output_file.c_str());
+      return plugin.BuildGame(project->game(), mode, output_file.c_str());
     } else if (ext == "yyp") {
       buffers::Project* project;
       if (!(project = yyp::LoadYYP(input_file))) return 1;
-      return plugin.BuildGame(project->mutable_game(), mode, output_file.c_str());
+      return plugin.BuildGame(project->game(), mode, output_file.c_str());
 #endif
     } else {
       if (ext == "egm") {

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -27,9 +27,8 @@ class CompilerServiceImpl final : public Compiler::Service {
 
   Status CompileBuffer(ServerContext* /*context*/, const CompileRequest* request, ServerWriter<CompileReply>* writer) override {
     // use lambda capture to contain compile logic
-    auto fnc = [=] {
-      const CompileRequest req = *request;
-      plugin.BuildGame(const_cast<buffers::Game*>(&req.game()), emode_run, req.name().c_str());
+    auto fnc = [&] {
+      plugin.BuildGame(const_cast<buffers::Game*>(&request->game()), emode_run, request->name().c_str());
     };
     // asynchronously launch the compile request
     std::future<void> future = std::async(fnc);

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -12,10 +12,11 @@
 #include <grpc++/server_builder.h>
 #include <grpc++/server_context.h>
 
-#include <boost/filesystem.hpp>
-
+#include <filesystem>
 #include <memory>
 #include <future>
+
+namespace fs = std::filesystem;
 
 using namespace grpc;
 using namespace buffers;
@@ -115,7 +116,7 @@ class CompilerServiceImpl final : public Compiler::Service {
           id = about.get("id"); // allow alias
         if (id.empty()) {
           // compilers use filename minus ext as id
-          boost::filesystem::path ey(subsystem);
+          fs::path ey(subsystem);
           id = ey.stem().string();
         }
 

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -28,7 +28,7 @@ class CompilerServiceImpl final : public Compiler::Service {
   Status CompileBuffer(ServerContext* /*context*/, const CompileRequest* request, ServerWriter<CompileReply>* writer) override {
     // use lambda capture to contain compile logic
     auto fnc = [&] {
-      plugin.BuildGame(&request->game(), emode_run, request->name().c_str());
+      plugin.BuildGame(request->game(), emode_run, request->name().c_str());
     };
     // asynchronously launch the compile request
     std::future<void> future = std::async(fnc);

--- a/CommandLine/emake/Server.cpp
+++ b/CommandLine/emake/Server.cpp
@@ -28,7 +28,7 @@ class CompilerServiceImpl final : public Compiler::Service {
   Status CompileBuffer(ServerContext* /*context*/, const CompileRequest* request, ServerWriter<CompileReply>* writer) override {
     // use lambda capture to contain compile logic
     auto fnc = [&] {
-      plugin.BuildGame(const_cast<buffers::Game*>(&request->game()), emode_run, request->name().c_str());
+      plugin.BuildGame(&request->game(), emode_run, request->name().c_str());
     };
     // asynchronously launch the compile request
     std::future<void> future = std::async(fnc);


### PR DESCRIPTION
These small changes here fix the crashes related to #1900 that I reported. With these changes RGM can now successfully compile multiple times in a row. It was simple minor mistakes I made when initially building the server and trying to get these different APIs glued together. What was going on basically was since the compile RPC takes a game (and not a project), I was making a temp project and moving ownership of the game to it. After the first compile, the game was getting destroyed by the project after return. Then the GRPC server came in and tried to delete the game, but it was already gone, hence segfault.

While I was in here Josh threatened me to accept const references instead. Also fundies forgot to remove boost from the server in #1894 so I had to do that too.