### PR TITLE
Fixes drawing on android

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/shader.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/shader.cpp
@@ -265,7 +265,11 @@ void main()
 {
   vec4 TexColor;
   if (en_TexturingEnabled == true){
-    TexColor = texture2D( en_TexSampler, v_TextureCoord.st ) * v_Color;
+    #if __VERSION__ > 120
+        TexColor = texture( en_TexSampler, v_TextureCoord.st ) * v_Color;
+    #else
+        TexColor = texture2D( en_TexSampler, v_TextureCoord.st ) * v_Color;
+    #endif
   }else{
     TexColor = v_Color;
   }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
@@ -80,7 +80,7 @@ int graphics_create_texture_custom(unsigned width, unsigned height, unsigned ful
 int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, void* pxdata, bool mipmap) {
   unsigned char* converted_pxdata = bgra2rgba((unsigned char*)pxdata, width, height);
   int ret = graphics_create_texture_custom(width, height, fullwidth, fullheight, converted_pxdata, mipmap, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE);
-  delete converted_pxdata;
+  delete[] converted_pxdata;
   return ret;
 }
 
@@ -116,7 +116,7 @@ void graphics_push_texture_pixels(int texture, int width, int height, unsigned c
   glBindTexture(GL_TEXTURE_2D, get_texture_peer(texture));
   unsigned char* converted_pxdata = bgra2rgba(pxdata, width, height);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, converted_pxdata);
-  delete converted_pxdata;
+  delete[] converted_pxdata;
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
@@ -29,6 +29,22 @@
 
 namespace enigma {
 
+// Because GLES won't do the conversion for us
+unsigned char* bgra2rgba(unsigned char* in, int w, int h) {
+  unsigned char* out = new unsigned char[w * h * 4];
+  int offset = 0;
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      out[offset] = in[offset + 2];
+      out[offset + 1] = in[offset + 1];
+      out[offset + 2] = in[offset];
+      out[offset + 3] = in[offset + 3];
+      offset += 4;
+    }
+  }
+  return out;
+}
+
 GLuint get_texture_peer(int texid) {
   return (size_t(texid) >= textures.size() || texid < 0)
       ? 0 : ((GLTexture*)textures[texid])->peer;
@@ -61,9 +77,11 @@ int graphics_create_texture_custom(unsigned width, unsigned height, unsigned ful
   return id;
 }
 
-int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, void* pxdata, bool mipmap)
-{
-  return graphics_create_texture_custom(width, height, fullwidth, fullheight, pxdata, mipmap, GL_RGBA, GL_BGRA, GL_UNSIGNED_BYTE);
+int graphics_create_texture(unsigned width, unsigned height, unsigned fullwidth, unsigned fullheight, void* pxdata, bool mipmap) {
+  unsigned char* converted_pxdata = bgra2rgba((unsigned char*)pxdata, width, height);
+  int ret = graphics_create_texture_custom(width, height, fullwidth, fullheight, converted_pxdata, mipmap, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE);
+  delete converted_pxdata;
+  return ret;
 }
 
 void graphics_delete_texture(int texid) {
@@ -96,8 +114,9 @@ void graphics_push_texture_pixels(int texture, int x, int y, int width, int heig
 
 void graphics_push_texture_pixels(int texture, int width, int height, unsigned char* pxdata) {
   glBindTexture(GL_TEXTURE_2D, get_texture_peer(texture));
-
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_BGRA, GL_UNSIGNED_BYTE, pxdata);
+  unsigned char* converted_pxdata = bgra2rgba(pxdata, width, height);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, converted_pxdata);
+  delete converted_pxdata;
 }
 
 } // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
@@ -72,7 +72,7 @@ void compute_window_scaling() {
 
 void compute_window_size() {
   if (!regionWidth) return;
-  int isFullScreen = enigma_user::window_get_fullscreen();
+  compute_window_scaling();
   if (!isFullScreen) {
     if (windowAdapt && viewScale > 0) {  // If the window is to be adapted and Fixed Scale
       if (scaledWidth > windowWidth) windowWidth = scaledWidth;

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -41,9 +41,17 @@ void init_sdl_window_bridge_attributes();
 
 bool initGameWindow() {
   SDL_Init(SDL_INIT_VIDEO);
-  if (isSizeable) sdl_window_flags |= SDL_WINDOW_RESIZABLE;
-  if (!showBorder) sdl_window_flags |= SDL_WINDOW_BORDERLESS;
-  if (isFullScreen) sdl_window_flags |= SDL_WINDOW_FULLSCREEN;
+  #ifdef __ANDROID__
+    // If you set window'd window on android it spazzes out
+    sdl_window_flags |= SDL_WINDOW_FULLSCREEN;
+    // Lanscape oreintation for android by default
+    SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
+  #else
+    if (isSizeable) sdl_window_flags |= SDL_WINDOW_RESIZABLE;
+    if (!showBorder) sdl_window_flags |= SDL_WINDOW_BORDERLESS;
+    if (isFullScreen) sdl_window_flags |= SDL_WINDOW_FULLSCREEN;
+  #endif
+
   init_sdl_window_bridge_attributes();
   windowHandle = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, sdl_window_flags);
   return (windowHandle != nullptr);


### PR DESCRIPTION
GLES doesn't support texture2d and doesn't do bgra->rgba conversion so this pr provides fixes for both. Also, SDL behaves strangely when the window isn't fullscreen on android so I just force fullscreen for now.

Please merge https://github.com/enigma-dev/enigma-android/pull/1 & #1899 before this
 