### PR TITLE
[Win32, X11, SDL] Set Window Icon from Sprite at Runtime

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Icon.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Icon.cpp
@@ -1,0 +1,37 @@
+/** Copyright (C) 2020 Samuel Venable
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include "Icon.h"
+
+#include "Graphics_Systems/graphics_mandatory.h"
+#include "Universal_System/Resources/sprites_internal.h"
+#include "Widget_Systems/widgets_mandatory.h"
+#include "Universal_System/nlpo2.h"
+
+namespace enigma {
+
+void SetIconFromSprite(SDL_Window *window, int ind, unsigned subimg) {
+  sprite *spr; if (!get_sprite_mtx(spr, ind)) return;  
+  unsigned char *data = nullptr; unsigned pngwidth, pngheight;
+  data = graphics_copy_texture_pixels(spr->texturearray[subimg], &pngwidth, &pngheight);
+  SDL_Surface *surface = SDL_CreateRGBSurfaceFrom((void *)data, pngwidth, pngheight, 32, pngwidth * 4, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000);
+  SDL_SetWindowIcon(window, surface);
+  SDL_FreeSurface(surface);
+  delete[] data;
+}
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Icon.h
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Icon.h
@@ -1,0 +1,24 @@
+/** Copyright (C) 2020 Samuel Venable
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include <SDL2/SDL.h>
+
+namespace enigma {
+
+void SetIconFromSprite(SDL_Window *window, int ind, unsigned subimg);
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -2,6 +2,7 @@
 #include "Event.h"
 #include "Joystick.h"
 #include "Gamepad.h"
+#include "Icon.h"
 
 #include "Platforms/General/PFwindow.h"
 #include "Platforms/platforms_mandatory.h"

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -138,6 +138,30 @@ void io_handle() {
   enigma::update_mouse_variables();
 }
 
+static int currentIconIndex;
+static unsigned currentIconFrame;
+
+int window_get_icon_index() {
+  return currentIconIndex;
+}
+
+unsigned window_get_icon_subimg() {
+  return currentIconFrame;
+}
+
+void window_set_icon(int ind, unsigned subimg) {
+  // the line below prevents glitchy minimizing when 
+  // icons are changed rapidly (i.e. for animation).
+  if (window_get_minimized()) return;
+
+  // needs to be visible first to prevent segfault
+  if (!window_get_visible()) window_set_visible(true);
+  enigma::SetIconFromSprite(windowHandle, ind, subimg);
+
+  currentIconIndex = ind;
+  currentIconFrame = subimg;
+}
+
 int window_get_visible() {
   Uint32 flags = SDL_GetWindowFlags(windowHandle);
   return (flags & SDL_WINDOW_SHOWN);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSicon.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSicon.cpp
@@ -1,0 +1,49 @@
+/** Copyright (C) 2020 Samuel Venable
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+// Josh will probably gaze at this code lazily and think he has a better way to do it
+// but not realize we are dependent on converting the char array to an HICON datatype
+
+#include "WINDOWSicon.h"
+
+#include "Graphics_Systems/graphics_mandatory.h"
+#include "Universal_System/Resources/sprites_internal.h"
+#include "Widget_Systems/widgets_mandatory.h"
+
+namespace enigma {
+
+void SetIconFromSprite(HWND window, int ind, unsigned subimg) {
+  sprite *spr; if (!get_sprite_mtx(spr, ind)) return;
+
+  unsigned char *data = nullptr; unsigned pngwidth, pngheight;
+  data = graphics_copy_texture_pixels(spr->texturearray[subimg], &pngwidth, &pngheight);
+  HBITMAP hBitmap = CreateBitmap(pngwidth, pngheight, 1, 32, data);
+
+  ICONINFO iconinfo;
+  iconinfo.fIcon = TRUE;
+  iconinfo.xHotspot = 0;
+  iconinfo.yHotspot = 0;
+  iconinfo.hbmMask = hBitmap;
+  iconinfo.hbmColor = hBitmap;
+  HICON hIcon = CreateIconIndirect(&iconinfo);
+  PostMessage(window, WM_SETICON, ICON_SMALL, (LPARAM)hIcon);
+
+  DeleteObject(hIcon);
+  DeleteObject(hBitmap);
+}
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSicon.h
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSicon.h
@@ -1,0 +1,24 @@
+/** Copyright (C) 2020 Samuel Venable
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include <windows.h>
+
+namespace enigma {
+
+void SetIconFromSprite(HWND window, int ind, unsigned subimg);
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -21,6 +21,8 @@
 #include "Platforms/General/PFmain.h" // For those damn vk_ constants.
 #include "Platforms/General/PFwindow.h"
 
+#include "WINDOWSicon.h"
+
 #include "Widget_Systems/widgets_mandatory.h"
 
 #include "strings_util.h" // For string_replace_all
@@ -80,6 +82,30 @@ void* window_handle() {
   return enigma::hWnd;
 }
 #endif
+
+static int currentIconIndex;
+static unsigned currentIconFrame;
+
+int window_get_icon_index() {
+  return currentIconIndex;
+}
+
+unsigned window_get_icon_subimg() {
+  return currentIconFrame;
+}
+
+void window_set_icon(int ind, unsigned subimg) {
+  // the line below prevents glitchy minimizing when 
+  // icons are changed rapidly (i.e. for animation).
+  if (window_get_minimized()) return;
+
+  // needs to be visible first to prevent segfault
+  if (!window_get_visible()) window_set_visible(true);
+  enigma::SetIconFromSprite(enigma::hWnd, ind, subimg);
+
+  currentIconIndex = ind;
+  currentIconFrame = subimg;
+}
 
 // GM8.1 Used its own internal variables for these functions and reported the regular window dimensions when minimized,
 // Studio uses the native functions and will tell you the dimensions of the window are 0 when it is minimized,

--- a/ENIGMAsystem/SHELL/Platforms/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/Makefile
@@ -1,2 +1,4 @@
 SOURCES += $(wildcard Platforms/xlib/*.cpp) $(wildcard Platforms/General/POSIX/*.cpp)
-override LDLIBS += -lz -lpthread -lX11 -lXrandr -lXinerama
+override CXXFLAGS += $(shell pkg-config x11 --cflags)
+override CFLAGS += $(shell pkg-config x11 --cflags)
+override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread -lXrandr -lXinerama

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBicon.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBicon.cpp
@@ -1,0 +1,44 @@
+/** Copyright (C) 2018-2019 Robert B. Colton
+*** Copyright (C) 2019 Samuel Venable
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include "XLIBicon.h"
+
+#include "Graphics_Systems/graphics_mandatory.h"
+#include "Universal_System/image_formats.h"
+#include "Universal_System/Resources/sprites_internal.h"
+#include "Widget_Systems/widgets_mandatory.h"
+
+#include <X11/Xatom.h>
+
+namespace enigma {
+
+void XSetIconFromSprite(Display *display, Window window, int ind, unsigned subimg) {
+  sprite *spr; if (!get_sprite_mtx(spr, ind)) return;  
+  XSynchronize(display, True);
+  Atom property = XInternAtom(display, "_NET_WM_ICON", False);
+  unsigned char *data = nullptr; unsigned pngwidth, pngheight;
+  data = graphics_copy_texture_pixels(spr->texturearray[subimg], &pngwidth, &pngheight);
+  unsigned elem_numb = 2 + pngwidth * pngheight;
+  unsigned long *result = bgra_to_argb(data, pngwidth, pngheight);
+  XChangeProperty(display, window, property, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)result, elem_numb);
+  XFlush(display);
+  delete[] result;
+  delete[] data;
+}
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBicon.h
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBicon.h
@@ -1,0 +1,24 @@
+/** Copyright (C) 2019 Samuel Venable
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include <X11/Xlib.h>
+
+namespace enigma {
+
+void XSetIconFromSprite(Display *display, Window window, int ind, unsigned subimg);
+
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -22,10 +22,13 @@
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Universal_System/globalupdate.h"
 #include "Universal_System/roomsystem.h"
+#include "Universal_System/Resources/sprites.h"
+#include "Universal_System/Resources/background.h"
 
 #include "GameSettings.h"  // ABORT_ON_ALL_ERRORS (MOVEME: this shouldn't be needed here)
 #include "XLIBmain.h"
 #include "XLIBwindow.h"  // Type insurance for non-mandatory functions
+#include "XLIBicon.h"
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -148,6 +151,30 @@ void window_set_visible(bool visible) {
   } else {
     XUnmapWindow(disp, win);
   }
+}
+
+static int currentIconIndex;
+static unsigned currentIconFrame;
+
+int window_get_icon_index() {
+  return currentIconIndex;
+}
+
+unsigned window_get_icon_subimg() {
+  return currentIconFrame;
+}
+
+void window_set_icon(int ind, unsigned subimg) {
+  // the line below prevents glitchy minimizing when 
+  // icons are changed rapidly (i.e. for animation).
+  if (window_get_minimized()) return;
+
+  // needs to be visible first to prevent segfault
+  if (!window_get_visible()) window_set_visible(true);
+  enigma::XSetIconFromSprite(disp, win, ind, subimg);
+
+  currentIconIndex = ind;
+  currentIconFrame = subimg;
 }
 
 int window_get_visible() {

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/sprites_internal.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/sprites_internal.h
@@ -74,6 +74,8 @@ void sprite_add_subimage(int sprid, unsigned int w, unsigned int h, unsigned cha
                          collision_type ct);
 void spritestructarray_reallocate();
 
+bool get_sprite_mtx(sprite* &spr, int id);
+
 extern const bbox_rect_t &sprite_get_bbox(int sprid);
 extern const bbox_rect_t &sprite_get_bbox_relative(int sprid);
 }  //namespace enigma

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/spritestruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/spritestruct.cpp
@@ -48,6 +48,8 @@ bool get_sprite(enigma::sprite* &spr, int id)
     return true;
 }
 
+namespace enigma {
+
 bool get_sprite_mtx(enigma::sprite* &spr, int id)
 {
     bool rtn = get_sprite(spr, id);
@@ -57,11 +59,11 @@ bool get_sprite_mtx(enigma::sprite* &spr, int id)
     return rtn;
 }
 
-namespace enigma {
-  sprite** spritestructarray;
-  extern size_t sprite_idmax;
-  sprite::sprite() {}
-  sprite::sprite(int x) {}
+sprite** spritestructarray;
+extern size_t sprite_idmax;
+sprite::sprite() {}
+sprite::sprite(int x) {}
+
 }
 
 namespace enigma_user

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -21,6 +21,7 @@
 #include "image_formats_exts.h"
 #include "Universal_System/estring.h"
 #include "Widget_Systems/widgets_mandatory.h"
+#include "Universal_System/nlpo2.h"
 
 #include "gif_format.h"
 
@@ -50,6 +51,32 @@ namespace enigma
 
 std::map<std::string, ImageLoadFunction> image_load_handlers;
 std::map<std::string, ImageSaveFunction> image_save_handlers;
+
+unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight) {
+  unsigned widfull = nlpo2dc(pngwidth) + 1, hgtfull = nlpo2dc(pngheight) + 1, ih,iw;
+  const int bitmap_size = widfull * hgtfull * 4;
+  unsigned char *bitmap = new unsigned char[bitmap_size]();
+
+  unsigned i = 0;
+  unsigned elem_numb = pngwidth * pngheight + 2;
+  unsigned long *result = new unsigned long[elem_numb]();
+  result[i++] = pngwidth; result[i++] = pngheight;
+
+  for (ih = 0; ih < pngheight; ih++) {
+    unsigned tmp = ih * widfull * 4;
+    for (iw = 0; iw < pngwidth; iw++) {
+      bitmap[tmp + 0] = bgra_data[4 * pngwidth * ih + iw * 4 + 0];
+      bitmap[tmp + 1] = bgra_data[4 * pngwidth * ih + iw * 4 + 1];
+      bitmap[tmp + 2] = bgra_data[4 * pngwidth * ih + iw * 4 + 2];
+      bitmap[tmp + 3] = bgra_data[4 * pngwidth * ih + iw * 4 + 3];
+      result[i++] = bitmap[tmp + 0] | (bitmap[tmp + 1] << 8) | (bitmap[tmp + 2] << 16) | (bitmap[tmp + 3] << 24);
+      tmp += 4;
+    }
+  }
+
+  delete[] bitmap;
+  return result;
+}
 
 void image_add_loader(std::string format, ImageLoadFunction fnc) {
   image_load_handlers[format] = fnc;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -60,7 +60,7 @@ unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigne
   unsigned i = 0;
   unsigned elem_numb = pngwidth * pngheight + 2;
   unsigned long *result = new unsigned long[elem_numb]();
-  result[i++] = pngwidth; result[i++] = pngheight;
+  result[i++] = pngwidth; result[i++] = pngheight; // this is required for xlib icon hint
 
   for (ih = 0; ih < pngheight; ih++) {
     unsigned tmp = ih * widfull * 4;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -34,6 +34,8 @@ enum {
   color_fmt_bgr
 };
 
+unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight);
+
 /// Gets the image format, eg. ".bmp", ".png", etc.
 std::string image_get_format(std::string filename);
 /// Reverses the scan-lines from top to bottom or vice verse, this is not actually to be used, you should load and save the data correctly to avoid duplicating it

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
@@ -1,3 +1,6 @@
 SOURCES += Widget_Systems/xlib/zenity.cpp
 SOURCES += Widget_Systems/xlib/kdialog.cpp
 SOURCES += Widget_Systems/xlib/dialogs.cpp
+override CXXFLAGS +=  $(shell pkg-config x11 --cflags)
+override CFLAGS += $(shell pkg-config x11 --cflags)
+override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread


### PR DESCRIPTION
Well, for the first time in the roughly 10 years the ENIGMA game engine has been around, you can now natively set a PNG icon for your game that will show in the title bar, task manager, system monitor, and Alt+Tab process swapper. No thanks to those fat lards Josh, Robert, and fundies. No offense, I love you guys, but I couldn't take it any longer so I decided to step in and add Linux icon support. The Win32 and SDL equivalents have also been added in this pr.

Includes the following functions:

- window_get_icon_index() returns the sprite index of the current icon

- window_get_icon_subimg() returns the sprite subimg of the current icon

- void window_set_icon(ind, subimg) sets the icon to use for the game from the given sprite resource

![75078947-019c2900-54d5-11ea-93bf-73ae218ab611](https://user-images.githubusercontent.com/4379204/76168975-8f6d4a80-614a-11ea-96ba-0a0e6ccb2e35.png)

As a very small secondary change, I set up a more correct makefile for the xlib platform and xlib widget system to ensure the end user has the correct location detected for libx11 and friends.