### PR TITLE
Fix Default Proto Makefile Rules

### DIFF
--- a/Default.mk
+++ b/Default.mk
@@ -41,7 +41,9 @@ $(OBJ_DIR)/shared/%.o: $(SHARED_SRC_DIR)/%.cpp | obj_dirs
 	$(CXX) $(CXXFLAGS) -MMD -c -o $@ $<
 
 # Proto rules
-$(OBJ_DIR)/%.pb.o $(OBJ_DIR)/%.pb.d: | $(GENERATED)
+# The order-only dependency on $(GENERATED) is an over-approximation to force all protos to be built
+# before any object files. This matters on the first run when Make can't yet know about #includes.
+$(OBJ_DIR)/%.pb.o $(OBJ_DIR)/%.pb.d: $(OBJDIR)/%.pb.cc | $(GENERATED)
 	$(CXX) $(CXXFLAGS) -MMD -MP -c -o $(OBJ_DIR)/$*.pb.o $(OBJ_DIR)/$*.pb.cc
 
 $(OBJ_DIR)/%.pb.cc $(OBJ_DIR)/%.pb.h: %.proto | obj_dirs 


### PR DESCRIPTION
Fix fundies typo (9eefc9a850162617781cf86c2575a09f9fca68ad) on proto rules and restore the comment Rusky (eabb1b474d5abf7e2d58ae3eccf4ba875208a9c9) originally added there. This is an odd typo for fundies to make considering he copied everything else verbatim, but regardless this fixes #1901 and emake is successfully built the first time now.