### PR TITLE
[BGRA->ARGB] allow making prepending size optional relative to use case

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBicon.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBicon.cpp
@@ -34,7 +34,7 @@ void XSetIconFromSprite(Display *display, Window window, int ind, unsigned subim
   unsigned char *data = nullptr; unsigned pngwidth, pngheight;
   data = graphics_copy_texture_pixels(spr->texturearray[subimg], &pngwidth, &pngheight);
   unsigned elem_numb = 2 + pngwidth * pngheight;
-  unsigned long *result = bgra_to_argb(data, pngwidth, pngheight);
+  unsigned long *result = bgra_to_argb(data, pngwidth, pngheight, true);
   XChangeProperty(display, window, property, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)result, elem_numb);
   XFlush(display);
   delete[] result;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -58,7 +58,7 @@ unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigne
   unsigned char *bitmap = new unsigned char[bitmap_size]();
 
   unsigned i = 0;
-  unsigned elem_numb = pngwidth * pngheight + (prepend_size) ? 2 : 0;
+  unsigned elem_numb = pngwidth * pngheight + ((prepend_size) ? 2 : 0);
   unsigned long *result = new unsigned long[elem_numb]();
   if (prepend_size) {
     result[i++] = pngwidth; result[i++] = pngheight; // this is required for xlib icon hint

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -52,15 +52,17 @@ namespace enigma
 std::map<std::string, ImageLoadFunction> image_load_handlers;
 std::map<std::string, ImageSaveFunction> image_save_handlers;
 
-unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight) {
-  unsigned widfull = nlpo2dc(pngwidth) + 1, hgtfull = nlpo2dc(pngheight) + 1, ih,iw;
+unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight, bool prepend_size) {
+  unsigned widfull = nlpo2dc(pngwidth) + 1, hgtfull = nlpo2dc(pngheight) + 1, ih, iw;
   const int bitmap_size = widfull * hgtfull * 4;
   unsigned char *bitmap = new unsigned char[bitmap_size]();
 
   unsigned i = 0;
-  unsigned elem_numb = pngwidth * pngheight + 2;
+  unsigned elem_numb = pngwidth * pngheight + (prepend_size) ? 2 : 0;
   unsigned long *result = new unsigned long[elem_numb]();
-  result[i++] = pngwidth; result[i++] = pngheight; // this is required for xlib icon hint
+  if (prepend_size) {
+    result[i++] = pngwidth; result[i++] = pngheight; // this is required for xlib icon hint
+  }
 
   for (ih = 0; ih < pngheight; ih++) {
     unsigned tmp = ih * widfull * 4;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -34,7 +34,7 @@ enum {
   color_fmt_bgr
 };
 
-unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight);
+unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight, prepend_size = false);
 
 /// Gets the image format, eg. ".bmp", ".png", etc.
 std::string image_get_format(std::string filename);

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -34,7 +34,7 @@ enum {
   color_fmt_bgr
 };
 
-unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight, prepend_size = false);
+unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight, bool prepend_size = false);
 
 /// Gets the image format, eg. ".bmp", ".png", etc.
 std::string image_get_format(std::string filename);


### PR DESCRIPTION
XLib icon changing requires prepending the size (width, height) of the bitmap to the color grid image data as the first two values of the array. In most other cases, converting the colors of a bitmap will not want this information to be a part of that array, so I made an optional argument of a boolean to prepend the size to the dynamic array while keeping the default value for it to be `false`. This will help in the future to those who may need re-usability of that function to suit their needs more properly.