### PR TITLE
fixes emake output for "--list" & "--sever" and moves log files to /tmp

### DIFF
--- a/CI/build_and_run_game.sh
+++ b/CI/build_and_run_game.sh
@@ -10,12 +10,12 @@ else
   do
     MODE="$mode" ./ci-build.sh
     if [ "$COMPILER" == "MinGW64" ]; then
-      WINEPREFIX=~/.wine64 WINEARCH=win64 xvfb-run wine64 $OUTPUT > >(tee -a tee logs/enigma_game.log) 2> >(tee -a tee logs/enigma_game.log >&2)
+      WINEPREFIX=~/.wine64 WINEARCH=win64 xvfb-run wine64 $OUTPUT > >(tee -a tee /tmp/enigma_game.log) 2> >(tee -a tee /tmp/enigma_game.log >&2)
     elif [ "$COMPILER" == "MinGW32" ]; then
-      WINEPREFIX=~/.wine32 WINEARCH=win32 xvfb-run wine $OUTPUT > >(tee -a tee logs/enigma_game.log) 2> >(tee -a tee logs/enigma_game.log >&2)
+      WINEPREFIX=~/.wine32 WINEARCH=win32 xvfb-run wine $OUTPUT > >(tee -a tee /tmp/enigma_game.log) 2> >(tee -a tee /tmp/enigma_game.log >&2)
     #FIXME: these should run but are bugged
     elif [[ ! "$GRAPHICS" =~ "OpenGLES" ]] && [ "$PLATFORM" != "SDL" ] && [[ ! "$COMPILER" =~ "clang" ]]; then
-      xvfb-run $OUTPUT > >(tee -a tee logs/enigma_game.log) 2> >(tee -a tee logs/enigma_game.log >&2)
+      xvfb-run $OUTPUT > >(tee -a tee /tmp/enigma_game.log) 2> >(tee -a tee /tmp/enigma_game.log >&2)
     fi
     ./share_logs.sh
   done

--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -37,7 +37,7 @@ static std::string tolower(const std::string &str) {
 int main(int argc, char* argv[])
 {
   std::ofstream egmlog(fs::temp_directory_path().string() + "/enigma_libegm.log", std::ofstream::out);
-  std::ofstream elog(fs::temp_directory_path().string() + "/enigma.log", std::ofstream::out);
+  std::ofstream elog(fs::temp_directory_path().string() + "/enigma_compiler.log", std::ofstream::out);
 
   std::string ENIGMA_DEBUG = (std::getenv("ENIGMA_DEBUG") ? std::getenv("ENIGMA_DEBUG") : "");
   if (ENIGMA_DEBUG == "TRUE") {

--- a/CompilerSource/backend/ideprint.cpp
+++ b/CompilerSource/backend/ideprint.cpp
@@ -23,15 +23,13 @@ ideprint::ideprint(void(*ftu)(const char*)): f(ftu) {}
 
 #include <iostream>
 
-extern std::ostream realCout;
-
 // Now specialize it 
 // Declare functions it'll call
 void ide_dia_add_direct(const char* x) {
-  realCout << x; std::cout << x; fflush(stdout); ide_dia_add(x);
+  std::cout << x; fflush(stdout); ide_dia_add(x);
 }
 void ide_dia_add_debug(const char* x) {
-  realCout << x; std::cout << x; fflush(stdout); ide_dia_add(x);
+  std::cout << x; fflush(stdout); ide_dia_add(x);
 }
 // Link them together
 ideprint user(ide_dia_add_direct);

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -78,23 +78,8 @@ extern const char* establish_bearings(const char *compiler);
 //FIXME: remove this function from enigma.jar and here
 dllexport void libSetMakeDirectory(const char* dir) {} 
 
-static std::ofstream logFile("logs/enigma_compiler.log", std::ofstream::out);
-static std::ostream elog(nullptr);
-std::ostream realCout(nullptr);
-
 dllexport const char* libInit(EnigmaCallbacks* ecs)
-{
-  elog.rdbuf(logFile.rdbuf());
-  realCout.rdbuf(std::cout.rdbuf());
-  std::string ENIGMA_DEBUG = (std::getenv("ENIGMA_DEBUG") ? std::getenv("ENIGMA_DEBUG") : "");
-  if (ENIGMA_DEBUG != "TRUE") {
-    std::cout << "ENIGMA compiler log at: logs/enigma_compiler.log" << std::endl;
-    std::cout.rdbuf(elog.rdbuf());
-    std::cerr.rdbuf(elog.rdbuf());
-  } else {
-    realCout.rdbuf(nullptr);
-  }
-  
+{  
   if (ecs)
   {
     cout << "Linking up to IDE" << endl;

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: libpng-util libProtocols libEGM ENIGMA emake emake-tests test-runner .FORCE
 
 Game: .FORCE
 	@$(RM) -f logs/enigma_compile.log
-	@$(MAKE) -C ENIGMAsystem/SHELL > >(tee -a logs/enigma_compile.log) 2> >(tee -a logs/enigma_compile.log >&2)
+	@$(MAKE) -C ENIGMAsystem/SHELL > >(tee -a /tmp/enigma_compile.log) 2> >(tee -a /tmp/enigma_compile.log >&2)
 
 clean-game: .FORCE
 	$(MAKE) -C ENIGMAsystem/SHELL clean

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/share_logs.sh
+++ b/share_logs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for log in "logs/enigma_libegm.log" "logs/enigma_compiler.log" "logs/enigma_compile.log" "logs/enigma_game.log";
+for log in "/tmp/enigma_libegm.log" "/tmp/enigma_compiler.log" "/tmp/enigma_compile.log" "/tmp/enigma_game.log";
 do
   echo -n "$log: "
   cat $log | sed -r 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | curl -F 'sprunge=<-' http://sprunge.us


### PR DESCRIPTION
Note: This brings back a lot of garbage printing during parse that should probably be manually hidden as it makes no sense to anyone but josh