### PR TITLE
Curl Authorization Header

### DIFF
--- a/CommandLine/testing/GitHub-ImageDiff.sh
+++ b/CommandLine/testing/GitHub-ImageDiff.sh
@@ -22,10 +22,10 @@ function imgur_upload {
 }
 
 function enigmabot_post_comment {
-  echo $(curl --header "Content-Type: application/json" \
+  echo $(curl --header "Authorization: token $bot_comment_token Content-Type: application/json" \
               --request POST \
               --data '{"body":"'"$1"'"}' \
-              "$pullrequest?access_token=$bot_comment_token")
+              "$pullrequest")
 }
 
 gh_comment_header="Regression tests have indicated that graphical changes have been introduced. \

--- a/CommandLine/testing/Tests/draw_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/draw.edl
@@ -13,7 +13,7 @@ draw_set_color(c_red);
 draw_ellipse(100, 100, 300, 200, false);
 draw_set_color(c_green);
 draw_ellipse(350, 100, 550, 200, false);
-draw_set_color(c_fuchsia);
+draw_set_color(c_green);
 draw_triangle(300, 300, 500, 300, 400, 480, false);
 
 // test using current color & alpha per-vertex on 2D primitive


### PR DESCRIPTION
Use the workaround for authorization token in the header recommended by GitHub.
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/