### PR TITLE
EnigmaBot Authorization

### DIFF
--- a/CommandLine/testing/GitHub-ImageDiff.sh
+++ b/CommandLine/testing/GitHub-ImageDiff.sh
@@ -22,10 +22,10 @@ function imgur_upload {
 }
 
 function enigmabot_post_comment {
-  echo $(curl --header "Content-Type: application/json" \
+  echo $(curl --header "Authorization: token $bot_comment_token Content-Type: application/json" \
               --request POST \
               --data '{"body":"'"$1"'"}' \
-              "$pullrequest?access_token=$bot_comment_token")
+              "$pullrequest")
 }
 
 gh_comment_header="Regression tests have indicated that graphical changes have been introduced. \

--- a/CommandLine/testing/GitHub-ImageDiff.sh
+++ b/CommandLine/testing/GitHub-ImageDiff.sh
@@ -22,7 +22,8 @@ function imgur_upload {
 }
 
 function enigmabot_post_comment {
-  echo $(curl --header "Authorization: token $bot_comment_token\r\nContent-Type: application/json" \
+  echo $(curl --H "Authorization: token $bot_comment_token" \
+              --H "Content-Type: application/json" \
               --request POST \
               --data '{"body":"'"$1"'"}' \
               "$pullrequest")

--- a/CommandLine/testing/GitHub-ImageDiff.sh
+++ b/CommandLine/testing/GitHub-ImageDiff.sh
@@ -22,7 +22,7 @@ function imgur_upload {
 }
 
 function enigmabot_post_comment {
-  echo $(curl --header "Authorization: token $bot_comment_token Content-Type: application/json" \
+  echo $(curl --header "Authorization: token $bot_comment_token\r\nContent-Type: application/json" \
               --request POST \
               --data '{"body":"'"$1"'"}' \
               "$pullrequest")

--- a/CommandLine/testing/GitHub-ImageDiff.sh
+++ b/CommandLine/testing/GitHub-ImageDiff.sh
@@ -22,8 +22,8 @@ function imgur_upload {
 }
 
 function enigmabot_post_comment {
-  echo $(curl --H "Authorization: token $bot_comment_token" \
-              --H "Content-Type: application/json" \
+  echo $(curl -H "Authorization: token $bot_comment_token" \
+              -H "Content-Type: application/json" \
               --request POST \
               --data '{"body":"'"$1"'"}' \
               "$pullrequest")

--- a/CommandLine/testing/Tests/draw_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/draw.edl
@@ -5,7 +5,7 @@ draw_rectangle(dx-20,dy-20,dx+20,dy+20,false);
 // in which case the diamond should occlude the rect
 vertex_submit(vb_diamond,pr_trianglestrip);
 
-draw_set_color(c_blue);
+draw_set_color(c_red);
 draw_rectangle(50, 50, 600, 400, true);
 draw_set_color(c_olive);
 draw_circle(275, 175, 200, false);

--- a/CommandLine/testing/Tests/draw_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/draw.edl
@@ -5,7 +5,7 @@ draw_rectangle(dx-20,dy-20,dx+20,dy+20,false);
 // in which case the diamond should occlude the rect
 vertex_submit(vb_diamond,pr_trianglestrip);
 
-draw_set_color(c_red);
+draw_set_color(c_yellow);
 draw_rectangle(50, 50, 600, 400, true);
 draw_set_color(c_olive);
 draw_circle(275, 175, 200, false);

--- a/CommandLine/testing/Tests/draw_test.sog/draw.edl
+++ b/CommandLine/testing/Tests/draw_test.sog/draw.edl
@@ -5,7 +5,7 @@ draw_rectangle(dx-20,dy-20,dx+20,dy+20,false);
 // in which case the diamond should occlude the rect
 vertex_submit(vb_diamond,pr_trianglestrip);
 
-draw_set_color(c_yellow);
+draw_set_color(c_blue);
 draw_rectangle(50, 50, 600, 400, true);
 draw_set_color(c_olive);
 draw_circle(275, 175, 200, false);


### PR DESCRIPTION
Use the workaround for authorization token in the header recommended by GitHub.
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/