### PR TITLE
[POSIX shell] these functions were written by a dummy

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/shell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/shell.cpp
@@ -5,7 +5,7 @@ namespace enigma_user {
 
 void execute_shell(std::string operation, std::string fname, std::string args) {
   if (system(NULL)) {
-    system((fname + args + " &").c_str());
+    system(("\"" + fname + "\" " + args + " &").c_str());
   } else {
     DEBUG_MESSAGE("execute_shell cannot be used as there is no command processor!", MESSAGE_TYPE::M_ERROR);
     return;
@@ -16,7 +16,7 @@ void execute_shell(std::string fname, std::string args) { execute_shell("", fnam
 
 void execute_program(std::string operation, std::string fname, std::string args, bool wait) {
   if (system(NULL)) {
-    system((fname + args + (wait ? " &" : "")).c_str());
+    system(("\"" + fname + "\" " + args + (wait ? " &" : "")).c_str());
   } else {
     DEBUG_MESSAGE("execute_program cannot be used as there is no command processor!", MESSAGE_TYPE::M_ERROR);
     return;


### PR DESCRIPTION
the fname argument needs quotes around it to accept spaces and it also needs a space between that and the args argument so the fname and first argument aren't fused together like Frankenstein's monster. Whoever wrote these functions initially was on crack. At least now, it works how it's supposed to, like it does on Windows, thanks to me. I can't believe this has been broken for the 10+ years ENIGMA has been around lol