### PR TITLE
File I/O Test Cleanup

### DIFF
--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -206,4 +206,6 @@ gtest_expect_eq(filename_ext("C:/John/Doe/Smoe.gmx/datafiles/archive.tar.gz"),".
 gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/Doe/Smoe.dingtwo");
 
 /// We're done!
+file_delete(bin_path);
+file_delete(text_path);
 game_end();

--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -190,6 +190,9 @@ gtest_expect_false(file_exists("Games Are Fun.txt"));
 gtest_expect_false(file_exists("Development Community.txt"));
 gtest_expect_false(file_exists("ENIGMA John Doe.txt"));
 
+directory_delete("ENIGMA Folders");
+gtest_expect_false(directory_exists("ENIGMA Folders"));
+
 gtest_expect_eq(filename_name("C:/John/Doe/Smoe.txt"),"Smoe.txt");
 gtest_expect_eq(filename_path("C:/John/Doe/Smoe.txt"),"C:/John/Doe/");
 gtest_expect_eq(filename_dir("C:/John/Doe/Smoe.txt"),"C:/John/Doe");


### PR DESCRIPTION
Ensure file I/O test cleans up all files created. The test uses expects, not asserts, so it's unlikely that the test will exit before deleting the files unless there's an obscure error. I did this because fundies filed #1950 against the test.