### PR TITLE
add typedef for window identifiers

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
@@ -214,8 +214,8 @@ bool display_test_all(int w, int h, int freq, int bitdepth);
 void set_synchronization(bool enable);
 
 window_t window_handle();
-std::string window_identifier(); // a string containing the number corresponding to the game's main window handle (shell script)
-std::string window_get_identifier(window_t hwnd); // a string containing the number corresponding to the specified window pointer
+wid_t window_identifier(); // a string containing the number corresponding to the game's main window handle (shell script)
+wid_t window_get_identifier(window_t hwnd); // a string containing the number corresponding to the specified window handle
   
 int window_get_x();
 int window_get_y();

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Android/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Android/Window.cpp
@@ -28,7 +28,7 @@ namespace enigma {
 
 // called from initGameWindow()
 // capture sdl window hwnd/surf
-void window_id_init() {
+void window_init() {
   /*
   SDL_SysWMinfo systemInfo;
   SDL_VERSION(&systemInfo.version);

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Cocoa/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Cocoa/Window.cpp
@@ -21,8 +21,6 @@
 #include <SDL2/SDL_syswm.h>
 #include <string>
 
-using std::string;
-
 extern "C" void *cocoa_window_handle();
 extern "C" long cocoa_window_identifier();
 extern "C" long cocoa_window_get_identifier(void *hwnd);

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Cocoa/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Cocoa/Window.cpp
@@ -34,7 +34,7 @@ unsigned long WinNum; // CGWindowID a.k.a [NSWindow windowNumber]
 
 // called from initGameWindow()
 // capture sdl window win/winid
-void window_id_init() {
+void window_init() {
   enigma::NSWin = cocoa_window_handle();
   enigma::WinNum = cocoa_window_identifier();
 }
@@ -49,13 +49,13 @@ window_t window_handle() {
 
 // returns an identifier for the SDL2 window
 // this string can be used in shell scripts
-string window_identifier() {
+wid_t window_identifier() {
   return std::to_string(enigma::WinNum);
 }
 
 // returns an identifier for certain window
 // this string can be used in shell scripts
-string window_get_identifier(window_t hwnd) {
+wid_t window_get_identifier(window_t hwnd) {
   return std::to_string(cocoa_window_get_identifier(hwnd));
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Win32/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Win32/Window.cpp
@@ -22,8 +22,6 @@
 #include <SDL2/SDL_syswm.h>
 #include <string>
 
-using std::string;
-
 namespace enigma {
 
 HWND hWnd;
@@ -31,7 +29,7 @@ HINSTANCE hInstance;
 
 // called from initGameWindow()
 // capture sdl window hwnd/inst
-void window_id_init() {
+void window_init() {
   SDL_SysWMinfo systemInfo;
   SDL_VERSION(&systemInfo.version);
   SDL_GetWindowWMInfo(windowHandle, &systemInfo);
@@ -49,13 +47,13 @@ window_t window_handle() {
 
 // returns an identifier for the SDL2 window
 // this string can be used in shell scripts
-string window_identifier() {
+wid_t window_identifier() {
   return std::to_string(reinterpret_cast<unsigned long long>(window_handle()));
 }
 
 // returns an identifier for certain window
 // this string can be used in shell scripts
-string window_get_identifier(window_t hwnd) {
+wid_t window_get_identifier(window_t hwnd) {
   return std::to_string(reinterpret_cast<unsigned long long>(hwnd));
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -48,7 +48,7 @@ bool initGameWindow() {
   init_sdl_window_bridge_attributes();
   windowHandle = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, sdl_window_flags);
   bool notnull = (windowHandle != nullptr);
-  if (notnull) window_id_init();
+  if (notnull) window_init();
   return notnull;
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.h
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.h
@@ -14,7 +14,7 @@ namespace enigma
     extern std::unordered_map<SDL_Keycode,int> keymap;
     extern std::unordered_map<SDL_Keycode, int> inverse_keymap;
   }
-  void window_id_init();
+  void window_init();
 } //namespace enigma
 
 #endif

--- a/ENIGMAsystem/SHELL/Platforms/SDL/xlib/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/xlib/Window.cpp
@@ -22,8 +22,6 @@
 #include <SDL2/SDL_syswm.h>
 #include <string>
 
-using std::string;
-
 namespace enigma {
 
 namespace x11 {
@@ -35,7 +33,7 @@ Window win;
 
 // called from initGameWindow()
 // capture sdl window disp/hwnd
-void window_id_init() {
+void window_init() {
   SDL_SysWMinfo wmInfo;
   SDL_VERSION(&wmInfo.version);
   SDL_GetWindowWMInfo(enigma::windowHandle, &wmInfo);
@@ -54,13 +52,13 @@ window_t window_handle() {
 
 // returns an identifier for the SDL2 window
 // this string can be used in shell scripts
-string window_identifier() {
+wid_t window_identifier() {
   return std::to_string(reinterpret_cast<unsigned long long>(window_handle()));
 }
 
 // returns an identifier for certain window
 // this string can be used in shell scripts
-string window_get_identifier(window_t hwnd) {
+wid_t window_get_identifier(window_t hwnd) {
   return std::to_string(reinterpret_cast<unsigned long long>(hwnd));
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -82,13 +82,13 @@ window_t window_handle() {
 
 // returns an identifier for the HWND window
 // this string can be used in shell scripts
-string window_identifier() {
+wid_t window_identifier() {
   return std::to_string(reinterpret_cast<unsigned long long>(window_handle()));
 }
 
 // returns an identifier for certain window
 // this string can be used in shell scripts
-string window_get_identifier(window_t hwnd) {
+wid_t window_get_identifier(window_t hwnd) {
   return std::to_string(reinterpret_cast<unsigned long long>(hwnd));
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
+++ b/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
@@ -28,11 +28,15 @@
 #include <functional>
 #include <vector>
 
+// window handle type
 #if GM_COMPATIBILITY_VERSION <= 81
 typedef unsigned long long window_t;
 #else
 typedef void * window_t;
-#endif 
+#endif
+
+// window identifier type
+typedef std::string wid_t;
 
 namespace enigma_user {
   extern const int os_type;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -155,13 +155,13 @@ window_t window_handle() {
 
 // returns an identifier for the XLIB window
 // this string can be used in shell scripts
-string window_identifier() {
+wid_t window_identifier() {
   return std::to_string(reinterpret_cast<unsigned long long>(window_handle()));
 }
 
 // returns an identifier for certain window
 // this string can be used in shell scripts
-string window_get_identifier(window_t hwnd) {
+wid_t window_get_identifier(window_t hwnd) {
   return std::to_string(reinterpret_cast<unsigned long long>(hwnd));
 }
 


### PR DESCRIPTION
Allows there to be some differentiation between a window id and a std::string that is not a window id.

Additonally, for clarification, I renamed window_id_init() to window_init() because it initializes all window related constants to be retrieved natively from SDL's window, not just the window id number by itself.