### PR TITLE
Fix Sprite Ids

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Resources/spriteinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/spriteinit.cpp
@@ -49,7 +49,8 @@ namespace enigma
     // Fetch the highest ID we will be using
     int spr_highid;
     if (!fread(&spr_highid,4,1,exe)) return;
-    
+
+    if (sprcount == 0) return;
     sprites.resize(spr_highid+1);
 
     for (int i = 0; i < sprcount; i++)

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/spriteinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/spriteinit.cpp
@@ -50,7 +50,7 @@ namespace enigma
     int spr_highid;
     if (!fread(&spr_highid,4,1,exe)) return;
     
-    sprites.resize(spr_highid);
+    sprites.resize(spr_highid+1);
 
     for (int i = 0; i < sprcount; i++)
     {

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/spriteinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/spriteinit.cpp
@@ -49,6 +49,8 @@ namespace enigma
     // Fetch the highest ID we will be using
     int spr_highid;
     if (!fread(&spr_highid,4,1,exe)) return;
+    
+    sprites.resize(spr_highid);
 
     for (int i = 0; i < sprcount; i++)
     {
@@ -132,7 +134,7 @@ namespace enigma
         }
       }
       
-      sprites.add(std::move(spr));
+      sprites.assign(sprid, std::move(spr));
     }
   }
 }


### PR DESCRIPTION
fundies made a small goof in #1937 and initialized all the sprites with contiguous ids instead of their actual ids. This broke a few games, including 1945 reported in #1976.