### PR TITLE
swap sdl full screen modes

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -295,9 +295,9 @@ bool window_get_fullscreen() {
 
 void window_set_fullscreen(bool fullscreen) {
   if (fullscreen) {
-    int r = SDL_SetWindowFullscreen(windowHandle, SDL_WINDOW_FULLSCREEN);
+    int r = SDL_SetWindowFullscreen(windowHandle, SDL_WINDOW_FULLSCREEN_DESKTOP);
 
-    if (r != 0) r = SDL_SetWindowFullscreen(windowHandle, SDL_WINDOW_FULLSCREEN_DESKTOP);
+    if (r != 0) r = SDL_SetWindowFullscreen(windowHandle, SDL_WINDOW_FULLSCREEN);
 
     if (r != 0) DEBUG_MESSAGE(std::string("Could not set window to fullscreen! SDL Error: ") + SDL_GetError(), MESSAGE_TYPE::M_WARNING);
   } else {


### PR DESCRIPTION
Swaps sdl's default fullscreen mode to borderless window to match win32/xlib. Scaling is still bugged in true full screen.

workaround for #1980 