### PR TITLE
Fix Windows FFI

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSexternals.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSexternals.cpp
@@ -103,7 +103,13 @@ int external_define(string dll,string func,int calltype,bool returntype,int argc
   }
 
   ffi_type *restype = (returntype == ty_real) ? &ffi_type_double : &ffi_type_pointer;
-  status=ffi_prep_cif(&(a->cif), ((calltype==dll_stdcall)?FFI_STDCALL:FFI_DEFAULT_ABI), ac, restype, a->arg_type);
+  ffi_abi callabi;
+#if defined(X86_64) || (defined (__x86_64__) && defined (X86_DARWIN))
+  callabi = FFI_DEFAULT_ABI;
+#else
+  callabi = ((calltype==dll_stdcall)?FFI_STDCALL:FFI_DEFAULT_ABI);
+#endif
+  status=ffi_prep_cif(&(a->cif), callabi, ac, restype, a->arg_type);
 
   if (status != FFI_OK)
   {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSexternals.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSexternals.cpp
@@ -104,7 +104,7 @@ int external_define(string dll,string func,int calltype,bool returntype,int argc
 
   ffi_type *restype = (returntype == ty_real) ? &ffi_type_double : &ffi_type_pointer;
   ffi_abi callabi;
-#if defined(X86_64) || (defined (__x86_64__) && defined (X86_DARWIN))
+#if __x86_64__
   callabi = FFI_DEFAULT_ABI;
 #else
   callabi = ((calltype==dll_stdcall)?FFI_STDCALL:FFI_DEFAULT_ABI);


### PR DESCRIPTION
As I explained on #1972, which this pull request fixes, neither the `__cdecl` or `__stdcall` calling conventions are appropriate on 64 bit Windows. GML, even in the latest GMS2, is actually lacking in appropriate constants for the 64 bit calling conventions.