### PR TITLE
Fix DLL Strings

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSexternals.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSexternals.cpp
@@ -178,7 +178,7 @@ variant external_call(int id,variant a1,variant a2, variant a3, variant a4, vari
     else if (args[i].type == ty_pointer)
       array[i].p = args[i].rval.p;
     else
-      array[i].s = ((string)args[i]).c_str();
+      array[i].s = ((const string&)args[i]).c_str();
     arg_values[i]=&array[i];
   }
 


### PR DESCRIPTION
This was recommend by Josh as a fix for TKG's issue #1511 with passing strings to dlls. This cast allows the DLL to grab the pointer to the permanent string owned by the variant being cast. This should hypothetically fix the string corruption TKG was seeing because his dll will no longer be getting a pointer to a temporary string.