### PR TITLE
Move mingw cross jobs to azure / arch

### DIFF
--- a/CI/asound.conf
+++ b/CI/asound.conf
@@ -1,0 +1,4 @@
+pcm.!default {
+    type plug
+    slave.pcm "null"
+}

--- a/CI/mirrorlist.mingw32
+++ b/CI/mirrorlist.mingw32
@@ -1,0 +1,10 @@
+##
+## MSYS2 repository mirrorlist
+##
+
+## Primary
+## msys2.org
+Server = http://repo.msys2.org/msys/$arch/
+Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/$arch/
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
+Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/

--- a/CI/mirrorlist.mingw32
+++ b/CI/mirrorlist.mingw32
@@ -4,7 +4,7 @@
 
 ## Primary
 ## msys2.org
-Server = http://repo.msys2.org/msys/$arch/
-Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/$arch/
-Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
-Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/
+Server = http://repo.msys2.org/msys/i686/
+Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/i686/
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/i686/
+Server = https://mirror.yandex.ru/mirrors/msys2/msys/i686/

--- a/CI/mirrorlist.mingw32
+++ b/CI/mirrorlist.mingw32
@@ -1,10 +1,10 @@
 ##
-## MSYS2 repository mirrorlist
+## 32-bit Mingw-w64 repository mirrorlist
 ##
 
 ## Primary
 ## msys2.org
-Server = http://repo.msys2.org/msys/i686/
-Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/i686/
-Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/i686/
-Server = https://mirror.yandex.ru/mirrors/msys2/msys/i686/
+Server = http://repo.msys2.org/mingw/i686/
+Server = https://sourceforge.net/projects/msys2/files/REPOS/MINGW/i686/
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/mingw/i686/
+Server = https://mirror.yandex.ru/mirrors/msys2/mingw/i686/

--- a/CI/mirrorlist.mingw64
+++ b/CI/mirrorlist.mingw64
@@ -1,0 +1,10 @@
+##
+## 64-bit Mingw-w64 repository mirrorlist
+##
+
+## Primary
+## msys2.org
+Server = http://repo.msys2.org/mingw/x86_64/
+Server = https://sourceforge.net/projects/msys2/files/REPOS/MINGW/x86_64/
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/mingw/x86_64/
+Server = https://mirror.yandex.ru/mirrors/msys2/mingw/x86_64/

--- a/CI/mirrorlist.msys
+++ b/CI/mirrorlist.msys
@@ -1,0 +1,10 @@
+##
+## MSYS2 repository mirrorlist
+##
+
+## Primary
+## msys2.org
+Server = http://repo.msys2.org/msys/$arch/
+Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/$arch/
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
+Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/

--- a/CI/mirrorlist.msys
+++ b/CI/mirrorlist.msys
@@ -4,7 +4,7 @@
 
 ## Primary
 ## msys2.org
-Server = http://repo.msys2.org/msys/$arch/
-Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/$arch/
-Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
-Server = https://mirror.yandex.ru/mirrors/msys2/msys/$arch/
+Server = http://repo.msys2.org/msys/x86_64/
+Server = https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/x86_64/
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/x86_64/
+Server = https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/

--- a/CI/split_jobs.sh
+++ b/CI/split_jobs.sh
@@ -16,12 +16,10 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   JOBS[10]='NETWORK=BerkeleySockets'
   JOBS[11]='WIDGETS=GTK+'
   JOBS[12]='WIDGETS=xlib'
-  JOBS[13]='COLLISION=BBox EXTENSIONS="Alarms,Timelines,DataStructures,Asynchronous,BasicGUI,DateTime,GM5Compat,IniFilesystem,Json,XRandR,Paths,MotionPlanning,ttf,Box2DPhysics,StudioPhysics,BulletDynamics,ExternalFuncs"'
-  JOBS[14]='COMPILER=MinGW32 PLATFORM=Win32 Widgets=Win32 AUDIO=DirectSound EXTENSIONS="DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs" OUTPUT="/tmp/test.exe"'
-  JOBS[15]='COMPILER=MinGW64 PLATFORM=Win32 Widgets=Win32 AUDIO=DirectSound EXTENSIONS="DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs" OUTPUT="/tmp/test.exe"'
-  JOBS[16]='COMPILER=clang'
-  #JOBS[18]='COMPILER=gcc32'
-  #JOBS[20]='COMPILER=clang32'
+  JOBS[14]='COLLISION=BBox EXTENSIONS="Alarms,Timelines,DataStructures,Asynchronous,BasicGUI,DateTime,GM5Compat,IniFilesystem,Json,XRandR,Paths,MotionPlanning,ttf,Box2DPhysics,StudioPhysics,BulletDynamics,ExternalFuncs"'
+  JOBS[15]='COMPILER=clang'
+  #JOBS[16]='COMPILER=gcc32'
+  #JOBS[17]='COMPILER=clang32'
   JOB_COUNT=16
   TRAVIS_WORKERS=5
 elif [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,7 +141,8 @@ jobs:
               Include = /etc/pacman.d/mirrorlist.mingw64
               [msys]
               Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
-        pacman-key -r 4DF3B7664CA56930 D595C9AB2C51581E 5F92EFC1A47D45A1 9F418C233E652008 BBE514E53E0D0813 DA7EF2ABAEEA755C F40D263ECA25678A
+        pacman-key --populate msys2
+        pacman-key --refresh-keys
         pacman -Sy wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
         pacman -S mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,8 +61,6 @@ jobs:
       displayName: Run Test Harness
       
 - job: CrossCompile
-  variables:
-    aur_cache_ver: "v1.0.0"
   displayName: 'Cross Compile'
   pool:
     vmImage: 'ubuntu-latest'
@@ -94,14 +92,6 @@ jobs:
         EOF
       displayName: 'Bootstrap Archlinux'
     
-    - task: Cache@2
-      inputs:
-        key: $(aur_cache_ver)| "$(Agent.OS)"
-        restoreKeys: $(aur_cache_ver)
-        path: $(Build.BinariesDirectory)/root.x86_64/home/aur/packages/done
-        cacheHitVar: CACHE_RESTORED
-      displayName: 'Cache AUR Packages'
-    
     - bash: |
         set -e
         cd $(Build.BinariesDirectory)
@@ -113,21 +103,8 @@ jobs:
         sudo -u aur makepkg
         pacman -U --noconfirm  yay-*.tar.xz
         sudo -u aur yay -S --noconfirm --builddir /home/aur/packages lcov mingw-w64-gcc-bin mingw-w64-binutils-bin mingw-w64-crt-bin mingw-w64-headers-bin mingw-w64-winpthreads-bin
-        find /home/aur/packages/ -iname '*.pkg.tar.xz' -exec mv '{}' /home/aur/packages/done \;
-        chmod -R 775 /home/aur/packages/done
         EOF
       displayName: 'Build & Install AUR Packages'
-      condition: ne(variables.CACHE_RESTORED, 'true')
-      
-    - bash: |
-        set -e
-        cd $(Build.BinariesDirectory)
-        cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
-        set -e
-        pacman -U --noconfirm  /home/aur/packages/done/*.tar.xz
-        EOF
-      displayName: 'Install AUR Packages (Cached)'
-      condition: eq(variables.CACHE_RESTORED, 'true')
     
     - bash: |
         set -e
@@ -150,7 +127,6 @@ jobs:
         pacman -S --noconfirm mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF
       displayName: 'Install MinGW Engine Dependencies'
-      condition: always()
       
     - bash: |
         set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,8 +95,8 @@ jobs:
     
     - task: Cache@2
       inputs:
-        key: change_me_to_update_aur| "$(Agent.OS)"
-        restoreKeys: change_me_to_update_aur
+        key: cache_ver_1| "$(Agent.OS)"
+        restoreKeys: cache_ver_1
         path: $(Build.BinariesDirectory)/root.x86_64/home/aur/packages/done
         cacheHitVar: CACHE_RESTORED
     
@@ -112,6 +112,7 @@ jobs:
         pacman -U --noconfirm  yay-*.tar.xz
         sudo -u aur yay -S --noconfirm --builddir /home/aur/packages lcov mingw-w64-gcc-bin mingw-w64-binutils-bin mingw-w64-crt-bin mingw-w64-headers-bin mingw-w64-winpthreads-bin
         find /home/aur/packages/ -iname '*.pkg.tar.xz' -exec mv '{}' /home/aur/packages/done \;
+        chmod -R 775 /home/aur/packages/done
         EOF
       displayName: 'AUR Packages'
       condition: ne(variables.CACHE_RESTORED, 'true')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,14 @@ jobs:
         mkdir -p /home/aur/packages/done
         useradd -G wheel aur
         chown -R aur:aur /home/aur
+        echo "[multilib]
+        Include = /etc/pacman.d/mirrorlist
+        [mingw32]
+        Include = /etc/pacman.d/mirrorlist.mingw32
+        [mingw64]
+        Include = /etc/pacman.d/mirrorlist.mingw64
+        [msys]
+        Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         pacman-key --populate msys2
         pacman -Sy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,6 @@ pr:  # Trigger a build on every PR.
 variables:
 - template: azure-vars.yml@radialgm
 - group: Test Harness Auth
-- aur_cache_ver: "v1.0.0"
 
 jobs:
 - template: azure-jobs.yml@radialgm
@@ -62,6 +61,8 @@ jobs:
       displayName: Run Test Harness
       
 - job: CrossCompile
+  variables:
+    aur_cache_ver: "v1.0.0"
   displayName: 'Cross Compile'
   pool:
     vmImage: 'ubuntu-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,8 @@ jobs:
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         pacman-key --populate msys2
         pacman-key --refresh-keys
-        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
+        pacman -Syuu --verbose --debug
+        pacman -S --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         EOF
       displayName: 'Bootstrap Archlinux'
     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ jobs:
         set -e
         cd enigma-dev
         ./emake -x MinGW32 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test32.exe CommandLine/testing/SimpleTests/clean_exit.sog/
-        WINEPREFIX=/tmp/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
+        WINEDLLOVERRIDES="mscoree,mshtml=" WINEPREFIX=/tmp/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
         EOF
       displayName: 'Engine MinGW32'
       
@@ -156,6 +156,6 @@ jobs:
         set -e
         cd enigma-dev
         ./emake -x MinGW64 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test64.exe CommandLine/testing/SimpleTests/clean_exit.sog/
-        WINEPREFIX=/tmp/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
+        WINEDLLOVERRIDES="mscoree,mshtml=" WINEPREFIX=/tmp/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
         EOF
       displayName: 'Engine MinGW64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ jobs:
         pacman-key --populate archlinux
         pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-        mkdir -p /home/aur/packages/done
+        mkdir -p /home/aur/packages/
         useradd -G wheel aur
         chown -R aur:aur /home/aur
         EOF

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ jobs:
         set -e
         cd enigma-dev
         ./emake -x MinGW32 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test32.exe CommandLine/testing/SimpleTests/clean_exit.sog/
-        WINEDLLOVERRIDES="mscoree,mshtml=" WINEPREFIX=/tmp/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
+        LIBGL_ALWAYS_SOFTWARE=1 WINEDLLOVERRIDES="mscoree,mshtml=" WINEPREFIX=/tmp/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
         EOF
       displayName: 'Engine MinGW32'
       
@@ -156,6 +156,6 @@ jobs:
         set -e
         cd enigma-dev
         ./emake -x MinGW64 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test64.exe CommandLine/testing/SimpleTests/clean_exit.sog/
-        WINEDLLOVERRIDES="mscoree,mshtml=" WINEPREFIX=/tmp/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
+        LIBGL_ALWAYS_SOFTWARE=1 WINEDLLOVERRIDES="mscoree,mshtml=" WINEPREFIX=/tmp/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
         EOF
       displayName: 'Engine MinGW64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,7 @@ jobs:
         EOF
       displayName: 'Install AUR Packages (Cached)'
       condition: eq(variables.CACHE_RESTORED, 'true')
+    
     - bash: |
         set -e
         cd $(Build.BinariesDirectory)
@@ -149,6 +150,7 @@ jobs:
         pacman -S mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF
       displayName: 'Install MinGW Engine Dependencies'
+      condition: always()
       
     - bash: |
         set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,15 +101,16 @@ jobs:
         cd $(Build.BinariesDirectory)
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
+        echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/users
         mkdir /home/aur
         cd /home/aur
-        useradd aur
+        useradd -G wheel aur
         git clone https://aur.archlinux.org/yay-git.git
         chown -R aur:aur /home/aur
         cd yay-git
         sudo -u aur makepkg
         pacman -U --noconfirm  yay-*.tar.xz
-        yay -S --noconfirm lcov
+        sudo -u aur sudo yay -S --noconfirm lcov
         EOF
       displayName: 'AUR Packages'
       condition: ne(variables.CACHE_RESTORED, 'true')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:  # Trigger a build on every PR.
 variables:
 - template: azure-vars.yml@radialgm
 - group: Test Harness Auth
-- aur_cache_ver: 1.0
+- aur_cache_ver: "1.0"
 
 jobs:
 - template: azure-jobs.yml@radialgm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ jobs:
         cd yay-git
         sudo -u aur makepkg
         pacman -U --noconfirm  yay-*.tar.xz
-        sudo -u aur sudo yay -S --noconfirm lcov
+        sudo -u aur yay -S --noconfirm lcov
         EOF
       displayName: 'AUR Packages'
       condition: ne(variables.CACHE_RESTORED, 'true')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,8 +102,7 @@ jobs:
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2-trusted -o /usr/share/pacman/keyrings/msys2-trusted
         pacman-key --populate msys2
         pacman-key --refresh-keys
-        pacman -Syuu --verbose --debug
-        pacman -S --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
+        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         EOF
       displayName: 'Bootstrap Archlinux'
     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,9 @@ jobs:
         mkdir -p /home/aur/packages/done
         useradd -G wheel aur
         chown -R aur:aur /home/aur
+        curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
+        pacman-key --populate msys2
+        pacman -Sy
         EOF
       displayName: 'Bootstrap Archlinux'
     
@@ -144,7 +147,7 @@ jobs:
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         pacman-key --populate msys2
         pacman-key --refresh-keys
-        pacman -Sy wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
+        pacman -S wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
         pacman -S mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF
       displayName: 'Install MinGW Engine Dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ pr:  # Trigger a build on every PR.
 variables:
 - template: azure-vars.yml@radialgm
 - group: Test Harness Auth
+- aur_cache_ver: 1
 
 jobs:
 - template: azure-jobs.yml@radialgm
@@ -41,7 +42,6 @@ jobs:
         ./CI/split_jobs.sh install
         ./CI/build_sdl.sh
       displayName: Install Dependencies
-
     - script: |
         make -j4
         make -j4 emake
@@ -85,32 +85,21 @@ jobs:
         echo 'Server = https://mirrors.kernel.org/archlinux/\$repo/os/\$arch' >> /etc/pacman.d/mirrorlist
         pacman-key --init 
         pacman-key --populate archlinux
+        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
         mkdir -p /home/aur/packages/done
         useradd -G wheel aur
         chown -R aur:aur /home/aur
-        cp enigma-dev/CI/mirrorlist* /etc/pacman.d/
-        echo "[multilib]
-        Include = /etc/pacman.d/mirrorlist
-        [mingw32]
-        Include = /etc/pacman.d/mirrorlist.mingw32
-        [mingw64]
-        Include = /etc/pacman.d/mirrorlist.mingw64
-        [msys]
-        Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
-        curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
-        curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2-trusted -o /usr/share/pacman/keyrings/msys2-trusted
-        pacman-key --populate msys2
-        pacman -Syu --noconfirm core/base core/base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         EOF
       displayName: 'Bootstrap Archlinux'
     
     - task: Cache@2
       inputs:
-        key: cache_ver_1| "$(Agent.OS)"
-        restoreKeys: cache_ver_1
+        key: $(aur_cache_ver)| "$(Agent.OS)"
+        restoreKeys: $(aur_cache_ver)
         path: $(Build.BinariesDirectory)/root.x86_64/home/aur/packages/done
         cacheHitVar: CACHE_RESTORED
+      displayName: 'Cache AUR Packages'
     
     - bash: |
         set -e
@@ -118,15 +107,15 @@ jobs:
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
         cd /home/aur/packages
-        su aur -c 'git clone https://aur.archlinux.org/yay-git.git'
+        sudo -u aur git clone https://aur.archlinux.org/yay-git.git
         cd yay-git
-        su aur -c makepkg
+        sudo -u aur makepkg
         pacman -U --noconfirm  yay-*.tar.xz
-        su aur -c 'yay -S --noconfirm --builddir /home/aur/packages lcov mingw-w64-gcc-bin mingw-w64-binutils-bin mingw-w64-crt-bin mingw-w64-headers-bin mingw-w64-winpthreads-bin'
+        sudo -u aur yay -S --noconfirm --builddir /home/aur/packages lcov mingw-w64-gcc-bin mingw-w64-binutils-bin mingw-w64-crt-bin mingw-w64-headers-bin mingw-w64-winpthreads-bin
         find /home/aur/packages/ -iname '*.pkg.tar.xz' -exec mv '{}' /home/aur/packages/done \;
         chmod -R 775 /home/aur/packages/done
         EOF
-      displayName: 'AUR Packages'
+      displayName: 'Build & Install AUR Packages'
       condition: ne(variables.CACHE_RESTORED, 'true')
       
     - bash: |
@@ -136,15 +125,26 @@ jobs:
         set -e
         pacman -U --noconfirm  /home/aur/packages/done/*.tar.xz
         EOF
-      displayName: 'AUR Packages (Cached)'
+      displayName: 'Install AUR Packages (Cached)'
       condition: eq(variables.CACHE_RESTORED, 'true')
-
     - bash: |
         set -e
         cd $(Build.BinariesDirectory)
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
-        pacman -S wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
+        cp enigma-dev/CI/mirrorlist* /etc/pacman.d/
+        echo "[multilib]
+              Include = /etc/pacman.d/mirrorlist
+              [mingw32]
+              Include = /etc/pacman.d/mirrorlist.mingw32
+              [mingw64]
+              Include = /etc/pacman.d/mirrorlist.mingw64
+              [msys]
+              Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
+        curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
+        curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2-trusted -o /usr/share/pacman/keyrings/msys2-trusted
+        pacman-key --populate msys2
+        pacman -Sy wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
         pacman -S mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF
       displayName: 'Install MinGW Engine Dependencies'
@@ -157,7 +157,7 @@ jobs:
         cd enigma-dev
         make emake
         EOF
-      displayName: 'emake'
+      displayName: 'Build emake'
       
     - bash: |
         set -e
@@ -168,7 +168,7 @@ jobs:
         ./emake -x MinGW32 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test32.exe
         WINEPREFIX=~/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
         EOF
-      displayName: 'MinGW 32'
+      displayName: 'Engine MinGW32'
       
     - bash: |
         set -e
@@ -179,4 +179,4 @@ jobs:
         ./emake -x MinGW64 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test64.exe
         WINEPREFIX=~/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
         EOF
-      displayName: 'MinGW 64'
+      displayName: 'Engine MinGW64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
         cd $(Build.BinariesDirectory)
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
-        echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/users
+        echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
         mkdir /home/aur
         cd /home/aur
         useradd -G wheel aur

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
         echo 'Server = https://mirrors.kernel.org/archlinux/\$repo/os/\$arch' >> /etc/pacman.d/mirrorlist
         pacman-key --init 
         pacman-key --populate archlinux
-        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost
+        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
         mkdir -p /home/aur/packages/done
         useradd -G wheel aur
@@ -115,3 +115,63 @@ jobs:
         EOF
       displayName: 'AUR Packages'
       condition: ne(variables.CACHE_RESTORED, 'true')
+      
+    - bash: |
+        set -e
+        cd $(Build.BinariesDirectory)
+        cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
+        set -e
+        pacman -U --noconfirm  /home/aur/packages/done/*.tar.xz
+        EOF
+      displayName: 'AUR Packages (Cached)'
+      condition: eq(variables.CACHE_RESTORED, 'true')
+
+    - bash: |
+        set -e
+        cd $(Build.BinariesDirectory)
+        cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
+        set -e
+        echo "[multilib]
+              Include = /etc/pacman.d/mirrorlist
+              [mingw32]
+              Include = /etc/pacman.d/mirrorlist.mingw32
+              [mingw64]
+              Include = /etc/pacman.d/mirrorlist.mingw64
+              [msys]
+              Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
+        pacman -Sy wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
+        pacman -S mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
+        EOF
+      displayName: 'Install MinGW Engine Dependencies'
+      
+    - bash: |
+        set -e
+        cd $(Build.BinariesDirectory)
+        cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
+        set -e
+        cd enigma-dev
+        make emake
+        EOF
+      displayName: 'emake'
+      
+    - bash: |
+        set -e
+        cd $(Build.BinariesDirectory)
+        cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
+        set -e
+        cd enigma-dev
+        ./emake -x MinGW32 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test32.exe
+        WINEPREFIX=~/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
+        EOF
+      displayName: 'MinGW 32'
+      
+    - bash: |
+        set -e
+        cd $(Build.BinariesDirectory)
+        cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
+        set -e
+        cd enigma-dev
+        ./emake -x MinGW64 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test64.exe
+        WINEPREFIX=~/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
+        EOF
+      displayName: 'MinGW 64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,3 +60,56 @@ jobs:
         _BOT_PUSH_ON_GREEN_TOKEN: $(bot_push_on_green_token)
         _CODECOV_UPLOAD_TOKEN: $(codecov_upload_token)
       displayName: Run Test Harness
+      
+- job: CrossCompile
+  displayName: 'Cross Compile'
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  steps:
+    - checkout: self
+      persistCredentials: true
+      path: enigma-dev
+    
+    - bash: |
+        set -e
+        cd $(Build.BinariesDirectory)
+        ARCH_URL=`curl -s https://mirrors.acm.wpi.edu/archlinux/iso/latest/ | egrep -o 'archlinux-bootstrap-([0-9._]+)-x86_64.tar.gz' | head -n1`
+        echo https://mirrors.acm.wpi.edu/archlinux/iso/latest/$ARCH_URL
+        curl https://mirrors.acm.wpi.edu/archlinux/iso/latest/$ARCH_URL -o arch.tar.gz
+        sudo tar xzf arch.tar.gz
+        sudo mount --bind ./root.x86_64/ ./root.x86_64/
+        sudo cp -R $(Agent.BuildDirectory)/enigma-dev ./root.x86_64/
+        cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
+        set -e
+        echo 'Server = https://mirrors.kernel.org/archlinux/\$repo/os/\$arch' >> /etc/pacman.d/mirrorlist
+        pacman-key --init 
+        pacman-key --populate archlinux
+        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost
+        EOF
+      displayName: 'Bootstrap Archlinux'
+    
+    - task: Cache@2
+      inputs:
+        key: mykey | mylockfile
+        restoreKeys: mykey
+        path: $(Pipeline.Workspace)/mycache
+        cacheHitVar: CACHE_RESTORED
+    
+    - bash: |
+        set -e
+        cd $(Build.BinariesDirectory)
+        cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
+        set -e
+        mkdir /home/aur
+        cd /home/aur
+        useradd aur
+        chown -R aur:aur /home/aur
+        git clone https://aur.archlinux.org/yay-git.git
+        cd yay-git
+        sudo -u aur makepkg
+        pacman -U --noconfirm  yay-*.tar.xz
+        yay -S --noconfirm lcov
+        EOF
+      displayName: 'AUR Packages'
+      condition: ne(variables.CACHE_RESTORED, 'true')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,8 +146,8 @@ jobs:
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2-trusted -o /usr/share/pacman/keyrings/msys2-trusted
         pacman-key --populate msys2
-        pacman -Sy wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
-        pacman -S mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
+        pacman -Sy --noconfirm wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
+        pacman -S --noconfirm mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF
       displayName: 'Install MinGW Engine Dependencies'
       condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,7 @@ jobs:
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
         cd enigma-dev
-        ./emake -x MinGW32 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test32.exe
+        ./emake -x MinGW32 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test32.exe CommandLine/testing/SimpleTests/clean_exit.sog/
         WINEPREFIX=/tmp/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
         EOF
       displayName: 'Engine MinGW32'
@@ -155,7 +155,7 @@ jobs:
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
         cd enigma-dev
-        ./emake -x MinGW64 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test64.exe
+        ./emake -x MinGW64 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test64.exe CommandLine/testing/SimpleTests/clean_exit.sog/
         WINEPREFIX=/tmp/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
         EOF
       displayName: 'Engine MinGW64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,6 +132,7 @@ jobs:
         cd $(Build.BinariesDirectory)
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
+        cp enigma-dev/CI/mirrorlist* /etc/pacman.d/
         echo "[multilib]
               Include = /etc/pacman.d/mirrorlist
               [mingw32]
@@ -140,6 +141,7 @@ jobs:
               Include = /etc/pacman.d/mirrorlist.mingw64
               [msys]
               Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
+        pacman-key -r 4DF3B7664CA56930 D595C9AB2C51581E 5F92EFC1A47D45A1 9F418C233E652008 BBE514E53E0D0813 DA7EF2ABAEEA755C F40D263ECA25678A
         pacman -Sy wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
         pacman -S mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,6 @@ jobs:
         pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost
         echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
         mkdir -p /home/aur/packages/done
-        cd /home/aur/packages
         useradd -G wheel aur
         chown -R aur:aur /home/aur
         EOF
@@ -106,6 +105,7 @@ jobs:
         cd $(Build.BinariesDirectory)
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
+        cd /home/aur/packages
         sudo -u aur git clone https://aur.archlinux.org/yay-git.git
         cd yay-git
         sudo -u aur makepkg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,6 +141,7 @@ jobs:
               Include = /etc/pacman.d/mirrorlist.mingw64
               [msys]
               Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
+        curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         pacman-key --populate msys2
         pacman-key --refresh-keys
         pacman -Sy wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:  # Trigger a build on every PR.
 variables:
 - template: azure-vars.yml@radialgm
 - group: Test Harness Auth
-- aur_cache_ver: 1
+- aur_cache_ver: 1.0
 
 jobs:
 - template: azure-jobs.yml@radialgm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,8 +104,8 @@ jobs:
         mkdir /home/aur
         cd /home/aur
         useradd aur
-        chown -R aur:aur /home/aur
         git clone https://aur.archlinux.org/yay-git.git
+        chown -R aur:aur /home/aur
         cd yay-git
         sudo -u aur makepkg
         pacman -U --noconfirm  yay-*.tar.xz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,9 +120,9 @@ jobs:
         cd /home/aur/packages
         sudo -u aur git clone https://aur.archlinux.org/yay-git.git
         cd yay-git
-        sudo -u aur makepkg
+        su aur -c makepkg
         pacman -U --noconfirm  yay-*.tar.xz
-        sudo -u aur yay -S --noconfirm --builddir /home/aur/packages lcov mingw-w64-gcc-bin mingw-w64-binutils-bin mingw-w64-crt-bin mingw-w64-headers-bin mingw-w64-winpthreads-bin
+        su aur -c 'yay -S --noconfirm --builddir /home/aur/packages lcov mingw-w64-gcc-bin mingw-w64-binutils-bin mingw-w64-crt-bin mingw-w64-headers-bin mingw-w64-winpthreads-bin'
         find /home/aur/packages/ -iname '*.pkg.tar.xz' -exec mv '{}' /home/aur/packages/done \;
         chmod -R 775 /home/aur/packages/done
         EOF

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,6 @@ jobs:
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2-trusted -o /usr/share/pacman/keyrings/msys2-trusted
         pacman-key --populate msys2
-        pacman-key --refresh-keys
         pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         EOF
       displayName: 'Bootstrap Archlinux'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ jobs:
         set -e
         cd enigma-dev
         ./emake -x MinGW32 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test32.exe
-        WINEPREFIX=~/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
+        WINEPREFIX=.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
         EOF
       displayName: 'Engine MinGW32'
       
@@ -156,6 +156,6 @@ jobs:
         set -e
         cd enigma-dev
         ./emake -x MinGW64 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test64.exe
-        WINEPREFIX=~/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
+        WINEPREFIX=.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
         EOF
       displayName: 'Engine MinGW64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,7 @@ jobs:
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
         cd /home/aur/packages
-        sudo -u aur git clone https://aur.archlinux.org/yay-git.git
+        su aur -c 'git clone https://aur.archlinux.org/yay-git.git'
         cd yay-git
         su aur -c makepkg
         pacman -U --noconfirm  yay-*.tar.xz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,6 +99,7 @@ jobs:
         [msys]
         Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
+        curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2-trusted -o /usr/share/pacman/keyrings/msys2-trusted
         pacman-key --populate msys2
         pacman-key --refresh-keys
         pacman -Syuu --verbose --debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,7 @@ jobs:
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
         cp enigma-dev/CI/mirrorlist* /etc/pacman.d/
+        cp enigma-dev/CI/asound.conf /etc/asound.conf
         echo "[multilib]
               Include = /etc/pacman.d/mirrorlist
               [mingw32]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,6 @@ jobs:
         echo 'Server = https://mirrors.kernel.org/archlinux/\$repo/os/\$arch' >> /etc/pacman.d/mirrorlist
         pacman-key --init 
         pacman-key --populate archlinux
-        #pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
         mkdir -p /home/aur/packages/done
         useradd -G wheel aur
@@ -101,7 +100,8 @@ jobs:
         Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         pacman-key --populate msys2
-        pacman -Sy
+        pacman-key --refresh-keys
+        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         EOF
       displayName: 'Bootstrap Archlinux'
     
@@ -144,18 +144,6 @@ jobs:
         cd $(Build.BinariesDirectory)
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
-        cp enigma-dev/CI/mirrorlist* /etc/pacman.d/
-        echo "[multilib]
-              Include = /etc/pacman.d/mirrorlist
-              [mingw32]
-              Include = /etc/pacman.d/mirrorlist.mingw32
-              [mingw64]
-              Include = /etc/pacman.d/mirrorlist.mingw64
-              [msys]
-              Include = /etc/pacman.d/mirrorlist.msys"  >> /etc/pacman.conf
-        curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
-        pacman-key --populate msys2
-        pacman-key --refresh-keys
         pacman -S wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
         pacman -S mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,11 +85,12 @@ jobs:
         echo 'Server = https://mirrors.kernel.org/archlinux/\$repo/os/\$arch' >> /etc/pacman.d/mirrorlist
         pacman-key --init 
         pacman-key --populate archlinux
-        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
+        #pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
         mkdir -p /home/aur/packages/done
         useradd -G wheel aur
         chown -R aur:aur /home/aur
+        cp enigma-dev/CI/mirrorlist* /etc/pacman.d/
         echo "[multilib]
         Include = /etc/pacman.d/mirrorlist
         [mingw32]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:  # Trigger a build on every PR.
 variables:
 - template: azure-vars.yml@radialgm
 - group: Test Harness Auth
-- aur_cache_ver: "1.0"
+- aur_cache_ver: "v1.0.0"
 
 jobs:
 - template: azure-jobs.yml@radialgm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ jobs:
         set -e
         cd enigma-dev
         ./emake -x MinGW32 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test32.exe
-        WINEPREFIX=.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
+        WINEPREFIX=/tmp/.wine32 WINEARCH=win32 xvfb-run wine /tmp/test32.exe
         EOF
       displayName: 'Engine MinGW32'
       
@@ -156,6 +156,6 @@ jobs:
         set -e
         cd enigma-dev
         ./emake -x MinGW64 -p Win32 -w Win32 -a DirectSound -e DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,ExternalFuncs -o /tmp/test64.exe
-        WINEPREFIX=.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
+        WINEPREFIX=/tmp/.wine64 WINEARCH=win64 xvfb-run wine /tmp/test64.exe
         EOF
       displayName: 'Engine MinGW64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2-trusted -o /usr/share/pacman/keyrings/msys2-trusted
         pacman-key --populate msys2
-        pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
+        pacman -Syu --noconfirm core/base core/base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost xorg-server-xvfb
         EOF
       displayName: 'Bootstrap Archlinux'
     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,14 +86,19 @@ jobs:
         pacman-key --init 
         pacman-key --populate archlinux
         pacman -Syu --noconfirm base base-devel sudo go git protobuf yaml-cpp pugixml rapidjson boost
+        echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+        mkdir -p /home/aur/packages/done
+        cd /home/aur/packages
+        useradd -G wheel aur
+        chown -R aur:aur /home/aur
         EOF
       displayName: 'Bootstrap Archlinux'
     
     - task: Cache@2
       inputs:
-        key: mykey | mylockfile
-        restoreKeys: mykey
-        path: $(Pipeline.Workspace)/mycache
+        key: change_me_to_update_aur| "$(Agent.OS)"
+        restoreKeys: change_me_to_update_aur
+        path: $(Build.BinariesDirectory)/root.x86_64/home/aur/packages/done
         cacheHitVar: CACHE_RESTORED
     
     - bash: |
@@ -101,16 +106,12 @@ jobs:
         cd $(Build.BinariesDirectory)
         cat << EOF | sudo ./root.x86_64/bin/arch-chroot ./root.x86_64/
         set -e
-        echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-        mkdir /home/aur
-        cd /home/aur
-        useradd -G wheel aur
-        git clone https://aur.archlinux.org/yay-git.git
-        chown -R aur:aur /home/aur
+        sudo -u aur git clone https://aur.archlinux.org/yay-git.git
         cd yay-git
         sudo -u aur makepkg
         pacman -U --noconfirm  yay-*.tar.xz
-        sudo -u aur yay -S --noconfirm lcov
+        sudo -u aur yay -S --noconfirm --builddir /home/aur/packages lcov mingw-w64-gcc-bin mingw-w64-binutils-bin mingw-w64-crt-bin mingw-w64-headers-bin mingw-w64-winpthreads-bin
+        find /home/aur/packages/ -iname '*.pkg.tar.xz' -exec mv '{}' /home/aur/packages/done \;
         EOF
       displayName: 'AUR Packages'
       condition: ne(variables.CACHE_RESTORED, 'true')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2.gpg -o /usr/share/pacman/keyrings/msys2.gpg
         curl https://raw.githubusercontent.com/msys2/msys2-ci-base/master/usr/share/pacman/keyrings/msys2-trusted -o /usr/share/pacman/keyrings/msys2-trusted
         pacman-key --populate msys2
-        pacman -Sy --noconfirm wine mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
+        pacman -Sy --noconfirm wine pulseaudio lib32-libpulse mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-zlib mingw-w64-x86_64-libffi mingw-w64-x86_64-box2d mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-alure mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkg-config
         pacman -S --noconfirm mingw-w64-i686-openal mingw-w64-i686-dumb mingw-w64-i686-libvorbis mingw-w64-i686-libogg mingw-w64-i686-flac mingw-w64-i686-mpg123 mingw-w64-i686-libsndfile mingw-w64-i686-zlib mingw-w64-i686-libffi mingw-w64-i686-box2d mingw-w64-i686-glew mingw-w64-i686-glm mingw-w64-i686-alure mingw-w64-i686-SDL2 mingw-w64-i686-pkg-config
         EOF
       displayName: 'Install MinGW Engine Dependencies'


### PR DESCRIPTION
Moves mingw cross compile jobs to azure / arch because mingw on ubuntu is too old for std::filesystem and I can't find a ppa to upgrade it