### PR TITLE
Fix Fullscreen on Linux w/ Certain WM's

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -567,15 +567,16 @@ void window_set_fullscreen(bool full) {
       window_set_rectangle(tmpX, tmpY, tmpWidth, tmpHeight);
     }
   } else {
-    prefer_sizeable = enigma::isSizeable;
     if (full) {
       tmpX = enigma::windowX;
       tmpY = enigma::windowY;
       tmpWidth = enigma::windowWidth;
       tmpHeight = enigma::windowHeight;
+      prefer_sizeable = enigma::isSizeable;
       window_set_fullscreen_helper(full);
     } else {
       window_set_fullscreen_helper(full);
+      prefer_sizeable = enigma::isSizeable;
       window_set_rectangle(tmpX, tmpY, tmpWidth, tmpHeight);
     }
   }

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -517,15 +517,7 @@ void window_set_rectangle(int x, int y, int w, int h) {
 // FULLSCREEN //
 ////////////////
 
-namespace {
-
-bool prefer_sizeable = enigma::isSizeable;
-int tmpX = enigma::windowX;
-int tmpY = enigma::windowY;
-unsigned tmpWidth = enigma::windowWidth;
-unsigned tmpHeight = enigma::windowHeight;
-
-void window_set_fullscreen_helper(bool full) {
+void window_set_fullscreen(bool full) {
   if (enigma::isFullScreen == full && !full) return;
   enigma::isFullScreen = full;
   if (full) {
@@ -546,40 +538,6 @@ void window_set_fullscreen_helper(bool full) {
   xev.xclient.data.l[2] = 0;
   XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
   if (!full) XResizeWindow(disp, win, tmpSize::tmpW, tmpSize::tmpH);
-}
-
-} // anonymous namespace
-
-void window_set_fullscreen(bool full) {
-  if (!prefer_sizeable) {
-    if (full) {
-      tmpX = enigma::windowX;
-      tmpY = enigma::windowY;
-      tmpWidth = enigma::windowWidth;
-      tmpHeight = enigma::windowHeight;
-      prefer_sizeable = enigma::isSizeable;
-      window_set_sizeable(true);
-      window_set_fullscreen_helper(full);
-    } else {
-      window_set_fullscreen_helper(full);
-      window_set_sizeable(false);
-      prefer_sizeable = enigma::isSizeable;
-      window_set_rectangle(tmpX, tmpY, tmpWidth, tmpHeight);
-    }
-  } else {
-    if (full) {
-      tmpX = enigma::windowX;
-      tmpY = enigma::windowY;
-      tmpWidth = enigma::windowWidth;
-      tmpHeight = enigma::windowHeight;
-      prefer_sizeable = enigma::isSizeable;
-      window_set_fullscreen_helper(full);
-    } else {
-      window_set_fullscreen_helper(full);
-      prefer_sizeable = enigma::isSizeable;
-      window_set_rectangle(tmpX, tmpY, tmpWidth, tmpHeight);
-    }
-  }
 }
 
 bool window_get_fullscreen() {

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -517,9 +517,11 @@ void window_set_rectangle(int x, int y, int w, int h) {
 // FULLSCREEN //
 ////////////////
 
+// only use these booleans in
+// window_set_fullscreen(full)
+static bool prefer_sizeable = false;
+static bool initial_fullscreen = true;
 void window_set_fullscreen(bool full) {
-  bool prefer_sizeable = false;
-  bool initial_fullscreen = true;
   if (enigma::isFullScreen != full && full) {
     window_set_size(enigma::windowWidth, enigma::windowHeight);
     if (initial_fullscreen) {

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -542,16 +542,18 @@ static inline void window_set_fullscreen_helper(bool full) {
 
 static bool prefer_sizeable = enigma::isSizeable;
 void window_set_fullscreen(bool full) {
-  prefer_sizeable = enigma::isSizeable;
   if (!prefer_sizeable) {
     if (full) {
+      prefer_sizeable = enigma::isSizeable;
       window_set_sizeable(true);
       window_set_fullscreen_helper(full);
     } else {
       window_set_fullscreen_helper(full);
       window_set_sizeable(false);
+      prefer_sizeable = enigma::isSizeable;
     }
   } else {
+    prefer_sizeable = enigma::isSizeable;
     window_set_fullscreen_helper(full);
   }
 }

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -517,12 +517,15 @@ void window_set_rectangle(int x, int y, int w, int h) {
 // FULLSCREEN //
 ////////////////
 
+static bool prefer_sizeable = enigma::isSizeable;
 void window_set_fullscreen(bool full) {
   if (enigma::isFullScreen == full && !full) return;
   enigma::isFullScreen = full;
   if (full) {
+    prefer_sizeable = enigma::isSizeable;
     tmpSize::tmpW = enigma::windowWidth;
     tmpSize::tmpH = enigma::windowHeight;
+    window_set_sizeable(true);
   }
   Atom wmState = XInternAtom(disp, "_NET_WM_STATE", False);
   Atom aFullScreen = XInternAtom(disp, "_NET_WM_STATE_FULLSCREEN", False);
@@ -537,7 +540,10 @@ void window_set_fullscreen(bool full) {
   xev.xclient.data.l[1] = aFullScreen;
   xev.xclient.data.l[2] = 0;
   XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
-  if (!full) XResizeWindow(disp, win, tmpSize::tmpW, tmpSize::tmpH);
+  if (!full) {
+    window_set_size(tmpSize::tmpW, tmpSize::tmpH);
+    window_set_sizeable(prefer_sizeable);
+  }
 }
 
 bool window_get_fullscreen() {

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -540,11 +540,17 @@ static inline void window_set_fullscreen_helper(bool full) {
   if (!full) XResizeWindow(disp, win, tmpSize::tmpW, tmpSize::tmpH);
 }
 
+static bool prefer_sizeable = enigma::isSizeable;
 void window_set_fullscreen(bool full) {
-  if (!enigma::isSizeable) {
-    window_set_sizeable(true);
-    window_set_fullscreen_helper(full);
-    window_set_sizeable(false);
+  prefer_sizeable = enigma::isSizeable;
+  if (!prefer_sizeable) {
+    if (full) {
+      window_set_sizeable(true);
+      window_set_fullscreen_helper(full);
+    } else {
+      window_set_fullscreen_helper(full);
+      window_set_sizeable(false);
+    }
   } else {
     window_set_fullscreen_helper(full);
   }

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -517,9 +517,9 @@ void window_set_rectangle(int x, int y, int w, int h) {
 // FULLSCREEN //
 ////////////////
 
-static bool prefer_sizeable = false;
-static bool initial_fullscreen = true;
 void window_set_fullscreen(bool full) {
+  bool prefer_sizeable = false;
+  bool initial_fullscreen = true;
   if (enigma::isFullScreen != full && full) {
     window_set_size(enigma::windowWidth, enigma::windowHeight);
     if (initial_fullscreen) {

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -517,11 +517,9 @@ void window_set_rectangle(int x, int y, int w, int h) {
 // FULLSCREEN //
 ////////////////
 
-// only use these booleans in
-// window_set_fullscreen(full)
-static bool prefer_sizeable = false;
-static bool initial_fullscreen = true;
 void window_set_fullscreen(bool full) {
+  static bool prefer_sizeable = false;
+  static bool initial_fullscreen = true;
   if (enigma::isFullScreen != full && full) {
     window_set_size(enigma::windowWidth, enigma::windowHeight);
     if (initial_fullscreen) {

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -517,7 +517,15 @@ void window_set_rectangle(int x, int y, int w, int h) {
 // FULLSCREEN //
 ////////////////
 
-static inline void window_set_fullscreen_helper(bool full) {
+namespace {
+
+bool prefer_sizeable = enigma::isSizeable;
+int tmpX = enigma::windowX;
+int tmpY = enigma::windowY;
+unsigned tmpWidth = enigma::windowWidth;
+unsigned tmpHeight = enigma::windowHeight;
+
+void window_set_fullscreen_helper(bool full) {
   if (enigma::isFullScreen == full && !full) return;
   enigma::isFullScreen = full;
   if (full) {
@@ -539,14 +547,6 @@ static inline void window_set_fullscreen_helper(bool full) {
   XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
   if (!full) XResizeWindow(disp, win, tmpSize::tmpW, tmpSize::tmpH);
 }
-
-namespace {
-
-bool prefer_sizeable = enigma::isSizeable;
-int tmpX = enigma::windowX;
-int tmpY = enigma::windowY;
-unsigned tmpWidth = enigma::windowWidth;
-unsigned tmpHeight = enigma::windowHeight;
 
 } // anonymous namespace
 

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -540,10 +540,23 @@ static inline void window_set_fullscreen_helper(bool full) {
   if (!full) XResizeWindow(disp, win, tmpSize::tmpW, tmpSize::tmpH);
 }
 
-static bool prefer_sizeable = enigma::isSizeable;
+namespace {
+
+bool prefer_sizeable = enigma::isSizeable;
+int tmpX = enigma::windowX;
+int tmpY = enigma::windowY;
+unsigned tmpWidth = enigma::windowWidth;
+unsigned tmpHeight = enigma::windowHeight;
+
+} // anonymous namespace
+
 void window_set_fullscreen(bool full) {
   if (!prefer_sizeable) {
     if (full) {
+      tmpX = enigma::windowX;
+      tmpY = enigma::windowY;
+      tmpWidth = enigma::windowWidth;
+      tmpHeight = enigma::windowHeight;
       prefer_sizeable = enigma::isSizeable;
       window_set_sizeable(true);
       window_set_fullscreen_helper(full);
@@ -551,10 +564,20 @@ void window_set_fullscreen(bool full) {
       window_set_fullscreen_helper(full);
       window_set_sizeable(false);
       prefer_sizeable = enigma::isSizeable;
+      window_set_rectangle(tmpX, tmpY, tmpWidth, tmpHeight);
     }
   } else {
     prefer_sizeable = enigma::isSizeable;
-    window_set_fullscreen_helper(full);
+    if (full) {
+      tmpX = enigma::windowX;
+      tmpY = enigma::windowY;
+      tmpWidth = enigma::windowWidth;
+      tmpHeight = enigma::windowHeight;
+      window_set_fullscreen_helper(full);
+    } else {
+      window_set_fullscreen_helper(full);
+      window_set_rectangle(tmpX, tmpY, tmpWidth, tmpHeight);
+    }
   }
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -517,7 +517,7 @@ void window_set_rectangle(int x, int y, int w, int h) {
 // FULLSCREEN //
 ////////////////
 
-void window_set_fullscreen(bool full) {
+static inline void window_set_fullscreen_helper(bool full) {
   if (enigma::isFullScreen == full && !full) return;
   enigma::isFullScreen = full;
   if (full) {
@@ -538,6 +538,16 @@ void window_set_fullscreen(bool full) {
   xev.xclient.data.l[2] = 0;
   XSendEvent(disp, DefaultRootWindow(disp), False, SubstructureRedirectMask | SubstructureNotifyMask, &xev);
   if (!full) XResizeWindow(disp, win, tmpSize::tmpW, tmpSize::tmpH);
+}
+
+void window_set_fullscreen(bool full) {
+  if (!enigma::isSizeable) {
+    window_set_sizeable(true);
+    window_set_fullscreen_helper(full);
+    window_set_sizeable(false);
+  } else {
+    window_set_fullscreen_helper(full);
+  }
 }
 
 bool window_get_fullscreen() {


### PR DESCRIPTION
I don't know what WM Ubuntu Budgie has but one site said Mutter, so I guess that's the one.

Anyway, I discovered Ubuntu Budgie and several other distro's have WM's that don't like fullscreen switching when the window has a fixed size, and it will prevent the game from going fullscreen. This fixes the issue.

Weird, two fullscreen bugs I found, (and fixed), on two platforms, all in one night. Sheesh.

[reproducible.zip](https://github.com/enigma-dev/enigma-dev/files/4670554/reproducible.zip)