### PR TITLE
Shader Uniform Arrays Compatibility

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/shader.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/shader.h
@@ -22,6 +22,8 @@
 #include "GLSLshader.h"
 #include "OpenGLHeaders.h"
 
+#include "Universal_System/var4.h"
+
 #include <string>
 #include <memory>
 
@@ -110,15 +112,15 @@ void glsl_uniform2fv(int location, int size, const float *value);
 void glsl_uniform3fv(int location, int size, const float *value);
 void glsl_uniform4fv(int location, int size, const float *value);
 
-void glsl_uniform1iv(int location, int size, const float *value);
-void glsl_uniform2iv(int location, int size, const float *value);
-void glsl_uniform3iv(int location, int size, const float *value);
-void glsl_uniform4iv(int location, int size, const float *value);
+void glsl_uniform1iv(int location, int size, const int *value);
+void glsl_uniform2iv(int location, int size, const int *value);
+void glsl_uniform3iv(int location, int size, const int *value);
+void glsl_uniform4iv(int location, int size, const int *value);
 
-void glsl_uniform1uiv(int location, int size, const float *value);
-void glsl_uniform2uiv(int location, int size, const float *value);
-void glsl_uniform3uiv(int location, int size, const float *value);
-void glsl_uniform4uiv(int location, int size, const float *value);
+void glsl_uniform1uiv(int location, int size, const unsigned *value);
+void glsl_uniform2uiv(int location, int size, const unsigned *value);
+void glsl_uniform3uiv(int location, int size, const unsigned *value);
+void glsl_uniform4uiv(int location, int size, const unsigned *value);
 
 void glsl_uniform_matrix2fv(int location, int size, const float *matrix);
 void glsl_uniform_matrix3fv(int location, int size, const float *matrix);
@@ -136,6 +138,16 @@ void glsl_attribute_set(int location, int size, int type, bool normalize, int st
 #define shader_set_uniform_f  glsl_uniformf
 #define shader_set_uniform_i  glsl_uniformi
 #define shader_is_compiled    glsl_shader_get_compiled
+
+inline void shader_set_uniform_f_array(int location, const var& array) {
+  auto values = array.to_vector<float>();
+  glsl_uniform1fv(location, values.size(), values.data());
+}
+
+inline void shader_set_uniform_i_array(int location, const var& array) {
+  auto values = array.to_vector<int>();
+  glsl_uniform1iv(location, values.size(), values.data());
+}
 
 }
 


### PR DESCRIPTION
This adds the missing shader uniform array functions.
https://docs.yoyogames.com/source/dadiospice/002_reference/shaders/shader_set_uniform_f_array.html
https://docs.yoyogames.com/source/dadiospice/002_reference/shaders/shader_set_uniform_i_array.html

We already had them in our low-level GLSL API, but did not provide the GMS versions. This should resolve #1666 then. I also corrected a typo in the signature of these functions which 7a081caa7cd0cc0e78a040b86fd08a33a9043069 shows Harri did accidentally when he introduced them.