### PR TITLE
I doubt Josh will approve of this but w/e

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/ExternalFuncs/ExternalFuncs.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/ExternalFuncs/ExternalFuncs.cpp
@@ -40,6 +40,7 @@
 #include <cstdio>
 #include <map>
 #include <string>
+#include <iostream>
 
 #include <ffi.h>
 
@@ -111,7 +112,9 @@ int external_define(string dll,string func,int calltype,bool returntype,int argc
 
   if (status != FFI_OK)
   {
-    DEBUG_MESSAGE("Defining DLL failed.", MESSAGE_TYPE::M_ERROR);
+    // fundies will probably try to change this but don't let him because it will break widgets.
+    // DialogModule calls DLL's. Calling show_debug_message() in here will make ENIGMA dump out.
+    std::cout << "Defining DLL failed. | " __FILE__ ":" + std::to_string(__LINE__) << std::endl;
     return -1;
   }
 
@@ -121,20 +124,26 @@ int external_define(string dll,string func,int calltype,bool returntype,int argc
   	dllmod = enigma::ExternalLoad(dll.c_str());
   else
   {
-    DEBUG_MESSAGE("LOADING PREEXISTING HANDLE", MESSAGE_TYPE::M_WARNING);
+    // fundies will probably try to change this but don't let him because it will break widgets.
+    // DialogModule calls DLL's. Calling show_debug_message() in here will make ENIGMA dump out.
+    std::cout << "LOADING PREEXISTING HANDLE | " __FILE__ ":" + std::to_string(__LINE__) << std::endl;
     dllmod = dllHandles[dll];
   }
 
   if (dllmod == NULL)
   {
-    DEBUG_MESSAGE("Cannot load library \"" + dll + "\"", MESSAGE_TYPE::M_ERROR);
+    // fundies will probably try to change this but don't let him because it will break widgets.
+    // DialogModule calls DLL's. Calling show_debug_message() in here will make ENIGMA dump out.
+    std::cout << "Cannot load library \"" + dll + "\" | " __FILE__ ":" + std::to_string(__LINE__) << std::endl;
     return -1;
   }
 
   void *funcptr = enigma::ExternalFunc(dllmod,func.c_str());
   if (funcptr==NULL)
   {
-    DEBUG_MESSAGE("No such function" + func, MESSAGE_TYPE::M_ERROR);
+    // fundies will probably try to change this but don't let him because it will break widgets.
+    // DialogModule calls DLL's. Calling show_debug_message() in here will make ENIGMA dump out.
+    std::cout << "No such function " + func << " | " __FILE__ ":" + std::to_string(__LINE__) << std::endl;
     return -1;
   }
 
@@ -160,7 +169,9 @@ variant external_call(int id,variant a1,variant a2, variant a3, variant a4, vari
   map<int,external*>::iterator it;
   if ((it=externals.find(id)) == externals.end())
   {
-    DEBUG_MESSAGE("Unknown external function called", MESSAGE_TYPE::M_ERROR);
+    // fundies will probably try to change this but don't let him because it will break widgets.
+    // DialogModule calls DLL's. Calling show_debug_message() in here will make ENIGMA dump out.
+    std::cout << "Unknown external function called | " __FILE__ ":" + std::to_string(__LINE__) << std::endl;
     return 0;
   }
   external* a=it->second;

--- a/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
@@ -186,7 +186,7 @@ int get_color_ext(int defcol, string title) {
   return cocoa_get_color(defcol, title.c_str());
 }
 
-string message_get_caption() {
+string widget_get_caption() {
   if (dialog_caption == "") dialog_caption = cocoa_dialog_caption();
   if (error_caption == "") error_caption = "Error";
 
@@ -196,7 +196,7 @@ string message_get_caption() {
   return dialog_caption;
 }
 
-void message_set_caption(string title) {
+void widget_set_caption(string title) {
   dialog_caption = title; error_caption = title;
   if (dialog_caption == "") dialog_caption = cocoa_dialog_caption();
   if (error_caption == "") error_caption = "Error";

--- a/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/Info/About.ey
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/Info/About.ey
@@ -1,0 +1,9 @@
+%e-yaml
+---
+
+Name: Dialog Module
+Identifier: DialogModule
+Build-Platforms: Windows, MacOSX, Linux, FreeBSD, SDL
+Represents: Windows, MacOSX, Linux, FreeBSD, SDL
+Description: Requires the 'External Functions' extension enabled. Create widgets with DialogModule.dll (Windows), DialogModule.dylib (Mac), and/or DialogModule.so (Linux, FreeBSD). DialogModule.so needs to be rebuilt from source code if the library is not recognized. Download for your target architecture (x86, x64), here: https://github.com/time-killer-games/DialogModule
+Author: Samuel Venable

--- a/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/Info/widget_info.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/Info/widget_info.h
@@ -1,0 +1,5 @@
+// Informative header designed to grant superior control over platform-
+// or API-dependent behavior. This file can define any number of macros
+// describing various compatibility and feature points.
+
+#define ENIGMA_WT_DIALOGMODULE 1

--- a/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/Makefile
@@ -1,0 +1,1 @@
+SOURCES += Widget_Systems/DialogModule/dialogs.cpp

--- a/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/dialogs.cpp
@@ -1,0 +1,196 @@
+/** Copyright (C) 2020 Samuel Venable
+***
+*** This file is a part of the ENIGMA Development Environment.
+***
+*** ENIGMA is free software: you can redistribute it and/or modify it under the
+*** terms of the GNU General Public License as published by the Free Software
+*** Foundation, version 3 of the license or any later version.
+***
+*** This application and its source code is distributed AS-IS, WITHOUT ANY
+*** WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+*** FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+*** details.
+***
+*** You should have received a copy of the GNU General Public License along
+*** with this code. If not, see <http://www.gnu.org/licenses/>
+**/
+
+#include "Platforms/General/PFmain.h"
+#include "Platforms/General/PFwindow.h"
+#include "Platforms/General/PFfilemanip.h"
+#include "Platforms/General/PFexternals.h"
+#include "Widget_Systems/widgets_mandatory.h"
+#include "Widget_Systems/General/WSdialogs.h"
+#include "Universal_System/estring.h"
+#include <stdlib.h>
+#include <cstdio>
+#include <string>
+
+#ifdef DEBUG_MODE
+#include "Universal_System/Resources/resource_data.h"
+#include "Universal_System/Object_Tiers/object.h"
+#include "Universal_System/debugscope.h"
+#endif
+
+using std::string;
+
+static string dll = string("DialogModule.") + 
+#ifdef _WIN32
+"dll";
+#elif defined(__APPLE__) && defined(__MACH__)
+"dylib";
+#else
+"so";
+#endif
+
+namespace enigma {
+
+bool widget_system_initialize() {
+  dll = enigma_user::working_directory + dll;
+  string png = enigma_user::working_directory + 
+  enigma_user::filename_name(enigma_user::parameter_string(0)) + ".png";
+  enigma_user::widget_set_owner(reinterpret_cast<void *>(enigma_user::window_handle()));
+  if (enigma_user::file_exists(png)) enigma_user::widget_set_icon(png);
+  return enigma_user::file_exists(dll);
+}
+
+} // namespave enigma
+
+namespace enigma_user {
+
+  void show_info(string text, int bgcolor, int left, int top, int width, int height,
+    bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop,
+    bool pauseGame, string caption) {
+
+  }
+
+  void show_debug_message(string errortext, MESSAGE_TYPE type) {
+    #ifdef DEBUG_MODE
+    errortext += "\n\n" + enigma::debug_scope::GetErrors();
+    #endif
+    const bool fatal = (type == M_FATAL_ERROR || type == M_FATAL_USER_ERROR);
+    external_call(external_define(dll, "show_error", dll_cdecl, ty_real, 2, ty_string, ty_real), errortext, fatal);
+  }
+
+  int show_message(const string &str) {
+    return (int)external_call(external_define(dll, "show_message", dll_cdecl, ty_real, 1, ty_string), str);
+  }
+
+  int show_message_cancelable(string str) {
+    return (int)external_call(external_define(dll, "show_message_cancelable", dll_cdecl, ty_real, 1, ty_string), str);
+  }
+
+  bool show_question(string str) {
+    return (bool)external_call(external_define(dll, "show_question", dll_cdecl, ty_real, 1, ty_string), str);
+  }
+
+  int show_question_cancelable(string str) {
+    return (int)external_call(external_define(dll, "show_question_cancelable", dll_cdecl, ty_real, 1, ty_string), str);
+  }
+
+  int show_attempt(string str) {
+    return (int)external_call(external_define(dll, "show_attempt", dll_cdecl, ty_real, 1, ty_string), str);
+  }
+
+  string get_string(string str, string def) {
+    return external_call(external_define(dll, "get_string", dll_cdecl, ty_string, 2, ty_string, ty_string), str, def);
+  }
+
+  string get_password(string str, string def) {
+    return external_call(external_define(dll, "get_password", dll_cdecl, ty_string, 2, ty_string, ty_string), str, def);
+  }
+
+  double get_integer(string str, var def) {
+    double val = (strtod(def.c_str(), NULL)) ? : (double)def;
+    return (double)external_call(external_define(dll, "get_integer", dll_cdecl, ty_real, 2, ty_string, ty_real), str, val);
+  }
+
+  double get_passcode(string str, var def) {
+    double val = (strtod(def.c_str(), NULL)) ? : (double)def;
+    return (double)external_call(external_define(dll, "get_passcode", dll_cdecl, ty_real, 2, ty_string, ty_real), str, val);
+  }
+
+  string get_open_filename(string filter, string fname) {
+    return external_call(external_define(dll, "get_open_filename", dll_cdecl, ty_string, 2, ty_string, ty_string), filter, fname);
+  }
+
+  string get_open_filename_ext(string filter, string fname, string dir, string title) {
+    return external_call(external_define(dll, "get_open_filename_ext", dll_cdecl, ty_string, 4, ty_string, ty_string, ty_string, ty_string), 
+    filter, fname, dir, title);
+  }
+
+  string get_open_filenames(string filter, string fname) {
+    return external_call(external_define(dll, "get_open_filenames", dll_cdecl, ty_string, 2, ty_string, ty_string), filter, fname);
+  }
+
+  string get_open_filenames_ext(string filter, string fname, string dir, string title) {
+    return external_call(external_define(dll, "get_open_filenames_ext", dll_cdecl, ty_string, 4, ty_string, ty_string, ty_string, ty_string), 
+    filter, fname, dir, title);
+  }
+
+  string get_save_filename(string filter, string fname) {
+    return external_call(external_define(dll, "get_save_filename", dll_cdecl, ty_string, 2, ty_string, ty_string), filter, fname);
+  }
+
+  string get_save_filename_ext(string filter, string fname, string dir, string title) {
+    return external_call(external_define(dll, "get_save_filename_ext", dll_cdecl, ty_string, 4, ty_string, ty_string, ty_string, ty_string), 
+    filter, fname, dir, title);
+  }
+
+  string get_directory(string dname) {
+    return external_call(external_define(dll, "get_directory", dll_cdecl, ty_string, 1, ty_string), dname);
+  }
+
+  string get_directory_alt(string capt, string root) {
+    return external_call(external_define(dll, "get_directory_alt", dll_cdecl, ty_string, 2, ty_string, ty_string), capt, root);
+  }
+
+  int get_color(int defcol) {
+    return (int)external_call(external_define(dll, "get_color", dll_cdecl, ty_real, 1, ty_real), defcol);
+  }
+
+  int get_color_ext(int defcol, string title) {
+    return (int)external_call(external_define(dll, "get_color_ext", dll_cdecl, ty_real, 2, ty_real, ty_string), defcol, title);
+  }
+
+  string widget_get_caption() {
+    return external_call(external_define(dll, "widget_get_caption", dll_cdecl, ty_string, 0));
+  }
+
+  void widget_set_caption(string str) {
+    external_call(external_define(dll, "widget_set_caption", dll_cdecl, ty_real, 1, ty_string), str);
+  }
+
+  void *widget_get_owner() {
+    return (void *)external_call(external_define(dll, "widget_get_owner", dll_cdecl, ty_string, 0)).c_str();
+  }
+
+  void widget_set_owner(void *hwnd) {
+    external_call(external_define(dll, "widget_set_owner", dll_cdecl, ty_real, 1, ty_string), hwnd);
+  }
+
+  string widget_get_icon() {
+    return external_call(external_define(dll, "widget_get_icon", dll_cdecl, ty_string, 0));
+  }
+
+  void widget_set_icon(string icon) {
+    external_call(external_define(dll, "widget_set_icon", dll_cdecl, ty_real, 1, ty_string), icon);
+  }
+
+  string widget_get_system() {
+    return external_call(external_define(dll, "widget_get_system", dll_cdecl, ty_string, 0));
+  }
+
+  void widget_set_system(string sys) {
+    external_call(external_define(dll, "widget_set_system", dll_cdecl, ty_real, 1, ty_string), sys);
+  }
+
+  string widget_get_button_name(int type) {
+    return external_call(external_define(dll, "widget_get_button_name", dll_cdecl, ty_string, 1, ty_real), type);
+  }
+
+  void widget_set_button_name(int type, string name) {
+    external_call(external_define(dll, "widget_set_button_name", dll_cdecl, ty_real, 2, ty_real, ty_string), type, name);
+  }
+
+} // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/dialogs.cpp
@@ -65,11 +65,19 @@ namespace enigma_user {
   }
 
   void show_debug_message(string errortext, MESSAGE_TYPE type) {
+    const bool fatal = (type == M_FATAL_ERROR || type == M_FATAL_USER_ERROR);
     #ifdef DEBUG_MODE
     errortext += "\n\n" + enigma::debug_scope::GetErrors();
     #endif
-    const bool fatal = (type == M_FATAL_ERROR || type == M_FATAL_USER_ERROR);
-    external_call(external_define(dll, "show_error", dll_cdecl, ty_real, 2, ty_string, ty_real), errortext, fatal);
+    if (type != M_INFO && type != M_WARNING) {
+      external_call(external_define(dll, "show_error", dll_cdecl, ty_real, 2, ty_string, ty_real), errortext, fatal);
+    } else {
+      #ifndef DEBUG_MODE
+      errortext += "\n";
+      fputs(errortext.c_str(), stderr);
+      #endif
+      if (fatal) { abort(); }
+    }
   }
 
   int show_message(const string &str) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/include.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/DialogModule/include.h
@@ -1,0 +1,2 @@
+#include "Widget_Systems/widgets_mandatory.h"
+#include "Widget_Systems/General/WSdialogs.h"

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -98,5 +98,5 @@ enum {
 	// dumb stuff
 	inline bool action_if_question(std::string message) { return show_question(message); }
 	std::string get_login(std::string username, std::string password);
-	bool   get_std::string_canceled();
+	bool get_string_canceled();
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -68,7 +68,7 @@ enum {
 	bool show_question(std::string message);
 	int show_question_cancelable(std::string message);
 	int show_attempt(std::string errortext);
-	std::string get_std::string(std::string message, std::string def);
+	std::string get_string(std::string message, std::string def);
 	std::string get_password(std::string message, std::string def);
 	double get_integer(std::string message, var def);
 	double get_passcode(std::string message, var def);

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -61,8 +61,6 @@ enum {
 	static const std::string ws_x11_kdialog = "KDialog";
 
 	// dialog functions
-	std::string widget_get_system();
-	void widget_set_system(std::string sys);
 	int show_message_cancelable(std::string message);
 	int show_message_ext(std::string message, std::string but1, std::string but2, std::string but3);
 	bool show_question(std::string message);

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.h
@@ -18,9 +18,7 @@
 **/
 
 #include "Universal_System/var4.h"
-
 #include <string>
-using std::string;
 
 namespace enigma_user {
 
@@ -55,40 +53,52 @@ enum {
 };
 */
 
-	static string ws_win32       = "Win32";
-	static string ws_cocoa       = "Cocoa";
-	static string ws_x11_zenity  = "Zenity";
-	static string ws_x11_kdialog = "KDialog";
+	// dialog systems
+	static const std::string ws_win32       = "Win32";
+	static const std::string ws_cocoa       = "Cocoa";
+	static const std::string ws_x11         = "X11";
+	static const std::string ws_x11_zenity  = "Zenity";
+	static const std::string ws_x11_kdialog = "KDialog";
 
-	string widget_get_system();
-	void widget_set_system(string sys);
-	int show_message_cancelable(string message);
-	int show_message_ext(string message, string but1, string but2, string but3);
-	bool show_question(string message);
-	int show_question_cancelable(string message);
-	int show_attempt(string errortext);
-	string get_string(string message, string def);
-	string get_password(string message, string def);
-	double get_integer(string message, var def);
-	double get_passcode(string message, var def);
-	string get_open_filename(string filter, string fname);
-	string get_open_filenames(string filter, string fname);
-	string get_save_filename(string filter, string fname);
-	string get_open_filename_ext(string filter, string fname, string dir, string title);
-	string get_open_filenames_ext(string filter, string fname, string dir, string title);
-	string get_save_filename_ext(string filter, string fname, string dir, string title);
-	string get_directory(string dname);
-	string get_directory_alt(string capt, string root);
+	// dialog functions
+	std::string widget_get_system();
+	void widget_set_system(std::string sys);
+	int show_message_cancelable(std::string message);
+	int show_message_ext(std::string message, std::string but1, std::string but2, std::string but3);
+	bool show_question(std::string message);
+	int show_question_cancelable(std::string message);
+	int show_attempt(std::string errortext);
+	std::string get_std::string(std::string message, std::string def);
+	std::string get_password(std::string message, std::string def);
+	double get_integer(std::string message, var def);
+	double get_passcode(std::string message, var def);
+	std::string get_open_filename(std::string filter, std::string fname);
+	std::string get_open_filenames(std::string filter, std::string fname);
+	std::string get_save_filename(std::string filter, std::string fname);
+	std::string get_open_filename_ext(std::string filter, std::string fname, std::string dir, std::string title);
+	std::string get_open_filenames_ext(std::string filter, std::string fname, std::string dir, std::string title);
+	std::string get_save_filename_ext(std::string filter, std::string fname, std::string dir, std::string title);
+	std::string get_directory(std::string dname);
+	std::string get_directory_alt(std::string capt, std::string root);
 	int get_color(int defcol);
-	int get_color_ext(int defcol, string title);
-	string message_get_caption();
-	void message_set_caption(string title);
+	int get_color_ext(int defcol, std::string title);
 	
-	inline bool action_if_question(string message)
-	{
-		return show_question(message);
-	}
+	// dialog settings
+	std::string widget_get_caption();
+	void widget_set_caption(std::string title);
+	std::string widget_get_caption();
+	void widget_set_caption(std::string str);
+	void *widget_get_owner();
+	void widget_set_owner(void *hwnd);
+	std::string widget_get_icon();
+	void widget_set_icon(std::string icon);
+	std::string widget_get_system();
+	void widget_set_system(std::string sys);
+	std::string widget_get_button_name(int type);
+	void widget_set_button_name(int type, std::string name);
 	
-	string get_login(string username, string password);
-	bool   get_string_canceled();
+	// dumb stuff
+	inline bool action_if_question(std::string message) { return show_question(message); }
+	std::string get_login(std::string username, std::string password);
+	bool   get_std::string_canceled();
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -889,7 +889,7 @@ string get_directory_alt(string capt, string root) {
   return get_directory_helper(root, capt);
 }
 
-string message_get_caption() {
+string widget_get_caption() {
   if (dialog_caption.empty()) {
     wchar_t wstrWindowCaption[512];
     GetWindowTextW(enigma::hWnd, wstrWindowCaption, 512);
@@ -903,7 +903,7 @@ string message_get_caption() {
   return shorten(dialog_caption);
 }
 
-void message_set_caption(string title) {
+void widget_set_caption(string title) {
   if (!title.empty()) dialog_caption = widen(title);
   else dialog_caption = L"";
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -140,11 +140,11 @@ int get_color_ext(int defcol, string title) {
   return enigma::current_widget_engine->get_color_ext(defcol, title);
 }
 
-string message_get_caption() {
+string widget_get_caption() {
   return enigma::current_widget_engine->message_get_caption();
 }
 
-void message_set_caption(string title) {
+void widget_set_caption(string title) {
   enigma::current_widget_engine->message_set_caption(title);
 }
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -141,11 +141,11 @@ int get_color_ext(int defcol, string title) {
 }
 
 string widget_get_caption() {
-  return enigma::current_widget_engine->message_get_caption();
+  return enigma::current_widget_engine->widget_get_caption();
 }
 
 void widget_set_caption(string title) {
-  enigma::current_widget_engine->message_set_caption(title);
+  enigma::current_widget_engine->widget_set_caption(title);
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -539,14 +539,14 @@ int get_color_ext(int defcol, string title) override {
   return make_color_rgb(red, green, blue);
 }
 
-string message_get_caption() override {
+string widget_get_caption() override {
   if (dialog_caption.empty()) dialog_caption = window_get_caption();
   if (error_caption.empty()) error_caption = "Error";
   if (dialog_caption == window_get_caption() && error_caption == "Error")
     return ""; else return dialog_caption;
 }
 
-void message_set_caption(string title) override {
+void widget_set_caption(string title) override {
   dialog_caption = title; error_caption = title;
   if (dialog_caption.empty()) dialog_caption = window_get_caption();
   if (error_caption.empty()) error_caption = "Error";

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -501,14 +501,14 @@ int get_color_ext(int defcol, string title) override {
   return make_color_rgb(red, green, blue);
 }
 
-string message_get_caption() override {
+string widget_get_caption() override {
   if (dialog_caption.empty()) dialog_caption = window_get_caption();
   if (error_caption.empty()) error_caption = "Error";
   if (dialog_caption == window_get_caption() && error_caption == "Error")
     return ""; else return dialog_caption;
 }
 
-void message_set_caption(string title) override {
+void widget_set_caption(string title) override {
   dialog_caption = title; error_caption = title;
   if (dialog_caption.empty()) dialog_caption = window_get_caption();
   if (error_caption.empty()) error_caption = "Error";


### PR DESCRIPTION
I'm tired of maintaining two different copies of this code, one for enigma, and one for the game maker extension. For now on, if anyone wants to have access to the latest features of dialog module, they will need to download my dll, install libffi, and enable external functions with this widget system selected from the dropdown. The other widget systems will still get bug fixes, but I want all my focus to be on updating the dll so both enigma and gamemaker users can use something equally up-to-date at any given time. I spend way too much time messing with dialogs, this will cut down the need for maintenance by at least a third. Because only the dll will be getting new bells and whistles whenever I choose to do that; not the other systems. If I had my way, all our widget systems would be deleted except this one. (Can I *please* do this?)

Josh thinks using a dll is a dumb idea, but guess what? ENIGMA uses DLL's already, a crap ton of them, or at least on linux and bsd. Windows and mac are statically linked, but they are still third-party dependencies nonetheless. I don't see how this is any different, to be honest...

This will also enable me to make new changes to the library without even needing to make a new enigma pull request - as in this way the changes i can make in my own repository.

GameMaker extensions that call DLL's without using scripts will fail silently if the dll is not found. I figured since YoYo is doing this, and since I need this to happen for these changes, I see no harm in it just being printed instead, after all, fundies said, "terminal printing is better than GUI".

```
git clone -b patch-54 https://github.com/time-killer-games/enigma-dev-fork.git ~/enigma-dev
git clone https://github.com/time-killer-games/DialogModule.git # for building from source.
```
Example GM81 Project + Required Library: [DialogModule.zip](https://github.com/enigma-dev/enigma-dev/files/4778500/DialogModule.zip)
