### PR TITLE
Fix Execute Shell for Output Freeze

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -63,6 +63,7 @@ void execute_shell(string fname, string args) {
 }
 
 string execute_shell_for_output(const string &command) {
+  string output;
   tstring tstr_command = widen(command);
   wchar_t ctstr_command[32768];
   wcsncpy(ctstr_command, tstr_command.c_str(), 32768);
@@ -108,7 +109,7 @@ string execute_shell_for_output(const string &command) {
     CloseHandle(hStdInPipeWrite);
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
-    return buffer;
+    return output;
   }
   return "";
 }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -89,8 +89,8 @@ string execute_shell_for_output(const string &command) {
     CloseHandle(pi.hThread);
     CloseHandle(hStdOutPipeWrite);
     CloseHandle(hStdInPipeRead);
-    char buffer[BUFSIZ];
     for (;;) {
+      char buffer[BUFSIZ];
       DWORD dwRead = 0;
       BOOL success = ReadFile(hStdOutPipeRead, buffer, BUFSIZ, &dwRead, NULL);
       if (success || dwRead) {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -84,8 +84,6 @@ string execute_shell_for_output(const string &command) {
   si.hStdOutput = hStdOutPipeWrite;
   si.hStdInput = hStdInPipeRead;
   PROCESS_INFORMATION pi = { 0 };
-  DWORD dwRead = 0;
-  DWORD dwAvail = 0;
   if (CreateProcessW(NULL, ctstr_command, NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -86,21 +86,21 @@ string execute_shell_for_output(const string &command) {
   PROCESS_INFORMATION pi = { };
   if (CreateProcessW(NULL, ctstr_command, NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
     while (WaitForSingleObject(pi.hProcess, 5) == WAIT_TIMEOUT) {
-      MSG msg;
-      if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
-      }
       DWORD dwRead = 0;
       DWORD dwAvail = 0;
       PeekNamedPipe(hStdOutPipeRead, NULL, 0, NULL, &dwAvail, NULL);
       if (dwAvail) {
-        char buffer[dwAvail];
-        BOOL success = ReadFile(hStdOutPipeRead, buffer, dwAvail, &dwRead, NULL);
+        vector<char> buffer(dwAvail);
+        BOOL success = ReadFile(hStdOutPipeRead, &buffer[0], dwAvail, &dwRead, NULL);
         if (success || dwRead) {
           buffer[dwAvail] = 0;
-          output.append(buffer, dwAvail);
+          output.append(buffer.data(), dwAvail);
         }
+      }
+      MSG msg;
+      if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
       }
     }
     CloseHandle(hStdOutPipeWrite);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -86,7 +86,7 @@ string execute_shell_for_output(const string &command) {
   PROCESS_INFORMATION pi = { 0 };
   DWORD dwRead = 0;
   DWORD dwAvail = 0;
-  if (CreateProcessW(NULL, cwstr_command, NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
+  if (CreateProcessW(NULL, ctstr_command, NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
     CloseHandle(hStdOutPipeWrite);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -90,9 +90,8 @@ string execute_shell_for_output(const string &command) {
     CloseHandle(hStdOutPipeWrite);
     CloseHandle(hStdInPipeRead);
     char buffer[BUFSIZ];
-    BOOL success = TRUE;
-    DWORD dwRead = 0;
     for (;;) {
+      DWORD dwRead = 0;
       BOOL success = ReadFile(hStdOutPipeRead, buffer, BUFSIZ, &dwRead, NULL);
       if (success || dwRead) {
         buffer[dwRead] = 0;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -99,7 +99,6 @@ string execute_shell_for_output(const string &command) {
       if (success || dwRead) {
         buffer[dwRead] = 0;
         output.append(buffer, dwRead);
-        buffer[0] = 0;
       } else { break; }
     }
     CloseHandle(hStdOutPipeRead);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -90,21 +90,25 @@ string execute_shell_for_output(const string &command) {
         TranslateMessage(&msg);
         DispatchMessage(&msg);
       }
+      DWORD dwRead = 0;
+      DWORD dwAvail = 0;
+      PeekNamedPipe(hStdOutPipeRead, NULL, 0, NULL, &dwAvail, NULL);
+      if (dwAvail) {
+        char buffer[dwAvail];
+        BOOL success = ReadFile(hStdOutPipeRead, buffer, dwAvail, &dwRead, NULL);
+        if (success || dwRead) {
+          buffer[dwAvail] = 0;
+          output.append(buffer, dwAvail);
+        }
+      }
     }
     CloseHandle(hStdOutPipeWrite);
     CloseHandle(hStdInPipeRead);
-    char buffer[4096] = { };
-    DWORD dwRead = 0;
-    ok = ReadFile(hStdOutPipeRead, buffer, 4095, &dwRead, NULL);
-    while (ok == TRUE) {
-      buffer[dwRead] = 0;
-      ok = ReadFile(hStdOutPipeRead, buffer, 4095, &dwRead, NULL);
-    }
     CloseHandle(hStdOutPipeRead);
     CloseHandle(hStdInPipeWrite);
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
-    return shorten(widen(buffer));
+    return buffer;
   }
   return "";
 }


### PR DESCRIPTION
fixes a problem where execute_shell_for_output would hang the executed program whenever the output buffer exceeds 4096 characters.