### PR TITLE
Execute Program Wait Optimization

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -49,7 +49,7 @@ void execute_program(string fname, string args, bool wait) {
     while (DWORD eventSignalId = MsgWaitForMultipleObjects(1, &lpExecInfo.hProcess, false, INFINITE, QS_ALLEVENTS)) {
       if (eventSignalId == WAIT_OBJECT_0) break;
       MSG msg;
-      if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+      while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
         TranslateMessage(&msg);
         DispatchMessage(&msg);
       }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSshell.cpp
@@ -46,7 +46,8 @@ void execute_program(string fname, string args, bool wait) {
   lpExecInfo.hInstApp = (HINSTANCE)SE_ERR_DDEFAIL;
   ShellExecuteExW(&lpExecInfo);
   if (wait && lpExecInfo.hProcess != NULL) {
-    while (WaitForSingleObject(lpExecInfo.hProcess, 5) == WAIT_TIMEOUT) {
+    while (DWORD eventSignalId = MsgWaitForMultipleObjects(1, &lpExecInfo.hProcess, false, INFINITE, QS_ALLEVENTS)) {
+      if (eventSignalId == WAIT_OBJECT_0) break;
       MSG msg;
       if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
         TranslateMessage(&msg);


### PR DESCRIPTION
This should hypothetically improve efficiency in `execute_program` when the wait parameter is true and a long-running process is executing. The problem with the old method was that it was only waking up every 5 milliseconds or when the process exited. This changes it to wake up when the process exits or when a message is received.