### PR TITLE
DirectSound Initialization Retry

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -82,10 +82,9 @@ int audiosystem_initialize() {
   DSBUFFERDESC bufferDesc;
 
   // Initialize the direct sound interface pointer for the default sound device.
-  result = DirectSoundCreate8(NULL, &dsound, NULL);
-  if (FAILED(result)) {
+  // Allow the user to retry until a device is created.
+  while (FAILED(result = DirectSoundCreate8(NULL, &dsound, NULL))) {
     DEBUG_MESSAGE("Failed to create DirectSound8 object.", MESSAGE_TYPE::M_ERROR);
-    return false;
   }
 
   // Set the cooperative level to priority so the format of the primary sound buffer can be modified.


### PR DESCRIPTION
This solves #1770 the same way GM8.1 solves it, by displaying the error message in a loop that actually allows the user to retry. I tested it by simulating unplugging of my speakers by disabling the device in Device Manager. Sure enough, the dialog now correctly allows the user to abort or retry after the error occurs. If I enable my sound device after the error and retry, the game correctly starts and plays sound. Interestingly enough, once an application/process takes control over the sound device, there's no way to disable it in Device Manager short of physically removing the sound device (not possible?).

@time-killer-games what do you say about this one?