### PR TITLE
Add Directory Destroy Alias

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFfilemanip.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFfilemanip.h
@@ -42,7 +42,7 @@ int file_copy(std::string fname,std::string newname);
 int directory_exists(std::string dname);
 int directory_create(std::string dname);
 int directory_delete(std::string dname);
-int inline directory_destroy(std::string dname) { return directory_delete(dname); }
+inline int directory_destroy(std::string dname) { return directory_delete(dname); }
 
 std::string file_find_next();
 void file_find_close();

--- a/ENIGMAsystem/SHELL/Platforms/General/PFfilemanip.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFfilemanip.h
@@ -42,6 +42,7 @@ int file_copy(std::string fname,std::string newname);
 int directory_exists(std::string dname);
 int directory_create(std::string dname);
 int directory_delete(std::string dname);
+int inline directory_destroy(std::string dname) { return directory_delete(dname); }
 
 std::string file_find_next();
 void file_find_close();


### PR DESCRIPTION
Alternative to #2032 to resolve #1953.

One of the advantages to aliasing functions like this is it enables JDI to pickup the full signature of the function for syntax highlighting and auto completion. Unlike using a define, we won't later have to program JDI to fully pick up the signature of the function.