### PR TITLE
Show Debug Message Cleanup

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/terminal_io.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/terminal_io.cpp
@@ -32,7 +32,6 @@ namespace enigma_user {
 
 void cons_show_message(string message) { puts(message.c_str()); }
 void cons_print_overwritable(string message) { printf("%s\r", message.c_str()); }
-void show_debug_message(string message) { debug_message(message); }
 char cons_get_byte() {
   int c, first;
   first = c = getchar();

--- a/ENIGMAsystem/SHELL/Universal_System/terminal_io.h
+++ b/ENIGMAsystem/SHELL/Universal_System/terminal_io.h
@@ -33,7 +33,6 @@
 namespace enigma_user {
 void cons_show_message(std::string message);
 void cons_print_overwritable(std::string message);
-void show_debug_message(std::string message);
 char cons_get_byte();
 std::string cons_get_char();
 std::string cons_get_string();

--- a/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/Makefile
@@ -1,3 +1,3 @@
-SOURCES += Widget_Systems/Cocoa/dialogs.cpp
+SOURCES += Widget_Systems/Cocoa/dialogs.cpp Widget_Systems/General/WSdialogs.cpp
 SOURCES += Widget_Systems/Cocoa/dialogs.m
 LDLIBS += -lz -framework Cocoa

--- a/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Cocoa/dialogs.cpp
@@ -53,7 +53,7 @@ extern "C" int cocoa_get_color(int defcol, const char *title);
 static string dialog_caption;
 static string error_caption;
 
-static inline void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
+void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
   #ifdef DEBUG_MODE
   errortext += "\n\n" + enigma::debug_scope::GetErrors();
   #endif
@@ -73,20 +73,6 @@ string widget_get_system() {
 
 void widget_set_system(string sys) {
   // place holder
-}
-
-void show_debug_message(string errortext, MESSAGE_TYPE type) {
-  if (type != M_INFO && type != M_WARNING) {
-    show_debug_message_helper(errortext, type);
-  } else {
-    #ifndef DEBUG_MODE
-    errortext += "\n";
-    fputs(errortext.c_str(), stderr);
-    #endif
-    if (type == MESSAGE_TYPE::M_FATAL_ERROR || 
-      type == MESSAGE_TYPE::M_FATAL_USER_ERROR)
-      abort();
-  }
 }
 
 void show_info(string text, int bgcolor, int left, int top, int width, int height,

--- a/ENIGMAsystem/SHELL/Widget_Systems/GTK+/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/GTK+/Makefile
@@ -1,4 +1,4 @@
-SOURCES += $(wildcard Widget_Systems/GTK+/*.cpp)
+SOURCES += $(wildcard Widget_Systems/GTK+/*.cpp) Widget_Systems/General/WSdialogs.cpp
 override LDLIBS += -lgthread-2.0
 
 ifeq ($(PLATFORM), xlib)

--- a/ENIGMAsystem/SHELL/Widget_Systems/GTK+/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/GTK+/dialogs.cpp
@@ -34,11 +34,11 @@
 
 using namespace std;
 
-namespace enigma_user {
-
-void show_debug_message(string errortext, MESSAGE_TYPE type) {
-//TODO: Implement
+void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
+  //TODO: Implement
 }
+
+namespace enigma_user {
 
 bool show_question(std::string str) {
 //TODO: Implement

--- a/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/General/WSdialogs.cpp
@@ -1,0 +1,24 @@
+#include "Widget_Systems/widgets_mandatory.h"
+
+using std::string;
+
+void show_debug_message_helper(string errortext, MESSAGE_TYPE type);
+
+namespace enigma_user {
+
+void show_debug_message(string errortext, MESSAGE_TYPE type) {
+  if (type != M_INFO && type != M_WARNING) {
+    show_debug_message_helper(errortext, type);
+  } else {
+    #ifndef DEBUG_MODE
+    errortext += "\n";
+    fputs(errortext.c_str(), stderr);
+    fflush(stderr);
+    #endif
+    if (type == MESSAGE_TYPE::M_FATAL_ERROR || 
+      type == MESSAGE_TYPE::M_FATAL_USER_ERROR)
+      abort();
+  }
+}
+
+}

--- a/ENIGMAsystem/SHELL/Widget_Systems/None/default_log.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/None/default_log.cpp
@@ -20,6 +20,7 @@ if (type == MESSAGE_TYPE::M_USER_ERROR || type == MESSAGE_TYPE::M_FATAL_USER_ERR
   } 
   
   else printf((enigma::error_type(type) + ": %s\n").c_str(), err.c_str());
+  fflush(stdout);
   
   if (type == MESSAGE_TYPE::M_FATAL_ERROR || type == MESSAGE_TYPE::M_FATAL_USER_ERROR) exit(133);
   ABORT_ON_ALL_ERRORS();

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/Makefile
@@ -1,3 +1,3 @@
-SOURCES += $(wildcard Widget_Systems/Win32/*.cpp)
+SOURCES += $(wildcard Widget_Systems/Win32/*.cpp) Widget_Systems/General/WSdialogs.cpp
 RESOURCES += $(wildcard Widget_Systems/Win32/*.rc)
 override LDLIBS += -lcomctl32 -luuid -lole32

--- a/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/Win32/dialogs.cpp
@@ -564,7 +564,7 @@ static inline int get_color_helper(int defcol, string title) {
   return -1;
 }
 
-static inline void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
+void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
   #ifdef DEBUG_MODE
   errortext += "\n\n" + enigma::debug_scope::GetErrors();
   #endif
@@ -600,20 +600,6 @@ string widget_get_system() {
 
 void widget_set_system(string sys) {
   // place holder
-}
-
-void show_debug_message(string errortext, MESSAGE_TYPE type) {
-  if (type != M_INFO && type != M_WARNING) {
-    show_debug_message_helper(errortext, type);
-  } else {
-    #ifndef DEBUG_MODE
-    errortext += "\r\n";
-    fputs(errortext.c_str(), stderr);
-    #endif
-    if (type == MESSAGE_TYPE::M_FATAL_ERROR || 
-      type == MESSAGE_TYPE::M_FATAL_USER_ERROR)
-      abort();
-  }
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
@@ -1,6 +1,4 @@
-SOURCES += Widget_Systems/xlib/zenity.cpp
-SOURCES += Widget_Systems/xlib/kdialog.cpp
-SOURCES += Widget_Systems/xlib/dialogs.cpp
+SOURCES += $(wildcard Widget_Systems/xlib/*.cpp) Widget_Systems/General/WSdialogs.cpp
 override CXXFLAGS +=  $(shell pkg-config x11 --cflags)
 override CFLAGS += $(shell pkg-config x11 --cflags)
 override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -163,7 +163,7 @@ static int show_question_helperfunc(string message) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
-static inline void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
+void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;
@@ -197,20 +197,6 @@ static inline void show_debug_message_helper(string errortext, MESSAGE_TYPE type
 
 class KDialogWidgets : public enigma::CommandLineWidgetEngine {
  public:
-
-void show_debug_message(string errortext, MESSAGE_TYPE type) override {
-  if (type != M_INFO && type != M_WARNING) {
-    show_debug_message_helper(errortext, type);
-  } else {
-    #ifndef DEBUG_MODE
-    errortext += "\n";
-    fputs(errortext.c_str(), stderr);
-    #endif
-    if (type == MESSAGE_TYPE::M_FATAL_ERROR || 
-      type == MESSAGE_TYPE::M_FATAL_USER_ERROR)
-      abort();
-  }
-}
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -153,7 +153,7 @@ static int show_question_helperfunc(string message) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
-static inline void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
+void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;
@@ -187,20 +187,6 @@ static inline void show_debug_message_helper(string errortext, MESSAGE_TYPE type
 
 class ZenityWidgets : public enigma::CommandLineWidgetEngine {
  public:
-
-void show_debug_message(string errortext, MESSAGE_TYPE type) override {
-  if (type != M_INFO && type != M_WARNING) {
-    show_debug_message_helper(errortext, type);
-  } else {
-    #ifndef DEBUG_MODE
-    errortext += "\n";
-    fputs(errortext.c_str(), stderr);
-    #endif
-    if (type == MESSAGE_TYPE::M_FATAL_ERROR || 
-      type == MESSAGE_TYPE::M_FATAL_USER_ERROR)
-      abort();
-  }
-}
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {
 


### PR DESCRIPTION
This fixes #2034 to make `show_debug_message` usable again.

* Remove `show_debug_message` from the terminal I/O sources.
* Move common definition of function to `Widget_Systems/General/WSdialogs.cpp` for Win32, Cocoa, kdialog, & zenity.
* Flush stderr for the common version.
* Flush stdout for the None system implementation.
