### PR TITLE
Async Input Polling

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -76,6 +76,8 @@ int enigma_main(int argc, char** argv) {
     if (handleEvents() != 0) break;
     if (gameWait() != 0) continue;
 
+    updateInput();
+
     // if any extensions need updated, update them now
     // just before we fire off user events like step
     for (auto update_hook : extension_update_hooks)

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -41,6 +41,7 @@ namespace enigma {
   void set_program_args(int argc, char** argv);
   void initTimer();
   int updateTimer();
+  void updateInput();
   int gameWait();
   void set_room_speed(int rs);
 }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -52,7 +52,7 @@ namespace enigma
   using enigma_user::keyboard_lastchar;
   using enigma_user::keyboard_string;
 
-  extern char mousestatus[3],last_mousestatus[3],keybdstatus[256],last_keybdstatus[256];
+  extern char keybdstatus[256],last_keybdstatus[256];
   extern int windowX, windowY, windowColor;
   extern HCURSOR currentCursor;
 
@@ -235,13 +235,6 @@ namespace enigma
          enigma_user::mouse_hscrolls += hdeltadelta / WHEEL_DELTA;
          hdeltadelta %= WHEEL_DELTA;
          return 0;
-
-      case WM_LBUTTONUP:   ReleaseCapture(); mousestatus[0]=0; return 0;
-      case WM_LBUTTONDOWN: SetCapture(hWnd); mousestatus[0]=1; return 0;
-      case WM_RBUTTONUP:   ReleaseCapture(); mousestatus[1]=0; return 0;
-      case WM_RBUTTONDOWN: SetCapture(hWnd); mousestatus[1]=1; return 0;
-      case WM_MBUTTONUP:   ReleaseCapture(); mousestatus[2]=0; return 0;
-      case WM_MBUTTONDOWN: SetCapture(hWnd); mousestatus[2]=1; return 0;
 
       case WM_ERASEBKGND:
         RECT rc;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -296,6 +296,14 @@ int updateTimer() {
   return 0;
 }
 
+extern char mousestatus[3];
+
+void updateInput() {
+  mousestatus[0] = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) ? 1 : 0;
+  mousestatus[1] = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ? 1 : 0;
+  mousestatus[2] = (GetAsyncKeyState(VK_MBUTTON) & 0x8000) ? 1 : 0;
+}
+
 int handleEvents() {
   if (enigma::game_isending) PostQuitMessage(enigma::game_return);
 


### PR DESCRIPTION
This was an experiment on #1828 which arrived at some tangible results. Essentially this pull request is seeing what it would be like if we did not use the message based input for Win32, but instead used the API that allows directly polling the state of the mouse and keyboard. This does in fact resolve the mouse capture anomalies and allow ENIGMA to properly detect mouse button releases outside of the game window.

This is my most likely guess as to how modern GMS is handling input as the only other possible options are DirectInput or RAWINPUT, neither of which do I think YoYoGames is using for the keyboard or mouse. Though, I do know from documentation, that YoYo uses DirectInput for gamepads above 4.