### PR TITLE
Fix Win32/SDL Mouse Capture Anomalies

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
@@ -253,6 +253,7 @@ void SDL_Event_Handler::mouseButtonDown(const SDL_Event *event) {
 void SDL_Event_Handler::mouseButtonUp(const SDL_Event *event) {
   int btn = SDL_map_button_enum(event->button.button);
   if (btn < 0) return;
+  if (!SDL_GetMouseState(NULL, NULL)) SDL_CaptureMouse(SDL_FALSE);
   enigma::last_mousestatus[btn] = enigma::mousestatus[btn];
   enigma::mousestatus[btn] = false;
 }

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
@@ -253,7 +253,6 @@ void SDL_Event_Handler::mouseButtonDown(const SDL_Event *event) {
 void SDL_Event_Handler::mouseButtonUp(const SDL_Event *event) {
   int btn = SDL_map_button_enum(event->button.button);
   if (btn < 0) return;
-  SDL_CaptureMouse(SDL_FALSE);
   enigma::last_mousestatus[btn] = enigma::mousestatus[btn];
   enigma::mousestatus[btn] = false;
 }

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
@@ -135,8 +135,8 @@ int SDL_Event_Handler::processEvents() {
 int SDL_map_button_enum(const char button) {
   switch (button) {
     case SDL_BUTTON_LEFT: return 0;
-    case SDL_BUTTON_MIDDLE: return 1;
-    case SDL_BUTTON_RIGHT: return 2;
+    case SDL_BUTTON_RIGHT: return 1;
+    case SDL_BUTTON_MIDDLE: return 2;
     default: return -1;
   }
 }

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -236,11 +236,11 @@ namespace enigma
          hdeltadelta %= WHEEL_DELTA;
          return 0;
 
-      case WM_LBUTTONUP:   ReleaseCapture(); mousestatus[0]=0; return 0;
+      case WM_LBUTTONUP:   { if (!wParam) ReleaseCapture(); mousestatus[0]=0; return 0; }
       case WM_LBUTTONDOWN: SetCapture(hWnd); mousestatus[0]=1; return 0;
-      case WM_RBUTTONUP:   ReleaseCapture(); mousestatus[1]=0; return 0;
+      case WM_RBUTTONUP:   { if (!wParam) ReleaseCapture(); mousestatus[1]=0; return 0; }
       case WM_RBUTTONDOWN: SetCapture(hWnd); mousestatus[1]=1; return 0;
-      case WM_MBUTTONUP:   ReleaseCapture(); mousestatus[2]=0; return 0;
+      case WM_MBUTTONUP:   { if (!wParam) ReleaseCapture(); mousestatus[2]=0; return 0; }
       case WM_MBUTTONDOWN: SetCapture(hWnd); mousestatus[2]=1; return 0;
 
       case WM_ERASEBKGND:


### PR DESCRIPTION
Alright, I did it, I figured out how to fix #1828 correctly. Initial guesses that all mouse buttons need to be released for the mouse capture to be released are correct. The problem was I didn't want to call out to any other API, but then I realized all of the UP mouse input messages have a wParam which tells us the state of the other mouse buttons. Clearly it tells us whether all mouse buttons have been released!

With these changes the mouse capture works perfectly, the same as GMSv1.4, and other applications as it is expected to work. The mouse is correctly captured now and mouse releases are always properly detected inside and outside of the window.

What's funny is other people haven't figured out the wParam trick, and I notice several people using integers counters and other weird tricks. SDL video API is an example of this where they seem to be holding a counter variable of how many mouse buttons are pressed, though I do suppose that could have other uses. What's interesting is that this does not apply to SDL windowing API, which I still have to patch here, because it lets you control the mouse capture.
http://hg.libsdl.org/SDL/diff/1b87a8beab9d/src/video/win32/SDL_win32events.c

SFML is at least smart enough to check the wParam like me, but they check all of the modifiers individually.
https://github.com/SFML/SFML/pull/457/files

freeglut was also patched in the same way, though they use the async key polling in the place of wParam.
https://sourceforge.net/p/freeglut/mailman/message/30537813/
```cpp
         else if (!GetAsyncKeyState(VK_LBUTTON) && !GetAsyncKeyState(VK_MBUTTON) && !GetAsyncKeyState(VK_RBUTTON))
           /* Make sure all mouse buttons are released before releasing capture */
           ReleaseCapture () ;
```

Edit: There is no need to fix Cocoa here, because I read in online Stackoverflow posts as well as comments in the SDL source where the Cocoa backend has only a stub for capture, that Cocoa automatically handles mouse capture for mouse events.