### PR TITLE
Fix KDialog/Zenity Debug Message

### DIFF
--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -82,10 +82,6 @@ int show_attempt(string errortext) {
   return enigma::current_widget_engine->show_attempt(errortext);
 }
 
-void show_debug_message(string errortext, MESSAGE_TYPE type) {
-  enigma::current_widget_engine->show_debug_message(errortext, type);
-}
-
 string get_string(string message, string def) {
   return enigma::current_widget_engine->get_string(message, def);
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -42,8 +42,8 @@ bool widget_system_initialize() {
 
 } // namespace enigma
 
-void show_debug_message_helper(string message, MESSAGE_TYPE type) {
-  enigma::current_widget_engine->show_debug_message(message, type);
+void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
+  enigma::current_widget_engine->show_debug_message(errortext, type);
 }
 
 namespace enigma_user {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -22,6 +22,10 @@
 #include <string>
 using std::string;
 
+void show_debug_message_helper(string message, MESSAGE_TYPE type) {
+  enigma::current_widget_engine->show_debug_message(message, type);
+}
+
 namespace enigma {
 
 CommandLineWidgetEngine *current_widget_engine = zenity_widgets;

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -22,10 +22,6 @@
 #include <string>
 using std::string;
 
-void show_debug_message_helper(string message, MESSAGE_TYPE type) {
-  enigma::current_widget_engine->show_debug_message(message, type);
-}
-
 namespace enigma {
 
 CommandLineWidgetEngine *current_widget_engine = zenity_widgets;
@@ -45,6 +41,10 @@ bool widget_system_initialize() {
 }
 
 } // namespace enigma
+
+void show_debug_message_helper(string message, MESSAGE_TYPE type) {
+  enigma::current_widget_engine->show_debug_message(message, type);
+}
 
 namespace enigma_user {
     

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -163,7 +163,7 @@ static int show_question_helperfunc(string message) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
-void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
+void show_debug_message_kdialog_helper(string errortext, MESSAGE_TYPE type) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;
@@ -197,6 +197,10 @@ void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
 
 class KDialogWidgets : public enigma::CommandLineWidgetEngine {
  public:
+
+void show_debug_message(string message, MESSAGE_TYPE type) override {
+  show_debug_zenity_helperfunc(message);
+}
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -199,7 +199,7 @@ class KDialogWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
 void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_zenity_helperfunc(message);
+  show_debug_message_zenity_helperfunc(message);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -163,7 +163,7 @@ static int show_question_helperfunc(string message) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
-void show_debug_message_helperfunc(string errortext, MESSAGE_TYPE type) {
+static void show_debug_message_helperfunc(string errortext, MESSAGE_TYPE type) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -199,7 +199,7 @@ class KDialogWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
 void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_message_helperfunc(message);
+  show_debug_message_helperfunc(message, type);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -198,8 +198,8 @@ void show_debug_message_helperfunc(string errortext, MESSAGE_TYPE type) {
 class KDialogWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
-void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_message_helperfunc(message, type);
+void show_debug_message(string errortext, MESSAGE_TYPE type) override {
+  show_debug_message_helperfunc(errortext, type);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -199,7 +199,7 @@ class KDialogWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
 void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_message_zenity_helperfunc(message);
+  show_debug_message_kdialog_helperfunc(message);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/kdialog.cpp
@@ -163,7 +163,7 @@ static int show_question_helperfunc(string message) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
-void show_debug_message_kdialog_helper(string errortext, MESSAGE_TYPE type) {
+void show_debug_message_helperfunc(string errortext, MESSAGE_TYPE type) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;
@@ -199,7 +199,7 @@ class KDialogWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
 void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_message_kdialog_helperfunc(message);
+  show_debug_message_helperfunc(message);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -189,7 +189,7 @@ class ZenityWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
 void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_zenity_helperfunc(message);
+  show_debug_message_zenity_helperfunc(message);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -153,7 +153,7 @@ static int show_question_helperfunc(string message) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
-void show_debug_message_helperfunc(string errortext, MESSAGE_TYPE type) {
+static void show_debug_message_helperfunc(string errortext, MESSAGE_TYPE type) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -153,7 +153,7 @@ static int show_question_helperfunc(string message) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
-void show_debug_message_zenity_helper(string errortext, MESSAGE_TYPE type) {
+void show_debug_message_helperfunc(string errortext, MESSAGE_TYPE type) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;
@@ -189,7 +189,7 @@ class ZenityWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
 void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_message_zenity_helperfunc(message);
+  show_debug_message_helperfunc(message);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -188,8 +188,8 @@ void show_debug_message_helperfunc(string errortext, MESSAGE_TYPE type) {
 class ZenityWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
-void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_message_helperfunc(message, type);
+void show_debug_message(string errortext, MESSAGE_TYPE type) override {
+  show_debug_message_helperfunc(errortext, type);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -189,7 +189,7 @@ class ZenityWidgets : public enigma::CommandLineWidgetEngine {
  public:
 
 void show_debug_message(string message, MESSAGE_TYPE type) override {
-  show_debug_message_helperfunc(message);
+  show_debug_message_helperfunc(message, type);
 }
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -153,7 +153,7 @@ static int show_question_helperfunc(string message) {
   return (int)strtod(str_result.c_str(), NULL);
 }
 
-void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
+void show_debug_message_zenity_helper(string errortext, MESSAGE_TYPE type) {
   if (error_caption.empty()) error_caption = "Error";
   string str_command;
   string str_title;
@@ -187,6 +187,10 @@ void show_debug_message_helper(string errortext, MESSAGE_TYPE type) {
 
 class ZenityWidgets : public enigma::CommandLineWidgetEngine {
  public:
+
+void show_debug_message(string message, MESSAGE_TYPE type) override {
+  show_debug_zenity_helperfunc(message);
+}
 
 void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) override {
 


### PR DESCRIPTION
I made a goof in #2037 and accidentally broke KDialog/Zenity because I didn't realize in #1812 that tkg set up a dynamic engine to change dialog systems (something that could be accomplished if we just added hot loading to ENIGMA). What made things worse is that the Azure build was broke yesterday (but it's fixed today!) so I merged it without expecting it to pass.