### PR TITLE
DirectSound Global Focus

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -169,7 +169,7 @@ int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
   bufferDesc.dwSize = sizeof(DSBUFFERDESC);
   // DSBCAPS_CTRLFX causes all kinds of weird nasty shit, please read #1508 on GitHub
   // before considering whether to readd it to the dwFlags below
-  bufferDesc.dwFlags = DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY;
+  bufferDesc.dwFlags = DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_GLOBALFOCUS;
   bufferDesc.dwBufferBytes = waveHeader->dataSize;
   bufferDesc.dwReserved = 0;
   bufferDesc.lpwfxFormat = &waveFormat;


### PR DESCRIPTION
This is a minor technicality that allows DirectSound to play sounds when the window is not focused, as OpenAL already behaves. Setting global focus on the secondary buffers is the only way to achieve this.

I tested and can confirm this is the way GM8.1 worked and it should be able to play looping sounds when not focused and regardless of whether the freeze on lose focus is ticked. GMSv1.4 with its legacy DirectSound system also behaved the same.

I am sure that `DSBCAPS_GLOBALFOCUS` is more correct than `DSBCAPS_STICKYFOCUS` from further testing. If the latter is used, and I open GM8.1 at the same time, switch focus to it causes ENIGMA to be muted. Only with `DSBCAPS_GLOBALFOCUS` is GM8.1 prevented from muting ENIGMA and vice versa. This was not the behavior with GMSv1.4 even though it claimed to load a DirectSound system, and it couldn't mean they switched to sticky focus, because adding global focus to ENIGMA did not allow ENIGMA to cause GMSv1.4 to be muted. So I don't know what exactly the situation is with GMSv1.4.

This partly alleviates #1801 for very short sounds (e.g, GM8.1 beep3.wav or GM6 beep1.wav).