### PR TITLE
Cleanup Daft Window Procedure

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -67,8 +67,6 @@ namespace enigma
   {
     switch (message)
     {
-      case WM_CREATE:
-        return 0;
       case WM_SHOWWINDOW:
         enigma::windowWidth = enigma_user::window_get_width();
         enigma::windowHeight = enigma_user::window_get_height();
@@ -86,9 +84,6 @@ namespace enigma
         if (treatCloseAsEscape) {
           PostQuitMessage(game_return);
         }
-        return 0;
-
-      case WM_DESTROY:
         return 0;
 
       case WM_SETFOCUS:
@@ -249,21 +244,14 @@ namespace enigma
         FillRect((HDC) wParam, &rc, CreateSolidBrush(windowColor));
         return 1L;
 
-      case WM_PAINT:
-        DefWindowProc(hWndParameter, message, wParam, lParam);
-        return 0;
-
       case WM_SYSCOMMAND: {
         if (wParam == SC_MAXIMIZE) {
           ShowWindow(hWnd, SW_MAXIMIZE);
           enigma::windowWidth = enigma_user::window_get_width();
           enigma::windowHeight = enigma_user::window_get_height();
           enigma::compute_window_scaling();
-          break;
-        } else {
-          return DefWindowProc(hWndParameter, message, wParam, lParam);
         }
-        return 0;
+        break;
       }
     }
     return DefWindowProc (hWndParameter, message, wParam, lParam);


### PR DESCRIPTION
There was a ton of vestigial junk in here that I got rid of and still made the same 100% logically equivalent. I see no reason to catch messages if we aren't using them and not let them get to the DefWindowProc, and I researched to make sure there wasn't a case that we were explicitly doing that.

I then promptly tested out some games including my own and tkg's usual Key to Success. I ran some benchmarks to check the framerate and stuff too and I didn't see any issues or regressions.