### PR TITLE
Fix Game Settings During Create

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -123,6 +123,11 @@ namespace enigma
     //Initialize extensions
     enigma::extensions_initialize();
 
+    // apply global game settings
+    enigma_user::window_set_sizeable(isSizeable);
+    enigma_user::window_set_showborder(showBorder);
+    enigma_user::window_set_fullscreen(isFullScreen);
+    
     //Go to the first room
     if (enigma_user::room_count)
       enigma::game_start();
@@ -134,11 +139,6 @@ namespace enigma
     // resize and center window
     enigma_user::window_set_size(windowWidth, windowHeight);
     enigma_user::window_center();
-    
-    // apply global game settings
-    enigma_user::window_set_sizeable(isSizeable);
-    enigma_user::window_set_showborder(showBorder);
-    enigma_user::window_set_fullscreen(isFullScreen);
 
     return 0;
   }


### PR DESCRIPTION
This fixes the ability to read the state of the global game settings in the create event of objects. The settings should be correctly applied and realized by the time these events are fired. 

```cpp
show_message(window_get_showborder());
show_message(window_get_sizeable());
show_message(window_get_fullscreen());
```

@time-killer-games This is the case with both GMSv1.4 and GM8.1 so there is no way around this.