### PR TITLE
Fix Xlib Sizeable Crash

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -333,8 +333,6 @@ void window_set_sizeable(bool sizeable) {
   }
   XSetWMNormalHints(disp, win, sh);
   XFree(sh);
-
-  XResizeWindow(disp, win, enigma::windowWidth, enigma::windowHeight);
 }
 
 void window_set_min_width(int width) {


### PR DESCRIPTION
THE STATE OF THE WINDOW SHOULD NOT BE MADE TO DEPEND UPON OTHER STATE OF THE WINDOW THAT IT DOES NOT ACTUALLY DEPEND UPON ITSELF