### PR TITLE
Win32 Event Handling Quit Cleanup

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -297,8 +297,6 @@ int updateTimer() {
 }
 
 int handleEvents() {
-  if (enigma::game_isending) PostQuitMessage(enigma::game_return);
-
   while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
     if (msg.message == WM_QUIT) {
       enigma::game_return = msg.wParam;


### PR DESCRIPTION
In an effort to better understand if we are handling quit messages, closing, and ending the game properly I reached the conclusion that this line in the Win32 event handling is useless for several reasons. In GM8.1 it is not possible for `game_end();` to cause an event loop driven by functions like `io_handle();` to break, the current event always finishes. If `game_isending` is true when this loop enters, meaning `game_end();` was called, it can not have any effect anyway regardless of whether it posts a quit message to the loop. The only time it can possibly have any effect is when the engine's outer main loop calls it, which doesn't matter anyway because that loop is a while loop whose predicate is the same variable!