### PR TITLE
Fix Win32 System Command Input

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -90,6 +90,20 @@ namespace enigma
     keybdstatus[key]=0;
   }
 
+  static void handle_keydown(WPARAM wParam, LPARAM lParam) {
+    handle_keydown(wParam);
+    WPARAM extended = map_leftright_keys(wParam, lParam);
+    if (extended == wParam) return;
+    handle_keydown(extended);
+  }
+
+  static void handle_keyup(WPARAM wParam, LPARAM lParam) {
+    handle_keyup(wParam);
+    WPARAM extended = map_leftright_keys(wParam, lParam);
+    if (extended == wParam) return;
+    handle_keyup(extended);
+  }
+
   LRESULT (CALLBACK *touch_extension_callback)(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam);
   void (*WindowResizedCallback)();
 
@@ -207,17 +221,11 @@ namespace enigma
         }
         return 0;
 
-      case WM_KEYDOWN:    handle_keydown(wParam); return 0;
-      case WM_KEYUP:      handle_keyup(wParam);   return 0;
-      case WM_SYSKEYDOWN:
-        handle_keydown(wParam);
-        handle_keydown(map_leftright_keys(wParam, lParam));
-        break;
-      case WM_SYSKEYUP:
-        handle_keyup(wParam);
-        handle_keyup(map_leftright_keys(wParam, lParam));
-        break;
-      
+      case WM_KEYDOWN:    handle_keydown(wParam, lParam); return 0;
+      case WM_KEYUP:      handle_keyup(wParam, lParam);   return 0;
+      case WM_SYSKEYDOWN: handle_keydown(wParam, lParam); break;
+      case WM_SYSKEYUP:   handle_keyup(wParam, lParam);   break;
+  
       case WM_MOUSEWHEEL:
          vdeltadelta += (int)HIWORD(wParam);
          enigma_user::mouse_vscrolls += vdeltadelta / WHEEL_DELTA;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -200,13 +200,11 @@ namespace enigma
         keybdstatus[key]=1;
         if (key!=18)
         {
-          if ((lParam&(1<<29))>0) {
-            if (wParam == VK_F4) PostMessage(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0);
-            last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
-          } else
-            last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
+          if ((lParam&(1<<29))>0)
+               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
+          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
         }
-        return 0;
+        break;
       }
       case WM_SYSKEYUP: {
         int key = enigma_user::keyboard_get_map(wParam);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -204,7 +204,7 @@ namespace enigma
                last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
           else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
         }
-        return 0;
+        break;
       }
       case WM_SYSKEYUP: {
         int key = enigma_user::keyboard_get_map(wParam);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -201,7 +201,7 @@ namespace enigma
         if (key!=18)
         {
           if ((lParam&(1<<29))>0) {
-            if (wParam == VK_F4) PostMessage(hWnd, WM_CLOSE, 0, 0);
+            if (wParam == VK_F4) PostMessage(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0);
             last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
           } else
             last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -217,7 +217,7 @@ namespace enigma
                last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
           else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
         }
-        return 0;
+        break;
       }
       case WM_MOUSEWHEEL:
          vdeltadelta += (int)HIWORD(wParam);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -200,11 +200,13 @@ namespace enigma
         keybdstatus[key]=1;
         if (key!=18)
         {
-          if ((lParam&(1<<29))>0)
-               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
-          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
+          if ((lParam&(1<<29))>0) {
+            if (wParam == VK_F4) PostMessage(hWnd, WM_CLOSE, 0, 0);
+            last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
+          } else
+            last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
         }
-        break;
+        return 0;
       }
       case WM_SYSKEYUP: {
         int key = enigma_user::keyboard_get_map(wParam);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -200,7 +200,7 @@ namespace enigma
         keybdstatus[key]=1;
         if (key!=18)
         {
-          if ((lParam&(1<<29))>0)
+          if (HIWORD(lParam) & KF_ALTDOWN)
                last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
           else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
         }
@@ -213,9 +213,9 @@ namespace enigma
         keybdstatus[key]=0;
         if (key!=(unsigned int)18)
         {
-          if ((lParam&(1<<29))>0)
-               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
-          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
+          if (HIWORD(lParam) & KF_ALTDOWN)
+               last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=1;
+          else last_keybdstatus[18]=keybdstatus[18], keybdstatus[18]=0;
         }
         break;
       }


### PR DESCRIPTION
So after other conversations with Josh I noticed ALT+F4 wasn't actually closing the game in ENIGMA.

Apparently this is handled by `DefWindowProc` in `WM_SYSKEYDOWN` which then generates a `WM_SYSCOMMAND` for `SC_CLOSE` and sends a `WM_CLOSE` message to the Window.

![ENIGMA System Command Menu](https://user-images.githubusercontent.com/3212801/85957163-1f810b00-b959-11ea-96c6-d126f555a3e7.png)

I don't know if this is a problem on other platforms, but I do know it's not an issue with SDL. Anyway the simple solution here is to just break and allow `DefWindowProc` to handle `WM_SYSKEYDOWN` for us, which we already do for `WM_SYSCOMMAND` after we intercept some messages tkg needed.

Microsoft says this is correct too.
>As the name implies, system key strokes are primarily intended for use by the operating system. If you intercept the WM_SYSKEYDOWN message, call DefWindowProc afterward. Otherwise, you will block the operating system from handling the command.
https://docs.microsoft.com/en-us/windows/win32/learnwin32/keyboard-input