### PR TITLE
SDL Keyboard Direct Scancodes

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Window.cpp
@@ -346,7 +346,9 @@ int display_get_height() {
 
 bool keyboard_check_direct(int key) {
   const Uint8* state = SDL_GetKeyboardState(nullptr);
-  return state[enigma::keyboard::inverse_keymap[key]];
+  const SDL_Keycode keycode = enigma::keyboard::inverse_keymap[key];
+  const SDL_Scancode scancode = SDL_GetScancodeFromKey(keycode);
+  return state[scancode];
 }
 
 void keyboard_key_press(int key) {


### PR DESCRIPTION
This stops it from crashing by giving it the scancode like it wants instead of the keycode. It does actually work now, except for CTRL, ALT, & Shift which will be fixed by #2058 later.

The documentation is clear that it expects scancodes, not keycodes, which do have different values.
https://wiki.libsdl.org/SDL_GetKeyboardState

Here's a test I devised that works in Win32 master but not SDL master, only this pull request.
```cpp
var text;
text = "";
text += string(keyboard_check_direct(vk_alt)) + " ";
text += string(keyboard_check_direct(vk_lalt)) + " ";
text += string(keyboard_check_direct(vk_ralt)) + "#";
text += string(keyboard_check_direct(vk_control)) + " ";
text += string(keyboard_check_direct(vk_lcontrol)) + " ";
text += string(keyboard_check_direct(vk_rcontrol)) + "#";
text += string(keyboard_check_direct(vk_shift)) + " ";
text += string(keyboard_check_direct(vk_lshift)) + " ";
text += string(keyboard_check_direct(vk_rshift)) + "#";
draw_text(0, 0, text);
```
