### PR TITLE
Win32 Direct Keyboard State

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -571,27 +571,20 @@ int window_get_cursor()
 
 bool keyboard_check_direct(int key)
 {
-   BYTE keyState[256];
-
-   if ( GetKeyboardState( keyState ) )  {
-	  for (int x = 0; x < 256; x++)
-		keyState[x] = (char) (GetKeyState(x) >> 8);
-   } else {
-      //TODO: print error message.
-	  return 0;
-   }
+  BYTE keyState[256];
+  if (!GetKeyboardState(keyState)) return false;
 
   if (key == vk_anykey) {
     for(int i = 0; i < 256; i++)
-      if (keyState[i] == 1) return 1;
+      if ((char)keyState[i] < 0) return 1;
     return 0;
   }
   if (key == vk_nokey) {
     for(int i = 0; i < 256; i++)
-      if (keyState[i] == 1) return 0;
+      if ((char)keyState[i] < 0) return 0;
     return 1;
   }
-  return keyState[key & 0xFF];
+  return (char)keyState[key & 0xFF] < 0;
 }
 
 void keyboard_key_press(int key) {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -571,20 +571,7 @@ int window_get_cursor()
 
 bool keyboard_check_direct(int key)
 {
-  BYTE keyState[256];
-  if (!GetKeyboardState(keyState)) return false;
-
-  if (key == vk_anykey) {
-    for(int i = 0; i < 256; i++)
-      if ((char)keyState[i] < 0) return 1;
-    return 0;
-  }
-  if (key == vk_nokey) {
-    for(int i = 0; i < 256; i++)
-      if ((char)keyState[i] < 0) return 0;
-    return 1;
-  }
-  return (char)keyState[key & 0xFF] < 0;
+  return GetAsyncKeyState(key) < 0;
 }
 
 void keyboard_key_press(int key) {


### PR DESCRIPTION
So apparently I implemented (d08c3d9c6cab16827557f161d547be55e305357b) this way back and never tested it, then copied it to Linux where Josh later fixed it. Regardless, it doesn't work on master and it's also really slow because I didn't know how to write it and had it polling the keyboard state twice.

Anyway I made a little test to see if it was working and discovered that apparently the logical `vk_nokey` and `vk_anykey` were never supported by `keyboard_check_direct()`, not in GM8.1 or GMSv1.4 afaict.
```cpp
var text;
text = string(keyboard_check_direct(vk_nokey)) + " " + string(keyboard_check_direct(vk_anykey));
draw_text(0,0,text);
```

Now when I benchmark this with the #2059 test I had, it's still slower (100,000~ microseconds) than our SDL (5000~ microseconds) and GMSv1.4 (50,000~ microseconds) even after the fix. There could be two reasons for this. either SDL & GMSv1.4 are caching the direct keyboard state once in a frame or `GetKeyState`/`GetAsyncKeyState` should be used here. The latter seems more likely since again GM never supported the `vk_nokey` and `vk_anykey` logical keys for this function, and there would be no way to tell their state if this function only polled a single key instead of the entire keyboard. Regardless, when I tested removing that and just using `GetKeyState`/`GetAsyncKeyState` the function then performed around 30,000~ microseconds  suggesting it was closer to GM at that point and that SDL might be caching or not as low-level as it appears.

The documentation also seems to suggest that `GetKeyboardState` is message based hardly distinguishing it from our existing high-level input that is based on messaging.

>The status changes as a thread removes keyboard messages from its message queue.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getkeyboardstate

Since `GetKeyState` also says the same & more, it seems like `GetAsyncKeyState` really is the real candidate.
>The status does **_not_** reflect the interrupt-level state associated with the hardware.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getkeystate

Finally, `GetAsyncKeyState` does mention that it checks at the time the function is called.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getasynckeystate
