### PR TITLE
Cleanup Win32 Keyboard Simulation

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -481,6 +481,13 @@ void window_mouse_set(int x, int y)
 
 }
 
+static void keyboard_set_direct(int key, bool down) {
+  UINT scancode = MapVirtualKey(key, MAPVK_VK_TO_VSC_EX);
+  DWORD flags = ((scancode >> 8) == 0xE0) ? KEYEVENTF_EXTENDEDKEY : 0;
+  if (!down) flags |= KEYEVENTF_KEYUP;
+  keybd_event(key, scancode, flags, 0);
+}
+
 namespace enigma_user
 {
 
@@ -595,13 +602,11 @@ bool keyboard_check_direct(int key)
 }
 
 void keyboard_key_press(int key) {
-  UINT scancode = MapVirtualKey(key, MAPVK_VK_TO_VSC);
-  keybd_event(key, scancode, 0, 0);
+  keyboard_set_direct(key, true);
 }
 
 void keyboard_key_release(int key) {
-  UINT scancode = MapVirtualKey(key, MAPVK_VK_TO_VSC);
-  keybd_event(key, scancode, KEYEVENTF_KEYUP, 0);
+  keyboard_set_direct(key, false);
 }
 
 bool keyboard_get_capital() {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -33,6 +33,10 @@
 #define byte __windows_byte_workaround
 #include <windows.h>
 #undef byte
+// mingw32 cross-compile bug workaround below
+#ifndef MAPVK_VK_TO_VSC_EX
+#define MAPVK_VK_TO_VSC_EX 0x04
+#endif
 
 #include <stdio.h>
 #include <string>

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -595,24 +595,13 @@ bool keyboard_check_direct(int key)
 }
 
 void keyboard_key_press(int key) {
-  BYTE keyState[256];
-
-  GetKeyboardState((LPBYTE)&keyState);
-
-  // Simulate a key press
-  keybd_event( key,
-        keyState[key],
-        KEYEVENTF_EXTENDEDKEY | 0,
-        0 );
+  UINT scancode = MapVirtualKey(key, MAPVK_VK_TO_VSC);
+  keybd_event(key, scancode, 0, 0);
 }
 
 void keyboard_key_release(int key) {
-  BYTE keyState[256];
-
-  GetKeyboardState((LPBYTE)&keyState);
-
-  // Simulate a key release
-  keybd_event( key, keyState[key], KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+  UINT scancode = MapVirtualKey(key, MAPVK_VK_TO_VSC);
+  keybd_event(key, scancode, KEYEVENTF_KEYUP, 0);
 }
 
 bool keyboard_get_capital() {


### PR DESCRIPTION
Lot of inefficient junk in here from when I (b6a1b612387ea9c1878b0ef2a2864fe2aef84035) originally added these. It looks like I must have copied them straight from the tutorial about setting the numlock but without actually bothering to pay too much attention because for some reason I thought the keystate was equivalent to its scancode, well it's _NOT_. There is no need at all for these functions to query the current state of the entire keyboard.

The next thing I did was use `MapVirtualKey` to obtain the correct scancode of the virtual key parameter for us to provide in the simulated keyboard event, even if most programs ignore it.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-mapvirtualkeya

I appended `KEYEVENTF_EXTENDEDKEY` once I was sure of its meaning.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-keybd_event

Finally, I did a little testing in GM8 and ENIGMA and didn't see any issues, both were still able to send input to other applications as long as the "Freeze on lose focus" option is disabled.
```cpp
// hold space to simulate some w letters
if (keyboard_check(vk_space))
    keyboard_key_press(ord('W'));
// press backspace to preemptively release space
// thus ending the stream of w letters
if (keyboard_check_released(vk_backspace))
    keyboard_key_release(vk_space);
// the w key remains down until the user presses & releases it
// or we programmatically release it
draw_text(0,0,keyboard_string + "#" + string(keyboard_check(ord('W'))));
```