### PR TITLE
Cleanup Keyboard Text

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -67,7 +67,6 @@ int enigma_main(int argc, char** argv) {
   initialize_everything();
 
   while (!game_isending) {
-
     if (!((std::string)enigma_user::room_caption).empty())
       enigma_user::window_set_caption(enigma_user::room_caption);
     update_mouse_variables();
@@ -100,7 +99,6 @@ std::string working_directory = "";
 std::string program_directory = "";
 std::string temp_directory = "";
 std::string game_save_id = "";
-std::string keyboard_string = "";
 int keyboard_key = 0;
 double fps = 0;
 unsigned long delta_time = 0;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -50,7 +50,6 @@ namespace enigma_user {
 extern std::string working_directory;
 extern std::string program_directory;
 extern std::string temp_directory;
-extern std::string keyboard_string;
 extern int keyboard_key;
 extern double fps;
 extern unsigned long delta_time;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
@@ -46,6 +46,15 @@ void input_push() {
   enigma_user::mouse_hscrolls = enigma_user::mouse_vscrolls = 0;
 }
 
+void platform_text_input(std::string text) {
+  if (enigma_user::keyboard_lastkey == enigma_user::vk_backspace) {
+    if (!enigma_user::keyboard_string.empty()) enigma_user::keyboard_string.pop_back();
+    return;
+  }
+  enigma_user::keyboard_string += text;
+  enigma_user::keyboard_lastchar = enigma_user::keyboard_string.back();
+}
+
 void compute_window_scaling() {
   if (!regionWidth) return;
   parWidth = isFullScreen ? enigma_user::display_get_width() : windowWidth;
@@ -87,8 +96,9 @@ void compute_window_size() {
 
 namespace enigma_user {
 
-std::string keyboard_lastchar = "";
 int keyboard_lastkey = 0;
+std::string keyboard_string = "";
+std::string keyboard_lastchar = "";
 
 double mouse_x, mouse_y;
 int mouse_button, mouse_lastbutton;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
@@ -40,6 +40,7 @@ extern int window_max_height;
 
 void input_initialize();
 void input_push();
+void platform_text_input(std::string text);
 
 }  // namespace enigma
 
@@ -156,8 +157,9 @@ enum {
 
 extern double mouse_x, mouse_y;
 extern int mouse_button, mouse_lastbutton;
-extern std::string keyboard_lastchar;
 extern int keyboard_lastkey;
+extern std::string keyboard_string;
+extern std::string keyboard_lastchar;
 extern short mouse_hscrolls;
 extern short mouse_vscrolls;
 

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
@@ -227,8 +227,6 @@ void SDL_Event_Handler::keyboardDown(const SDL_Event *event) {
   int key = enigma::keyboard::keymap[event->key.keysym.sym];
   enigma::last_keybdstatus[key] = enigma::keybdstatus[key];
   enigma::keybdstatus[key] = true;
-
-  if (key == enigma_user::vk_backspace && !enigma_user::keyboard_string.empty()) enigma_user::keyboard_string.pop_back();
 }
 
 void SDL_Event_Handler::keyboardUp(const SDL_Event *event) {
@@ -238,8 +236,7 @@ void SDL_Event_Handler::keyboardUp(const SDL_Event *event) {
 }
 
 void SDL_Event_Handler::textInput(const SDL_Event *event) {
-  enigma_user::keyboard_string += event->text.text;
-  enigma_user::keyboard_lastchar = enigma_user::keyboard_string.back();
+  enigma::platform_text_input(event->text.text);
 }
 
 void SDL_Event_Handler::mouseButtonDown(const SDL_Event *event) {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -26,10 +26,11 @@ using std::map;
 
 //#include <winuser.h> // includes windows.h
 
-#include "Platforms/General/PFmain.h" // for keyboard_string
+#include "Platforms/General/PFmain.h"
 #include "Platforms/General/PFwindow.h" // For those damn vk_ constants.
 #include "Universal_System/Instances/instance_system.h"
 #include "Universal_System/Instances/instance.h"
+#include "Universal_System/estring.h"
 
 #include "Platforms/platforms_mandatory.h"
 
@@ -49,8 +50,6 @@ namespace enigma
 
   using enigma_user::keyboard_key;
   using enigma_user::keyboard_lastkey;
-  using enigma_user::keyboard_lastchar;
-  using enigma_user::keyboard_string;
 
   extern char mousestatus[3],last_mousestatus[3],keybdstatus[256],last_keybdstatus[256];
   extern int windowX, windowY, windowColor;
@@ -168,15 +167,10 @@ namespace enigma
           return TRUE;
         }
         break;
-      case WM_CHAR:
-        keyboard_lastchar = string(1,wParam);
-        if (keyboard_lastkey == enigma_user::vk_backspace) {
-          if (!keyboard_string.empty()) keyboard_string.pop_back();
-        } else {
-          keyboard_string += keyboard_lastchar;
-        }
-        return 0;
 
+      case WM_CHAR:
+        enigma::platform_text_input(shorten(tstring(1,wParam)));
+        return 0;
       case WM_KEYDOWN: {
         int key = enigma_user::keyboard_get_map(wParam);
         keyboard_lastkey = key;

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -24,6 +24,7 @@
 #include "XLIBwindow.h"
 
 #include "Platforms/General/PFmain.h"
+#include "Platforms/General/PFwindow.h"
 #include "Platforms/General/PFsystem.h"
 #include "Platforms/platforms_mandatory.h"
 #include "Widget_Systems/widgets_mandatory.h"
@@ -65,16 +66,11 @@ int handleEvents() {
           actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0xFF]);
         else
           actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0x1FF]);
-        {  // Set keyboard_lastchar. Seems to work without
+        {
           char str[1];
           int len = XLookupString(&e.xkey, str, 1, NULL, NULL);
           if (len > 0) {
-            enigma_user::keyboard_lastchar = string(1, str[0]);
-            if (actualKey == enigma_user::vk_backspace) {
-              if (!enigma_user::keyboard_string.empty()) enigma_user::keyboard_string.pop_back();
-            } else {
-              enigma_user::keyboard_string += enigma_user::keyboard_lastchar;
-            }
+            enigma::platform_text_input(string(1, str[0]));
           }
         }
         enigma_user::keyboard_lastkey = actualKey;


### PR DESCRIPTION
It is really nice to clean this one up before it gets more out of hand. Basic idea is to stop copying the `keyboard_string` and `keyboard_lastchar` logic all over the place. SDL's text handling abstraction really inspired me. The goal here is to also add UTF-8 support for keyboard_string on the xlib and Win32 platforms.

Simple test for you.
```
draw_text(0,0,keyboard_string + "#" + keyboard_lastchar);
```