### PR TITLE
Window Scores Caption Cleanup

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -23,6 +23,10 @@ int frames_count = 0;
 unsigned long current_time_mcs = 0;
 bool game_window_focused = true;
 
+// located in actions.h but not included
+// to avoid multiple definitions
+std::string game_format_caption();
+
 int gameWait() {
   if (enigma_user::os_is_paused()) {
     if (pausedSteps < 1) {
@@ -67,9 +71,9 @@ int enigma_main(int argc, char** argv) {
   initialize_everything();
 
   while (!game_isending) {
+    std::string caption = game_format_caption();
+    if (!caption.empty()) enigma_user::window_set_caption(caption);
 
-    if (!((std::string)enigma_user::room_caption).empty())
-      enigma_user::window_set_caption(enigma_user::room_caption);
     update_mouse_variables();
 
     if (updateTimer() != 0) continue;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -56,6 +56,11 @@ extern double fps;
 extern unsigned long delta_time;
 extern unsigned long current_time;
 
+extern std::string caption_score, caption_lives, caption_health;
+extern bool show_score, show_lives, show_health;
+extern double score;
+extern double health;
+
 void sleep(int ms);
 void game_end();
 void game_end(int ret);

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -154,15 +154,9 @@ int window_get_height()
 
 void window_set_caption(const string &caption)
 {
-/*  if (caption == "")
-      if (score != 0)
-        caption = "Score: " + string(score);  //GM does this but it's rather fucktarded */
-
-    if (caption != current_caption)
-    {
-        SetWindowText(enigma::hWnd,(char*) caption.c_str());
-        current_caption = caption;
-    }
+  if (caption == current_caption) return;
+  SetWindowText(enigma::hWnd,(char*) caption.c_str());
+  current_caption = caption;
 }
 
 string window_get_caption()

--- a/ENIGMAsystem/SHELL/Universal_System/GAME_GLOBALS.h
+++ b/ENIGMAsystem/SHELL/Universal_System/GAME_GLOBALS.h
@@ -38,7 +38,7 @@ GM Global variables
 #endif
 
 namespace enigma_user {
-std::string caption_score = "Score:", caption_lives = "Lives:", caption_health = "Health:";
+std::string caption_score = "Score: ", caption_lives = "Lives: ", caption_health = "Health: ";
 bool argument_relative = false;
 double health = 100;
 

--- a/ENIGMAsystem/SHELL/Universal_System/GAME_GLOBALS.h
+++ b/ENIGMAsystem/SHELL/Universal_System/GAME_GLOBALS.h
@@ -38,10 +38,6 @@ GM Global variables
 #endif
 
 namespace enigma_user {
-std::string caption_score = "Score: ", caption_lives = "Lives: ", caption_health = "Health: ";
-bool argument_relative = false;
-double health = 100;
-
 // TODO: MOVEME: Who put this here?
 #ifndef JUST_DEFINE_IT_RUN
 std::deque<int> instance_id;
@@ -49,9 +45,8 @@ std::deque<int> instance_id;
 int *instance_id;
 #endif
 
-double score = 0;
+bool argument_relative = false;
 bool secure_mode = false;
-bool show_score = 0, show_lives = 0, show_health = 0;
 int transition_kind = 0;
 int transition_steps = 80;
 bool automatic_redraw = true;

--- a/ENIGMAsystem/SHELL/Universal_System/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/actions.h
@@ -30,30 +30,9 @@
 #include "Instances/instance_system_base.h"
 #include "lives.h"
 
-#include <sstream>
 #include <stdio.h>
 
 namespace enigma {
-
-std::string game_format_caption() {
-  std::ostringstream out;
-  // round ALL the numbers, like 5.5 to 6 lives
-  // e.g, GM8.1 behavior
-  out.precision(0);
-
-  // DON'T append anything that isn't set so the main loop
-  // could optimize the caption out completely
-  if (!((std::string)enigma_user::room_caption).empty())
-    out << (std::string)enigma_user::room_caption << " ";
-  if (enigma_user::show_score && enigma_user::score != 0)
-    out << enigma_user::caption_score << std::fixed << enigma_user::score << " ";
-  if (enigma_user::show_lives)
-    out << enigma_user::caption_lives << std::fixed << (double)enigma_user::lives << " ";
-  if (enigma_user::show_health)
-    out << enigma_user::caption_health << std::fixed << enigma_user::health;
-
-  return out.str();
-}
 
     int initialize_everything();
     variant ev_perf(int type, int numb);

--- a/ENIGMAsystem/SHELL/Universal_System/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/actions.h
@@ -30,9 +30,30 @@
 #include "Instances/instance_system_base.h"
 #include "lives.h"
 
+#include <sstream>
 #include <stdio.h>
 
 namespace enigma {
+
+std::string game_format_caption() {
+  std::ostringstream out;
+  // round ALL the numbers, like 5.5 to 6 lives
+  // e.g, GM8.1 behavior
+  out.precision(0);
+
+  // DON'T append anything that isn't set so the main loop
+  // could optimize the caption out completely
+  if (!((std::string)enigma_user::room_caption).empty())
+    out << (std::string)enigma_user::room_caption << " ";
+  if (enigma_user::show_score && enigma_user::score != 0)
+    out << enigma_user::caption_score << enigma_user::score << " ";
+  if (enigma_user::show_lives)
+    out << enigma_user::caption_lives << (double)enigma_user::lives << " ";
+  if (enigma_user::show_health)
+    out << enigma_user::caption_health << enigma_user::health;
+
+  return out.str();
+}
 
     int initialize_everything();
     variant ev_perf(int type, int numb);

--- a/ENIGMAsystem/SHELL/Universal_System/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/actions.h
@@ -46,11 +46,11 @@ std::string game_format_caption() {
   if (!((std::string)enigma_user::room_caption).empty())
     out << (std::string)enigma_user::room_caption << " ";
   if (enigma_user::show_score && enigma_user::score != 0)
-    out << enigma_user::caption_score << enigma_user::score << " ";
+    out << enigma_user::caption_score << std::fixed << enigma_user::score << " ";
   if (enigma_user::show_lives)
-    out << enigma_user::caption_lives << (double)enigma_user::lives << " ";
+    out << enigma_user::caption_lives << std::fixed << (double)enigma_user::lives << " ";
   if (enigma_user::show_health)
-    out << enigma_user::caption_health << enigma_user::health;
+    out << enigma_user::caption_health << std::fixed << enigma_user::health;
 
   return out.str();
 }


### PR DESCRIPTION
This comment in the Win32 window caption has pissed me off ever since I first saw it and every time I look at it because I know it not be true.

I devised another little test to prove it as well. The score caption is shown by default in GM8.1, yes, but it is only appended to the regular `room_caption` and its logic was clearly never contained in `window_set_caption` at all.
```cpp
// caption_score is "Score: " by default
// yes with a space at the end
caption_score = "Score: ";
// show_score is true by default
// but health and lives are NOT!
show_score = true;
score = 5;

// doesn't persist beyond keyboard wait
// and does NOT append score!
window_set_caption("lol");
keyboard_wait();

// persists but will append score, health, & lives
room_caption = "lol";

// persists until you press a key 
// but does NOT append score!
window_set_caption("lol");
keyboard_wait();
```

Another thing I realized from the step event is that the score is in fact not shown when it's 0, but health and lives are!
```cpp
if (score != 0) score = 0;
else score = 5;
```

Finally, the variables appear not to be reflexive with respect to setting the caption. Again, score, lives, & health do not effect `window_set_caption` at all.
```cpp
show_score = true; show_lives = true; show_health = true;

// caption persists throughout the loop
// score/health/lives must NOT be reflexive
window_set_caption("lol");
while (true) {
    io_handle();
    if (score != 0) score = 0;
    else score = 5;
    if (health != 0) health = 0;
    else health = 5;
    if (lives != 0) lives = 0;
    else lives = 5;
}
```

The captions are always in the order room, score, lives, health with spaces between the captions but not between the captions and the values (though the default captions contain spaces for the values as I said above).
```cpp
show_score = true; show_lives = true; show_health = true;

room_caption = "lol";
score = 5;
health = 10;
lives = 14;
```

The caption values are all displayed rounded in GM8.1 I saw 6 for all of the below.
```cpp
show_score = true; show_lives = true; show_health = true;
score = 5.5; lives = 5.5; health = 5.5;
// GM8.1 does NOT cache room caption, even though it may cache window caption!
// this should be the same as what is actually on the damn window
draw_text(0,0,window_get_caption());
```