### PR TITLE
Correct Executable Background Texture Bounds

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Resources/backgroundinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/backgroundinit.cpp
@@ -96,6 +96,7 @@ namespace enigma
       RawImage img = image_pad(pixels, width, height, nlpo2dc(width)+1, nlpo2dc(height)+1);
       int texID = graphics_create_texture(width, height, img.w, img.h, img.pxdata, false);
       Background bkg(width, height, texID, useAsTileset, tileWidth, tileHeight, hOffset, vOffset, hSep, vSep);
+      bkg.textureBounds = TexRect(0, 0, static_cast<gs_scalar>(width) / img.w, static_cast<gs_scalar>(height) / img.h);
       backgrounds.assign(bkgid, std::move(bkg));
 
       delete[] pixels;


### PR DESCRIPTION
This fixes #2064 by correcting the mistake fundies made in #1975 and actually giving the backgrounds loaded from the executable their texture bounds, as they used to work. I'm not sure if fundies possibly made the same mistake on #1937 for sprites or not. We could also later add some non power of two textures to our tests to prevent stuff like this, I wouldn't have run into it if not for a non power of two background.