### PR TITLE
Keyboard Direct Logical Keys

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSwindow.cpp
@@ -582,14 +582,45 @@ int window_get_cursor()
 
 bool keyboard_check_direct(int key)
 {
+  if (key == vk_anykey) {
+    // whack-a-mole the pressed key
+    for (int i = 0; i < 255; ++i)
+      if (GetAsyncKeyState(i) < 0) return true;
+    return false;
+  } else if (key == vk_nokey) {
+    // whack-a-mole the released key
+    for (int i = 0; i < 255; ++i)
+      if (GetAsyncKeyState(i) < 0) return false;
+    return true;
+  }
   return GetAsyncKeyState(key) < 0;
 }
 
 void keyboard_key_press(int key) {
+  if (key == vk_anykey) {
+    // press a random key
+    keyboard_set_direct(random(255), false);
+  } else if (key == vk_nokey) {
+    // press NONE of the keys aka
+    // release ALL of the keys
+    for (int i = 0; i < 255; ++i)
+      keyboard_set_direct(i, false);
+    return;
+  }
   keyboard_set_direct(key, true);
 }
 
 void keyboard_key_release(int key) {
+  if (key == vk_anykey) {
+    // release a random key
+    keyboard_set_direct(random(255), false);
+  } else if (key == vk_nokey) {
+    // release NONE of the keys aka
+    // press ALL of the keys
+    for (int i = 0; i < 255; ++i)
+      keyboard_set_direct(i, true);
+    return;
+  }
   keyboard_set_direct(key, false);
 }
 


### PR DESCRIPTION
I felt bad about removing some extra functionality in #2060 I had provided in the keyboard direct functions before, so I decided to show that it could still be done. I created this pull request to demonstrate the absurdity of their meaning in this context.

Since the direct keyboard state can only be checked below the interrupt level it is possible that while checking the state of any key any of the other keys could have already been pressed and released, but we would never know. This is why I am not even really sure the original purpose of these functions in GM to begin with, unless Mark Overmars really did just want people to create keyloggers and viruses with Game Maker back in the day.

**NOTE**: No rational person would ever merge this pull request.