### PR TITLE
Win32 Prevent Window Disabling

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -85,8 +85,9 @@ namespace enigma
           PostQuitMessage(game_return);
         }
         return 0;
-
+        
       case WM_ENABLE:
+        // don't allow modal dialogs to disable the close buttons
         if (!wParam) EnableWindow(hWnd, TRUE);
         return 0;
       case WM_SETFOCUS:

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -86,12 +86,14 @@ namespace enigma
         }
         return 0;
 
+      case WM_ENABLE:
+        if (!wParam) EnableWindow(hWnd, TRUE);
+        return 0;
       case WM_SETFOCUS:
         input_initialize();
         game_window_focused = true;
         pausedSteps = 0;
         return 0;
-
       case WM_KILLFOCUS:
         for (int i = 0; i < 255; i++)
         {


### PR DESCRIPTION
This is perhaps the greatest pull request in ENIGMA's history. Long story short, GMSv1.4 did something I actually like a long time ago. They made all of the modal non-async dialogs not stop you from closing the main game window.

However, my testing indicates that they did this by making all of the dialogs ownerless, nonmodal (still blocking), and top most. The reason I believe this is because the dialogs get their own icon in the taskbar, but still stay on top of the game window and block the thread. The only way I could get `MessageBox` to behave the same was by zeroing the owner, and adding `MB_TOPMOST` flag.

That got me thinking a little more about window procedures and if I could do this a better way without having to muck up all of the various dialog systems. Then I had a lightbulb moment that I could just prevent anything at all from disabling the game window from being closed, hence this pull request.

The beauty of this pull request means all of the dialogs are still owned by the main window. There will also only be a single taskbar icon for the game, just like before. The dialogs will still stay on top and be minimized and restored with the game window. And best of all, you will be able to close the game window directly without answering the dialogs!

Anyway, I thought it could possibly be as simple as sinking some message sent to `DefWindowProc` but it apparently isn't.
https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-enable
The only way I ended up getting this working was by intercepting `WM_ENABLE`, checking if the window is being disabled, and enabling the window. This does not seem to break the focus at all, as when dialogs are shown they still get the focus and are front and center.
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enablewindow?redirectedfrom=MSDN

I can't think of any time people would want the game window to be disabled in a nonclosable state, even with dialogs. Understand that this could interfere with some dialog extensions which would like to make the window disabled, but I don't see the point in allowing them to do so. It would be nice if we could perhaps find a simple way to distinguish if the disable message came from a child window, then we could discriminate only dialogs. Finally, if this is that big of a deal we could just make it a local setting that is only activated when running from the IDE or an environment variable, or like the secure setting.