### PR TITLE
Damn Stop Button

### DIFF
--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -255,8 +255,8 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
   cout << "Initializing dialog boxes" << endl;
   // reset this as IDE will soon enable stop button
   build_stopping = false;
-  ide_dia_clear();
-  ide_dia_open(); // <- stop button usually enabled
+  ide_dia_clear(); // <- stop button usually enabled IDE side
+  ide_dia_open();
   cout << "Initialized." << endl;
 
   CompileState state;

--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -242,6 +242,8 @@ static bool ends_with(std::string const &fullString, std::string const &ending) 
 }
 
 int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) {
+  build_stopping = false;
+
   std::filesystem::path exename;
   if (exe_filename) {
     exename = exe_filename;

--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -242,8 +242,6 @@ static bool ends_with(std::string const &fullString, std::string const &ending) 
 }
 
 int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) {
-  build_stopping = false;
-
   std::filesystem::path exename;
   if (exe_filename) {
     exename = exe_filename;
@@ -255,8 +253,10 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
   }
 
   cout << "Initializing dialog boxes" << endl;
+  // reset this as IDE will soon enable stop button
+  build_stopping = false;
   ide_dia_clear();
-  ide_dia_open();
+  ide_dia_open(); // <- stop button usually enabled
   cout << "Initialized." << endl;
 
   CompileState state;

--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -660,6 +660,7 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
   }
 
   int makeres = e_execs(compilerInfo.MAKE_location, make, flags);
+  if (build_stopping) { build_stopping = false; return 0; }
 
   // Stop redirecting GCC output
   if (redirect_make)

--- a/CompilerSource/frontend.h
+++ b/CompilerSource/frontend.h
@@ -20,4 +20,7 @@ extern syntax_error ide_passback_error;
 /// An std::string to handle allocation and free for the error string passed to the IDE.
 extern string error_sstring;
 
+/// A way to signal the compilation to stop.
+extern volatile bool build_stopping;
+
 #endif

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -51,13 +51,14 @@ using namespace std;
 #endif
 std::mutex e_exec_process_mutex;
 
-void e_exec_shutdown() {
+void e_exec_stop() {
   std::lock_guard<std::mutex> lock(e_exec_process_mutex);
   if (!e_exec_process) return;
 #if CURRENT_PLATFORM_ID == OS_WINDOWS
-  TerminateProcess(e_exec_process, 0);
+  DWORD e_exec_pid = GetProcessId(e_exec_process);
+  GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, e_exec_pid);
 #else
-  kill(e_exec_process, SIGTERM);
+  kill(e_exec_process, SIGINT);
 #endif
   e_exec_process = 0;
 }
@@ -234,7 +235,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       cout << "\n\n********* EXECUTE:\n" << parameters << "\n\n";
 
-      if (CreateProcess(NULL,(CHAR*)parameters.c_str(),NULL,&inheritibility,TRUE,CREATE_DEFAULT_ERROR_MODE,Cenviron_use,NULL,&StartupInfo,&ProcessInformation ))
+      if (CreateProcess(NULL,(CHAR*)parameters.c_str(),NULL,&inheritibility,TRUE,CREATE_DEFAULT_ERROR_MODE|CREATE_NEW_PROCESS_GROUP,Cenviron_use,NULL,&StartupInfo,&ProcessInformation ))
       {
         std::unique_lock<std::mutex> lock(e_exec_process_mutex);
         e_exec_process = ProcessInformation.hProcess;

--- a/CompilerSource/general/bettersystem.h
+++ b/CompilerSource/general/bettersystem.h
@@ -27,6 +27,7 @@
 
 #include <string>
 
+void e_exec_shutdown();
 int e_exec(const char* fcmd, const char* *Cenviron = NULL);
 int e_execp(const char* cmd, std::string path);
 int e_execs(std::string cmd);

--- a/CompilerSource/general/bettersystem.h
+++ b/CompilerSource/general/bettersystem.h
@@ -27,7 +27,6 @@
 
 #include <string>
 
-void e_exec_stop();
 int e_exec(const char* fcmd, const char* *Cenviron = NULL);
 int e_execp(const char* cmd, std::string path);
 int e_execs(std::string cmd);

--- a/CompilerSource/general/bettersystem.h
+++ b/CompilerSource/general/bettersystem.h
@@ -27,7 +27,7 @@
 
 #include <string>
 
-void e_exec_shutdown();
+void e_exec_stop();
 int e_exec(const char* fcmd, const char* *Cenviron = NULL);
 int e_execp(const char* cmd, std::string path);
 int e_execs(std::string cmd);

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -76,7 +76,7 @@ extern const char* establish_bearings(const char *compiler);
 //FIXME: remove this function from enigma.jar and here
 DLLEXPORT void libSetMakeDirectory(const char* /*dir*/) {} 
 
-DLLEXPORT void libStopBuild() { e_exec_shutdown(); } 
+DLLEXPORT void libStopBuild() { e_exec_stop(); } 
 
 DLLEXPORT const char* libInit_path(EnigmaCallbacks* ecs, const char* enigma_path) 
 {

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -76,7 +76,8 @@ extern const char* establish_bearings(const char *compiler);
 //FIXME: remove this function from enigma.jar and here
 DLLEXPORT void libSetMakeDirectory(const char* /*dir*/) {} 
 
-DLLEXPORT void libStopBuild() { e_exec_stop(); } 
+volatile bool build_stopping = false;
+DLLEXPORT void libStopBuild() { build_stopping = true; } 
 
 DLLEXPORT const char* libInit_path(EnigmaCallbacks* ecs, const char* enigma_path) 
 {

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -66,6 +66,7 @@ extern const char* establish_bearings(const char *compiler);
 #  define DLLEXPORT
 #endif
 
+#include "general/bettersystem.h"
 #include "languages/lang_CPP.h"
 #include <System/builtins.h>
 #include <API/jdi.h>
@@ -74,6 +75,8 @@ extern const char* establish_bearings(const char *compiler);
 
 //FIXME: remove this function from enigma.jar and here
 DLLEXPORT void libSetMakeDirectory(const char* /*dir*/) {} 
+
+DLLEXPORT void libStopBuild() { e_exec_shutdown(); } 
 
 DLLEXPORT const char* libInit_path(EnigmaCallbacks* ecs, const char* enigma_path) 
 {


### PR DESCRIPTION
This is the real alternative to #2067 allowing you to close the game, regardless of whether there's a dialog open or the game has hung. Obviously we've wanted a damn stop button for a very long time, but I didn't know how to do it before. This is very nice for if you accidentally press debug and you meant to hit run or etc, so you don't have to wait through a lengthy build process to fix your mistake.

The solution I came up with for right now is to add a new DLL method that sets a volatile `build_stopping` bool interpreted by `bettersystem` to indicate it should send a CTRL+C SIGINT signal to any child processes the ENIGMA build is waiting on. This means it can interrupt the make process or the game when it's being run.

I should mention that although ENIGMA's build is single threaded, the LGM plugin actually calls it from a thread. That means the thread that lets the user press the stop button and signals the DLL to shutdown the processes is a different thread than the one doing the build, since it was detached when the user pressed the run button.