### PR TITLE
POSIX Build Stopping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,16 @@ jobs:
   allow_failures:
     - os: osx
   include:
-   # - stage: ENIGMA CI
-   #   env: WORKER=0
-   # - stage: ENIGMA CI
-    #  env: WORKER=1
-   # - stage: ENIGMA CI
-    #  env: WORKER=2
-   # - stage: ENIGMA CI
-     # env: WORKER=3
-    #- stage: ENIGMA CI
-     # env: WORKER=4
+    - stage: ENIGMA CI
+      env: WORKER=0
+    - stage: ENIGMA CI
+      env: WORKER=1
+    - stage: ENIGMA CI
+      env: WORKER=2
+    - stage: ENIGMA CI
+      env: WORKER=3
+    - stage: ENIGMA CI
+      env: WORKER=4
     - stage: ENIGMA CI
       env: COMPILER=Android GRAPHICS=OpenGLES2 PLATFORM=SDL MODE=Compile ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3
       before_install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,16 @@ jobs:
     - os: osx
   include:
     - stage: ENIGMA CI
+      env: WORKER=0
+    - stage: ENIGMA CI
+      env: WORKER=1
+    - stage: ENIGMA CI
+      env: WORKER=2
+    - stage: ENIGMA CI
+      env: WORKER=3
+    - stage: ENIGMA CI
+      env: WORKER=4
+    - stage: ENIGMA CI
       env: COMPILER=Android GRAPHICS=OpenGLES2 PLATFORM=SDL MODE=Compile ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3
       before_install: 
         - git clone --depth 1 https://github.com/enigma-dev/enigma-android.git android

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,16 @@ jobs:
   allow_failures:
     - os: osx
   include:
-    - stage: ENIGMA CI
-      env: WORKER=0
-    - stage: ENIGMA CI
-      env: WORKER=1
-    - stage: ENIGMA CI
-      env: WORKER=2
-    - stage: ENIGMA CI
-      env: WORKER=3
-    - stage: ENIGMA CI
-      env: WORKER=4
+   # - stage: ENIGMA CI
+   #   env: WORKER=0
+   # - stage: ENIGMA CI
+    #  env: WORKER=1
+   # - stage: ENIGMA CI
+    #  env: WORKER=2
+   # - stage: ENIGMA CI
+     # env: WORKER=3
+    #- stage: ENIGMA CI
+     # env: WORKER=4
     - stage: ENIGMA CI
       env: COMPILER=Android GRAPHICS=OpenGLES2 PLATFORM=SDL MODE=Compile ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3
       before_install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,6 @@ jobs:
     - os: osx
   include:
     - stage: ENIGMA CI
-      env: WORKER=0
-    - stage: ENIGMA CI
-      env: WORKER=1
-    - stage: ENIGMA CI
-      env: WORKER=2
-    - stage: ENIGMA CI
-      env: WORKER=3
-    - stage: ENIGMA CI
-      env: WORKER=4
-    - stage: ENIGMA CI
       env: COMPILER=Android GRAPHICS=OpenGLES2 PLATFORM=SDL MODE=Compile ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3
       before_install: 
         - git clone --depth 1 https://github.com/enigma-dev/enigma-android.git android

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -395,13 +395,13 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (waitpid(fk,&result,WNOHANG) == 0) {
+      while (waitpid(-fk,&result,WNOHANG) == 0) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,
           // important for GNU make to stop outputting
           // before run buttons are enabled again
-          waitpid(fk,&result,__WALL);
+          waitpid(-fk,&result,__WALL);
           break;
         }
         usleep(10000); // hundreth of a second

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,7 +405,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(-fk,&result,WNOHANG|__WALL)) {
+      while (!waitpid(fk,&result,WNOHANG|__WALL)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,6 +405,9 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
+      while (!waitpid(fk,&result,WNOHANG)) {
+        if (!waitpid(-fk,&result,WNOHANG)) break;
+      }
       while (!waitpid(-fk,&result,WNOHANG|__WALL)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -346,13 +346,10 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       int result = -1;
       pid_t fk = fork();
+      setpgid(0,0); // new process group
 
       if (!fk)
       {
-        // equivalent to DETACHED_PROCESS on Win32 (e.g, the CreateProcess default)
-        // i.e, creates a new session & process group with child as leader
-        setsid();
-
         // Redirect STDOUT
         if (redirout == "") {
             int flags = fcntl(STDOUT_FILENO, F_GETFD);
@@ -398,6 +395,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
+      tcsetpgrp(STDIN_FILENO, fk); // set child group foreground
       while (waitpid(fk,&result,WNOHANG) == 0) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -346,7 +346,8 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       int result = -1;
       pid_t fk = fork();
-      setpgid(fk, 0); // new process group
+      setsid();
+      //setpgid(fk, 0); // new process group
 
       if (!fk)
       {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -394,8 +394,13 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      //TODO: respect build_stopping here
-      waitpid(fk,&result,0);
+      do {
+        if (!build_stopping) {
+          ualarm(10000, 10000);
+          continue;
+        }
+        kill(fk, SIGINT);
+      } while waitpid(fk,&result,0) == -1;
       for (char** i = argv+1; *i; i++)
         free(*i);
       free(argv);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -397,7 +397,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       while (waitpid(fk,&result,WNOHANG) == 0) {
         if (build_stopping) {
-          kill(fk,SIGINT); // send CTRL+C
+          kill(fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,
           // important for GNU make to stop outputting
           waitpid(fk,0,__WALL);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,9 +405,6 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(fk,&result,WNOHANG)) {
-        if (!waitpid(-fk,&result,WNOHANG)) break;
-      }
       while (!waitpid(-fk,&result,WNOHANG|__WALL)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -350,7 +350,11 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       if (!fk)
       {
-        close(STDIN_FILENO);
+        // We need an STDIN
+        int flags = fcntl(STDIN_FILENO, F_GETFD);
+        if (flags != -1)
+          flags &= ~FD_CLOEXEC,
+          fcntl(STDIN_FILENO, F_SETFD, flags);
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -350,11 +350,11 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       if (!fk)
       {
-        // We need an STDIN
-        int flags = fcntl(STDIN_FILENO, F_GETFD);
-        if (flags != -1)
-          flags &= ~FD_CLOEXEC,
-          fcntl(STDIN_FILENO, F_SETFD, flags);
+        // Duplicate STDIN
+        // Necessary for background process group,
+        // else SIGTTIN when attempting to read.
+        dup2(STDIN_FILENO, STDIN_FILENO);
+        close(STDIN_FILENO);
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -356,9 +356,6 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         int infd = open("/dev/zero", O_RDONLY);
         dup2(infd, STDIN_FILENO);
         close(STDIN_FILENO);
-        // need FD_CLOEXEC to get EOF signal
-        // gradlew does this insanity!
-        fcntl(infd, F_SETFD, FD_CLOEXEC);
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -400,6 +400,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           kill(fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,
           // important for GNU make to stop outputting
+          // before run buttons are enabled again
           waitpid(fk,0,__WALL);
           break;
         }

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -400,7 +400,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           continue;
         }
         kill(fk, SIGINT);
-      } while (waitpid(fk,&result,0) == -1);
+      } while (waitpid(fk,&result,WNOHANG) == -1);
       for (char** i = argv+1; *i; i++)
         free(*i);
       free(argv);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,7 +405,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(-fk,&result,WNOHANG|WUNTRACED)) {
+      while (!waitpid(-fk,&result,WNOHANG)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -397,7 +397,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       while (waitpid(fk,&result,WNOHANG) == 0) {
         if (build_stopping) {
-          kill(fk,SIGINT); // send CTRL+C to process group
+          kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,
           // important for GNU make to stop outputting
           // before run buttons are enabled again

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -353,7 +353,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         // Redirect STDIN
         // Background process groups get SIGTTIN if
         // reading from the terminal.
-        int infd = open("/dev/null", O_RDONLY);
+        int infd = open("/dev/zero", O_RDONLY);
         dup2(infd, STDIN_FILENO);
         close(STDIN_FILENO);
         // need FD_CLOEXEC to get EOF signal

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -390,7 +390,8 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         }
         else usenviron = environ;
 
-          execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
+        setpgid(fk, 0); // new process group
+        execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
         exit(-1);
       }
 

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -353,7 +353,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         // Redirect STDIN
         // Background process groups get SIGTTIN if
         // reading from the terminal.
-        int infd = open("/dev/zero", O_RDONLY);
+        int infd = open("/dev/null", O_RDONLY);
         dup2(infd, STDIN_FILENO);
 
         // Redirect STDOUT

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -355,7 +355,6 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         // reading from the terminal.
         int infd = open("/dev/zero", O_RDONLY);
         dup2(infd, STDIN_FILENO);
-        close(STDIN_FILENO);
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -346,6 +346,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       int result = -1;
       pid_t fk = fork();
+      setpgid(fk, 0); // new process group
 
       if (!fk)
       {
@@ -390,7 +391,6 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         }
         else usenviron = environ;
 
-        setpgid(fk, 0); // new process group
         execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
         exit(-1);
       }

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,7 +405,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(-fk,&result,WNOHANG)) {
+      while (!waitpid(-fk,&result,WNOHANG|__WALL)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -353,7 +353,9 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         // Redirect STDIN
         // Background process groups get SIGTTIN if
         // reading from the terminal.
-        close(STDIN_FILENO); // read from /dev/null
+        int infd = open("/dev/null", O_RDONLY);
+        dup2(infd, STDIN_FILNO);
+        close(STDIN_FILENO);
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -354,7 +354,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         // Background process groups get SIGTTIN if
         // reading from the terminal.
         int infd = open("/dev/null", O_RDONLY);
-        dup2(infd, STDIN_FILNO);
+        dup2(infd, STDIN_FILENO);
         close(STDIN_FILENO);
 
         // Redirect STDOUT

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -346,6 +346,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       int result = -1;
       pid_t fk = fork();
+
       if (!fk)
       {
         // equivalent to DETACHED_PROCESS on Win32 (e.g, the CreateProcess default)

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -395,7 +395,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           if (!usenviron[i]) break;
           std::cout << "gradle environment " << usenviron[i] << std::endl;
         }
-        tcsetpgrp(STDIN_FILENO, getpgid()); // become foreground group
+        tcsetpgrp(STDIN_FILENO, getpgid(0)); // become foreground group
         execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
         exit(-1);
       }
@@ -411,7 +411,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         }
         usleep(10000); // hundreth of a second
       }
-      tcsetpgrp(STDIN_FILENO, getpgid()); // retake the terminal
+      tcsetpgrp(STDIN_FILENO, getpgid(0)); // retake the terminal
       for (char** i = argv+1; *i; i++)
         free(*i);
       free(argv);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -346,12 +346,12 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       int result = -1;
       pid_t fk = fork();
-      //setsid();
-      setpgid(getpid(), getpid()); // new process group
-
       if (!fk)
       {
-        std::cout << "gradle out?" << std::endl;
+        // equivalent to DETACHED_PROCESS on Win32 (e.g, the CreateProcess default)
+        // i.e, creates a new session & process group with child as leader
+        setsid();
+
         // Redirect STDOUT
         if (redirout == "") {
             int flags = fcntl(STDOUT_FILENO, F_GETFD);
@@ -392,14 +392,12 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           *dest = NULL;
         }
         else usenviron = environ;
-        std::cout << "gradle exec?" << std::endl;
+
         execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
-        std::cout << "gradle done?" << std::endl;
         exit(-1);
       }
 
       while (waitpid(fk,&result,WNOHANG) == 0) {
-        //std::cout << "gradle" << std::endl;
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -401,7 +401,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           // wait for entire process group to signal,
           // important for GNU make to stop outputting
           // before run buttons are enabled again
-          waitpid(fk,0,__WALL);
+          waitpid(fk,&result,__WALL);
           break;
         }
         usleep(10000); // hundreth of a second

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,7 +405,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(fk,&result,WNOHANG|__WALL)) {
+      while (!waitpid(fk,&result,WNOHANG)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -395,13 +395,14 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (waitpid(-fk,&result,WNOHANG) == 0) {
+      pid_t fkgid = getpgid(fk);
+      while (waitpid(-fkgid,&result,WNOHANG) == 0) {
         if (build_stopping) {
-          kill(-fk,SIGINT); // send CTRL+C to process group
+          kill(-fkgid,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,
           // important for GNU make to stop outputting
           // before run buttons are enabled again
-          waitpid(-fk,&result,__WALL);
+          waitpid(-fkgid,&result,__WALL);
           break;
         }
         usleep(10000); // hundreth of a second

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -350,12 +350,10 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       if (!fk)
       {
-        // Duplicate STDIN
-        // Necessary for background process group,
-        // else SIGTTIN when attempting to read.
-        int dupin = dup(STDIN_FILENO);
-        dup2(dupin, STDIN_FILENO);
-        close(dupin);
+        // Redirect STDIN
+        // Background process groups get SIGTTIN if
+        // reading from the terminal.
+        close(STDIN_FILENO); // read from /dev/null
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,7 +405,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(fk,&result,WNOHANG|WUNTRACED) && !WIFEXITED(result) && !WIFSIGNALED(result)) {
+      while (!waitpid(-fk,&result,WNOHANG|WUNTRACED) && !WIFEXITED(result) && !WIFSIGNALED(result)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -350,6 +350,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       if (!fk)
       {
+        std::cout << "gradle out?" << std::endl;
         // Redirect STDOUT
         if (redirout == "") {
             int flags = fcntl(STDOUT_FILENO, F_GETFD);
@@ -390,13 +391,14 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           *dest = NULL;
         }
         else usenviron = environ;
-
+        std::cout << "gradle exec?" << std::endl;
         execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
+        std::cout << "gradle done?" << std::endl;
         exit(-1);
       }
 
       while (waitpid(fk,&result,WNOHANG) == 0) {
-        std::cout << "gradle" << std::endl;
+        //std::cout << "gradle" << std::endl;
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -358,10 +358,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         close(STDIN_FILENO);
         // need FD_CLOEXEC to get EOF signal
         // gradlew does this insanity!
-        int flags = fcntl(infd, F_GETFD);
-        if (flags != -1)
-          flags |= FD_CLOEXEC,
-          fcntl(infd, F_SETFD, flags);
+        fcntl(infd, F_SETFD, FD_CLOEXEC);
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -419,7 +419,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
             } else if (WIFCONTINUED(result)) {
                 std::cout << "continued" << std::endl;
             }
-        usleep(10000); // hundreth of a second
+        usleep(10000); // hundredth of a second
       }
       for (char** i = argv+1; *i; i++)
         free(*i);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -394,13 +394,13 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      do {
-        if (!build_stopping) {
-          ualarm(10000, 10000);
-          continue;
+      while (waitpid(fk,&result,WNOHANG) == 0) {
+        if (build_stopping) {
+          kill(fk,SIGINT);
+          break;
         }
-        kill(fk, SIGINT);
-      } while (waitpid(fk,&result,WNOHANG) == -1);
+        usleep(10000);
+      }
       for (char** i = argv+1; *i; i++)
         free(*i);
       free(argv);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -398,6 +398,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
       while (waitpid(fk,&result,WNOHANG) == 0) {
         if (build_stopping) {
           kill(fk,SIGINT);
+          waitpid(fk,0,__WALL);
           break;
         }
         usleep(10000);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,7 +405,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(-fk,&result,WNOHANG|WUNTRACED) && !WIFEXITED(result) && !WIFSIGNALED(result)) {
+      while (!waitpid(-fk,&result,WNOHANG|WUNTRACED)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -391,11 +391,6 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         }
         else usenviron = environ;
 
-        for (int i = 0;;++i) {
-          if (!usenviron[i]) break;
-          std::cout << "gradle environment " << usenviron[i] << std::endl;
-        }
-        tcsetpgrp(STDIN_FILENO, getpgid(0)); // become foreground group
         execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
         exit(-1);
       }
@@ -411,7 +406,6 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         }
         usleep(10000); // hundreth of a second
       }
-      tcsetpgrp(STDIN_FILENO, getpgid(0)); // retake the terminal
       for (char** i = argv+1; *i; i++)
         free(*i);
       free(argv);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -350,6 +350,8 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       if (!fk)
       {
+        close(STDIN_FILENO);
+
         // Redirect STDOUT
         if (redirout == "") {
             int flags = fcntl(STDOUT_FILENO, F_GETFD);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -356,6 +356,12 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         int infd = open("/dev/null", O_RDONLY);
         dup2(infd, STDIN_FILENO);
         close(STDIN_FILENO);
+        // need FD_CLOEXEC to get EOF signal
+        // gradlew does this insanity!
+        int flags = fcntl(infd, F_GETFD);
+        if (flags != -1)
+          flags |= FD_CLOEXEC,
+          fcntl(infd, F_SETFD, flags);
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -395,14 +395,13 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      pid_t fkgid = getpgid(fk);
-      while (waitpid(-fkgid,&result,WNOHANG) == 0) {
+      while (waitpid(fk,&result,WNOHANG) == 0) {
         if (build_stopping) {
-          kill(-fkgid,SIGINT); // send CTRL+C to process group
+          kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,
           // important for GNU make to stop outputting
           // before run buttons are enabled again
-          waitpid(-fkgid,&result,__WALL);
+          waitpid(-fk,&result,__WALL);
           break;
         }
         usleep(10000); // hundreth of a second

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -396,6 +396,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
       }
 
       while (waitpid(fk,&result,WNOHANG) == 0) {
+        std::cout << "gradle" << std::endl;
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -400,7 +400,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           continue;
         }
         kill(fk, SIGINT);
-      } while waitpid(fk,&result,0) == -1;
+      } while (waitpid(fk,&result,0) == -1);
       for (char** i = argv+1; *i; i++)
         free(*i);
       free(argv);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -410,15 +410,6 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           waitpid(-fk,&result,__WALL);
           break;
         }
-           if (WIFEXITED(result)) {
-                std::cout << "exited, status=" << WEXITSTATUS(result) << std::endl;
-            } else if (WIFSIGNALED(result)) {
-                std::cout << "killed by signal " << WTERMSIG(result) << std::endl;
-            } else if (WIFSTOPPED(result)) {
-                std::cout << "stopped by signal " << WSTOPSIG(result) << std::endl;
-            } else if (WIFCONTINUED(result)) {
-                std::cout << "continued" << std::endl;
-            }
         usleep(10000); // hundredth of a second
       }
       for (char** i = argv+1; *i; i++)

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -395,6 +395,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           if (!usenviron[i]) break;
           std::cout << "gradle environment " << usenviron[i] << std::endl;
         }
+        tcsetpgrp(STDIN_FILENO, getpgid()); // become foreground group
         execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
         exit(-1);
       }
@@ -410,6 +411,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         }
         usleep(10000); // hundreth of a second
       }
+      tcsetpgrp(STDIN_FILENO, getpgid()); // retake the terminal
       for (char** i = argv+1; *i; i++)
         free(*i);
       free(argv);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,7 +405,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (waitpid(fk,&result,WNOHANG) == 0) {
+      while (!waitpid(fk,&result,WNOHANG) && !WIFEXITED(result) && !WIFSIGNALED(result)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -405,7 +405,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(fk,&result,WNOHANG) && !WIFEXITED(result) && !WIFSIGNALED(result)) {
+      while (!waitpid(fk,&result,WNOHANG|WUNTRACED) && !WIFEXITED(result) && !WIFSIGNALED(result)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,
@@ -414,6 +414,15 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
           waitpid(-fk,&result,__WALL);
           break;
         }
+           if (WIFEXITED(result)) {
+                std::cout << "exited, status=" << WEXITSTATUS(result) << std::endl;
+            } else if (WIFSIGNALED(result)) {
+                std::cout << "killed by signal " << WTERMSIG(result) << std::endl;
+            } else if (WIFSTOPPED(result)) {
+                std::cout << "stopped by signal " << WSTOPSIG(result) << std::endl;
+            } else if (WIFCONTINUED(result)) {
+                std::cout << "continued" << std::endl;
+            }
         usleep(10000); // hundreth of a second
       }
       for (char** i = argv+1; *i; i++)

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -346,8 +346,8 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       int result = -1;
       pid_t fk = fork();
-      setsid();
-      //setpgid(fk, 0); // new process group
+      //setsid();
+      setpgid(getpid(), getpid()); // new process group
 
       if (!fk)
       {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -353,8 +353,9 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         // Duplicate STDIN
         // Necessary for background process group,
         // else SIGTTIN when attempting to read.
-        dup2(STDIN_FILENO, STDIN_FILENO);
-        close(STDIN_FILENO);
+        int dupin = dup(STDIN_FILENO);
+        dup2(dupin, STDIN_FILENO);
+        close(dupin);
 
         // Redirect STDOUT
         if (redirout == "") {

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -391,11 +391,11 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         }
         else usenviron = environ;
 
+        std::cout << "gradle environment " << useenviron << std::endl;
         execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
         exit(-1);
       }
 
-      tcsetpgrp(STDIN_FILENO, fk); // set child group foreground
       while (waitpid(fk,&result,WNOHANG) == 0) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -397,11 +397,13 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
       while (waitpid(fk,&result,WNOHANG) == 0) {
         if (build_stopping) {
-          kill(fk,SIGINT);
+          kill(fk,SIGINT); // send CTRL+C
+          // wait for entire process group to signal,
+          // important for GNU make to stop outputting
           waitpid(fk,0,__WALL);
           break;
         }
-        usleep(10000);
+        usleep(10000); // hundreth of a second
       }
       for (char** i = argv+1; *i; i++)
         free(*i);

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -391,7 +391,10 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         }
         else usenviron = environ;
 
-        std::cout << "gradle environment " << useenviron << std::endl;
+        for (int i = 0;;++i) {
+          if (!usenviron[i]) break;
+          std::cout << "gradle environment " << usenviron[i] << std::endl;
+        }
         execve(ename.c_str(), (char*const*)argv, (char*const*)usenviron);
         exit(-1);
       }


### PR DESCRIPTION
Following up on #2068 to bring the game compile interrupt to Linux. This one was a little tricky for me because `waitpid` does not have an easy version that accepts a timeout and I was afraid sleeping would be a busy wait. I tried it on Linux myself and it seemed to work without high CPU usage, so I presume my concerns were unfounded. Regardless I opted to make it 10,000 microsecond sleep, or 10 milliseconds, or a hundreth of a second which is the same as the Win32 version I already merged.