### PR TITLE
Conditional Build Stopping

### DIFF
--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -301,7 +301,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
 
     volatile bool stop_signal = false;
     void sigchld(int stat) {
-      if (stat == SIGCHILD)
+      if (stat == SIGCHLD)
         stop_signal = true;
     }
 

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -293,12 +293,10 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
       free(a);
     }
 
-    #include <mutex>
-    #include <semaphore>
-    std::mutex stop_mutex;
-    std::binary_semaphore stop_semaphore;
+    #include <semaphore.h>
+    sem_t stop_semaphore;
     void e_exec_stop() {
-      stop_semaphore.release();
+      sem_init(&stop_semaphore,0,1);
     }
 
     int e_exec(const char* fcmd, const char* *Cenviron)
@@ -416,7 +414,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (build_semaphore.acquire() && errno != ECHILD)
+      while (sem_wait(&stop_semaphore) && errno != ECHILD)
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -294,11 +294,11 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
     }
 
     #include <mutex>
-    #include <condition_variable>
+    #include <semaphore>
     std::mutex stop_mutex;
-    std::condition_variable stop_condition;
+    std::binary_semaphore stop_semaphore;
     void e_exec_stop() {
-      stop_condition.notify_all();
+      stop_semaphore.release();
     }
 
     int e_exec(const char* fcmd, const char* *Cenviron)
@@ -416,7 +416,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!pthread_cond_wait(stop_condition.native_handle(), stop_mutex.native_handle()) && errno != ECHILD)
+      while (build_semaphore.acquire() && errno != ECHILD)
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -414,7 +414,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (sem_wait(&stop_semaphore) && errno != ECHILD)
+      while (!sem_wait(&stop_semaphore) && errno != EINTR)
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -293,6 +293,8 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
       free(a);
     }
 
+    #include <mutex>
+    #include <condition_variable>
     std::mutex stop_mutex;
     std::condition_variable stop_condition;
     void e_exec_stop() {
@@ -414,7 +416,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!pthread_cond_wait(stop_condition.native_handle(), stop_mutex.native_handle()) && errno != ECHLD)
+      while (!pthread_cond_wait(stop_condition.native_handle(), stop_mutex.native_handle()) && errno != ECHILD)
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/general/bettersystem.h
+++ b/CompilerSource/general/bettersystem.h
@@ -27,6 +27,7 @@
 
 #include <string>
 
+void e_exec_stop();
 int e_exec(const char* fcmd, const char* *Cenviron = NULL);
 int e_execp(const char* cmd, std::string path);
 int e_execs(std::string cmd);

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -77,7 +77,10 @@ extern const char* establish_bearings(const char *compiler);
 DLLEXPORT void libSetMakeDirectory(const char* /*dir*/) {} 
 
 volatile bool build_stopping = false;
-DLLEXPORT void libStopBuild() { build_stopping = true; } 
+DLLEXPORT void libStopBuild() {
+  build_stopping = true;
+  e_exec_stop();
+} 
 
 DLLEXPORT const char* libInit_path(EnigmaCallbacks* ecs, const char* enigma_path) 
 {


### PR DESCRIPTION
Rather than check for build stopping at regular 10 millisecond intervals, it's probably more efficient to just wait on a semaphore.