### PR TITLE
emake Interrupt

### DIFF
--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -36,6 +36,10 @@ void EnigmaPlugin::LogMakeToConsole() {
   log_make_to_console();
 }
 
+void EnigmaPlugin::StopBuild() {
+  libStopBuild();
+}
+
 int EnigmaPlugin::BuildGame(deprecated::JavaStruct::EnigmaStruct* data,
                             GameMode mode, const char* fpath) {
   return compileEGMf(data, fpath, mode);

--- a/CommandLine/emake/EnigmaPlugin.cpp
+++ b/CommandLine/emake/EnigmaPlugin.cpp
@@ -1,7 +1,6 @@
 #include "EnigmaPlugin.hpp"
 #include "Main.hpp"
 
-#include "OS_Switchboard.h"
 #include "enigma.h"
 
 EnigmaPlugin::EnigmaPlugin()

--- a/CommandLine/emake/EnigmaPlugin.hpp
+++ b/CommandLine/emake/EnigmaPlugin.hpp
@@ -36,6 +36,7 @@ public:
   syntax_error* SyntaxCheck(int count, const char** names, const char* code);
   void HandleGameLaunch();
   void LogMakeToConsole();
+  void StopBuild();
   int BuildGame(deprecated::JavaStruct::EnigmaStruct* data, GameMode mode, const char* fpath);
   int BuildGame(const buffers::Game& data, GameMode mode, const char* fpath);
   const char* NextResource();

--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include "SOG.hpp"
+#include "OS_Switchboard.h"
 
 #ifdef CLI_ENABLE_EGM
 #include "gmk.h"

--- a/CompilerSource/enigma.h
+++ b/CompilerSource/enigma.h
@@ -6,9 +6,10 @@
 #include "frontend.h"
 
 extern "C" {
-  
+
 const char* libInit(EnigmaCallbacks* ecs);
 const char* libInit_path(EnigmaCallbacks* ecs, const char* enigma_path);
+void libStopBuild();
 int compileEGMf(deprecated::JavaStruct::EnigmaStruct *es, const char* exe_filename, int mode);
 int compileProto(const buffers::Project *proj, const char* exe_filename, int mode);
 const char* next_available_resource();


### PR DESCRIPTION
As per #2073, emake should handle SIGINT/CTRL+C to tell ENIGMA to stop the build, just like the IDE stop button does. However, there's no point in merging this yet as I didn't do POSIX and the feature is broke in MSYS2/MinGW because of MinTTY or something.