### PR TITLE
Fix Issue Config Website URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -14,4 +14,4 @@ contact_links:
     about: "Problems with ENIGMA⟷LGM plugin related UI issues, such as extension & API selection, logging, and populating resources."
   - name: The Website
     url: "https://github.com/enigma-dev/Site"
-    about: "Problems related to the [enigma-dev.org](https://enigma-dev.org) website, community, forum, and Wiki."
+    about: "Problems related to the https://enigma-dev.org website, community, forum, and Wiki."


### PR DESCRIPTION
I tried to tell Josh he was going overboard making it markdown.
![Markdown Issue Config Broke URL](https://user-images.githubusercontent.com/3212801/87863805-7745dd00-c92d-11ea-9bb0-5f88c227b0b9.png)
