### PR TITLE
Fix GMX Timeline Actions

### DIFF
--- a/CommandLine/libEGM/gmx.cpp
+++ b/CommandLine/libEGM/gmx.cpp
@@ -304,10 +304,10 @@ void PackRes(const LookupMap& resMap, std::string &dir, int id, pugi::xml_node &
         continue;
       } 
         
-      if (gmxName == "action") {
+      if (string_endswith(gmxName, "action")) {
         std::vector<Action> actions;
         int cid = 0;
-        for (pugi::xml_node n = child.child("action"); n != nullptr; n = n.next_sibling()) {
+        for (pugi::xml_node n = child.first_element_by_path(gmxName.c_str()); n != nullptr; n = n.next_sibling()) {
           if (strcmp(n.name(), "action") == 0) {  // skip over any siblings that aren't twins <foo/><bar/><foo/> <- bar would be skipped
             n.append_attribute("visited") = "true";
             Action action;

--- a/CommandLine/libEGM/gmx.cpp
+++ b/CommandLine/libEGM/gmx.cpp
@@ -304,7 +304,7 @@ void PackRes(const LookupMap& resMap, std::string &dir, int id, pugi::xml_node &
         continue;
       } 
         
-      if (string_endswith(gmxName, "action")) {
+      if (string_ends_with(gmxName, "action")) {
         std::vector<Action> actions;
         int cid = 0;
         for (pugi::xml_node n = child.first_element_by_path(gmxName.c_str()); n != nullptr; n = n.next_sibling()) {

--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -234,19 +234,12 @@ template<typename T> void write_asset_map(std::string& str, vector<T> resources,
   str += "  }\n},\n";
 }
 
-static bool ends_with(std::string const &fullString, std::string const &ending) {
-    if (fullString.length() < ending.length())
-      return false;
-
-    return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
-}
-
 int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) {
   std::filesystem::path exename;
   if (exe_filename) {
     exename = exe_filename;
     const std::filesystem::path buildext = compilerInfo.exe_vars["BUILD-EXTENSION"];
-    if (!ends_with(exename.u8string(), buildext.u8string())) {
+    if (!string_endswith(exename.u8string(), buildext.u8string())) {
       exename += buildext;
       exe_filename = exename.u8string().c_str();
     }

--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -239,7 +239,7 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
   if (exe_filename) {
     exename = exe_filename;
     const std::filesystem::path buildext = compilerInfo.exe_vars["BUILD-EXTENSION"];
-    if (!string_endswith(exename.u8string(), buildext.u8string())) {
+    if (!string_ends_with(exename.u8string(), buildext.u8string())) {
       exename += buildext;
       exe_filename = exename.u8string().c_str();
     }

--- a/shared/protos/Timeline.proto
+++ b/shared/protos/Timeline.proto
@@ -6,7 +6,7 @@ import "options.proto";
 message Timeline {
   message Moment {
     optional int32 step = 1;
-    optional string code = 2 [(gmx) = "action"];
+    optional string code = 2 [(gmx) = "event/action"];
   }
 
   optional int32 id = 1 [(gmx) = "GMX_DEPRECATED"];

--- a/shared/strings_util.h
+++ b/shared/strings_util.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <sstream>
 
-inline bool string_endswith(std::string const &fullString, std::string const &ending) {
+inline bool string_ends_with(std::string const &fullString, std::string const &ending) {
     if (fullString.length() < ending.length())
       return false;
 

--- a/shared/strings_util.h
+++ b/shared/strings_util.h
@@ -5,6 +5,13 @@
 #include <vector>
 #include <sstream>
 
+inline bool string_endswith(std::string const &fullString, std::string const &ending) {
+    if (fullString.length() < ending.length())
+      return false;
+
+    return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+}
+
 inline std::string string_replace_all(std::string str, std::string substr, std::string nstr) {
   size_t pos = 0;
   while ((pos = str.find(substr, pos)) != std::string::npos)


### PR DESCRIPTION
Yeah I tested it, of course I tested it. Timelines in GMX have a slightly different structure for moments than objects do for events. This means we need to support XML paths for the action nodes, which I've now added. First, I moved the `string_endswith` utility out of the compiler source and into the shared string utility header. I then have the GMX reader use that to check if the end of the GMX path name is "action" and in that case to handle the actions. It now looks for the first action child using the full path as well.

Also fyi, there's probably more tweaking to be done yet to the actions to code conversion because opening up a timeline in RGM right now looks like the following. The original version from the LGM plugin I believe does this in the codegen as well, but ideally the user won't want the extra braces so we should look into that later.
![RGM Timeline Moments Code](https://user-images.githubusercontent.com/3212801/88751130-fce33d00-d124-11ea-83dc-dd837dbe111c.png)


```xml
<timeline>
  <entry>
    <step>0</step>
    <event>
      <action>
        ...
      </action>
      <action>
        ...
      </action>
    </event>
  </entry>
  <entry>
    <step>1</step>
    <event>
      <action>
        ...
      </action>
    </event>
  </entry>
</timeline>

<object>
  <events>
    <event enumb="0" eventtype="8">
      <action>
        ...
      </action>
    </event>
    <event enumb="0" eventtype="2">
      <action>
        ...
      </action>
    </event>
  </events>
</object>
```