### PR TITLE
Stop API Enabling

### DIFF
--- a/CompilerSource/frontend.h
+++ b/CompilerSource/frontend.h
@@ -22,5 +22,7 @@ extern string error_sstring;
 
 /// A way to signal the compilation to stop.
 extern volatile bool build_stopping;
+/// Must be enabled a priori.
+extern volatile bool build_enable_stop;
 
 #endif

--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -406,7 +406,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
         exit(-1);
       }
 
-      while (!waitpid(fk,&result,WNOHANG)) {
+      while (!waitpid(fk,&result,build_enable_stop?WNOHANG:0)) {
         if (build_stopping) {
           kill(-fk,SIGINT); // send CTRL+C to process group
           // wait for entire process group to signal,

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -73,8 +73,10 @@ extern const char* establish_bearings(const char *compiler);
 
 #include <cstdlib>
 
-volatile bool build_stopping = false;
-DLLEXPORT void libStopBuild() { build_stopping = true; } 
+volatile bool build_stopping = false,
+         bool build_enable_stop = false;
+DLLEXPORT void libStopBuild() { build_stopping = true; }
+DLLEXPORT void libEnableStop() { build_enable_stop = true; } 
 
 DLLEXPORT const char* libInit_path(EnigmaCallbacks* ecs, const char* enigma_path) 
 {

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -76,7 +76,7 @@ extern const char* establish_bearings(const char *compiler);
 volatile bool build_stopping = false,
               build_enable_stop = false;
 DLLEXPORT void libStopBuild() { build_stopping = true; }
-DLLEXPORT void libEnableStop() { build_enable_stop = true; } 
+DLLEXPORT void libEnableStopAPI() { build_enable_stop = true; } 
 
 DLLEXPORT const char* libInit_path(EnigmaCallbacks* ecs, const char* enigma_path) 
 {

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -74,7 +74,7 @@ extern const char* establish_bearings(const char *compiler);
 #include <cstdlib>
 
 volatile bool build_stopping = false,
-         bool build_enable_stop = false;
+              build_enable_stop = false;
 DLLEXPORT void libStopBuild() { build_stopping = true; }
 DLLEXPORT void libEnableStop() { build_enable_stop = true; } 
 


### PR DESCRIPTION
This addresses issues like #2073 which were caused by #2068 and #2070 when build stopping was added. The problem is that build stopping requires make/game to be run in a background process group, but that causes emake's own CTRL+C not to automatically be forwarded. I chose to do it Josh's way and just put it back the way it was and instead provide another method which enables the stop API so that the plugin can continue using it. This way, depending on our future requirements for emake, we can later reuse the functionality.

NOTE: I need additional feedback from fundies yet, I only guarded the creation of the process group for now. I need to know if redirecting STDIN was also a problem because as far as I am aware that's correct regardless of whether we create a process group or not and should have always been that way.