### PR TITLE
Buffers CI Test & Functionality

### DIFF
--- a/CommandLine/testing/SimpleTests/buffers.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/buffers.sog/create.edl
@@ -1,0 +1,12 @@
+gtest_expect_false(buffer_exists(-1));
+gtest_expect_false(buffer_exists(0));
+gtest_expect_false(buffer_exists(1));
+
+var buffer_create_test;
+buffer_create_test = buffer_create(137, buffer_fixed, 4);
+gtest_expect_eq(buffer_get_size(buffer_create_test), 137);
+gtest_expect_eq(buffer_get_type(buffer_create_test), buffer_fixed);
+gtest_expect_eq(buffer_get_alignment(buffer_create_test), 4);
+gtest_expect_true(buffer_exists(buffer_create_test));
+buffer_delete(buffer_create_test);
+gtest_expect_false(buffer_exists(buffer_create_test));

--- a/CommandLine/testing/SimpleTests/buffers.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/buffers.sog/create.edl
@@ -1,12 +1,43 @@
+/// BUFFER TYPE SIZES
+gtest_expect_eq(buffer_sizeof(buffer_string), 0);
+gtest_expect_eq(buffer_sizeof(buffer_text), 0);
+gtest_expect_eq(buffer_sizeof(buffer_u8), 1);
+gtest_expect_eq(buffer_sizeof(buffer_s8), 1);
+gtest_expect_eq(buffer_sizeof(buffer_bool), 1);
+gtest_expect_eq(buffer_sizeof(buffer_u16), 2);
+gtest_expect_eq(buffer_sizeof(buffer_s16), 2);
+gtest_expect_eq(buffer_sizeof(buffer_f16), 2);
+gtest_expect_eq(buffer_sizeof(buffer_u32), 4);
+gtest_expect_eq(buffer_sizeof(buffer_s32), 4);
+gtest_expect_eq(buffer_sizeof(buffer_f32), 4);
+gtest_expect_eq(buffer_sizeof(buffer_u64), 8);
+gtest_expect_eq(buffer_sizeof(buffer_f64), 8);
+
+/// NOTHING SHOULD EXIST YET
 gtest_expect_false(buffer_exists(-1));
 gtest_expect_false(buffer_exists(0));
 gtest_expect_false(buffer_exists(1));
 
-var buffer_create_test;
-buffer_create_test = buffer_create(137, buffer_fixed, 4);
-gtest_expect_eq(buffer_get_size(buffer_create_test), 137);
-gtest_expect_eq(buffer_get_type(buffer_create_test), buffer_fixed);
-gtest_expect_eq(buffer_get_alignment(buffer_create_test), 4);
-gtest_expect_true(buffer_exists(buffer_create_test));
-buffer_delete(buffer_create_test);
-gtest_expect_false(buffer_exists(buffer_create_test));
+/// BEGIN FIXED BUFFER TEST
+var buffer_fixed_test;
+buffer_fixed_test = buffer_create(137, buffer_fixed, 4);
+gtest_assert_true(buffer_exists(buffer_fixed_test));
+
+gtest_expect_eq(buffer_get_size(buffer_fixed_test), 137);
+gtest_expect_eq(buffer_get_type(buffer_fixed_test), buffer_fixed);
+gtest_expect_eq(buffer_get_alignment(buffer_fixed_test), 4);
+gtest_expect_eq(buffer_tell(buffer_fixed_test), 0);
+gtest_expect_eq(buffer_read(buffer_fixed_test, buffer_u8), 0);
+gtest_expect_eq(buffer_tell(buffer_fixed_test), 1);
+buffer_seek(buffer_fixed_test, buffer_seek_end, 0);
+gtest_expect_eq(buffer_tell(buffer_fixed_test), 137);
+buffer_seek(buffer_fixed_test, buffer_seek_relative, -10);
+gtest_expect_eq(buffer_tell(buffer_fixed_test), 127);
+buffer_seek(buffer_fixed_test, buffer_seek_start, 23);
+gtest_expect_eq(buffer_tell(buffer_fixed_test), 23);
+
+buffer_delete(buffer_fixed_test);
+gtest_expect_false(buffer_exists(buffer_fixed_test));
+
+/// DONE!
+game_end();

--- a/ENIGMAsystem/SHELL/Universal_System/buffers.h
+++ b/ENIGMAsystem/SHELL/Universal_System/buffers.h
@@ -53,7 +53,9 @@ enum {
   buffer_f32 = 8,
   buffer_f64 = 9,
   buffer_bool = 10,
-  buffer_string = 11
+  buffer_string = 11,
+  buffer_u64 = 12,
+  buffer_text = 13,
 };
 
 int buffer_create(unsigned size, int type, unsigned alignment);

--- a/ENIGMAsystem/SHELL/Universal_System/buffers.h
+++ b/ENIGMAsystem/SHELL/Universal_System/buffers.h
@@ -57,6 +57,7 @@ enum {
 };
 
 int buffer_create(unsigned size, int type, unsigned alignment);
+bool buffer_exists(int buffer);
 void buffer_delete(int buffer);
 void buffer_copy(int src_buffer, unsigned src_offset, unsigned size, int dest_buffer, unsigned dest_offset);
 void buffer_save(int buffer, std::string filename);

--- a/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
@@ -105,6 +105,11 @@ int buffer_create(unsigned size, int type, unsigned alignment) {
 void buffer_delete(int buffer) {
   get_buffer(binbuff, buffer);
   delete binbuff;
+  enigma::buffers[buffer] = nullptr;
+}
+
+bool buffer_exists(int buffer) {
+  return (buffer >= 0 && buffer < enigma::buffers.size() && enigma::buffers[buffer] != nullptr);
 }
 
 void buffer_copy(int src_buffer, unsigned src_offset, unsigned size, int dest_buffer, unsigned dest_offset) {

--- a/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
@@ -54,7 +54,7 @@ void BinaryBuffer::Seek(unsigned offset) {
         position -= GetSize();
         return;
       default:
-        position = GetSize() - 1;
+        position = GetSize() - (position - GetSize());
         return;
     }
   }
@@ -109,7 +109,7 @@ void buffer_delete(int buffer) {
 }
 
 bool buffer_exists(int buffer) {
-  return (buffer >= 0 && buffer < enigma::buffers.size() && enigma::buffers[buffer] != nullptr);
+  return (buffer >= 0 && (size_t)buffer < enigma::buffers.size() && enigma::buffers[buffer] != nullptr);
 }
 
 void buffer_copy(int src_buffer, unsigned src_offset, unsigned size, int dest_buffer, unsigned dest_offset) {
@@ -278,31 +278,18 @@ void buffer_seek(int buffer, int base, unsigned offset) {
 
 unsigned buffer_sizeof(int type) {
   switch (type) {
-    case buffer_u8:
+    case buffer_u8: case buffer_s8: case buffer_bool:
       return 1;
-    case buffer_s8:
-      return 1;
-    case buffer_u16:
+    case buffer_u16: case buffer_s16: case buffer_f16:
       return 2;
-    case buffer_s16:
-      return 2;
-    case buffer_u32:
+    case buffer_u32: case buffer_s32: case buffer_f32:
       return 4;
-    case buffer_s32:
-      return 4;
-    case buffer_f16:
-      return 2;
-    case buffer_f32:
-      return 4;
-    case buffer_f64:
+    case buffer_u64: case buffer_f64:
       return 8;
-    case buffer_bool:
-      return 1;
-    case buffer_string:
-      return 0;
-    default:
-      return 0;
+    case buffer_string: case buffer_text: default:
+      break;
   }
+  return 0;
 }
 
 int buffer_tell(int buffer) {


### PR DESCRIPTION
* Added basic buffer CI test that covers the basic functions. Will need expanded later.
* Added missing `buffer_u64` and `buffer_text` types that were recently added with same GMSv1.4 enum int values.
* Added missing `buffer_exists` function. Can later be moved to AssetArray for cleanup.
* Tweaked buffer seek past end behavior to match GMSv1.4 for fixed and fast buffer types.
* Flattened the `buffer_sizeof` implementation and added the new types to it.