### PR TITLE
Room Layers Protocol Format

### DIFF
--- a/shared/protos/Room.proto
+++ b/shared/protos/Room.proto
@@ -112,24 +112,8 @@ message Room {
     optional string name = 2;
     optional bool visible = 3;
 
-    optional int32 x = 4;
-    optional int32 y = 5;
-    optional int32 hspeed = 6;
-    optional int32 vspeed = 7;
-
-    optional int32 script_begin = 10;
-    optional int32 script_end = 11;
-    optional int32 shader = 12;
-    optional int32 path = 13;
-
-    message EditorSettings {
-      optional bool locked = 1;
-    }
-
     repeated Instance instances = 17;
     repeated Tile tiles = 18 ;
-
-    optional EditorSettings editor_settings = 31;
   }
 
   repeated Layer layers = 20;

--- a/shared/protos/Room.proto
+++ b/shared/protos/Room.proto
@@ -107,6 +107,62 @@ message Room {
 
   repeated Tile tiles = 18 [(gmx) = "tiles/tile"];
 
+  message Sprite {
+    optional string name = 1;
+    optional int32 id = 2 [(id_start) = 0];
+    optional string sprite_type = 3 [(resource_ref)="sprite"];
+    optional double x = 4;
+    optional double y = 5;
+    optional double z = 6;
+    optional double xscale = 7 [default = 1];
+    optional double yscale = 8 [default = 1];
+    optional double zscale = 9 [default = 1];
+    optional double rotation  = 10;
+    optional double zrotation = 11;
+    optional int32 color = 12 [default = 0xFFFFFF];
+    optional int32 speed = 13;
+  }
+
+  message ParticleSystem {
+    //TODO: where? is API for layerelementtype_particlesystem
+  }
+
+  message Layer {
+    optional int32 depth = 1;
+    optional string name = 2;
+    optional bool visible = 3;
+
+    optional int32 x = 4;
+    optional int32 y = 5;
+    optional int32 hspeed = 6;
+    optional int32 vspeed = 7;
+
+    message Element {
+      oneof type {
+        Background background = 1;
+        Instance instance = 2;
+        Tile tile = 3;
+        Sprite sprite = 4;
+        ParticleSystem particle = 5;
+      }
+    }
+
+    repeated Element elements = 8;
+
+    optional int32 script_begin = 10;
+    optional int32 script_end = 11;
+    optional int32 shader = 12;
+    optional int32 path = 13;
+
+    message EditorSettings {
+      optional bool locked = 1;
+    }
+
+    optional EditorSettings editor_settings = 31;
+  }
+
+  repeated Layer layers = 20;
+
   message RoomPhysicsSettings {
     optional bool use_physics = 1 [(gmx) = "PhysicsWorld"];
     optional int32 phy_world_top = 2 [(gmx) = "PhysicsWorldTop"];

--- a/shared/protos/Room.proto
+++ b/shared/protos/Room.proto
@@ -108,12 +108,13 @@ message Room {
   repeated Tile tiles = 18 [(gmx) = "tiles/tile"];
 
   message Layer {
-    optional int32 depth = 1;
-    optional string name = 2;
-    optional bool visible = 3;
+    optional string name = 1;
+    optional int32 id = 2;
+    optional int32 depth = 3;
+    optional bool visible = 4;
 
-    repeated Instance instances = 17;
-    repeated Tile tiles = 18 ;
+    repeated Instance instances = 5;
+    repeated Tile tiles = 6;
   }
 
   repeated Layer layers = 20;

--- a/shared/protos/Room.proto
+++ b/shared/protos/Room.proto
@@ -107,26 +107,6 @@ message Room {
 
   repeated Tile tiles = 18 [(gmx) = "tiles/tile"];
 
-  message Sprite {
-    optional string name = 1;
-    optional int32 id = 2 [(id_start) = 0];
-    optional string sprite_type = 3 [(resource_ref)="sprite"];
-    optional double x = 4;
-    optional double y = 5;
-    optional double z = 6;
-    optional double xscale = 7 [default = 1];
-    optional double yscale = 8 [default = 1];
-    optional double zscale = 9 [default = 1];
-    optional double rotation  = 10;
-    optional double zrotation = 11;
-    optional int32 color = 12 [default = 0xFFFFFF];
-    optional int32 speed = 13;
-  }
-
-  message ParticleSystem {
-    //TODO: where? is API for layerelementtype_particlesystem
-  }
-
   message Layer {
     optional int32 depth = 1;
     optional string name = 2;
@@ -137,18 +117,6 @@ message Room {
     optional int32 hspeed = 6;
     optional int32 vspeed = 7;
 
-    message Element {
-      oneof type {
-        Background background = 1;
-        Instance instance = 2;
-        Tile tile = 3;
-        Sprite sprite = 4;
-        ParticleSystem particle = 5;
-      }
-    }
-
-    repeated Element elements = 8;
-
     optional int32 script_begin = 10;
     optional int32 script_end = 11;
     optional int32 shader = 12;
@@ -157,6 +125,9 @@ message Room {
     message EditorSettings {
       optional bool locked = 1;
     }
+
+    repeated Instance instances = 17;
+    repeated Tile tiles = 18 ;
 
     optional EditorSettings editor_settings = 31;
   }


### PR DESCRIPTION
This is just to kick off implementing GMS2-like, Tiled-inspired layers to the room protocol. I believe people desire an API like this and the use case is organizing instances by depth so they can be toggled together (e.g, activation & visibility) simultaneously. It also simplifies the editing experience to allow tiles and instances to coexist.
https://docs2.yoyogames.com/source/_build/3_scripting/4_gml_reference/rooms/layers/index.html

Eventually the repeated layers would completely replace tiles and instances, and libEGM would convert all GM projects to use a default layer for compatibility. For now, I just allow the layers to go unused. The next step would be implementing the API to the engine before libEGM and RGM are updated to reflect this.

* GMS2 deprecates backgrounds so I wasn't sure if they should stay on the root room, go to the layers, or become a layer element. I really don't think I have a preference because you really don't need that many backgrounds in a room, though for editing purposes I can see why people would want different ones for different layers.
* I have not yet found the API for `layerelementtype_particlesystem` although it's referenced in the documentation.
* GMS2 only allows one path per layer, but we could allow for more than that.
