### PR TITLE
Generalize Keyboard Input Processing

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -119,7 +119,6 @@ std::string program_directory = "";
 std::string temp_directory = "";
 std::string game_save_id = "";
 std::string keyboard_string = "";
-int keyboard_key = 0;
 double fps = 0;
 unsigned long delta_time = 0;
 unsigned long current_time = 0;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -53,7 +53,6 @@ extern std::string working_directory;
 extern std::string program_directory;
 extern std::string temp_directory;
 extern std::string keyboard_string;
-extern int keyboard_key;
 extern double fps;
 extern unsigned long delta_time;
 extern unsigned long current_time;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
@@ -7,6 +7,9 @@
 
 namespace enigma {
 
+using enigma_user::keyboard_key;
+using enigma_user::keyboard_lastkey;
+
 int window_min_width = -1;
 int window_max_width = -1;
 int window_min_height = -1;
@@ -44,6 +47,19 @@ void input_push() {
     last_keybdstatus[i] = keybdstatus[i];
   }
   enigma_user::mouse_hscrolls = enigma_user::mouse_vscrolls = 0;
+}
+
+void input_key_down(int key) {
+  keyboard_lastkey = key;
+  keyboard_key = key;
+  last_keybdstatus[key]=keybdstatus[key];
+  keybdstatus[key]=1;
+}
+
+void input_key_up(int key) {
+  keyboard_key = 0;
+  last_keybdstatus[key]=keybdstatus[key];
+  keybdstatus[key]=0;
 }
 
 void compute_window_scaling() {

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.cpp
@@ -7,9 +7,6 @@
 
 namespace enigma {
 
-using enigma_user::keyboard_key;
-using enigma_user::keyboard_lastkey;
-
 int window_min_width = -1;
 int window_max_width = -1;
 int window_min_height = -1;
@@ -50,14 +47,14 @@ void input_push() {
 }
 
 void input_key_down(int key) {
-  keyboard_lastkey = key;
-  keyboard_key = key;
+  enigma_user::keyboard_lastkey = key;
+  enigma_user::keyboard_key = key;
   last_keybdstatus[key]=keybdstatus[key];
   keybdstatus[key]=1;
 }
 
 void input_key_up(int key) {
-  keyboard_key = 0;
+  enigma_user::keyboard_key = 0;
   last_keybdstatus[key]=keybdstatus[key];
   keybdstatus[key]=0;
 }
@@ -105,6 +102,7 @@ namespace enigma_user {
 
 std::string keyboard_lastchar = "";
 int keyboard_lastkey = 0;
+int keyboard_key = 0;
 
 double mouse_x, mouse_y;
 int mouse_button, mouse_lastbutton;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
@@ -159,6 +159,7 @@ enum {
 extern double mouse_x, mouse_y;
 extern int mouse_button, mouse_lastbutton;
 extern std::string keyboard_lastchar;
+extern int keyboard_key;
 extern int keyboard_lastkey;
 extern short mouse_hscrolls;
 extern short mouse_vscrolls;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFwindow.h
@@ -40,6 +40,8 @@ extern int window_max_height;
 
 void input_initialize();
 void input_push();
+void input_key_down(int key);
+void input_key_up(int key);
 
 }  // namespace enigma
 

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
@@ -224,16 +224,13 @@ void SDL_Event_Handler::controllerButtonUp(const SDL_Event *event) {
 
 void SDL_Event_Handler::keyboardDown(const SDL_Event *event) {
   int key = enigma::keyboard::keymap[event->key.keysym.sym];
-  enigma::last_keybdstatus[key] = enigma::keybdstatus[key];
-  enigma::keybdstatus[key] = true;
-
+  input_key_down(key);
   if (key == enigma_user::vk_backspace && !enigma_user::keyboard_string.empty()) enigma_user::keyboard_string.pop_back();
 }
 
 void SDL_Event_Handler::keyboardUp(const SDL_Event *event) {
   int key = enigma::keyboard::keymap[event->key.keysym.sym];
-  enigma::last_keybdstatus[key] = enigma::keybdstatus[key];
-  enigma::keybdstatus[key] = false;
+  input_key_up(key);
 }
 
 void SDL_Event_Handler::textInput(const SDL_Event *event) {

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -47,12 +47,11 @@ namespace enigma
   extern HWND hWnd;
   extern HDC window_hDC;
 
-  using enigma_user::keyboard_key;
   using enigma_user::keyboard_lastkey;
   using enigma_user::keyboard_lastchar;
   using enigma_user::keyboard_string;
 
-  extern char mousestatus[3],last_mousestatus[3],keybdstatus[256],last_keybdstatus[256];
+  extern char mousestatus[3],last_mousestatus[3];
   extern int windowX, windowY, windowColor;
   extern HCURSOR currentCursor;
 
@@ -162,25 +161,17 @@ namespace enigma
 
       case WM_KEYDOWN: {
         int key = enigma_user::keyboard_get_map(wParam);
-        keyboard_lastkey = key;
-        keyboard_key = key;
-        last_keybdstatus[key]=keybdstatus[key];
-        keybdstatus[key]=1;
+        input_key_down(key);
         return 0;
       }
       case WM_KEYUP: {
         int key = enigma_user::keyboard_get_map(wParam);
-        keyboard_key = 0;
-        last_keybdstatus[key]=keybdstatus[key];
-        keybdstatus[key]=0;
+        input_key_up(key);
         return 0;
       }
       case WM_SYSKEYDOWN: {
         int key = enigma_user::keyboard_get_map(wParam);
-        keyboard_lastkey = key;
-        keyboard_key = key;
-        last_keybdstatus[key]=keybdstatus[key];
-        keybdstatus[key]=1;
+        input_key_down(key);
         if (key!=18)
         {
           if ((lParam&(1<<29))>0)
@@ -191,9 +182,7 @@ namespace enigma
       }
       case WM_SYSKEYUP: {
         int key = enigma_user::keyboard_get_map(wParam);
-        keyboard_key = 0;
-        last_keybdstatus[key]=keybdstatus[key];
-        keybdstatus[key]=0;
+        input_key_up(key);
         if (key!=(unsigned int)18)
         {
           if ((lParam&(1<<29))>0)

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -77,14 +77,7 @@ int handleEvents() {
             }
           }
         }
-        enigma_user::keyboard_lastkey = actualKey;
-        enigma_user::keyboard_key = actualKey;
-        if (enigma::last_keybdstatus[actualKey] == 1 && enigma::keybdstatus[actualKey] == 0) {
-          enigma::keybdstatus[actualKey] = 1;
-          continue;
-        }
-        enigma::last_keybdstatus[actualKey] = enigma::keybdstatus[actualKey];
-        enigma::keybdstatus[actualKey] = 1;
+        input_key_down(actualKey);
         continue;
       }
       case KeyRelease: {
@@ -97,8 +90,7 @@ int handleEvents() {
         else
           actualKey = enigma_user::keyboard_get_map((int)enigma::keymap[gk & 0x1FF]);
 
-        enigma::last_keybdstatus[actualKey] = enigma::keybdstatus[actualKey];
-        enigma::keybdstatus[actualKey] = 0;
+        input_key_up(actualKey);
         continue;
       }
       case ButtonPress: {

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -81,7 +81,6 @@ int handleEvents() {
         continue;
       }
       case KeyRelease: {
-        enigma_user::keyboard_key = 0;
         gk = XLookupKeysym(&e.xkey, 0);
         if (gk == NoSymbol) continue;
 


### PR DESCRIPTION
This follows from #2041 to immediately resolve #2119 for SDL by moving all of the keyboard state event processing and message handling logic to a general platform helper. Keyboard text handling is not included because in #2062 I am still working on that. In another pull request I can cleanup the mouse processing too. Then we can finally write an input regression test, which I have an idea to do using a stack and recording the states for several frames starting with a pressed and then checking expected values. That should hopefully enable me to get rid of most of the anomalous behavior that remains.