### PR TITLE
Associative Room Layers

### DIFF
--- a/shared/protos/Room.proto
+++ b/shared/protos/Room.proto
@@ -107,6 +107,62 @@ message Room {
 
   repeated Tile tiles = 18 [(gmx) = "tiles/tile"];
 
+  message Sprite {
+    optional string name = 1;
+    optional int32 id = 2 [(id_start) = 0];
+    optional string sprite_type = 3 [(resource_ref)="sprite"];
+    optional double x = 4;
+    optional double y = 5;
+    optional double z = 6;
+    optional double xscale = 7 [default = 1];
+    optional double yscale = 8 [default = 1];
+    optional double zscale = 9 [default = 1];
+    optional double rotation  = 10;
+    optional double zrotation = 11;
+    optional int32 color = 12 [default = 0xFFFFFF];
+    optional int32 speed = 13;
+  }
+
+  message ParticleSystem {
+    //TODO: where? is API for layerelementtype_particlesystem
+  }
+
+  message Layer {
+    optional int32 depth = 1;
+    optional string name = 2;
+    optional bool visible = 3;
+
+    optional int32 x = 4;
+    optional int32 y = 5;
+    optional int32 hspeed = 6;
+    optional int32 vspeed = 7;
+
+    message Element {
+      oneof type {
+        Background background = 1;
+        Instance instance = 2;
+        Tile tile = 3;
+        Sprite sprite = 4;
+        ParticleSystem particle = 5;
+      }
+    }
+
+    repeated Element elements = 8;
+
+    optional int32 script_begin = 10;
+    optional int32 script_end = 11;
+    optional int32 shader = 12;
+    optional int32 path = 13;
+
+    message EditorSettings {
+      optional bool locked = 1;
+    }
+
+    optional EditorSettings editor_settings = 31;
+  }
+
+  repeated Layer layers = 20;
+
   message RoomPhysicsSettings {
     optional bool use_physics = 1 [(gmx) = "PhysicsWorld"];
     optional int32 phy_world_top = 2 [(gmx) = "PhysicsWorldTop"];

--- a/shared/protos/Room.proto
+++ b/shared/protos/Room.proto
@@ -123,9 +123,13 @@ message Room {
     optional int32 speed = 13;
   }
 
+  repeated Sprite sprites = 20;
+
   message ParticleSystem {
     //TODO: where? is API for layerelementtype_particlesystem
   }
+
+  //repeated ParticleSystem particles = 21;
 
   message Layer {
     optional int32 depth = 1;
@@ -137,22 +141,10 @@ message Room {
     optional int32 hspeed = 6;
     optional int32 vspeed = 7;
 
-    message Element {
-      oneof type {
-        Background background = 1;
-        Instance instance = 2;
-        Tile tile = 3;
-        Sprite sprite = 4;
-        ParticleSystem particle = 5;
-      }
-    }
-
-    repeated Element elements = 8;
-
-    optional int32 script_begin = 10;
-    optional int32 script_end = 11;
-    optional int32 shader = 12;
-    optional int32 path = 13;
+    optional int32 script_begin = 8;
+    optional int32 script_end = 9;
+    optional int32 shader = 10;
+    optional int32 path = 11;
 
     message EditorSettings {
       optional bool locked = 1;
@@ -161,7 +153,7 @@ message Room {
     optional EditorSettings editor_settings = 31;
   }
 
-  repeated Layer layers = 20;
+  repeated Layer layers = 23;
 
   message RoomPhysicsSettings {
     optional bool use_physics = 1 [(gmx) = "PhysicsWorld"];


### PR DESCRIPTION
This is the alternative to #2116 that adds logical layers to the room proto, so the layers exist independent of the layer items, avoiding the fragmentation problems with the SVG format. I believe people desire an API like this and the use case is organizing instances by depth so you could perform post processing on them. It also simplifies the editing experience to allow tiles and instances to coexist.
https://docs2.yoyogames.com/source/_build/3_scripting/4_gml_reference/rooms/layers/index.html

Although we can still achieve layers in the editor without adding them to the proto format, doing so allows a bit more customization by the user, such as associating a depth/layer to a post processing shader and a begin/end script. This way layers can also be saved if they don't actually contain any layer items and are empty. With this solution libEGM does not need to be changed necessarily, the editor can just bucket the instances/tiles by depth and let the user edit them. The GMS2 API for this can also be added for compatibility around these layers.

* GMS2 deprecates backgrounds so I'm not sure where to go with them yet, but I'm thinking under the same tab as views. So they won't have anything to do with the layers or be connected to them, unless somebody has a better idea.
* I have not yet found the API for `layerelementtype_particlesystem` although it's referenced in the documentation.
* GMS2 only allows one path per layer, but we could allow for more than that.