### PR TITLE
Instance Destroy Objects

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Instances/instance.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Instances/instance.cpp
@@ -97,12 +97,14 @@ void instance_activate_object(int obj) {
 
 void instance_destroy(int id, bool dest_ev)
 {
-  enigma::object_basic* who = enigma::fetch_instance_by_id(id);
-  if (who and enigma::cleanups.find(who) == enigma::cleanups.end()) {
-    if (dest_ev)
-        who->myevent_destroy();
-    if (enigma::cleanups.find(who) == enigma::cleanups.end())
-        who->unlink();
+  for (enigma::iterator it = enigma::fetch_inst_iter_by_int(id); it; ++it) {
+    enigma::object_basic* who = (*it);
+    if (enigma::cleanups.find(who) == enigma::cleanups.end()) {
+      if (dest_ev)
+          who->myevent_destroy();
+      if (enigma::cleanups.find(who) == enigma::cleanups.end())
+          who->unlink();
+    }
   }
 }
 


### PR DESCRIPTION
This is not a regression and has been this way for 8 years. In GMS where they finally added this function, the id parameter can mean an instance or an object, so I had to update the function. I changed it to use the instance iterators so that it can loop over all instances of a given object. It seems to work pretty good.
https://docs.yoyogames.com/source/dadiospice/002_reference/objects%20and%20instances/instances/instance%20functions/instance_destroy.html