### PR TITLE
Let Win32 EXE run from paths w/ foreign characters

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -61,7 +61,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 void (*touch_extension_register)(HWND hWnd);
 
-void windowsystem_write_exename(char *exenamehere) { GetModuleFileName(NULL, exenamehere, 1024); }
+void windowsystem_write_exename(wchar_t *exenamehere) { GetModuleFileNameW(NULL, exenamehere, 1024); }
 
 void Sleep(int ms) { ::Sleep(ms); }
 

--- a/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
+++ b/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
@@ -67,7 +67,11 @@ namespace enigma
   int ENIGMA_events();
 
   // This method should write the name of the running module to exenamehere.
+  #ifdef _WIN32
+  void windowsystem_write_exename(wchar_t* exenamehere);
+  #else
   void windowsystem_write_exename(char* exenamehere);
+  #endif
 
   // This method should take an integer framerate and perform the necessary operations to limit fps to that rate.
   void set_room_speed(int framerate);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -76,14 +76,13 @@ namespace enigma
     // Open the exe for resource load
     do { // Allows break
       FILE* resfile;
-      #ifdef _WIN32
       if (resource_file_path != std::string("$exe")) {
+        #ifdef _WIN32
         std::wstring wstr = widen(resource_file_path);
         if (!_wfopen_s(&resfile,wstr.c_str(),L"rb, css=UTF-8")) {
-      #else
-      if (resource_file_path != std::string("$exe")) {
+        #else
         if (!(resfile = fopen(resource_file_path,"rb"))) {
-      #endif
+        #endif
           DEBUG_MESSAGE("Resource load fail: exe unopenable", MESSAGE_TYPE::M_ERROR);
           break;
         }

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -29,6 +29,10 @@
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 
+#ifdef _WIN32
+#include "Universal_System/estring.h"
+#endif
+
 #include <ctime>
 #include <cstdio>
 
@@ -41,11 +45,7 @@ namespace enigma_user
 
 namespace enigma
 {
-  #ifdef _WIN32
-  extern const wchar_t* resource_file_path;
-  #else
   extern const char* resource_file_path;
-  #endif
   extern int event_system_initialize(); //Leave this here until you can find a more brilliant way to include it; it's pretty much not-optional.
   extern void timeline_system_initialize();
   extern int game_settings_initialize();
@@ -77,8 +77,9 @@ namespace enigma
     do { // Allows break
       FILE* resfile;
       #ifdef _WIN32
-      if (resource_file_path != std::wstring(L"$exe")) {
-        if (!_wfopen_s(&resfile,resource_file_path,L"rb")) 
+      if (resource_file_path != std::string("$exe")) {
+        std::wstring wstr = widen(resource_file_path);
+        if (!_wfopen_s(&resfile,wstr.c_str(),L"rb, css=UTF-8")) {
       #else
       if (resource_file_path != std::string("$exe")) {
         if (!(resfile = fopen(resource_file_path,"rb"))) {
@@ -90,11 +91,11 @@ namespace enigma
         #ifdef _WIN32
         wchar_t exename[4097];
         windowsystem_write_exename(exename);
-        if (!_wfopen_s(&resfile,exename,L"rb")) {
+        if (!_wfopen_s(&resfile,exename,L"rb, css=UTF-8")) {
         #else
         char exename[4097];
         windowsystem_write_exename(exename);
-        if (!(resfile = fopen(exename,"rb"))) {
+        if (!fopen(exename,"rb")) {
         #endif
           DEBUG_MESSAGE("No resource data in exe", MESSAGE_TYPE::M_ERROR);
           break;

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -94,7 +94,7 @@ namespace enigma
         #else
         char exename[4097];
         windowsystem_write_exename(exename);
-        if (!(resfile = fopen(exename,"rb")) {
+        if (!(resfile = fopen(exename,"rb"))) {
         #endif
           DEBUG_MESSAGE("No resource data in exe", MESSAGE_TYPE::M_ERROR);
           break;

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -78,7 +78,7 @@ namespace enigma
       FILE* resfile;
       #ifdef _WIN32
       if (resource_file_path != std::wstring(L"$exe")) {
-        if (!(resfile = _wfopen(resource_file_path,L"rb"))) {
+        if (!_wfopen_s(&resfile,resource_file_path,L"rb")) 
       #else
       if (resource_file_path != std::string("$exe")) {
         if (!(resfile = fopen(resource_file_path,"rb"))) {
@@ -90,7 +90,7 @@ namespace enigma
         #ifdef _WIN32
         wchar_t exename[4097];
         windowsystem_write_exename(exename);
-        if (!(resfile = _wfopen(exename,L"rb"))) {
+        if (!(resfile = _wfopen_s(&resfile,exename,L"rb"))) {
         #else
         char exename[4097];
         windowsystem_write_exename(exename);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -94,7 +94,7 @@ namespace enigma
         #else
         char exename[4097];
         windowsystem_write_exename(exename);
-        if (!(resfile = fopen(exename,"rb")){
+        if (!(resfile = fopen(exename,"rb")) {
         #endif
           DEBUG_MESSAGE("No resource data in exe", MESSAGE_TYPE::M_ERROR);
           break;

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -41,7 +41,11 @@ namespace enigma_user
 
 namespace enigma
 {
+  #ifdef _WIN32
+  extern const wchar_t* resource_file_path;
+  #else
   extern const char* resource_file_path;
+  #endif
   extern int event_system_initialize(); //Leave this here until you can find a more brilliant way to include it; it's pretty much not-optional.
   extern void timeline_system_initialize();
   extern int game_settings_initialize();
@@ -72,15 +76,26 @@ namespace enigma
     // Open the exe for resource load
     do { // Allows break
       FILE* resfile;
+      #ifdef _WIN32
+      if (resource_file_path != std::wstring(L"$exe")) {
+        if (!(resfile = _wfopen(resource_file_path,L"rb"))) {
+      #else
       if (resource_file_path != std::string("$exe")) {
         if (!(resfile = fopen(resource_file_path,"rb"))) {
+      #endif
           DEBUG_MESSAGE("Resource load fail: exe unopenable", MESSAGE_TYPE::M_ERROR);
           break;
         }
       } else {
+        #ifdef _WIN32
+        wchar_t exename[4097];
+        windowsystem_write_exename(exename);
+        if (!(resfile = _wfopen(exename,L"rb"))) {
+        #else
         char exename[4097];
         windowsystem_write_exename(exename);
         if (!(resfile = fopen(exename,"rb"))) {
+        #endif
           DEBUG_MESSAGE("No resource data in exe", MESSAGE_TYPE::M_ERROR);
           break;
         }

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -90,7 +90,7 @@ namespace enigma
         #ifdef _WIN32
         wchar_t exename[4097];
         windowsystem_write_exename(exename);
-        if (!(resfile = _wfopen_s(&resfile,exename,L"rb"))) {
+        if (!_wfopen_s(&resfile,exename,L"rb")) {
         #else
         char exename[4097];
         windowsystem_write_exename(exename);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/loading.cpp
@@ -94,7 +94,7 @@ namespace enigma
         #else
         char exename[4097];
         windowsystem_write_exename(exename);
-        if (!fopen(exename,"rb")) {
+        if (!(resfile = fopen(exename,"rb")){
         #endif
           DEBUG_MESSAGE("No resource data in exe", MESSAGE_TYPE::M_ERROR);
           break;


### PR DESCRIPTION
"Resource load fail: exe unopenable" error will be thrown if your exe has a file name or absolute path it is inside of containing non-English characters such as Cyrillic.

This pr will fix that when it's done.