### PR TITLE
Cleanup Font Metrics Initialization

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Resources/fontinit.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/fontinit.cpp
@@ -100,15 +100,15 @@ void exe_loadfonts(FILE* exe) {
         if (!fread(&gty2, 4, 1, exe)) return;
         fontglyph fg;
 
-        fg.x = int(origin + .5);
-        fg.y = int(baseline + .5);
-        fg.x2 = int(origin + .5) + gwid;
-        fg.y2 = int(baseline + .5) + ghgt;
+        fg.x = round(origin);
+        fg.y = round(baseline);
+        fg.x2 = round(origin) + gwid;
+        fg.y2 = round(baseline) + ghgt;
         fg.tx = gtx;
         fg.ty = gty;
         fg.tx2 = gtx2;
         fg.ty2 = gty2;
-        fg.xs = advance + .5;
+        fg.xs = advance;
 
         if (fg.y < ymin) ymin = fg.y;
         if (fg.y2 > ymax) ymax = fg.y2;


### PR DESCRIPTION
This is a small change that begins to fix the font rendering issues with subpixel alignment. I first changed Josh's rounding-to-zero (from fe4737f1cef66a1074490c5908ea2730674993bb) with regular round, so the code is clearer and because fonts never have negative dimensions anyway.

Then I removed his adding of a half pixel to the horizontal spacing of each glyph. The reason he didn't round here is because the xs member is a float, to allow fractional metrics and kerning. However, since he doesn't round, there's absolutely no point adding the half pixel. This immediately improves the font rendering under both OpenGL and Direct3D backends because the plugin has always been configured to draw fonts without fractional metrics. It seems that fractional font metrics were disabled by IsmAvatar originally when the plugin was still in this repo (a1166fff4ce64e47441d861ca127a5a26ac4255a), which was a good call.
https://github.com/enigma-dev/lgmplugin/blob/03093f884ab4ab336ca03fbed7c98dca1845ea89/org/enigma/EnigmaWriter.java#L750

Arguably, we can later add support for fractional metrics. We would first enable it in the plugin and then have to deal with the rounding. For now though, this is a great stop gap that immediately improves the situation. There are additional steps left to deal with this problem though. The first is the implementation of the "Interpolate Colors between Pixels" setting which GM uses to toggle interpolation for the 2D stuff only, including text. The other is that we need to apply a half pixel offset to D3D9 (because of its dreaded bug). As I've mentioned many times, ANGLE does it in the ffp replacement shader for D3D9 which GMS uses.