### PR TITLE
Fix Direct3D11 White Texture Crash

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -42,12 +42,15 @@ const D3D11_BLEND blend_equivs[11] = {
   D3D11_BLEND_INV_DEST_COLOR, D3D11_BLEND_SRC_ALPHA_SAT
 };
 
+// causes HLSL shader to sample white (1,1,1,1) like GLSL when a texture is not set,
+// otherwise primitives without a texture will be invisible or rgba(0,0,0,0)
 ID3D11ShaderResourceView *getDefaultWhiteTexture() {
     static int texid = -1;
     if (texid == -1) {
-      unsigned* data = new unsigned[1];
-      data[0] = 0xFFFFFFFF;
-      texid = enigma::graphics_create_texture(enigma::RawImage((unsigned char*)data, 1, 1) , false);
+      enigma::RawImage ri;
+      ri.resize(1,1);
+      reinterpret_cast<unsigned*>(ri.pxdata)[0] = 0xFFFFFFFF;
+      texid = enigma::graphics_create_texture(ri, false);
     }
     return static_cast<enigma::DX11Texture*>(enigma::textures[texid].get())->view;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11d3d.cpp
@@ -45,7 +45,8 @@ const D3D11_BLEND blend_equivs[11] = {
 ID3D11ShaderResourceView *getDefaultWhiteTexture() {
     static int texid = -1;
     if (texid == -1) {
-      unsigned data[1] = {0xFFFFFFFF};
+      unsigned* data = new unsigned[1];
+      data[0] = 0xFFFFFFFF;
       texid = enigma::graphics_create_texture(enigma::RawImage((unsigned char*)data, 1, 1) , false);
     }
     return static_cast<enigma::DX11Texture*>(enigma::textures[texid].get())->view;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -37,7 +37,7 @@ struct RawImage {
   }
   void resize(unsigned w, unsigned h) {
     delete[] pxdata;
-    pxdata = new unsigned char[w*h];
+    pxdata = new unsigned char[w*h*4];
     this->w = w;
     this->h = h;
   }

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -35,6 +35,12 @@ struct RawImage {
   RawImage(RawImage &&other): pxdata(other.pxdata), w(other.w), h(other.h) {
     other.pxdata = nullptr;
   }
+  void resize(unsigned w, unsigned h) {
+    delete[] pxdata;
+    pxdata = new unsigned char[w*h];
+    this->w = w;
+    this->h = h;
+  }
   unsigned char* pxdata;
   unsigned w, h;
 };


### PR DESCRIPTION
The RAII of RawImage was causing a crash in D3D11 when lazy creating the default white texture. The simple solution here was to use a dynamically allocated 1x1 pixel array for the default white texture so it's not deleting stack-allocated memory. This white texture is necessary for the default shader or something, and I recall GMS doing the same thing based on my testing. If I recall correctly, this comes from ANGLE and has something to do with GLSL vs HLSL differences when sampling a texture that's not bound.

https://www.seas.upenn.edu/~pcozzi/OpenGLInsights/OpenGLInsights-ANGLE.pdf
![ANGLE Direct3D Incomplete Textures](https://user-images.githubusercontent.com/3212801/98738327-884fa980-2375-11eb-869a-8319bef2f33d.png)
