### PR TITLE
Fix Sprite Function Definition Signatures

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
@@ -172,7 +172,7 @@ bool sprite_exists(int spr) {
   return sprites.exists(spr);
 }
 
-void sprite_delete(int ind, bool free_texture = true) {
+void sprite_delete(int ind, bool free_texture) {
   if (free_texture) sprites.get(ind).FreeTextures();
   sprites.destroy(ind);
 }
@@ -181,7 +181,7 @@ int sprite_duplicate(int ind) {
   return sprites.duplicate(ind);  
 }
 
-void sprite_assign(int ind, int copy_sprite, bool free_texture = true) {
+void sprite_assign(int ind, int copy_sprite, bool free_texture) {
   if (free_texture) sprites.get(ind).FreeTextures();
   Sprite copy = sprites.get(copy_sprite);
   sprites.assign(ind, std::move(copy));


### PR DESCRIPTION
The default arguments aren't supposed to go in the source, they are already in the declaration of the header. This fixes the recompilation errors you get if you try to edit the source.