### PR TITLE
Fix Surfaces and Power of Two Typo

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
@@ -33,12 +33,14 @@ int graphics_create_texture(const RawImage& img, bool mipmap, unsigned* fullwidt
   D3D11_TEXTURE2D_DESC tdesc;
   D3D11_SUBRESOURCE_DATA tbsd;
   
-  unsigned fw, fh;
+  unsigned fw = img.w, fh = img.h;
   if (fullwidth == nullptr) fullwidth = &fw; 
   if (fullheight == nullptr) fullheight = &fh;
   
-  *fullwidth  = nlpo2dc(img.w) + 1;
-  *fullheight = nlpo2dc(img.h) + 1;
+  if (img.pxdata != nullptr) {
+    *fullwidth  = nlpo2dc(img.w) + 1;
+    *fullheight = nlpo2dc(img.h) + 1;
+  }
 
   tbsd.SysMemPitch = (*fullwidth) * 4;
   // not needed since this is a 2d texture,

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
@@ -38,8 +38,8 @@ int graphics_create_texture(const RawImage& img, bool mipmap, unsigned* fullwidt
   if (fullheight == nullptr) fullheight = &fh;
   
   if (img.pxdata != nullptr) {
-    *fullwidth  = nlpo2dc(img.w);
-    *fullheight = nlpo2dc(img.h);
+    *fullwidth  = nlpo2(img.w);
+    *fullheight = nlpo2(img.h);
   }
 
   tbsd.SysMemPitch = (*fullwidth) * 4;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D11/DX11textures.cpp
@@ -38,8 +38,8 @@ int graphics_create_texture(const RawImage& img, bool mipmap, unsigned* fullwidt
   if (fullheight == nullptr) fullheight = &fh;
   
   if (img.pxdata != nullptr) {
-    *fullwidth  = nlpo2dc(img.w) + 1;
-    *fullheight = nlpo2dc(img.h) + 1;
+    *fullwidth  = nlpo2dc(img.w);
+    *fullheight = nlpo2dc(img.h);
   }
 
   tbsd.SysMemPitch = (*fullwidth) * 4;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -142,8 +142,8 @@ int graphics_create_texture(const RawImage& img, bool mipmap, unsigned* fullwidt
   if (fullheight == nullptr) fullheight = &fh;
   
   if (img.pxdata != nullptr) {
-    *fullwidth  = nlpo2dc(img.w);
-    *fullheight = nlpo2dc(img.h);
+    *fullwidth  = nlpo2(img.w);
+    *fullheight = nlpo2(img.h);
   }
   
   LPDIRECT3DTEXTURE9 texture = NULL;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -142,8 +142,8 @@ int graphics_create_texture(const RawImage& img, bool mipmap, unsigned* fullwidt
   if (fullheight == nullptr) fullheight = &fh;
   
   if (img.pxdata != nullptr) {
-    *fullwidth  = nlpo2dc(img.w) + 1;
-    *fullheight = nlpo2dc(img.h) + 1;
+    *fullwidth  = nlpo2dc(img.w);
+    *fullheight = nlpo2dc(img.h);
   }
   
   LPDIRECT3DTEXTURE9 texture = NULL;

--- a/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/Direct3D9/DX9textures.cpp
@@ -137,12 +137,14 @@ void graphics_push_texture_pixels(int texture, int x, int y, int width, int heig
 
 int graphics_create_texture(const RawImage& img, bool mipmap, unsigned* fullwidth, unsigned* fullheight)
 {
-  unsigned fw, fh;
+  unsigned fw = img.w, fh = img.h;
   if (fullwidth == nullptr) fullwidth = &fw; 
   if (fullheight == nullptr) fullheight = &fh;
   
-  *fullwidth  = nlpo2dc(img.w)+1;
-  *fullheight = nlpo2dc(img.h)+1;
+  if (img.pxdata != nullptr) {
+    *fullwidth  = nlpo2dc(img.w) + 1;
+    *fullheight = nlpo2dc(img.h) + 1;
+  }
   
   LPDIRECT3DTEXTURE9 texture = NULL;
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/texture_atlas.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/texture_atlas.cpp
@@ -230,7 +230,7 @@ namespace enigma_user {
     enigma::texture_atlas_array.emplace(id,enigma::texture_atlas());
 
     if (w != -1 && h != -1){ //If we set the size manually
-      unsigned int fullwidth = enigma::nlpo2dc(w)+1, fullheight = enigma::nlpo2dc(h)+1; //We only take power of two
+      unsigned int fullwidth = enigma::nlpo2(w), fullheight = enigma::nlpo2(h); //We only take power of two
       enigma::texture_atlas_array[id].width = fullwidth;
       enigma::texture_atlas_array[id].height = fullheight;
       enigma::texture_atlas_array[id].texture = enigma::graphics_create_texture(enigma::RawImage(nullptr, fullwidth, fullheight), false);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
@@ -43,8 +43,8 @@ int graphics_create_texture_custom(const RawImage& img, bool mipmap, unsigned* f
   if (fullheight == nullptr) fullheight = &fh;
   
   if (img.pxdata != nullptr) {
-    *fullwidth  = nlpo2dc(img.w) + 1;
-    *fullheight = nlpo2dc(img.h) + 1;
+    *fullwidth  = nlpo2dc(img.w);
+    *fullheight = nlpo2dc(img.h);
   }
   
   bool pad = img.pxdata != nullptr && (img.w != *fullwidth || img.h != *fullheight);

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
@@ -38,12 +38,14 @@ GLuint get_texture_peer(int texid) {
 //This allows GL3 surfaces to bind and hold many different types of data
 int graphics_create_texture_custom(const RawImage& img, bool mipmap, unsigned* fullwidth, unsigned* fullheight, GLint internalFormat, GLenum format, GLenum type)
 {
-  unsigned fw, fh;
+  unsigned fw = img.w, fh = img.h;
   if (fullwidth == nullptr) fullwidth = &fw; 
   if (fullheight == nullptr) fullheight = &fh;
   
-  *fullwidth  = nlpo2dc(img.w)+1;
-  *fullheight = nlpo2dc(img.h)+1;
+  if (img.pxdata != nullptr) {
+    *fullwidth  = nlpo2dc(img.w) + 1;
+    *fullheight = nlpo2dc(img.h) + 1;
+  }
   
   bool pad = img.pxdata != nullptr && (img.w != *fullwidth || img.h != *fullheight);
   

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL-Common/textures.cpp
@@ -43,8 +43,8 @@ int graphics_create_texture_custom(const RawImage& img, bool mipmap, unsigned* f
   if (fullheight == nullptr) fullheight = &fh;
   
   if (img.pxdata != nullptr) {
-    *fullwidth  = nlpo2dc(img.w);
-    *fullheight = nlpo2dc(img.h);
+    *fullwidth  = nlpo2(img.w);
+    *fullheight = nlpo2(img.h);
   }
   
   bool pad = img.pxdata != nullptr && (img.w != *fullwidth || img.h != *fullheight);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/backgrounds.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/backgrounds.cpp
@@ -27,7 +27,7 @@
 
 using enigma::Background;
 using enigma::backgrounds;
-using enigma::nlpo2dc;
+using enigma::nlpo2;
 using enigma::TexRect;
 using enigma::Color;
 using enigma::RawImage;
@@ -74,7 +74,7 @@ int background_add(std::string filename, bool transparent, bool smooth, bool pre
 }
 
 int background_create_color(unsigned w, unsigned h, int col, bool preload) {
-  unsigned int fullwidth = nlpo2dc(w) + 1, fullheight = nlpo2dc(h) + 1;
+  unsigned int fullwidth = nlpo2(w), fullheight = nlpo2(h);
   RawImage img(new unsigned char[fullwidth * fullheight * 4], fullwidth, fullheight);
   std::fill((unsigned*)(img.pxdata), (unsigned*)(img.pxdata) + fullwidth * fullheight, (COL_GET_R(col) | (COL_GET_G(col) << 8) | (COL_GET_B(col) << 16) | 255 << 24));
   int textureID = graphics_create_texture(img, false);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
@@ -19,7 +19,6 @@
 
 #include "sprites_internal.h"
 #include "Universal_System/image_formats.h"
-#include "Universal_System/nlpo2.h"
 #include "Graphics_Systems/graphics_mandatory.h"
 #include "Graphics_Systems/General/GStextures.h"
 #include "Graphics_Systems/General/GScolor_macros.h"
@@ -29,7 +28,6 @@
 
 using enigma::Sprite;
 using enigma::sprites;
-using enigma::nlpo2dc;
 using enigma::TexRect;
 using enigma::Color;
 using enigma::RawImage;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -186,7 +186,7 @@ RawImage image_crop(const RawImage& in, unsigned newWidth, unsigned newHeight) {
 }
 
 unsigned long *bgra_to_argb(unsigned char *bgra_data, unsigned pngwidth, unsigned pngheight, bool prepend_size) {
-  unsigned widfull = nlpo2dc(pngwidth) + 1, hgtfull = nlpo2dc(pngheight) + 1, ih, iw;
+  unsigned widfull = nlpo2(pngwidth), hgtfull = nlpo2(pngheight), ih, iw;
   const int bitmap_size = widfull * hgtfull * 4;
   unsigned char *bitmap = new unsigned char[bitmap_size]();
 

--- a/ENIGMAsystem/SHELL/Universal_System/nlpo2.h
+++ b/ENIGMAsystem/SHELL/Universal_System/nlpo2.h
@@ -40,7 +40,9 @@ inline unsigned int nlpo2dc(unsigned int x)  // Taking x, returns n such that n 
   x |= x >> 2;
   x |= x >> 4;
   x |= x >> 8;
-  return x | (x >> 16);
+  x |= x >> 16;
+  ++x;
+  return x;
 }
 
 }  //namespace enigma

--- a/ENIGMAsystem/SHELL/Universal_System/nlpo2.h
+++ b/ENIGMAsystem/SHELL/Universal_System/nlpo2.h
@@ -33,7 +33,7 @@
 
 namespace enigma {
 
-inline unsigned int nlpo2dc(unsigned int x)  // Taking x, returns n such that n = 2**k where k is an integer and n >= x.
+inline unsigned int nlpo2(unsigned int x)  // Taking x, returns n such that n = 2**k where k is an integer and n >= x.
 {
   --x;
   x |= x >> 1;

--- a/ENIGMAsystem/SHELL/Universal_System/nlpo2.h
+++ b/ENIGMAsystem/SHELL/Universal_System/nlpo2.h
@@ -26,8 +26,8 @@
 \********************************************************************************/
 
 // This was forged in hell.
-#ifndef ENIGMA_NLPO2DC_H
-#define ENIGMA_NLPO2DC_H
+#ifndef ENIGMA_NLPO2_H
+#define ENIGMA_NLPO2_H
 
 #include <stdio.h>
 
@@ -47,4 +47,4 @@ inline unsigned int nlpo2(unsigned int x)  // Taking x, returns n such that n = 
 
 }  //namespace enigma
 
-#endif  //ENIGMA_NLPO2DC_H
+#endif  //ENIGMA_NLPO2_H


### PR DESCRIPTION
Surfaces use the same texture creation routine as sprites/backgrounds so they can provide a texture id to the user for drawing onto user defined primitives. Surfaces don't need to be automatically resized to a power of two. Although it is recommended by the GM manual, it was never explicitly required except for HTML5.

>It is highly **_recommended_** that all surfaces be created with a size that is a power of 2, ie: 16, 128, 512 or 1024 pixels in size, for example. This is not exactly necessary on certain platforms (like Windows and MacOS) but it will certainly increase compatibility on those targets, while for HTML5 and devices it is essential and very it's important that you remember this or you may run into problems later.
https://docs.yoyogames.com/source/dadiospice/002_reference/surfaces/surface_create.html

Khronos basically says the same thing.

>Render targets are a common place where you want to have a specific, **_arbitrary_** size for your textures. 
https://www.khronos.org/opengl/wiki/NPOT_Texture

Also fixed an age old typo from a5bcd1b6809a9844c59e6a8cfeadbfc2a8c5d7bf in the next-largest power of two function that was permeating off-by-ones everywhere.