### PR TITLE
Default OpenAL Audio on Windows

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/Info/About.ey
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/Info/About.ey
@@ -10,4 +10,4 @@ Depends:
 	Build-platforms: Windows, SDL
 
 Represents:
-	Build-platforms: Windows
+	Build-platforms: None

--- a/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/Info/About.ey
+++ b/ENIGMAsystem/SHELL/Audio_Systems/OpenAL/Info/About.ey
@@ -9,4 +9,4 @@ Author: Josh Ventura
 Depends:
 	Build-platforms: Windows, Linux, MacOSX, SDL
 Represents:
-	Build-platforms: Linux, MacOSX, SDL
+	Build-platforms: Windows, Linux, MacOSX, SDL


### PR DESCRIPTION
I am doing this because I get tired of having to change it all the time, the DirectSound system is just not a good default.

* DirectSound crashes on MP3s and anything other than WAVs.
* DirectSound has crappy support for mixing and positional sound.
* GMS encourages people to use the newer audio API which makes it more difficult to just run stuff.
