### PR TITLE
Fix SDL Gamepad Button Mapping

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
@@ -7,6 +7,13 @@ namespace enigma {
 
 static std::vector<Gamepad> gamepads;
 
+using namespace enigma_user;
+
+int digitalButtons[15] = {
+  gp_face1, gp_face2, gp_face3, gp_face4, gp_select, 0, gp_start, gp_stickl, gp_stickr, gp_shoulderl, gp_shoulderr,
+  gp_padu, gp_padd, gp_padl, gp_padr
+};
+
 void Gamepad::clear() {
   for (unsigned i = 0; i < enigma_user::gp_padr; ++i) {
     state.lastButtonStatus[i] = false;
@@ -33,7 +40,7 @@ void pushGamepads() {
   for (Gamepad& gp : gamepads) gp.push();
 }
 
-void setGamepadButton(int gamepad, int btn, bool pressed) { gamepads[gamepad].state.buttonStatus[btn] = pressed; }
+void setGamepadButton(int gamepad, int btn, bool pressed) { gamepads[gamepad].state.buttonStatus[digitalButtons[btn]] = pressed; }
 
 void addGamepad(unsigned i) {
   if (!SDL_IsGameController(i)) {

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
@@ -9,9 +9,9 @@ static std::vector<Gamepad> gamepads;
 
 using namespace enigma_user;
 
-int digitalButtons[15] = {
+int digitalButtons[gp_axisrv] = {
   gp_face1, gp_face2, gp_face3, gp_face4, gp_select, 0, gp_start, gp_stickl, gp_stickr, gp_shoulderl, gp_shoulderr,
-  gp_padu, gp_padd, gp_padl, gp_padr
+  gp_padu, gp_padd, gp_padl, gp_padr, 0, 0, 0, 0
 };
 
 void Gamepad::clear() {

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
@@ -40,7 +40,13 @@ void pushGamepads() {
   for (Gamepad& gp : gamepads) gp.push();
 }
 
-void setGamepadButton(int gamepad, int btn, bool pressed) { gamepads[gamepad].state.buttonStatus[digitalButtons[btn]] = pressed; }
+void setGamepadButton(int gamepad, int btn, bool pressed) {
+#ifdef DEBUG_MODE
+  if (gamepad < 0 || gamepad >= static_cast<int>(gamepads.size())) return;
+  if (btn < 0 || btn >= gp_axisrv) return;
+#endif
+  gamepads[gamepad].state.buttonStatus[digitalButtons[btn]] = pressed;
+}
 
 void addGamepad(unsigned i) {
   if (!SDL_IsGameController(i)) {


### PR DESCRIPTION
Addresses #2129 in support of user. We basically need a map of SDL button constants aligned to our own.
https://wiki.libsdl.org/SDL_GameControllerButton

I do the same thing in the XInput extension, except the map is inverted since my gamepad struct holds XInput state. I am not sure if honestly we could just make a generalized structure and reuse it in all of the places. I don't know what's better, converting to or from.

The SDL gamepads also need additional work yet such as threshold for other buttons and stuff.