### PR TITLE
DirectSound Environmental Audio

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -249,8 +249,7 @@ void sound_effect_chorus(int sound, float wetdry, float depth, float feedback, f
 	DSFXChorus effectParams = { };
   effectParams.fWetDryMix = wetdry;
   effectParams.fDepth = depth;
-  // MinGW/WINE bug?
-  //effectParams.fFeedback = Feedback;
+  effectParams.fFeedback = feedback;
   effectParams.fFrequency = frequency;
   effectParams.lWaveform = wave;
   effectParams.fDelay = delay;

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -26,6 +26,27 @@ using std::string;
 
 #include "Universal_System/estring.h"
 
+namespace enigma {
+
+template <typename EffectInterface, typename EffectParams>
+void set_sound_effect_parameters(int sound, REFGUID rguidObject, DWORD dwIndex, REFGUID rguidInterface, EffectParams* effectParams) {
+  const Sound& snd = sounds.get(sound);
+
+  IDirectSoundBuffer8* soundBuffer8 = 0;
+  snd.soundBuffer->QueryInterface(IID_IDirectSoundBuffer8, (void**)&soundBuffer8);
+
+  EffectInterface* sndFX8 = 0;
+  soundBuffer8->GetObjectInPath(rguidObject, dwIndex, rguidInterface, (void**)&sndFX8);
+  if (sndFX8) {
+    sndFX8->SetAllParameters(effectParams);
+    sndFX8->Release();
+  }
+
+  soundBuffer8->Release();
+}
+
+} // namespace enigma
+
 namespace enigma_user {
 
 bool sound_exists(int sound) { return sounds.exists(sound); }
@@ -230,32 +251,34 @@ void sound_3d_set_sound_velocity(int sound, float x, float y, float z) {
 
 void sound_effect_chorus(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay,
                          long phase) {
-  /*
 	DSFXChorus effectParams = { };
   effectParams.fWetDryMix = wetdry;
   effectParams.fDepth = depth;
-  effectParams.fFeedback = Feedback;
+  // MinGW/WINE bug?
+  //effectParams.fFeedback = Feedback;
   effectParams.fFrequency = frequency;
   effectParams.lWaveform = wave;
   effectParams.fDelay = delay;
   effectParams.lPhase = phase;
-  */
+
+  enigma::set_sound_effect_parameters<IDirectSoundFXChorus8, DSFXChorus>(
+    sound, GUID_DSFX_STANDARD_CHORUS, 0, IID_IDirectSoundFXChorus8, &effectParams);
 }
 
 void sound_effect_echo(int sound, float wetdry, float feedback, float leftdelay, float rightdelay, long pandelay) {
-  /*
   DSFXEcho effectParams = { };
   effectParams.fWetDryMix = wetdry;
   effectParams.fFeedback = feedback;
   effectParams.fLeftDelay = leftdelay;
   effectParams.fRightDelay = rightdelay;
   effectParams.lPanDelay = pandelay;
-  */
+
+  enigma::set_sound_effect_parameters<IDirectSoundFXEcho8, DSFXEcho>(
+    sound, GUID_DSFX_STANDARD_ECHO, 0, IID_IDirectSoundFXEcho8, &effectParams);
 }
 
 void sound_effect_flanger(int sound, float wetdry, float depth, float feedback, float frequency, long wave, float delay,
                           long phase) {
-  /*
   DSFXFlanger effectParams = { };
   effectParams.fWetDryMix = wetdry;
   effectParams.fDepth = depth;
@@ -264,30 +287,33 @@ void sound_effect_flanger(int sound, float wetdry, float depth, float feedback, 
   effectParams.lWaveform = wave;
   effectParams.fDelay = delay;
   effectParams.lPhase = phase;
-  */
+
+  enigma::set_sound_effect_parameters<IDirectSoundFXFlanger8, DSFXFlanger>(
+    sound, GUID_DSFX_STANDARD_FLANGER, 0, IID_IDirectSoundFXFlanger8, &effectParams);
 }
 
 void sound_effect_gargle(int sound, unsigned rate, unsigned wave) {
-  /*
   DSFXGargle effectParams = { };
   effectParams.dwRateHz = rate;
   effectParams.dwWaveShape = wave;
-  */
+
+  enigma::set_sound_effect_parameters<IDirectSoundFXGargle8, DSFXGargle>(
+    sound, GUID_DSFX_STANDARD_GARGLE, 0, IID_IDirectSoundFXGargle8, &effectParams);
 }
 
 void sound_effect_reverb(int sound, float gain, float mix, float time, float ratio) {
-  /*
   DSFXWavesReverb effectParams = { };
   effectParams.fInGain = gain;
   effectParams.fReverbMix = mix;
   effectParams.fReverbTime = time;
   effectParams.fHighFreqRTRatio = ratio;
-  */
+
+  enigma::set_sound_effect_parameters<IDirectSoundFXWavesReverb8, DSFXWavesReverb>(
+    sound, GUID_DSFX_WAVES_REVERB, 0, IID_IDirectSoundFXWavesReverb8, &effectParams);
 }
 
 void sound_effect_compressor(int sound, float gain, float attack, float release, float threshold, float ratio,
                              float delay) {
-  /*
   DSFXCompressor effectParams = { };
   effectParams.fGain = gain;
   effectParams.fAttack = attack;
@@ -295,16 +321,19 @@ void sound_effect_compressor(int sound, float gain, float attack, float release,
   effectParams.fThreshold = threshold;
   effectParams.fRatio = ratio;
   effectParams.fPredelay = delay;
-  */
+
+  enigma::set_sound_effect_parameters<IDirectSoundFXCompressor8, DSFXCompressor>(
+    sound, GUID_DSFX_STANDARD_COMPRESSOR, 0, IID_IDirectSoundFXCompressor8, &effectParams);
 }
 
 void sound_effect_equalizer(int sound, float center, float bandwidth, float gain) {
-  /*
   DSFXParamEq effectParams = { };
   effectParams.fCenter = center;
   effectParams.fBandwidth = bandwidth;
   effectParams.fGain = gain;
-  */
+
+  enigma::set_sound_effect_parameters<IDirectSoundFXParamEq8, DSFXParamEq>(
+    sound, GUID_DSFX_STANDARD_PARAMEQ, 0, IID_IDirectSoundFXParamEq8, &effectParams);
 }
 
 static const GUID sound_effect_guids[7] = {
@@ -359,7 +388,12 @@ void sound_effect_set(int sound, int effect) {
   // query for the effect interface and set the effects on the sound buffer
   IDirectSoundBuffer8* soundBuffer8 = 0;
   snd.soundBuffer->QueryInterface(IID_IDirectSoundBuffer8, (void**)&soundBuffer8);
-  soundBuffer8->SetFX(numOfEffects, dsEffects, dwResults);
+  if (soundBuffer8) {
+    soundBuffer8->SetFX(numOfEffects, dsEffects, dwResults);
+    soundBuffer8->Release();
+  }
+  delete[] dsEffects;
+  delete[] dwResults;
 
   if (wasPlaying) snd.soundBuffer->Play(0, 0, wasLooping ? DSBPLAY_LOOPING : 0);  // resume
 }

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -32,17 +32,12 @@ template <typename EffectInterface, typename EffectParams>
 void set_sound_effect_parameters(int sound, REFGUID rguidObject, DWORD dwIndex, REFGUID rguidInterface, EffectParams* effectParams) {
   const Sound& snd = sounds.get(sound);
 
-  IDirectSoundBuffer8* soundBuffer8 = 0;
+  ComPtr<IDirectSoundBuffer8> soundBuffer8 = 0;
   snd.soundBuffer->QueryInterface(IID_IDirectSoundBuffer8, (void**)&soundBuffer8);
 
-  EffectInterface* sndFX8 = 0;
+  ComPtr<EffectInterface> sndFX8 = 0;
   soundBuffer8->GetObjectInPath(rguidObject, dwIndex, rguidInterface, (void**)&sndFX8);
-  if (sndFX8) {
-    sndFX8->SetAllParameters(effectParams);
-    sndFX8->Release();
-  }
-
-  soundBuffer8->Release();
+  if (sndFX8) sndFX8->SetAllParameters(effectParams);
 }
 
 } // namespace enigma
@@ -386,12 +381,9 @@ void sound_effect_set(int sound, int effect) {
   if (wasPlaying) snd.soundBuffer->Stop();  // pause
 
   // query for the effect interface and set the effects on the sound buffer
-  IDirectSoundBuffer8* soundBuffer8 = 0;
+  ComPtr<IDirectSoundBuffer8> soundBuffer8 = 0;
   snd.soundBuffer->QueryInterface(IID_IDirectSoundBuffer8, (void**)&soundBuffer8);
-  if (soundBuffer8) {
-    soundBuffer8->SetFX(numOfEffects, dsEffects, dwResults);
-    soundBuffer8->Release();
-  }
+  if (soundBuffer8) soundBuffer8->SetFX(numOfEffects, dsEffects, dwResults);
   delete[] dsEffects;
   delete[] dwResults;
 

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSsystem.cpp
@@ -169,7 +169,7 @@ int sound_add_from_buffer(int id, void* buffer, size_t bufsize) {
   bufferDesc.dwSize = sizeof(DSBUFFERDESC);
   // DSBCAPS_CTRLFX causes all kinds of weird nasty shit, please read #1508 on GitHub
   // before considering whether to readd it to the dwFlags below
-  bufferDesc.dwFlags = DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_GLOBALFOCUS;
+  bufferDesc.dwFlags = DSBCAPS_CTRLPAN | DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLFREQUENCY | DSBCAPS_GLOBALFOCUS | DSBCAPS_CTRLFX;
   bufferDesc.dwBufferBytes = waveHeader->dataSize;
   bufferDesc.dwReserved = 0;
   bufferDesc.lpwfxFormat = &waveFormat;


### PR DESCRIPTION
Well, here it is, ENIGMA can finally support environmental audio thanks to all the hard work of our Virtual Reality buddies.

* Fix memory leak on reference-counted COM interfaces by using ComPtr
* Fix memory leak in `sound_effect_set` by deleting the dynamically allocated effect description arrays
* Implement all sound effect parameter functions using a generic templated helper

```gml
// create event
effect = se_none;

// step event
if (keyboard_check_released(ord('0')))
	effect = se_none;
if (keyboard_check_released(ord('1')))
	effect ^= se_chorus;
if (keyboard_check_released(ord('2')))
	effect ^= se_echo;
if (keyboard_check_released(ord('3')))
	effect ^= se_flanger;
if (keyboard_check_released(ord('4')))
	effect ^= se_gargle;
if (keyboard_check_released(ord('5')))
	effect ^= se_reverb;
if (keyboard_check_released(ord('6')))
	effect ^= se_compressor;
if (keyboard_check_released(ord('7')))
	effect ^= se_equalizer;
if (keyboard_check_released(vk_anykey))
	sound_effect_set(snd_0,effect);
if (keyboard_check_released(vk_space))
	sound_play(snd_0);

// draw event
if (effect & se_chorus)
	draw_text(0, 0, "Chorus");
if (effect & se_echo)
	draw_text(0, 20, "Echo");
if (effect & se_flanger)
	draw_text(0, 40, "Flanger");
if (effect & se_gargle)
	draw_text(0, 60, "Gargle");
if (effect & se_reverb)
	draw_text(0, 80, "Reverb");
if (effect & se_compressor)
	draw_text(0, 100, "Compressor");
if (effect & se_equalizer)
	draw_text(0, 120, "Equalizer");
```