### PR TITLE
Fix SDL Gamepad Remove Crash

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
@@ -83,9 +83,13 @@ void addGamepad(unsigned i) {
 }
 
 void removeGamepad(unsigned i) {
+  if (gamepads[i].controller == nullptr) return;
+
   DEBUG_MESSAGE("Disconnected gamepad " + std::to_string(i) + ": " + SDL_GameControllerName(gamepads[i].controller), MESSAGE_TYPE::M_INFO);
   if (gamepads[i].haptic != nullptr) SDL_HapticClose(gamepads[i].haptic);
   SDL_GameControllerClose(gamepads[i].controller);
+  gamepads[i].haptic = nullptr;
+  gamepads[i].controller = nullptr;
 }
 
 }  // namespace enigma


### PR DESCRIPTION
This fixes a crash cleaning up gamepads at exit. You have to combine this with #2175 to get rid of the out of bounds issues. Then the issue remaining is just trying to close an already closed joystick if you already unplugged the joystick. All I had to do here was null the pointers and check if they are null like a good developer.