### PR TITLE
Fix SDL Gamepad Hotplugging

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Event.cpp
@@ -213,8 +213,6 @@ void SDL_Event_Handler::windowResized(const SDL_Event *event) {
 
 // map of joystick instance ids to device indexes
 std::unordered_map<SDL_JoystickID,int> joystickDevices;
-// give us a reference to map gamepad joy ids
-extern std::vector<Gamepad> gamepads;
 
 void SDL_Event_Handler::joyDeviceAdded(const SDL_Event *event) {
   addGamepad(event->cdevice.which);

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.cpp
@@ -5,7 +5,7 @@
 
 namespace enigma {
 
-static std::vector<Gamepad> gamepads;
+std::vector<Gamepad> gamepads;
 
 using namespace enigma_user;
 

--- a/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.h
+++ b/ENIGMAsystem/SHELL/Platforms/SDL/Gamepad.h
@@ -24,7 +24,7 @@ struct Gamepad {
   void push();
 };
 
-//extern std::vector<Gamepad> gamepads;
+extern std::vector<Gamepad> gamepads;
 
 void initGamepads();
 void cleanupGamepads();


### PR DESCRIPTION
This fixes #2091 in support of user. The problem is basically that the `cdevice->which` member is the device index (what GM uses) for device add events, but is actually the joystick instance id for button/axis/remove events. So clearly all we needed was a map of the joystick instance ids to the device indexes.

To clarify, you plug controller in, it has device index 0, and joystick instance id 0. You unplug it and plug it back in again, it still has device index 0, but then it has joystick instance id 1, and so on. It keeps getting incremented by one, because it's basically trying to track the player index, which we don't need because GM uses device index. Little test here you can do to make sure input still works after hot plugging.
```gml
draw_text(0,0,string(gamepad_is_connected(0)));
draw_text(0,20,string(gamepad_button_check(0, gp_padl)));
```

I really hated having to program it this way, and was stuck thinking of alternatives. The only other way I see to do this without the map is to disable the events and manually poll the gamepads/joysticks in our main loop like I do for XInput extension. I would probably rather do it that way anyway. We could generalize the gamepad structure from my XInput extension and the SDL system so they are both using the same structure, and then generalize all of the gamepad joystick functions for every platform.