### PR TITLE
Fileio whitespace

### DIFF
--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -1,5 +1,6 @@
 /// BINARY FILES
 var bin_path = "file_bin_test.bin";
+var bin_white = "file_bin_test_white.bin";
 
 // BINARY WRITE
 var bin_write;
@@ -69,6 +70,18 @@ file_bin_write_byte(bin_read,-1); // underflows to 255
 file_bin_write_byte(bin_read,256); // overflows to 0
 file_bin_close(bin_read);
 
+// Test byte reading exhaustively
+file_text_close(file_text_open_write(bin_white));
+bin_write = file_bin_open(bin_white,2);
+
+for (int bytes0to255=0; bytes0to255<$100; bytes0to255+=1)
+	{
+	file_bin_write_byte(bin_write,bytes0to255);
+	file_bin_seek(bin_write,bytes0to255);
+	gtest_expect_eq(file_bin_read_byte(bin_write),bytes0to255)
+	}
+file_bin_close(bin_write);
+
 // BINARY READ & WRITE
 var bin_read_write;
 bin_read_write = file_bin_open(bin_path,2);
@@ -94,7 +107,7 @@ gtest_expect_eq(file_bin_read_byte(bin_read_write),1);
 gtest_expect_eq(file_bin_read_byte(bin_read_write),2);
 gtest_expect_eq(file_bin_read_byte(bin_read_write),3);
 file_bin_close(bin_read_write);
-
+	
 /// TEXT FILES
 var text_path = "file_text_test.txt";
 
@@ -210,5 +223,6 @@ gtest_expect_eq(filename_change_ext("C:/John/Doe/Smoe.txt",".dingtwo"),"C:/John/
 
 /// We're done!
 file_delete(bin_path);
+file_delete(bin_white);
 file_delete(text_path);
 game_end();

--- a/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/fileio.cpp
@@ -220,7 +220,7 @@ void file_bin_write_byte(int fileid, unsigned char byte) {
 // Reads a byte of data from the file and returns this
 int file_bin_read_byte(int fileid) {
   unsigned char byte = 0;
-  enigma::files.get(fileid).fs >> byte;
+  enigma::files.get(fileid).fs >> std::noskipws >> byte;
   bool good = enigma::files.get(fileid).fs.good();
   try_io_and_print(enigma::files.get(fileid))
   return (!good) ? -1 : static_cast<int>(byte);


### PR DESCRIPTION
file_bin_read_byte skips over whitespace characters (08, 09, 0A, 0B, 0C, 0D, 0E and 20) unless the std::noskipws flag is used. Some gtests are added for this, to write then read back all byte values from 0-255