### PR TITLE
Update file IO command line test: Renamed function 'directory_delete'

### DIFF
--- a/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
+++ b/CommandLine/testing/SimpleTests/file_input_output.sog/create.edl
@@ -203,7 +203,7 @@ gtest_expect_false(file_exists("Games Are Fun.txt"));
 gtest_expect_false(file_exists("Development Community.txt"));
 gtest_expect_false(file_exists("ENIGMA John Doe.txt"));
 
-directory_delete("ENIGMA Folders");
+directory_destroy("ENIGMA Folders");
 gtest_expect_false(directory_exists("ENIGMA Folders"));
 
 gtest_expect_eq(filename_name("C:/John/Doe/Smoe.txt"),"Smoe.txt");


### PR DESCRIPTION
Change function name 'directory_delete' to 'directory_destroy' at line 206, 
as discovered by gfundies and TKG