### PR TITLE
include shader funcs still a mess tho

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/include.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL1/include.h
@@ -1,2 +1,3 @@
 #include "Info/graphics_info.h"
 #include "Graphics_Systems/General/include.h"
+#include "Graphics_Systems/OpenGL1/shader.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/include.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGL3/include.h
@@ -1,2 +1,3 @@
 #include "Info/graphics_info.h"
 #include "Graphics_Systems/General/include.h"
+#include "Graphics_Systems/OpenGL-Common/shader.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES2/include.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES2/include.h
@@ -1,2 +1,3 @@
 #include "Info/graphics_info.h"
 #include "Graphics_Systems/General/include.h"
+#include "Graphics_Systems/OpenGL-Common/shader.h"

--- a/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES3/include.h
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/OpenGLES3/include.h
@@ -1,2 +1,3 @@
 #include "Info/graphics_info.h"
 #include "Graphics_Systems/General/include.h"
+#include "Graphics_Systems/OpenGL-Common/shader.h"


### PR DESCRIPTION
This gives users access to glsl_ shader funcs again. The shader_ ones still seem broken because they use #define. These functions really need to be refactored to be consistent but this at least gives users some way to use shaders for now. 