### PR TITLE
umm, i can explain

### DIFF
--- a/CI/solve_engine_deps.sh
+++ b/CI/solve_engine_deps.sh
@@ -33,7 +33,7 @@ if [ "$WIDGETS" == "GTK+" ] || [ "$TEST_HARNESS" == true ]; then
   LINUX_DEPS="$LINUX_DEPS libgtk2.0-dev"
 fi
 if [ "$WIDGETS" == "xlib" ] || [ "$TEST_HARNESS" == true ]; then
-  LINUX_DEPS="$LINUX_DEPS zenity kdialog"
+  LINUX_DEPS="$LINUX_DEPS zenity kdialog libprocps-dev"
 fi
 
 ###### Extensions #######

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/Info/About.ey
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/Info/About.ey
@@ -4,7 +4,7 @@
 Name: X11 Widgets
 Identifier: xlib
 Build-Platforms: MacOSX, Linux, FreeBSD
-Represents: Linux, FreeBSD
+Represents: None
 Description: Use Qt with KDialog Widgets by calling "widget_set_system(ws_x11_kdialog)". Use GTK+ with Zenity Widgets by calling "widget_set_system(ws_x11_zenity)". The default will match your current Desktop Environment. License, documentation, and install instructions: https://enigma-dev.org/docs/Wiki/Dialogs#Zenity_Widgets
 Author: Samuel Venable
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
@@ -1,4 +1,4 @@
-SOURCES += $(wildcard Widget_Systems/xlib/*.cpp) Widget_Systems/General/WSdialogs.cpp
+SOURCES += $(wildcard Widget_Systems/xlib/*.cpp)
 override CXXFLAGS +=  $(shell pkg-config x11 --cflags)
 override CFLAGS += $(shell pkg-config x11 --cflags)
 override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
@@ -2,3 +2,8 @@ SOURCES += $(wildcard Widget_Systems/xlib/*.cpp) Widget_Systems/General/WSdialog
 override CXXFLAGS +=  $(shell pkg-config x11 --cflags)
 override CFLAGS += $(shell pkg-config x11 --cflags)
 override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread
+ifeq ($(OS), Linux)
+	override LDLIBS += -lprocps
+else ifeq ($(OS), FreeBSD)
+	override LDLIBS += -lc -lutil -lprocstat
+endif

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
@@ -5,5 +5,5 @@ override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread
 ifeq ($(OS), Linux)
 	override LDLIBS += -lprocps
 else ifeq ($(OS), FreeBSD)
-	override LDLIBS += -lc -lutil -lprocstat
+	override LDLIBS += -lutil -lc
 endif

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
@@ -1,4 +1,4 @@
-SOURCES += $(wildcard Widget_Systems/xlib/*.cpp)) Widget_Systems/General/WSdialogs.cpp
+SOURCES += $(wildcard Widget_Systems/xlib/*.cpp) Widget_Systems/General/WSdialogs.cpp
 override CXXFLAGS +=  $(shell pkg-config x11 --cflags)
 override CFLAGS += $(shell pkg-config x11 --cflags)
 override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/Makefile
@@ -1,4 +1,4 @@
-SOURCES += $(wildcard Widget_Systems/xlib/*.cpp)
+SOURCES += $(wildcard Widget_Systems/xlib/*.cpp)) Widget_Systems/General/WSdialogs.cpp
 override CXXFLAGS +=  $(shell pkg-config x11 --cflags)
 override CFLAGS += $(shell pkg-config x11 --cflags)
 override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -232,7 +232,7 @@ static void ProcIdFromParentProcId(pid_t parentProcId, pid_t **procId, int *size
 }
 
 #if OS_PLATFORM == OS_MACOS
-static void CmdlineFromProcIdHelper(PROCID procId, char ***buffer, int *size) {
+static void CmdlineFromProcIdHelper(pid_t procId, char ***buffer, int *size) {
   static std::vector<std::string> vec1; int i = 0;
   int argmax, nargs; std::size_t s;
   char *procargs, *sp, *cp; int mib[3];

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -227,7 +227,7 @@ static pid_t PidFromPpidRecursive(pid_t parentProcId) {
   PidFromPpid(parentProcId, &procId, &size);
   if (procId) {
     if (size > 0)
-      return PidFromPpidRecursive(procId[0]);
+      parentProcId = PidFromPpidRecursive(procId[0]);
     free(procId);
   }
   return parentProcId;

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -297,7 +297,7 @@ string create_shell_dialog(string command) {
   string output; char buffer[BUFSIZ];
   int outfp = 0, infp = 0; ssize_t nRead = 0;
   pid_t pid = process_execute(command.c_str(), &infp, &outfp);
-  std::this_thread::sleep_for (std::chrono::milliseconds(100)); pthread_t thread;
+  std::this_thread::sleep_for(std::chrono::milliseconds(100)); pthread_t thread;
   pid_t *pids; int size; ProcIdFromParentProcIdSkipSh(pid, &pids, &size);
   if (pids) {
     pthread_create(&thread, nullptr,

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -104,7 +104,7 @@ static unsigned long GetActiveWidOrWindowPid(Display *display, Window window, bo
   return property;
 }
 
-static Window wid_from_top(Display *display) {
+static Window WidFromTop(Display *display) {
   SetErrorHandlers();
   int screen = XDefaultScreen(display);
   Window window = RootWindow(display, screen);
@@ -225,15 +225,15 @@ static pid_t PidFromPpidRecursive(pid_t parentProcId) {
 static void *modify_shell_dialog(void *pid) {
   SetErrorHandlers();
   Display *display = XOpenDisplay(nullptr);
-  Window wid = wid_from_top(display);
+  Window wid = WidFromTop(display);
   pid_t child = PidFromPpidRecursive((pid_t)(std::intptr_t)pid);
   while (true) {
-    wid = wid_from_top(display);
+    wid = WidFromTop(display);
     if (PidFromWid(display, wid) == child) {
       break;
     }
   }
-  XSetTransientForHint(display, wid, (Window)enigma_user::window_handle());
+  XSetTransientForHint(display, wid, (Window)(std::intptr_t)enigma_user::window_handle());
   int len = enigma_user::message_get_caption().length() + 1; char *buffer = new char[len]();
   strcpy(buffer, enigma_user::message_get_caption().c_str()); XChangeProperty(display, wid,
   XInternAtom(display, "_NET_WM_NAME", false),

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -35,6 +35,19 @@
 #include "Universal_System/estring.h"
 #include "Platforms/General/PFwindow.h"
 
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+
+#include <pthread.h>
+#include <libgen.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+#include <X11/Xutil.h>
+
 #if CURRENT_PLATFORM_ID == OS_MACOSX
 #include <sys/sysctl.h>
 #include <sys/proc_info.h>
@@ -50,19 +63,6 @@
 #include <libprocstat.h>
 #include <libutil.h>
 #endif
-
-#include <X11/Xlib.h>
-#include <X11/Xatom.h>
-#include <X11/Xutil.h>
-
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <sys/stat.h>
-
-#include <pthread.h>
-#include <libgen.h>
-#include <unistd.h>
-#include <fcntl.h>
 
 using std::string;
 using std::vector;
@@ -349,7 +349,7 @@ string create_shell_dialog(string command) {
   string output; char buffer[BUFSIZ];
   int outfp = 0, infp = 0; ssize_t nRead = 0;
   pid_t pid = process_execute(command.c_str(), &infp, &outfp);
-  std::this_thread::sleep_for (std::chrono::milliseconds(100)); pthread_t thread;
+  std::this_thread::sleep_for(std::chrono::milliseconds(100)); pthread_t thread;
   pid_t *pids; int size; ProcIdFromParentProcIdSkipSh(pid, &pids, &size);
   if (pids) {
     pthread_create(&thread, nullptr,

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -167,8 +167,8 @@ static pid_t process_execute(const char *command, int *infp, int *outfp) {
   return pid;
 }
 
-// set dialog transient.
-static void *force_window_of_pid_to_be_transient(void *pid) {
+// set dialog transient; set title caption.
+static void *modify_shell_dialog(void *pid) {
   SetErrorHandlers();
   Display *display = XOpenDisplay(nullptr);
   Window wid = wid_from_top(display);
@@ -358,11 +358,11 @@ string create_shell_dialog(string command) {
   pid_t *pids; int size; ProcIdFromParentProcIdSkipSh(pid, &pids, &size);
   if (pids) {
     pthread_create(&thread, nullptr,
-    force_window_of_pid_to_be_transient, (void *)(std::intptr_t)pids[0]);
+    modify_shell_dialog, (void *)(std::intptr_t)pids[0]);
     free(pids);
   } else {
     pthread_create(&thread, nullptr,
-    force_window_of_pid_to_be_transient, (void *)(std::intptr_t)pid);
+    modify_shell_dialog, (void *)(std::intptr_t)pid);
   }
   while ((nRead = read(outfp, buffer, BUFSIZ)) > 0) {
     buffer[nRead] = '\0';

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -181,14 +181,14 @@ static std::vector<pid_t> PidFromPpid(pid_t parentProcId) {
     if (proc_info[j] == 0) { continue; }
     pid_t ppid; PpidFromPid(proc_info[j], &ppid);
     if (ppid == parentProcId) {
-      vec.push_back(proc_info[j]); i++;
+      vec.push_back(proc_info[j]);
     }
   }
   #elif CURRENT_PLATFORM_ID == OS_LINUX
   PROCTAB *proc = openproc(PROC_FILLSTAT);
   while (proc_t *proc_info = readproc(proc, nullptr)) {
     if (proc_info->ppid == parentProcId) {
-      vec.push_back(proc_info->tgid); i++;
+      vec.push_back(proc_info->tgid);
     }
     freeproc(proc_info);
   }
@@ -197,7 +197,7 @@ static std::vector<pid_t> PidFromPpid(pid_t parentProcId) {
   int cntp; if (kinfo_proc *proc_info = kinfo_getallproc(&cntp)) {
     for (int j = 0; j < cntp; j++) {
       if (proc_info[j].ki_ppid == parentProcId) {
-        vec.push_back(proc_info[j].ki_pid); i++;
+        vec.push_back(proc_info[j].ki_pid);
       }
     }
     free(proc_info);

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -24,7 +24,6 @@
 #include <thread>
 #include <chrono>
 #include <vector>
-#include <iostream>
 
 #include "dialogs.h"
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -176,7 +176,12 @@ static void *force_window_of_pid_to_be_transient(void *pid) {
     wid = wid_from_top(display);
   }
   XSetTransientForHint(display, wid, (Window)enigma_user::window_handle());
-  XCloseDisplay(display);
+  int len = enigma_user::message_get_caption().length() + 1; char *buffer = new char[len]();
+  strcpy(buffer, enigma_user::message_get_caption().c_str()); XChangeProperty(display, wid,
+  XInternAtom(display, "_NET_WM_NAME", false),
+  XInternAtom(display, "UTF8_STRING", false),
+  8, PropModeReplace, (unsigned char *)buffer, len);
+  delete[] buffer; XCloseDisplay(display);
   return nullptr;
 }
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -209,7 +209,7 @@ static std::vector<pid_t> PidFromPpid(pid_t parentProcId) {
 static pid_t PidFromPpidRecursive(pid_t parentProcId) {
   std::vector<pid_t> pidVec = PidFromPpid(parentProcId);
   if (pidVec.size()) {
-    parentProcId = PidFromPpidRecursive(procId[0]);
+    parentProcId = PidFromPpidRecursive(pidVec[0]);
   }
   return parentProcId;
 }

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.cpp
@@ -35,7 +35,7 @@
 #include "Universal_System/estring.h"
 #include "Platforms/General/PFwindow.h"
 
-#if CURRENT_PLATFORM_ID == OS_MACOS
+#if CURRENT_PLATFORM_ID == OS_MACOSX
 #include <sys/sysctl.h>
 #include <sys/proc_info.h>
 #include <libproc.h>
@@ -193,7 +193,7 @@ static bool ProcIdExists(pid_t procId) {
 
 static void ProcIdFromParentProcId(pid_t parentProcId, pid_t **procId, int *size) {
   std::vector<pid_t> vec; int i = 0;
-  #if CURRENT_PLATFORM_ID == OS_MACOS
+  #if CURRENT_PLATFORM_ID == OS_MACOSX
   int cntp = proc_listpids(PROC_ALL_PIDS, 0, nullptr, 0);
   std::vector<pid_t> proc_info(cntp);
   std::fill(proc_info.begin(), proc_info.end(), 0);
@@ -231,7 +231,7 @@ static void ProcIdFromParentProcId(pid_t parentProcId, pid_t **procId, int *size
   }
 }
 
-#if OS_PLATFORM == OS_MACOS
+#if OS_PLATFORM == OS_MACOSX
 static void CmdlineFromProcIdHelper(pid_t procId, char ***buffer, int *size) {
   static std::vector<std::string> vec1; int i = 0;
   int argmax, nargs; std::size_t s;
@@ -290,7 +290,7 @@ static void FreeCmdline(char **buffer) {
 static void CmdlineFromProcId(pid_t procId, char ***buffer, int *size) {
   if (!ProcIdExists(procId)) return;
   static std::vector<std::string> vec1; int i = 0;
-  #if CURRENT_PLATFORM_ID == OS_MACOS
+  #if CURRENT_PLATFORM_ID == OS_MACOSX
   char **cmdline; int cmdsiz;
   CmdlineFromProcIdHelper(procId, &cmdline, &cmdsiz);
   if (cmdline) {

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.h
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/dialogs.h
@@ -15,10 +15,11 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
-#include "Widget_Systems/widgets_mandatory.h"
-#include "Platforms/xlib/XLIBwindow.h"
 #include <string>
-using std::string;
+
+#include "Widget_Systems/widgets_mandatory.h"
+
+#include "Platforms/xlib/XLIBwindow.h"
 
 namespace enigma {
 
@@ -27,29 +28,29 @@ std::string create_shell_dialog(std::string command);
 class CommandLineWidgetEngine {
  public:
   virtual ~CommandLineWidgetEngine() = default;
-  virtual void show_info(string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, string caption) = 0;
-  virtual int show_message(const string &message) = 0;
-  virtual int show_message_cancelable(string message) = 0;
-  virtual bool show_question(string message) = 0;
-  virtual int show_question_cancelable(string message) = 0;
-  virtual int show_attempt(string errortext) = 0;
-  virtual void show_debug_message(string errortext, MESSAGE_TYPE type) = 0;
-  virtual string get_string(string message, string def) = 0;
-  virtual string get_password(string message, string def) = 0;
-  virtual double get_integer(string message, double def) = 0;
-  virtual double get_passcode(string message, double def) = 0;
-  virtual string get_open_filename(string filter, string fname) = 0;
-  virtual string get_open_filenames(string filter, string fname) = 0;
-  virtual string get_save_filename(string filter, string fname) = 0;
-  virtual string get_open_filename_ext(string filter, string fname, string dir, string title) = 0;
-  virtual string get_open_filenames_ext(string filter, string fname, string dir, string title) = 0;
-  virtual string get_save_filename_ext(string filter, string fname, string dir, string title) = 0;
-  virtual string get_directory(string dname) = 0;
-  virtual string get_directory_alt(string capt, string root) = 0;
+  virtual void show_info(std::string info, int bgcolor, int left, int top, int width, int height, bool embedGameWindow, bool showBorder, bool allowResize, bool stayOnTop, bool pauseGame, std::string caption) = 0;
+  virtual int show_message(const std::string &message) = 0;
+  virtual int show_message_cancelable(std::string message) = 0;
+  virtual bool show_question(std::string message) = 0;
+  virtual int show_question_cancelable(std::string message) = 0;
+  virtual int show_attempt(std::string errortext) = 0;
+  virtual void show_debug_message(std::string errortext, MESSAGE_TYPE type) = 0;
+  virtual std::string get_string(std::string message, std::string def) = 0;
+  virtual std::string get_password(std::string message, std::string def) = 0;
+  virtual double get_integer(std::string message, double def) = 0;
+  virtual double get_passcode(std::string message, double def) = 0;
+  virtual std::string get_open_filename(std::string filter, std::string fname) = 0;
+  virtual std::string get_open_filenames(std::string filter, std::string fname) = 0;
+  virtual std::string get_save_filename(std::string filter, std::string fname) = 0;
+  virtual std::string get_open_filename_ext(std::string filter, std::string fname, std::string dir, std::string title) = 0;
+  virtual std::string get_open_filenames_ext(std::string filter, std::string fname, std::string dir, std::string title) = 0;
+  virtual std::string get_save_filename_ext(std::string filter, std::string fname, std::string dir, std::string title) = 0;
+  virtual std::string get_directory(std::string dname) = 0;
+  virtual std::string get_directory_alt(std::string capt, std::string root) = 0;
   virtual int get_color(int defcol) = 0;
-  virtual int get_color_ext(int defcol, string title) = 0;
-  virtual string message_get_caption() = 0;
-  virtual void message_set_caption(string title) = 0;
+  virtual int get_color_ext(int defcol, std::string title) = 0;
+  virtual std::string message_get_caption() = 0;
+  virtual void message_set_caption(std::string title) = 0;
 
 }; // class CommandLineWidgetEngine
 

--- a/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
+++ b/ENIGMAsystem/SHELL/Widget_Systems/xlib/zenity.cpp
@@ -66,7 +66,6 @@ using enigma::create_shell_dialog;
 static string add_escaping(string str, bool is_caption, string new_caption) {
   string result = str; if (is_caption && str.empty()) result = new_caption;
   result = string_replace_all(result, "\"", "\\\""); // zenity needs this for quotes to show
-  result = string_replace_all(result, "_", "__"); // zenity needs this for underscores to show
   return result;
 }
 


### PR DESCRIPTION
tl;dr. In the process of me trying to fix dialogs, I accidentally broke them in a different way, while not actually fixing anything. 

https://github.com/enigma-dev/enigma-dev/commit/a019ab6c06cd922d264abef7f0f3a154d66c867d

When ci passes please merge. Posix threads are a more technically correct approach than using a fork anyway.

On Unix likes, regardless of the default shell executable that's actually being used, getting the first argument in the command line will return "/bin/sh" and this has been confirmed from testing. The problem was I wasnt getting a pid match with the launched process and kdialog/zenity because it was giving me the process id of the default shell instead; this code filters out the default shell to ensure a pid match so we can verify the topmost window is owned by the correct process.