### PR TITLE
Add stuff for Xlib on macOS (via XQuartz)

### DIFF
--- a/CompilerSource/general/bettersystem.cpp
+++ b/CompilerSource/general/bettersystem.cpp
@@ -310,7 +310,7 @@ void myReplace(std::string& str, const std::string& oldStr, const std::string& n
       proc_listpids(PROC_ALL_PIDS, 0, &proc_info[0], sizeof(pid_t) * cntp);
       for (int j = cntp; j > 0; j--) {
         if (proc_info[j] == 0) { continue; }
-        if (ppid == ParentProcIdFromProcId(proc_info[j])) {
+        if (parentProcId == ParentProcIdFromProcId(proc_info[j])) {
           vec.push_back(proc_info[j]); i++;
         }
       }

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Darwin/DARWINprogdir.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Darwin/DARWINprogdir.cpp
@@ -1,0 +1,14 @@
+#include "Platforms/General/POSIX/POSIXprogdir.h"
+#include <libproc.h>
+#include <unistd.h>
+
+namespace enigma {
+
+  void initialize_program_directory() {
+    char exe[PROC_PIDPATHINFO_MAXSIZE];
+    if (proc_pidpath(getpid(), exe, sizeof(exe)) > 0) {
+      enigma_user::program_directory = exe;
+    }
+  }
+  
+} // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/xlib/Darwin/DARWINjoystick.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/Darwin/DARWINjoystick.cpp
@@ -1,0 +1,23 @@
+// FIXME: actually add support for joysticks. 
+
+#include "Platforms/General/PFjoystick.h"
+#include "Widget_Systems/widgets_mandatory.h"
+#include <string>
+
+using std::string;
+
+namespace enigma
+{
+  static bool init_jsmsg = false;
+  
+  void init_joysticks() {
+    if (init_jsmsg) {
+      DEBUG_MESSAGE("Joysticks are not yet implemented in X11 for Darwin!", MESSAGE_TYPE::M_WARNING);
+      init_jsmsg = true;
+    }
+  }
+
+  void handle_joysticks() {
+    
+  }
+}  // namespace enigma

--- a/ENIGMAsystem/SHELL/Platforms/xlib/Darwin/XLIBsystem.h
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/Darwin/XLIBsystem.h
@@ -1,0 +1,5 @@
+#include "Platforms/General/PFsystem.h"
+
+namespace enigma_user {
+const int os_type = os_macosx;
+}  // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Platforms/xlib/Makefile
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/Makefile
@@ -9,9 +9,13 @@ else ifeq ($(OS), FreeBSD)
 	SOURCES += $(wildcard Platforms/xlib/BSD/*.cpp)
 	override CXXFLAGS += -IPlatforms/xlib/BSD/
 	override CFLAGS += -IPlatforms/xlib/BSD/
+else ifeq ($(OS), Darwin)
+	SOURCES += $(wildcard Platforms/General/POSIX/Darwin/*.cpp)
+	SOURCES += $(wildcard Platforms/xlib/Darwin/*.cpp)
+	override CXXFLAGS += -IPlatforms/xlib/Darwin/
+	override CFLAGS += -IPlatforms/xlib/Darwin/
 endif
 SOURCES += $(wildcard Platforms/xlib/*.cpp) $(wildcard Platforms/General/POSIX/*.cpp) Platforms/General/PFshell/PFshell.cpp
 override CXXFLAGS += $(shell pkg-config x11 --cflags)
 override CFLAGS += $(shell pkg-config x11 --cflags)
 override LDLIBS += $(shell pkg-config x11 --libs) -lz -lpthread -lXrandr -lXinerama
-


### PR DESCRIPTION
ENIGMA deps for XQuartz/Darwin platform:

brew install wget git llvm gcc gdb make pkgconfig protobuf protobuf-c lzlib glew glm libpng libGLU freeglut mesa openal-soft libogg alure libsndfile freealut libvorbis vorbis-tools Box2D dumb sdl2 freetype2 libffi libX11 libXrandr libXinerama java openjdk@8 rapidjson libyaml boost pulseaudio pugixml yaml-cpp grpc

sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
echo 'export PATH="/usr/local/opt/openjdk/bin:$PATH"' >> ~/.zshrc
export CPPFLAGS="-I/usr/local/opt/openjdk/include"