### PR TITLE
Implement buffer_set_surface().

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
@@ -269,7 +269,6 @@ void buffer_get_surface(int buffer, int surface, int mode, unsigned offset, int 
 }
 
 void buffer_set_surface(int buffer, int surface, int mode, unsigned offset, int modulo) {
-  get_buffer(binbuff, buffer);
   int tex = surface_get_texture(surface);
   int wid = surface_get_width(surface);
   int hgt = surface_get_height(surface);

--- a/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
@@ -21,6 +21,7 @@
 
 #include "Resources/AssetArray.h" // TODO: start actually using for this resource
 #include "Graphics_Systems/graphics_mandatory.h"
+#include "Graphics_Systems/General/GSsurface.h"
 #include "Widget_Systems/widgets_mandatory.h"
 
 #include <cstring>
@@ -261,18 +262,18 @@ int buffer_get_type(int buffer) {
   return binbuff->type;
 }
 
-//NOTE: This function should most likely be added in graphics systems.
 void buffer_get_surface(int buffer, int surface, int mode, unsigned offset, int modulo) {
   //get_buffer(binbuff, buffer);
   //TODO: Write this function
   DEBUG_MESSAGE("Function unimplemented: buffer_get_surface", MESSAGE_TYPE::M_WARNING);
 }
 
-//NOTE: This function should most likely be added in graphics systems.
 void buffer_set_surface(int buffer, int surface, int mode, unsigned offset, int modulo) {
-  //get_buffer(binbuff, buffer);
-  //TODO: Write this function
-  DEBUG_MESSAGE("Function unimplemented: buffer_set_surface", MESSAGE_TYPE::M_WARNING);
+  get_buffer(binbuff, buffer);
+  int tex = surface_get_texture(surface);
+  int wid = surface_get_width(surface);
+  int hgt = surface_get_height(surface);
+  enigma::graphics_push_texture_pixels(tex, wid, hgt, (unsigned char *)buffer_get_address(buffer));
 }
 
 void buffer_resize(int buffer, unsigned size) {

--- a/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
@@ -275,7 +275,7 @@ void buffer_set_surface(int buffer, int surface, int mode, unsigned offset, int 
   if (buffer_get_size(buffer) == buffer_sizeof(buffer_u64) * wid * hgt) {
     enigma::graphics_push_texture_pixels(tex, wid, hgt, (unsigned char *)buffer_get_address(buffer));
   } else { // execution can not continue safely with wrong buffer size
-    DEBUG_MESSAGE("Buffer allocated with wrong length! Cannot continue...", MESSAGE_TYPE::M_FATAL_ERROR);
+    DEBUG_MESSAGE("Buffer allocated with wrong length!", MESSAGE_TYPE::M_WARNING);
   }
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/bufferstruct.cpp
@@ -272,7 +272,11 @@ void buffer_set_surface(int buffer, int surface, int mode, unsigned offset, int 
   int tex = surface_get_texture(surface);
   int wid = surface_get_width(surface);
   int hgt = surface_get_height(surface);
-  enigma::graphics_push_texture_pixels(tex, wid, hgt, (unsigned char *)buffer_get_address(buffer));
+  if (buffer_get_size(buffer) == buffer_sizeof(buffer_u64) * wid * hgt) {
+    enigma::graphics_push_texture_pixels(tex, wid, hgt, (unsigned char *)buffer_get_address(buffer));
+  } else { // execution can not continue safely with wrong buffer size
+    DEBUG_MESSAGE("Buffer allocated with wrong length! Cannot continue...", MESSAGE_TYPE::M_FATAL_ERROR);
+  }
 }
 
 void buffer_resize(int buffer, unsigned size) {


### PR DESCRIPTION
It works!!!!!

Allows my video player in https://github.com/enigma-dev/enigma-dev/pull/2214 to render pixels to a surface from buffer_get_address().

![Screenshot_20210508_215944](https://user-images.githubusercontent.com/4379204/117554737-80707980-b027-11eb-9754-b71bcc8b3f21.png)

Screenshot taken on FreeBSD. Note FreeBSD is the only platoform my other pr (the video player one) currently works in, on Windows and Linux you will get undefined references, which I am in the process of figuring out before that pr will be ready for merging. 

However this is a separate task entirely, and should be good to go when the CI passes.