### PR TITLE
Cleanup Win32 Resize Scaling

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWScallback.cpp
@@ -52,12 +52,10 @@ namespace enigma
   using enigma_user::keyboard_string;
 
   extern char mousestatus[3],last_mousestatus[3];
-  extern int windowX, windowY, windowColor;
+  extern int windowColor;
   extern HCURSOR currentCursor;
 
-  static RECT tempWindow;
   static short hdeltadelta = 0, vdeltadelta = 0;
-  static int tempLeft = 0, tempTop = 0, tempRight = 0, tempBottom = 0, tempWidth, tempHeight;
 
   LRESULT (CALLBACK *touch_extension_callback)(HWND hWndParameter, UINT message, WPARAM wParam, LPARAM lParam);
   void (*WindowResizedCallback)();
@@ -107,23 +105,7 @@ namespace enigma
         }
         return 0;
 
-      case WM_ENTERSIZEMOVE:
-        GetWindowRect(hWndParameter,&tempWindow);
-        tempLeft = tempWindow.left;
-        tempTop = tempWindow.top;
-        tempRight = tempWindow.right;
-        tempBottom = tempWindow.bottom;
-        return 0;
-
       case WM_EXITSIZEMOVE:
-        GetWindowRect(hWndParameter,&tempWindow);
-        tempWidth = windowWidth + (tempWindow.right - tempWindow.left) - (tempRight - tempLeft);
-        tempHeight = windowHeight + (tempWindow.bottom - tempWindow.top) - (tempBottom - tempTop);
-
-        windowX += tempWindow.left - tempLeft;
-        windowY += tempWindow.top - tempTop;
-        windowWidth = tempWidth;
-        windowHeight = tempHeight;
         enigma::windowWidth = enigma_user::window_get_width();
         enigma::windowHeight = enigma_user::window_get_height();
         enigma::compute_window_scaling();


### PR DESCRIPTION
Following Aj's #2230 pull, I am removing this old dead code from the Win32 platform. The history of this code starts with @polygoned when he originally attempted to add the scaling options (9c1dd6b891caf4a1594f47aaa708893afd4644fd) to ENIGMA. He made the EXIT/end resize event be the one to redo the scaling calculation. Since that time we've cleaned that code up and abstracted it to apply to all platforms. However, we left a lot of his dead manual code in here that isn't needed anymore. This removes it, with no change in behavior as far as I can tell from my testing. We still compute scale in the normal resize event.