### PR TITLE
Fix D3D Mode Projection

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -72,9 +72,6 @@ void d3d_start() {
   enigma::d3dCulling = rs_none;
   enigma::alphaTest = true;
 
-  // Switch to perspective projection mode
-  d3d_set_perspective(true);
-
   // Set up modelview matrix
   d3d_transform_set_identity();
 

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -72,7 +72,7 @@ void d3d_start() {
   enigma::d3dCulling = rs_none;
   enigma::alphaTest = true;
 
-  // Set up projection matrix
+  // Switch to perspective projection mode
   d3d_set_perspective(true);
 
   // Set up modelview matrix

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -23,8 +23,6 @@
 #include "GScolors.h"
 #include "GScolor_macros.h"
 
-#include "Universal_System/roomsystem.h" // for view variables
-
 #include <unordered_map>
 #include <vector>
 #include <algorithm>
@@ -75,7 +73,7 @@ void d3d_start() {
   enigma::alphaTest = true;
 
   // Set up projection matrix
-  d3d_set_projection_perspective(0, 0, view_wview[view_current], view_hview[view_current], 0);
+  d3d_set_perspective(true);
 
   // Set up modelview matrix
   d3d_transform_set_identity();
@@ -92,8 +90,6 @@ void d3d_end() {
   enigma::d3dZWriteEnable = false;
   enigma::d3dCulling = rs_none;
   enigma::alphaTest = false;
-
-  d3d_set_projection_ortho(0, 0, view_wview[view_current], view_hview[view_current], 0); //This should probably be changed not to use views
 }
 
 void d3d_set_perspective(bool enable) {


### PR DESCRIPTION
I started working on this because of #2237 where I can't get a 3D SOG game to run because of an assertion in GLM perspective. The reason was because SOG games don't have views initialized and GLM is asserting on `d3d_start` passing 0 for aspect ratio. Luckily for me, `d3d_start` is actually incorrect with respect to intended behavior.

In GameMaker, switching to 3D mode automatically switches to perspective projection. However, this means perspective mode, which controls the default camera of the draw loop, not a one time projection. This is why it is unnecessary for us to set a projection immediately when start and end are called. I actually fixed perspective mode in #1388. There is no need to turn perspective off since in that same pull request I check in the draw loop if 3D mode and perspective mode are both enabled.
http://gamemaker.info/en/manual/415_01_mode
![GM 3D Start Perspective](https://user-images.githubusercontent.com/3212801/123317558-286cd400-d4fc-11eb-86e6-3d9485a8cb4b.png)

I made a little test here to see if `d3d_start` or `d3d_end` are supposed to also set a projection immediately.
```gml
for (i = 0; i < 50; i += 1)
    draw_clear(c_black);
d3d_start();
for (i = 0; i < 50; i += 1)
    draw_clear(c_black);
// confirm no state caching
for (i = 0; i < 50; i += 1)
    d3d_set_hidden((i mod 2) == 0);
for (i = 0; i < 50; i += 1)
    draw_clear(c_black);
d3d_end();
for (i = 0; i < 50; i += 1)
    draw_clear(c_black);
screen_refresh();
game_end();
```
I then analyzed GM8 and GMSv1.4 executable in [apitrace](https://apitrace.github.io/) and saw that neither make a call to [IDirect3DDevice8::SetTransform](https://docs.microsoft.com/en-us/previous-versions/ms889727(v=msdn.10)).
![GM8 apitrace 3D Start](https://user-images.githubusercontent.com/3212801/123339363-71328600-d518-11eb-9f51-2a91b30e270a.png)
