### PR TITLE
Remove D3D Start Clearing

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSd3d.cpp
@@ -74,9 +74,6 @@ void d3d_start() {
 
   // Set up modelview matrix
   d3d_transform_set_identity();
-
-  draw_clear(enigma_user::c_black);
-  d3d_clear_depth(1.0f);
 }
 
 void d3d_end() {


### PR DESCRIPTION
GMSv1.4 no longer calls the clear command when switching 3D mode. The reason this was done in the past is GM8 did call a device reset to lazily create the depth buffer, which necessitated making a clear call. However, GM8 did not immediately clear the `D3DCLEAR_ZBUFFER` depth buffer.

```gml
repeat (50) draw_clear(c_yellow);
d3d_start();
d3d_end();
repeat (50) draw_clear(c_yellow);
game_end();
```

| GM8                                                                                                                            | GMSv1.4                                                                                                                        |
|--------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
| ![GM8 apitrace D3D Mode](https://user-images.githubusercontent.com/3212801/123523965-4d487f00-d695-11eb-84dc-533007475cdc.png) | ![GMS apitrace D3D Mode](https://user-images.githubusercontent.com/3212801/123523926-0f4b5b00-d695-11eb-8d90-57eeba36cf6a.png) |