### PR TITLE
Remove AppVeyor Pacboy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,13 +37,13 @@ environment:
     - {MODE: Compile}
 
     # Catch-all
-    - {GRAPHICS: Direct3D11, AUDIO: DirectSound, WIDGETS: Win32, EXTENSIONS: "DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,IniFilesystem,Box2DPhysics,StudioPhysics,ExternalFuncs", PACKAGES: "box2d:x libffi:x"}
-    - {GRAPHICS: OpenGL1, AUDIO: OpenAL, PACKAGES: "glew:x openal:x dumb:x alure:x libmodplug:x libvorbis:x libogg:x flac:x mpg123:x libsndfile:x libgme:x"}
-    - {GRAPHICS: OpenGLES3, PLATFORM: SDL, PACKAGES: "SDL2:x libepoxy:x"}
+    - {GRAPHICS: Direct3D11, AUDIO: DirectSound, WIDGETS: Win32, EXTENSIONS: "DirectShow,WindowsTouch,XInput,MediaControlInterface,FileDropper,IniFilesystem,Box2DPhysics,StudioPhysics,ExternalFuncs", PACKAGES: "mingw-w64-x86_64-box2d mingw-w64-x86_64-libffi"}
+    - {GRAPHICS: OpenGL1, AUDIO: OpenAL, PACKAGES: "mingw-w64-x86_64-glew mingw-w64-x86_64-openal mingw-w64-x86_64-dumb mingw-w64-x86_64-alure mingw-w64-x86_64-libmodplug mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-flac mingw-w64-x86_64-mpg123 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libgme"}
+    - {GRAPHICS: OpenGLES3, PLATFORM: SDL, PACKAGES: "mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libepoxy"}
     #TODO: Fix GTK+ on Windows
-    #- {WIDGETS: GTK+, PACKAGES: "gtk2:x"}
+    #- {WIDGETS: GTK+, PACKAGES: "mingw-w64-x86_64-gtk2"}
     #TODO: Fix Bullet Physics on Windows
-    #- {EXTENSIONS: "BulletDynamics", PACKAGES: "bullet:x"}
+    #- {EXTENSIONS: "BulletDynamics", PACKAGES: "mingw-w64-x86_64-bullet"}
 
 init:
   - echo "%APPVEYOR_JOB_ID%"
@@ -58,7 +58,7 @@ init:
 
 install:
   - set PATH=C:\msys64;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;%PATH%
-  - bash -lc "pacboy --noconfirm -Sy boost:x pugixml:x rapidjson:x yaml-cpp:x grpc:x protobuf:x glm:x libpng:x re2:x %PACKAGES%"
+  - bash -lc "pacman --noconfirm -Sy mingw-w64-x86_64-boost mingw-w64-x86_64-pugixml mingw-w64-x86_64-rapidjson mingw-w64-x86_64-yaml-cpp mingw-w64-x86_64-grpc mingw-w64-x86_64-protobuf mingw-w64-x86_64-glm mingw-w64-x86_64-libpng mingw-w64-x86_64-re2 %PACKAGES%"
   - gcc -v
   - ps: |
       If ($env:APPVEYOR_JOB_NUMBER -eq 1) {


### PR DESCRIPTION
They killed off pacboy, which I had used to save the world a few characters. That change has finally propagated to AppVeyor's CI systems, and now I need to update it there. Actually, they didn't remove it, just stopped including pactoys in base install. Let's just get it out of our CI for good since it only complicates things.

```
msys/pactoys-git r2.07ca37f-2
    A set of pacman packaging utilities
```
