### PR TITLE
Add file_get_date_accessed_*() and file_get_date_modified_*() functions.

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -59,7 +59,7 @@ int file_get_date_modified(const char *fname, int type) {
   else result = -1; // error; invalid type...
   std::error_code ec;
   auto ftime = std::filesystem::last_write_time(p, ec);
-  get_last_write_time(ftime, fname, type);
+  get_last_write_time(fname, type);
   return result;
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -32,6 +32,11 @@ using std::string;
 
 #include "include.h"
 
+#if defined(_WIN32)
+#include "Universal_System/estring.h"
+#endif
+
+#include <sys/types.h>
 #include <sys/stat.h>
 
 namespace {
@@ -46,8 +51,15 @@ enum dt_type {
 };
 
 int file_get_date_accessed_modified(const char *fname, bool modified, int type) {
-  int result = -1; struct stat info = { 0 }; stat(fname, &info);
+  int result = 0;
+  #if defined(_WIN32)
+  std::wstring wfname = widen(fname);
+  struct _stat info = { 0 }; _wstat(wfname.c_str(), &info);
   time_t time = modified ? info.st_mtime : info.st_atime;
+  #else
+  struct stat info = { 0 }; stat(fname, &info);
+  time_t time = modified ? info.st_mtime : info.st_atime;
+  #endif
   struct tm *timeinfo = std::localtime(&time);
   if      (type == dt_year)   result = timeinfo->tm_year + 1900;
   else if (type == dt_month)  result = timeinfo->tm_mon  + 1;

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -46,8 +46,7 @@ enum dt_type {
 };
 
 int file_get_date_modified(const char *fname, int type) {
-  int result = -1;
-  struct stat info = { 0 }; stat(fname, &info);
+  int result = -1; struct stat info = { 0 }; stat(fname, &info);
   struct tm *timeinfo = std::localtime(&info.st_mtime);
   if      (type == dt_year)   result = timeinfo->tm_year + 1900;
   else if (type == dt_month)  result = timeinfo->tm_mon + 1;
@@ -55,7 +54,6 @@ int file_get_date_modified(const char *fname, int type) {
   else if (type == dt_hour)   result = timeinfo->tm_hour;
   else if (type == dt_minute) result = timeinfo->tm_min;
   else if (type == dt_second) result = timeinfo->tm_sec;
-  else result = -1; // error; invalid type...
   return result;
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -51,7 +51,7 @@ enum dt_type {
 };
 
 int file_get_date_accessed_modified(const char *fname, bool modified, int type) {
-  int result = 0;
+  int result = -1;
   #if defined(_WIN32)
   std::wstring wfname = widen(fname);
   struct _stat info = { 0 }; _wstat(wfname.c_str(), &info);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -57,9 +57,6 @@ int file_get_date_modified(const char *fname, int type) {
   else if (type == dt_minute) result = timeinfo->tm_min;
   else if (type == dt_second) result = timeinfo->tm_sec;
   else result = -1; // error; invalid type...
-  std::error_code ec;
-  auto ftime = std::filesystem::last_write_time(p, ec);
-  get_last_write_time(fname, type);
   return result;
 }
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -49,7 +49,7 @@ int file_get_date_modified(const char *fname, int type) {
   int result = -1; struct stat info = { 0 }; stat(fname, &info);
   struct tm *timeinfo = std::localtime(&info.st_mtime);
   if      (type == dt_year)   result = timeinfo->tm_year + 1900;
-  else if (type == dt_month)  result = timeinfo->tm_mon + 1;
+  else if (type == dt_month)  result = timeinfo->tm_mon  + 1;
   else if (type == dt_day)    result = timeinfo->tm_mday;
   else if (type == dt_hour)   result = timeinfo->tm_hour;
   else if (type == dt_minute) result = timeinfo->tm_min;

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -49,7 +49,6 @@ int file_get_date_modified(const char *fname, int type) {
   int result = -1;
   struct stat info = { 0 }; stat(fname, &info);
   struct tm *timeinfo = localtime(&info.st_mtime);
-  struct tm *timeinfo = std::localtime(&cftime);
   if      (type == dt_year)   result = timeinfo->tm_year + 1900;
   else if (type == dt_month)  result = timeinfo->tm_mon + 1;
   else if (type == dt_day)    result = timeinfo->tm_mday;

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -51,23 +51,24 @@ enum dt_type {
 };
 
 int file_get_date_accessed_modified(const char *fname, bool modified, int type) {
-  int result = -1;
+  int result = -1; // returns -1 on failure
   #if defined(_WIN32)
   std::wstring wfname = widen(fname);
-  struct _stat info = { 0 }; _wstat(wfname.c_str(), &info);
+  struct _stat info = { 0 }; result = _wstat(wfname.c_str(), &info);
   time_t time = modified ? info.st_mtime : info.st_atime;
   #else
-  struct stat info = { 0 }; stat(fname, &info);
+  struct stat info = { 0 }; result = stat(fname, &info);
   time_t time = modified ? info.st_mtime : info.st_atime;
   #endif
+  if (result == -1) return result; // failure: stat errored
   struct tm *timeinfo = std::localtime(&time);
-  if      (type == dt_year)   result = timeinfo->tm_year + 1900;
-  else if (type == dt_month)  result = timeinfo->tm_mon  + 1;
-  else if (type == dt_day)    result = timeinfo->tm_mday;
-  else if (type == dt_hour)   result = timeinfo->tm_hour;
-  else if (type == dt_minute) result = timeinfo->tm_min;
-  else if (type == dt_second) result = timeinfo->tm_sec;
-  return result;
+  if      (type == dt_year)   return timeinfo->tm_year + 1900;
+  else if (type == dt_month)  return timeinfo->tm_mon  + 1;
+  else if (type == dt_day)    return timeinfo->tm_mday;
+  else if (type == dt_hour)   return timeinfo->tm_hour;
+  else if (type == dt_minute) return timeinfo->tm_min;
+  else if (type == dt_second) return timeinfo->tm_sec;
+  else return result; // failure: enum value not found
 }
 
 } // anonymous namepsace

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -45,9 +45,10 @@ enum dt_type {
   dt_second
 };
 
-int file_get_date_modified(const char *fname, int type) {
+int file_get_date_accessed_modified(const char *fname, bool modified, int type) {
   int result = -1; struct stat info = { 0 }; stat(fname, &info);
-  struct tm *timeinfo = std::localtime(&info.st_mtime);
+  time_t time = modified ? info.st_mtime : info.st_atime;
+  struct tm *timeinfo = std::localtime(&time);
   if      (type == dt_year)   result = timeinfo->tm_year + 1900;
   else if (type == dt_month)  result = timeinfo->tm_mon  + 1;
   else if (type == dt_day)    result = timeinfo->tm_mday;
@@ -506,28 +507,52 @@ string date_datetime_stringf(time_t date,string format)
     return string(buffer);
 }
 
+int file_get_date_accessed_year(string fname) {
+  return file_get_date_modified(fname.c_str(), false, dt_year);
+}
+
+int file_get_date_accessed_month(string fname) {
+  return file_get_date_modified(fname.c_str(), false, dt_month);
+}
+
+int file_get_date_accessed_day(string fname) {
+  return file_get_date_modified(fname.c_str(), false, dt_day);
+}
+
+int file_get_date_accessed_hour(string fname) {
+  return file_get_date_modified(fname.c_str(), false, dt_hour);
+}
+
+int file_get_date_accessed_minute(string fname) {
+  return file_get_date_modified(fname.c_str(), false, dt_minute);
+}
+
+int file_get_date_accessed_second(string fname) {
+  return file_get_date_modified(fname.c_str(), false, dt_second);
+}
+
 int file_get_date_modified_year(string fname) {
-  return file_get_date_modified(fname.c_str(), dt_year);
+  return file_get_date_modified(fname.c_str(), true, dt_year);
 }
 
 int file_get_date_modified_month(string fname) {
-  return file_get_date_modified(fname.c_str(), dt_month);
+  return file_get_date_modified(fname.c_str(), true, dt_month);
 }
 
 int file_get_date_modified_day(string fname) {
-  return file_get_date_modified(fname.c_str(), dt_day);
+  return file_get_date_modified(fname.c_str(), true, dt_day);
 }
 
 int file_get_date_modified_hour(string fname) {
-  return file_get_date_modified(fname.c_str(), dt_hour);
+  return file_get_date_modified(fname.c_str(), true, dt_hour);
 }
 
 int file_get_date_modified_minute(string fname) {
-  return file_get_date_modified(fname.c_str(), dt_minute);
+  return file_get_date_modified(fname.c_str(), true, dt_minute);
 }
 
 int file_get_date_modified_second(string fname) {
-  return file_get_date_modified(fname.c_str(), dt_second);
+  return file_get_date_modified(fname.c_str(), true, dt_second);
 }
 
 } // namespace enigma_user

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -25,14 +25,49 @@
 **  or programs made in the environment.                                        **
 **                                                                              **
 \********************************************************************************/
-#include <time.h>
+#include <ctime>
 #include <string>
-using std::string;
 
 #include "include.h"
 
+#include <sys/stat.h>
+
+using std::string;
+
+namespace {
+
+enum dt_type {
+  dt_year, 
+  dt_month, 
+  dt_day, 
+  dt_hour, 
+  dt_minute, 
+  dt_second
+};
+
+int file_get_date_modified(const char *fname, int type) {
+  int result = -1;
+  struct stat info = { 0 }; stat(fname, &info);
+  struct tm *timeinfo = localtime(&info.st_mtime);
+  struct tm *timeinfo = std::localtime(&cftime);
+  if      (type == dt_year)   result = timeinfo->tm_year + 1900;
+  else if (type == dt_month)  result = timeinfo->tm_mon + 1;
+  else if (type == dt_day)    result = timeinfo->tm_mday;
+  else if (type == dt_hour)   result = timeinfo->tm_hour;
+  else if (type == dt_minute) result = timeinfo->tm_min;
+  else if (type == dt_second) result = timeinfo->tm_sec;
+  else result = -1; // error; invalid type...
+  std::error_code ec;
+  auto ftime = std::filesystem::last_write_time(p, ec);
+  get_last_write_time(ftime, fname, type);
+  return result;
+}
+
+} // anonymous namepsace
+
 namespace enigma_user
 {
+
 time_t date_current_datetime()
 {
     return time(NULL);
@@ -476,5 +511,30 @@ string date_datetime_stringf(time_t date,string format)
     strftime(buffer,80,format.c_str(),localtime(&date));
     return string(buffer);
 }
+
+int file_get_date_modified_year(string fname) {
+  return file_get_date_modified(fname.c_str(), dt_year);
 }
+
+int file_get_date_modified_month(string fname) {
+  return file_get_date_modified(fname.c_str(), dt_month);
+}
+
+int file_get_date_modified_day(string fname) {
+  return file_get_date_modified(fname.c_str(), dt_day);
+}
+
+int file_get_date_modified_hour(string fname) {
+  return file_get_date_modified(fname.c_str(), dt_hour);
+}
+
+int file_get_date_modified_minute(string fname) {
+  return file_get_date_modified(fname.c_str(), dt_minute);
+}
+
+int file_get_date_modified_second(string fname) {
+  return file_get_date_modified(fname.c_str(), dt_second);
+}
+
+} // namespace enigma_user
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -48,7 +48,7 @@ enum dt_type {
 int file_get_date_modified(const char *fname, int type) {
   int result = -1;
   struct stat info = { 0 }; stat(fname, &info);
-  struct tm *timeinfo = localtime(&info.st_mtime);
+  struct tm *timeinfo = std::localtime(&info.st_mtime);
   if      (type == dt_year)   result = timeinfo->tm_year + 1900;
   else if (type == dt_month)  result = timeinfo->tm_mon + 1;
   else if (type == dt_day)    result = timeinfo->tm_mday;

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/date_time.cpp
@@ -28,11 +28,11 @@
 #include <ctime>
 #include <string>
 
+using std::string;
+
 #include "include.h"
 
 #include <sys/stat.h>
-
-using std::string;
 
 namespace {
 

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/include.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/include.h
@@ -110,6 +110,13 @@ string date_date_string(time_t date);
 string date_time_string(time_t date);
 string date_datetime_stringf(time_t date,string format);
 
+int file_get_date_accessed_year(string fname);
+int file_get_date_accessed_month(string fname);
+int file_get_date_accessed_day(string fname);
+int file_get_date_accessed_hour(string fname);
+int file_get_date_accessed_minute(string fname);
+int file_get_date_accessed_second(string fname);
+
 int file_get_date_modified_year(string fname);
 int file_get_date_modified_month(string fname);
 int file_get_date_modified_day(string fname);

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/include.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/DateTime/include.h
@@ -109,5 +109,13 @@ string date_datetime_string(time_t date);
 string date_date_string(time_t date);
 string date_time_string(time_t date);
 string date_datetime_stringf(time_t date,string format);
+
+int file_get_date_modified_year(string fname);
+int file_get_date_modified_month(string fname);
+int file_get_date_modified_day(string fname);
+int file_get_date_modified_hour(string fname);
+int file_get_date_modified_minute(string fname);
+int file_get_date_modified_second(string fname);
+
 }
 


### PR DESCRIPTION
Relying on <sys/stat.h> I know is bad but it is only temporary, as I intend to replace with std::filesystem down the line when we transition to C++20. A C++20 version is below for when the time comes, which feel free to test it though I already have:

```
#include <ctime>
#include <chrono>
#include <iomanip>
#include <filesystem>

namespace {

enum dt_type {
  dt_year, 
  dt_month, 
  dt_day, 
  dt_hour, 
  dt_minute, 
  dt_second
};

int result = -1;
int file_get_date_modified(const char *fname, int type) {
  using namespace std::chrono;
  // u8path is deprecated, but not removed in C++20
  auto p = std::filesystem::u8path(fname);
  auto get_last_write_time = [](
    std::filesystem::file_time_type const &ftime, int type) {
    std::time_t cftime = system_clock::to_time_t(file_clock::to_sys(ftime));
    struct tm *timeinfo = std::localtime(&cftime);
    if      (type == dt_year)   result = timeinfo->tm_year + 1900;
    else if (type == dt_month)  result = timeinfo->tm_mon  + 1;
    else if (type == dt_day)    result = timeinfo->tm_mday;
    else if (type == dt_hour)   result = timeinfo->tm_hour;
    else if (type == dt_minute) result = timeinfo->tm_min;
    else if (type == dt_second) result = timeinfo->tm_sec;
    else result = -1; // error; invalid type...
  };
  std::error_code ec;
  auto ftime = std::filesystem::last_write_time(p, ec);
  get_last_write_time(ftime, type);
  return result;
}

} // anonymous namespace
```
------------------------------

Test cpp (C++20):
------------------------------
```
#include <ctime>
#include <cstdio>
#include <chrono>
#include <iomanip>
#include <filesystem>

namespace {

enum dt_type {
  dt_year, 
  dt_month, 
  dt_day, 
  dt_hour, 
  dt_minute, 
  dt_second
};

int result = -1;
int file_get_date_modified(const char *fname, int type) {
  using namespace std::chrono;
  // u8path is deprecated, but not removed in C++20
  auto p = std::filesystem::u8path(fname);
  auto get_last_write_time = [](
    std::filesystem::file_time_type const &ftime, int type) {
    std::time_t cftime = system_clock::to_time_t(file_clock::to_sys(ftime));
    struct tm *timeinfo = std::localtime(&cftime);
    if      (type == dt_year)   result = timeinfo->tm_year + 1900;
    else if (type == dt_month)  result = timeinfo->tm_mon  + 1;
    else if (type == dt_day)    result = timeinfo->tm_mday;
    else if (type == dt_hour)   result = timeinfo->tm_hour;
    else if (type == dt_minute) result = timeinfo->tm_min;
    else if (type == dt_second) result = timeinfo->tm_sec;
    else result = -1; // error; invalid type...
  };
  std::error_code ec;
  auto ftime = std::filesystem::last_write_time(p, ec);
  get_last_write_time(ftime, type);
  return result;
}

} // anonymous namespace

int main(int argc, char **argv) {
  printf("%lu\n", file_get_date_modified(argv[0], dt_year));
}
```
Build with:
`g++ in.cpp -o out -std=c++20`
------------------------------
Test cpp (sys/stat.h)
------------------------------
```
#include <ctime>
#include <cstdio>

#include <sys/stat.h>

namespace {

enum dt_type {
  dt_year, 
  dt_month, 
  dt_day, 
  dt_hour, 
  dt_minute, 
  dt_second
};

int file_get_date_modified(const char *fname, int type) {
  int result = -1; struct stat info = { 0 }; stat(fname, &info);
  struct tm *timeinfo = std::localtime(&info.st_mtime);
  if      (type == dt_year)   result = timeinfo->tm_year + 1900;
  else if (type == dt_month)  result = timeinfo->tm_mon  + 1;
  else if (type == dt_day)    result = timeinfo->tm_mday;
  else if (type == dt_hour)   result = timeinfo->tm_hour;
  else if (type == dt_minute) result = timeinfo->tm_min;
  else if (type == dt_second) result = timeinfo->tm_sec;
  return result;
}

} // anonymous namespace

int main(int argc, char **argv) {
  printf("%lu\n", file_get_date_modified(argv[0], dt_year));
}
```
Build with:
`g++ in.cpp -o out -std=c++17`
------------------------------

Also, C++20 never introduced a way to get the last accessed timestamp of a file, thus the easiest workaround that supports UTF-8 would be to use _wstat() instead along with our widen() and shorten() helper functions, see:

https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions?view=msvc-160