### PR TITLE
Fix program_directory on FreeBSD / DragonFly BSD

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/BSD/BSDprogdir.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/BSD/BSDprogdir.cpp
@@ -21,7 +21,7 @@ namespace enigma {
         path = string(buffer) + "\0";
       }
     }
-    enigma_user::program_directory = path;
+    enigma_user::program_directory = enigma_user::filename_path(path);
   }
 
 } // namespace enigma


### PR DESCRIPTION
I forgot to filename_path() it.