### PR TITLE
Use std::chrono for Main Loop Timing

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -5,6 +5,7 @@
 #include "Platforms/platforms_mandatory.h"
 #include "Widget_Systems/widgets_mandatory.h"
 #include "Universal_System/roomsystem.h"
+#include "Universal_System/mathnc.h" // enigma_user::clamp
 
 #include <chrono> // std::chrono::microseconds
 #include <thread> // sleep_for
@@ -80,11 +81,13 @@ void update_current_time() {
 }
 
 long get_current_offset_difference_mcs() {
-  return std::chrono::duration_cast<std::chrono::microseconds>(timer_current - timer_offset).count();
+  auto delta = std::chrono::duration_cast<std::chrono::microseconds>(timer_current - timer_offset).count();
+  return enigma_user::clamp(delta, 0, 1000000);
 }
 
 long get_current_offset_slowing_difference_mcs() {
-  return std::chrono::duration_cast<std::chrono::microseconds>(timer_current - timer_offset_slowing).count();
+  auto delta = std::chrono::duration_cast<std::chrono::microseconds>(timer_current - timer_offset_slowing).count();
+  return enigma_user::clamp(delta, 0, 1000000);
 }
 
 void increase_offset_slowing(long increase_mcs) {

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -21,6 +21,8 @@ int current_room_speed;
 std::string* parameters;
 int parameterc;
 int frames_count = 0;
+// Monotic non-wall clock timer is required for accurate frame limiting.
+// https://github.com/enigma-dev/enigma-dev/pull/2259
 std::chrono::steady_clock::time_point timer_start;
 std::chrono::steady_clock::time_point timer_offset;
 std::chrono::steady_clock::time_point timer_offset_slowing;

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -233,7 +233,6 @@ void sleep(int ms) { enigma::Sleep(ms); }
 
 unsigned long get_timer() {
   enigma::update_current_time();
-
   return std::chrono::duration_cast<std::chrono::microseconds>(enigma::timer_current - enigma::timer_start).count();
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.cpp
@@ -96,7 +96,8 @@ void increase_offset_slowing(long increase_mcs) {
 
 void offset_modulus_one_second() {
   long passed_mcs = get_current_offset_difference_mcs();
-  timer_offset += std::chrono::microseconds(passed_mcs);
+  // rounds towards 0
+  timer_offset += std::chrono::duration_cast<std::chrono::seconds>(std::chrono::microseconds(passed_mcs));
   timer_offset_slowing = timer_offset;
 }
 

--- a/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
+++ b/ENIGMAsystem/SHELL/Platforms/General/PFmain.h
@@ -59,6 +59,7 @@ extern unsigned long delta_time;
 extern unsigned long current_time;
 
 void sleep(int ms);
+unsigned long get_timer(); // number of microseconds since the game started
 void game_end();
 void game_end(int ret);
 void action_end_game();

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -3,7 +3,6 @@
 #include "Universal_System/mathnc.h" // enigma_user::clamp
 #include "Widget_Systems/widgets_mandatory.h"
 
-#include <time.h> //CLOCK_MONOTONIC
 #include <sys/types.h>     //getpid
 #include <unistd.h>        //usleep
 

--- a/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/General/POSIX/Utility.cpp
@@ -9,10 +9,6 @@
 
 namespace enigma {
 
-static struct timespec time_offset;
-static struct timespec time_offset_slowing;
-static struct timespec time_current;
-
 void Sleep(int ms) {
   if (ms >= 1000) enigma_user::sleep(ms / 1000);
   if (ms > 0) usleep(ms % 1000 * 1000);
@@ -25,85 +21,4 @@ void windowsystem_write_exename(char* x) {
   x[irx] = 0;
 }
 
-void initTimer() {
-  clock_gettime(CLOCK_MONOTONIC, &time_offset);
-  time_offset_slowing.tv_sec = time_offset.tv_sec;
-  time_offset_slowing.tv_nsec = time_offset.tv_nsec;
-}
-
-void update_current_time() {
-  clock_gettime(CLOCK_MONOTONIC, &time_current);
-}
-
-int updateTimer() {
-
-  update_current_time();
-  {
-    long passed_mcs = (time_current.tv_sec - time_offset.tv_sec) * 1000000 +
-                      (time_current.tv_nsec / 1000 - +time_offset.tv_nsec / 1000);
-    passed_mcs = enigma_user::clamp(passed_mcs, 0, 1000000);
-    if (passed_mcs >= 1000000) {  // Handle resetting.
-
-      enigma_user::fps = frames_count;
-      frames_count = 0;
-      time_offset.tv_sec += passed_mcs / 1000000;
-      time_offset_slowing.tv_sec = time_offset.tv_sec;
-      time_offset_slowing.tv_nsec = time_offset.tv_nsec;
-    }
-  }
-
-  long spent_mcs = 0;
-  long last_mcs = 0;
-  if (current_room_speed > 0) {
-    spent_mcs = (time_current.tv_sec - time_offset_slowing.tv_sec) * 1000000 +
-                (time_current.tv_nsec / 1000 - time_offset_slowing.tv_nsec / 1000);
-    spent_mcs = enigma_user::clamp(spent_mcs, 0, 1000000);
-    long remaining_mcs = 1000000 - spent_mcs;
-    long needed_mcs = long((1.0 - 1.0 * frames_count / current_room_speed) * 1e6);
-    const int catchup_limit_ms = 50;
-    if (needed_mcs > remaining_mcs + catchup_limit_ms * 1000) {
-      // If more than catchup_limit ms is needed than is remaining, we risk running too fast to catch up.
-      // In order to avoid running too fast, we advance the offset, such that we are only at most catchup_limit ms behind.
-      // Thus, if the load is consistently making the game slow, the game is still allowed to run as fast as possible
-      // without any sleep.
-      // And if there is very heavy load once in a while, the game will only run too fast for catchup_limit ms.
-      time_offset_slowing.tv_nsec += 1000 * (needed_mcs - (remaining_mcs + catchup_limit_ms * 1000));
-      spent_mcs = (time_current.tv_sec - time_offset_slowing.tv_sec) * 1000000 +
-                  (time_current.tv_nsec / 1000 - time_offset_slowing.tv_nsec / 1000);
-      spent_mcs = enigma_user::clamp(spent_mcs, 0, 1000000);
-      remaining_mcs = 1000000 - spent_mcs;
-      needed_mcs = long((1.0 - 1.0 * frames_count / current_room_speed) * 1e6);
-    }
-    if (remaining_mcs > needed_mcs) {
-      const long sleeping_time = std::min((remaining_mcs - needed_mcs) / 5, long(999999));
-      usleep(std::max(long(1), sleeping_time));
-      return -1;
-    }
-  }
-
-  //TODO: The placement of this code is inconsistent with Win32 because events are handled after, ask Josh.
-  unsigned long dt = 0;
-  if (spent_mcs > last_mcs) {
-    dt = (spent_mcs - last_mcs);
-  } else {
-    //TODO: figure out what to do here this happens when the fps is reached and the timers start over
-    dt = enigma_user::delta_time;
-  }
-  last_mcs = spent_mcs;
-  enigma_user::delta_time = dt;
-  current_time_mcs += enigma_user::delta_time;
-  enigma_user::current_time += enigma_user::delta_time / 1000;
-
-  return 0;
-}
 }  //namespace enigma
-
-namespace enigma_user {
-
-unsigned long get_timer() {  // microseconds since the start of the game
-  enigma::update_current_time();
-
-  return (enigma::time_current.tv_sec) * 1000000 + (enigma::time_current.tv_nsec / 1000);
-}
-
-}  //namespace enigma_user

--- a/ENIGMAsystem/SHELL/Platforms/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/None/fillin.cpp
@@ -30,7 +30,6 @@
 #include <stdlib.h>  //getenv and system
 #include <sys/resource.h>
 #include <sys/stat.h>
-#include <time.h>  //clock
 #include <unistd.h>
 #include <cstdlib>
 #include <map>

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -93,74 +93,6 @@ bool set_working_directory(string dname) {
 } // enigma_user
 
 namespace enigma {
-bool use_pc;
-// Filetime.
-ULARGE_INTEGER time_offset_ft;
-ULARGE_INTEGER time_offset_slowing_ft;
-ULARGE_INTEGER time_current_ft;
-// High-resolution performance counter.
-LARGE_INTEGER time_offset_pc;
-LARGE_INTEGER time_offset_slowing_pc;
-LARGE_INTEGER time_current_pc;
-LARGE_INTEGER frequency_pc;
-// Timing functions.
-
-void initialize_timing() {
-  use_pc = QueryPerformanceFrequency(&frequency_pc);
-  if (use_pc) {
-    QueryPerformanceCounter(&time_offset_pc);
-    time_offset_slowing_pc.QuadPart = time_offset_pc.QuadPart;
-  } else {
-    FILETIME time_values;
-    GetSystemTimeAsFileTime(&time_values);
-    time_offset_ft.LowPart = time_values.dwLowDateTime;
-    time_offset_ft.HighPart = time_values.dwHighDateTime;
-    time_offset_slowing_ft.QuadPart = time_offset_ft.QuadPart;
-  }
-}
-void update_current_time() {
-  if (use_pc) {
-    QueryPerformanceCounter(&time_current_pc);
-  } else {
-    FILETIME time_values;
-    GetSystemTimeAsFileTime(&time_values);
-    time_current_ft.LowPart = time_values.dwLowDateTime;
-    time_current_ft.HighPart = time_values.dwHighDateTime;
-  }
-}
-long get_current_offset_difference_mcs() {
-  if (use_pc) {
-    return enigma_user::clamp((time_current_pc.QuadPart - time_offset_pc.QuadPart) * 1000000 / frequency_pc.QuadPart, 0, 1000000);
-  } else {
-    return enigma_user::clamp((time_current_ft.QuadPart - time_offset_ft.QuadPart) / 10, 0, 1000000);
-  }
-}
-long get_current_offset_slowing_difference_mcs() {
-  if (use_pc) {
-    return enigma_user::clamp((time_current_pc.QuadPart - time_offset_slowing_pc.QuadPart) * 1000000 / frequency_pc.QuadPart, 0,
-                 1000000);
-  } else {
-    return enigma_user::clamp((time_current_ft.QuadPart - time_offset_slowing_ft.QuadPart) / 10, 0, 1000000);
-  }
-}
-void increase_offset_slowing(long increase_mcs) {
-  if (use_pc) {
-    time_offset_slowing_pc.QuadPart += frequency_pc.QuadPart * increase_mcs / 1000000;
-  } else {
-    time_offset_slowing_ft.QuadPart += 10 * increase_mcs;
-  }
-}
-void offset_modulus_one_second() {
-  if (use_pc) {
-    long passed_mcs = get_current_offset_difference_mcs();
-    time_offset_pc.QuadPart += (passed_mcs / 1000000) * frequency_pc.QuadPart;
-    time_offset_slowing_pc.QuadPart = time_offset_pc.QuadPart;
-  } else {
-    long passed_mcs = get_current_offset_difference_mcs();
-    time_offset_ft.QuadPart += (passed_mcs / 1000000) * 10000000;
-    time_offset_slowing_ft.QuadPart = time_offset_ft.QuadPart;
-  }
-}
 
 static LONG_PTR ComputeInitialWindowStyle() {
   LONG_PTR newlong = 0;
@@ -223,79 +155,6 @@ bool initGameWindow() {
   return true;
 }
 
-long last_mcs = 0;
-long spent_mcs = 0;
-long remaining_mcs = 0;
-long needed_mcs = 0;
-
-void initTimer() {
-  UINT minimum_resolution = 1;
-  TIMECAPS timer_resolution_info;
-  if (timeGetDevCaps(&timer_resolution_info, sizeof(timer_resolution_info)) == MMSYSERR_NOERROR) {
-    minimum_resolution = timer_resolution_info.wPeriodMin;
-  }
-  timeBeginPeriod(minimum_resolution);
-  enigma::initialize_timing();
-}
-
-int updateTimer() {
-  // Update current time.
-  update_current_time();
-  {
-    // Find diff between current and offset.
-
-    long passed_mcs = enigma::get_current_offset_difference_mcs();
-    if (passed_mcs >= 1000000) {  // Handle resetting.
-      // If more than one second has passed, update fps variable, reset frames count,
-      // and advance offset by difference in seconds, rounded down.
-
-      enigma_user::fps = frames_count;
-      frames_count = 0;
-      enigma::offset_modulus_one_second();
-    }
-  }
-
-  if (current_room_speed > 0) {
-    spent_mcs = enigma::get_current_offset_slowing_difference_mcs();
-
-    remaining_mcs = 1000000 - spent_mcs;
-    needed_mcs = long((1.0 - 1.0 * frames_count / current_room_speed) * 1e6);
-    const int catchup_limit_ms = 50;
-    if (needed_mcs > remaining_mcs + catchup_limit_ms * 1000) {
-      // If more than catchup_limit ms is needed than is remaining, we risk running too fast to catch up.
-      // In order to avoid running too fast, we advance the offset, such that we are only at most catchup_limit ms behind.
-      // Thus, if the load is consistently making the game slow, the game is still allowed to run as fast as possible
-      // without any sleep.
-      // And if there is very heavy load once in a while, the game will only run too fast for catchup_limit ms.
-      enigma::increase_offset_slowing(needed_mcs - (remaining_mcs + catchup_limit_ms * 1000));
-
-      spent_mcs = enigma::get_current_offset_slowing_difference_mcs();
-      remaining_mcs = 1000000 - spent_mcs;
-      needed_mcs = long((1.0 - 1.0 * frames_count / current_room_speed) * 1e6);
-    }
-    if (remaining_mcs > needed_mcs) {
-      const long sleeping_time = std::min((remaining_mcs - needed_mcs) / 5, long(999999));
-      std::this_thread::sleep_for(std::chrono::microseconds(std::max(long(1), sleeping_time)));
-      return -1;
-    }
-  }
-
-  //TODO: The placement of this code is inconsistent with XLIB because events are handled before, ask Josh.
-  unsigned long dt = 0;
-  if (spent_mcs > last_mcs) {
-    dt = (spent_mcs - last_mcs);
-  } else {
-    //TODO: figure out what to do here this happens when the fps is reached and the timers start over
-    dt = enigma_user::delta_time;
-  }
-  last_mcs = spent_mcs;
-  enigma_user::delta_time = dt;
-  current_time_mcs += enigma_user::delta_time;
-  enigma_user::current_time += enigma_user::delta_time / 1000;
-
-  return 0;
-}
-
 int handleEvents() {
   if (enigma::game_isending) PostQuitMessage(enigma::game_return);
 
@@ -341,19 +200,6 @@ void initialize_directory_globals() {
 }  // namespace enigma
 
 namespace enigma_user {
-
-unsigned long get_timer() {  // microseconds since the start of the game
-  enigma::update_current_time();
-
-  LARGE_INTEGER time;
-  if (enigma::use_pc) {
-    time.QuadPart = enigma::time_current_pc.QuadPart * 1000000 / enigma::frequency_pc.QuadPart;
-  } else {
-    time.QuadPart = enigma::time_current_ft.QuadPart / 10;
-  }
-
-  return time.QuadPart;
-}
 
 unsigned long long disk_size(std::string drive) {
   DWORD sectorsPerCluster, bytesPerSector, totalClusters, freeClusters;

--- a/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/Win32/WINDOWSmain.cpp
@@ -30,8 +30,6 @@
 #include "Universal_System/var4.h"
 
 #include <mmsystem.h>
-#include <time.h>
-#include <chrono>
 #include <thread>
 #include <algorithm>
 #include <cstdio>

--- a/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
+++ b/ENIGMAsystem/SHELL/Platforms/platforms_mandatory.h
@@ -145,7 +145,6 @@ void window_set_sizeable(bool sizeable);
 void window_set_showborder(bool show);
 void window_set_showicons(bool show);
 void window_set_freezeonlosefocus(bool freeze);
-unsigned long get_timer(); // number of microseconds since the game started
 
 }  // namespace enigma_user
 

--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBwindow.cpp
@@ -34,7 +34,6 @@
 #include <X11/Xutil.h>
 #include <stdio.h>   //printf, NULL
 #include <stdlib.h>  //malloc
-#include <time.h>    //clock
 #include <unistd.h>  //usleep
 #include <climits>
 #include <map>


### PR DESCRIPTION
I generalized the timing code using high precision `std::chrono` in place of the performance counters. I was originally going to use [SDL_GetPerformanceCounter](https://wiki.libsdl.org/SDL_GetPerformanceCounter) and [SDL_GetPerformanceFrequency](https://wiki.libsdl.org/SDL_GetPerformanceFrequency) to generalize only the timers themselves. However, C++11 has been around long enough that I don't need to and fundies said Android even probably supports chrono at this point.

I have no idea if any of @forthevin's original logic can be further simplified. I do know there are comments left in here directed at @JoshDreamland about Win32 and Xlib's relative order of updating the timer and processing events. I did have to add a 4th timer start variable, due to the nature of chrono being wall-clock based epoch unlike the performance counters, to know how much time was elapsed since the start of the game.