### PR TITLE
bash is bad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all: libENIGMAShared libProtocols libEGM ENIGMA gm2egm emake emake-tests test-ru
 
 Game: .FORCE
 	@$(RM) -f logs/enigma_compile.log
-	@$(MAKE) -C ENIGMAsystem/SHELL > >(tee -a /tmp/enigma_compile.log) 2> >(tee -a /tmp/enigma_compile.log >&2)
+	@$(MAKE) -C ENIGMAsystem/SHELL 2>&1 | tee /tmp/enigma_compile.log
 
 clean-game: .FORCE
 	$(MAKE) -C ENIGMAsystem/SHELL clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Config.mk
 
 PATH := $(eTCpath)$(PATH)
-SHELL=/bin/bash
+SHELL=/bin/sh
 
 .PHONY: ENIGMA all clean Game clean-game clean-protos emake emake-tests gm2egm libpng-util libProtocols libEGM required-directories .FORCE
 

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
-declare -A deps
-deps["lateralgm.jar"]="IsmAvatar/LateralGM"
-deps["plugins/enigma.jar"]="enigma-dev/lgmplugin"
+key0="enigma-dev/lgmplugin"
+key1="IsmAvatar/LateralGM"
+dep0="plugins/enigma.jar"
+dep1="lateralgm.jar"
 
 get_latest () {
   local release=$(curl --silent "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
@@ -27,31 +28,11 @@ else
   curl -L -o "plugins/shared/jna.jar" "$jnaJar"
 fi
 
-if [ ! -f ".deps" ]; then
-  touch ".deps"
-fi
-  
-lineCount=$(wc -l < ".deps")
-lineNum=1;
+download_latest() {
+  latest0=$(get_latest "$key0")
+  grab_latest "$key0" "$latest0" "$dep0"
+  latest1=$(get_latest "$key1")
+  grab_latest "$key1" "$latest1" "$dep1"
+}
 
-for key in ${!deps[@]}; 
-do
-  
-  latest=$(get_latest ${deps[$key]})
-
-  if [ "$lineCount" -lt "$lineNum" ]; then
-    echo "$key $latest" >> ".deps"
-    grab_latest "${deps[$key]}" "$latest" "$key"
-  else
-    line=$(sed -n ${lineNum}p < ".deps")
-     if [ "$line" != "$latest" ]; then
-       grab_latest "${deps[$key]}" "$latest" "$key"
-       sed -i "${lineNum}s/.*/${latest}/" ".deps"
-     else
-       echo -e "$key \e[32mAlready up to date, skipping...\e[0m"
-     fi
-  fi
-  
-  lineNum=$(($lineNum+1))
-  
-done
+download_latest

--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,34 @@ else
   curl -L -o "plugins/shared/jna.jar" "$jnaJar"
 fi
 
+if [ ! -f ".deps" ]; then
+  touch ".deps"
+fi
+
+lineCount=$(wc -l < ".deps")
+lineNum=1;
+
+
+  latest=$(get_latest "$1")
+  grab_latest "$1" "$latest" "$2"
+
 download_latest() {
-  latest0=$(get_latest "$1")
-  grab_latest "$1" "$latest0" "$2"
+
+  if [ "$lineCount" -lt "$lineNum" ]; then
+    echo "$2 $latest" >> ".deps"
+    grab_latest "$1" "$latest" "$2"
+  else
+    line=$(sed -n ${lineNum}p < ".deps")
+     if [ "$line" != "$latest" ]; then
+       grab_latest "$1" "$latest" "$2"
+       sed -i "${lineNum}s/.*/${latest}/" ".deps"
+     else
+       echo -e "$2 \e[32mAlready up to date, skipping...\e[0m"
+     fi
+  fi
+
+  lineNum=$(($lineNum+1))
+
 }
 
 download_latest "enigma-dev/lgmplugin" "plugins/enigma.jar"

--- a/install.sh
+++ b/install.sh
@@ -30,10 +30,6 @@ fi
 lineCount=$(wc -l < ".deps")
 lineNum=1;
 
-
-  latest=$(get_latest "$1")
-  grab_latest "$1" "$latest" "$2"
-
 download_latest() {
 
   if [ "$lineCount" -lt "$lineNum" ]; then

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-key0="enigma-dev/lgmplugin"
-key1="IsmAvatar/LateralGM"
-dep0="plugins/enigma.jar"
-dep1="lateralgm.jar"
-
 get_latest () {
   local release=$(curl --silent "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
   echo "$release"
@@ -29,10 +24,9 @@ else
 fi
 
 download_latest() {
-  latest0=$(get_latest "$key0")
-  grab_latest "$key0" "$latest0" "$dep0"
-  latest1=$(get_latest "$key1")
-  grab_latest "$key1" "$latest1" "$dep1"
+  latest0=$(get_latest "$1")
+  grab_latest "$1" "$latest0" "$2"
 }
 
-download_latest
+download_latest "enigma-dev/lgmplugin" "plugins/enigma.jar"
+download_latest "IsmAvatar/LateralGM" "lateralgm.jar"


### PR DESCRIPTION
Not everyone likes being forced to install software just to run two small shell scripts that if written better they wouldn't need it. Not only that, Bourne shell is always located at /bin/sh. Bash is not always located at /bin/bash depending on the OS.

The install script for the jars was also an unnecessary amount of lines and written in such a way that it was over-complicating things that should be extremely simple.

MacOS is moving in the direction of removing bash as per the license change to GPL, this is why they changed zsh to be the default shell. Mac will always have /bin/sh. I mention Mac and not the other two platforms this fixes major issues with, because I know you guys don't really care about my BSD fetish; I understand your reasons.

I'm anticipating one of you guys telling me to add back the ".deps" and "checking if the files are already updated" shell logic, but I'm not sure how to do that in a way that is Bourne shell compliant as a lot of this is relatively new to me. Examples of how to do that are welcome. Otherwise, this pr will take a lot longer than what is necessary.

I allowed edits from the maintainers, and that's only with the assumption you don't accidentally or intentionally change it back to relying on bash-specific script logic. When this gets merged I'm going to see about updating the wiki install scripts and gut out the use of bash. Whoever found that necessary initially remains a mystery.