### PR TITLE
Fix Asset Unknown Multiple Definitions

### DIFF
--- a/CommandLine/libEGM/egm-read.cpp
+++ b/CommandLine/libEGM/egm-read.cpp
@@ -469,7 +469,7 @@ bool EGMFileFormat::LoadTree(const fs::path& fPath, YAML::Node yaml,
 
         LoadResource(fPath.string() + "/" + name + factory->second.ext, factory->second.func(b), id);
       } else {
-        buffer->mutable_unknown();
+        buffer->mutable_unknown_resource();
         errStream << "Warning: Unsupported resource type: " << n["type"] << std::endl;
       }
     }

--- a/CommandLine/libEGM/gmk.cpp
+++ b/CommandLine/libEGM/gmk.cpp
@@ -1224,7 +1224,7 @@ void LoadTree(Decoder &dec, TypeMap &typeMap, TreeNode* root) {
 
     auto typeMapIt = typeMap.find(type);
     if (typeMapIt == typeMap.end()) {
-      node->mutable_unknown();
+      node->mutable_unknown_resource();
       errStream << "No map of ids to protocol buffers for GMK kind '" << kind
           << "' so tree node with name '" << name << "' will not have "
           << "its protocol buffer set" << std::endl;

--- a/CommandLine/libEGM/gmx.cpp
+++ b/CommandLine/libEGM/gmx.cpp
@@ -124,7 +124,7 @@ class gmx_root_walker {
         }
         return;
     }
-    node->mutable_unknown();
+    node->mutable_unknown_resource();
     errStream << "Unsupported resource type: " << resType << " " << xmlNode.value() << std::endl;
   }
 

--- a/CommandLine/libEGM/yyp.cpp
+++ b/CommandLine/libEGM/yyp.cpp
@@ -294,7 +294,7 @@ std::unique_ptr<buffers::Project> YYPFileFormat::LoadProject(const fs::path& fPa
         auto *res = createFunc->second(node);
         PackRes(resDir, idCount[node->type_case()]++, nodeDoc, res, 0);
       } else {
-        node->mutable_unknown();
+        node->mutable_unknown_resource();
         errStream << "Unsupported resource type: " << resourceType << " " << node->name() << std::endl;
       }
     }

--- a/shared/protos/treenode.proto
+++ b/shared/protos/treenode.proto
@@ -21,7 +21,7 @@ message TreeNode {
   message UnknownResource {
   }
   oneof type {
-    UnknownResource unknown = 999;
+    UnknownResource unknown_resource = 999;
     Folder folder = 100;
     // NOTE: these are all off by 1 cause protobutt don't allow you to set field number to 0
     resources.Object object = 1;


### PR DESCRIPTION
This attempts to fix a conflict introduced by #2170 when the TreeNode was given a field named unknown. This causes multiple definitions of the `asset_unknown` enum constant.
https://github.com/enigma-dev/enigma-dev/blob/462579a776eb7cdb84ec41fb97c12df0733b7941/CompilerSource/compiler/compile.cpp#L238

My solution here was to just rename the new one added to TreeNode to `unknown_resource` for now.
```cpp
enum AssetType : int {
  asset_any = -2,
  asset_unknown = -1,
  asset_unknown_resource = 998,
  asset_folder = 99,
```