### PR TITLE
DirectSound Environmental Audio

### DIFF
--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -15,16 +15,18 @@
 *** with this code. If not, see <http://www.gnu.org/licenses/>
 **/
 
+#include "DSsystem.h"
+#include "Audio_Systems/General/ASbasic.h"
+#include "Audio_Systems/audio_mandatory.h"
+#include "Universal_System/estring.h"
+
+#include <string>
+#include <vector>
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>
-#include <string>
-using std::string;
-#include "../General/ASbasic.h"
-#include "Audio_Systems/audio_mandatory.h"
-#include "DSsystem.h"
 
-#include "Universal_System/estring.h"
+using std::string;
 
 namespace enigma {
 
@@ -335,8 +337,8 @@ static const GUID sound_effect_guids[7] = {
 void sound_effect_set(int sound, int effect) {
   size_t numOfEffects = 0;
 
-  DWORD* dwResults = 0;
-  DSEFFECTDESC* dsEffects = 0;
+  std::vector<DWORD> dwResults;
+  std::vector<DSEFFECTDESC> dsEffects;
 
   if (effect != 0) {
     // count the number of effect flags that were set
@@ -347,8 +349,8 @@ void sound_effect_set(int sound, int effect) {
     }
 
     // allocate an array of effect descriptions and results
-    dwResults = new DWORD[numOfEffects];
-    dsEffects = new DSEFFECTDESC[numOfEffects];
+    dwResults.resize(numOfEffects);
+    dsEffects.resize(numOfEffects);
 
     size_t eff = 0;
     // loop all the bits of the effect parameter to see which of the flags were set
@@ -380,9 +382,7 @@ void sound_effect_set(int sound, int effect) {
   // query for the effect interface and set the effects on the sound buffer
   ComPtr<IDirectSoundBuffer8> soundBuffer8 = 0;
   snd.soundBuffer->QueryInterface(IID_IDirectSoundBuffer8, (void**)&soundBuffer8);
-  if (soundBuffer8) soundBuffer8->SetFX(numOfEffects, dsEffects, dwResults);
-  delete[] dsEffects;
-  delete[] dwResults;
+  if (soundBuffer8) soundBuffer8->SetFX(numOfEffects, dsEffects.data(), dwResults.data());
 
   if (wasPlaying) snd.soundBuffer->Play(0, 0, wasLooping ? DSBPLAY_LOOPING : 0);  // resume
 }

--- a/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
+++ b/ENIGMAsystem/SHELL/Audio_Systems/DirectSound/DSbasic.cpp
@@ -203,7 +203,7 @@ void sound_3d_set_sound_cone(int sound, float x, float y, float z, double anglei
   const Sound& snd = sounds.get(sound);
 
   // query for the 3d buffer interface
-  IDirectSound3DBuffer8* sound3DBuffer8 = 0;
+  ComPtr<IDirectSound3DBuffer8> sound3DBuffer8 = 0;
   snd.soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**)&sound3DBuffer8);
 
   sound3DBuffer8->SetConeOrientation(x, y, z, DS3D_IMMEDIATE);
@@ -215,7 +215,7 @@ void sound_3d_set_sound_distance(int sound, float mindist, float maxdist) {
   const Sound& snd = sounds.get(sound);
 
   // query for the 3d buffer interface
-  IDirectSound3DBuffer8* sound3DBuffer8 = 0;
+  ComPtr<IDirectSound3DBuffer8> sound3DBuffer8 = 0;
   snd.soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**)&sound3DBuffer8);
 
   sound3DBuffer8->SetMinDistance(mindist, DS3D_IMMEDIATE);
@@ -226,7 +226,7 @@ void sound_3d_set_sound_position(int sound, float x, float y, float z) {
   const Sound& snd = sounds.get(sound);
 
   // query for the 3d buffer interface
-  IDirectSound3DBuffer8* sound3DBuffer8 = 0;
+  ComPtr<IDirectSound3DBuffer8> sound3DBuffer8 = 0;
   snd.soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**)&sound3DBuffer8);
 
   sound3DBuffer8->SetPosition(x, y, z, DS3D_IMMEDIATE);
@@ -236,7 +236,7 @@ void sound_3d_set_sound_velocity(int sound, float x, float y, float z) {
   const Sound& snd = sounds.get(sound);
 
   // query for the 3d buffer interface
-  IDirectSound3DBuffer8* sound3DBuffer8 = 0;
+  ComPtr<IDirectSound3DBuffer8> sound3DBuffer8 = 0;
   snd.soundBuffer->QueryInterface(IID_IDirectSound3DBuffer, (void**)&sound3DBuffer8);
 
   sound3DBuffer8->SetVelocity(x, y, z, DS3D_IMMEDIATE);


### PR DESCRIPTION
This is a recreation of #2166 because my branches got overloaded. The code is all correct but will not work yet as `DSBCAPS_CTRLFX` cannot be added to the buffers until #1508 is figured out for short audio clips.

* Fix memory leak on reference-counted COM interfaces by using ComPtr
* Fix memory leak in `sound_effect_set` by using stack-allocated vector for effect description arrays
* Implement all sound effect parameter functions using a generic templated helper

```gml
// create event
effect = se_none;

// step event
if (keyboard_check_released(ord('0')))
	effect = se_none;
if (keyboard_check_released(ord('1')))
	effect ^= se_chorus;
if (keyboard_check_released(ord('2')))
	effect ^= se_echo;
if (keyboard_check_released(ord('3')))
	effect ^= se_flanger;
if (keyboard_check_released(ord('4')))
	effect ^= se_gargle;
if (keyboard_check_released(ord('5')))
	effect ^= se_reverb;
if (keyboard_check_released(ord('6')))
	effect ^= se_compressor;
if (keyboard_check_released(ord('7')))
	effect ^= se_equalizer;
if (keyboard_check_released(vk_anykey))
	sound_effect_set(snd_0,effect);
if (keyboard_check_released(vk_space))
	sound_play(snd_0);

// draw event
if (effect & se_chorus)
	draw_text(0, 0, "Chorus");
if (effect & se_echo)
	draw_text(0, 20, "Echo");
if (effect & se_flanger)
	draw_text(0, 40, "Flanger");
if (effect & se_gargle)
	draw_text(0, 60, "Gargle");
if (effect & se_reverb)
	draw_text(0, 80, "Reverb");
if (effect & se_compressor)
	draw_text(0, 100, "Compressor");
if (effect & se_equalizer)
	draw_text(0, 120, "Equalizer");
```