### PR TITLE
Fix Transparency Color

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -73,10 +73,7 @@ RawImage create_from_screen_helper(int x, int y, int w, int h, bool removeback, 
   if (flipped)
     enigma::image_flip(i);
     
-  if (removeback) {
-    Color c = enigma::image_get_pixel_color(i, 0, h - 1);
-    enigma::image_swap_color(i, c, Color {0, 0, 0, 0});
-  }
+  if (removeback) enigma::image_swap_color(i);
   
   return i;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
@@ -378,10 +378,7 @@ int background_create_from_surface(int id, int x, int y, int w, int h, bool remo
 
   enigma::RawImage s(enigma::graphics_copy_texture_pixels(base.texture,x,y,w,h), w, h);
   
-  if (removeback) {
-    enigma::Color c = enigma::image_get_pixel_color(s, 0, h - 1);
-    enigma::image_swap_color(s, c, enigma::Color {0, 0, 0, 0});
-  }
+  if (removeback) enigma::image_swap_color(s);
   
   unsigned fullwidth, fullheight;
   int texID = enigma::graphics_create_texture(s, false, &fullwidth, &fullheight);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/backgrounds.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/backgrounds.cpp
@@ -54,10 +54,7 @@ Background background_add_helper(std::string filename, bool transparent, bool sm
 
   // If background is transparent, set the alpha to zero for pixels that should be
   // transparent from lower left pixel color
-  if (transparent) {
-    Color c = enigma::image_get_pixel_color(imgs[0], 0, imgs[0].h - 1);
-    enigma::image_swap_color(imgs[0], c, Color {0, 0, 0, 0});
-  }
+  if (transparent) enigma::image_swap_color(imgs[0]);
 
   nb.textureID = graphics_create_texture(imgs[0], mipmap, &fullwidth, &fullheight);
   nb.textureBounds = TexRect(0, 0, static_cast<gs_scalar>(imgs[0].w) / fullwidth, static_cast<gs_scalar>(imgs[0].h) / fullheight);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
@@ -51,9 +51,7 @@ Sprite sprite_add_helper(std::string filename, int imgnumb, bool precise, bool t
   Color c = enigma::image_get_pixel_color(imgs[0], 0, imgs[0].h - 1);
   
   if (imgs.size() == 1 && imgnumb > 1) {
-    if (transparent) {      
-      enigma::image_swap_color(imgs[0], c, Color {0, 0, 0, 0});
-    }
+    if (transparent) enigma::image_swap_color(imgs[0]);
   
     std::vector<RawImage> rawSubimages = enigma::image_split(imgs[0], imgnumb);
     for (const RawImage& i : rawSubimages) {
@@ -61,9 +59,7 @@ Sprite sprite_add_helper(std::string filename, int imgnumb, bool precise, bool t
     }
   } else {
     for (RawImage& i : imgs) {
-      if (transparent) {
-        enigma::image_swap_color(i, c, Color {0, 0, 0, 0});
-      }
+      if (transparent) enigma::image_swap_color(i);
       ns.AddSubimage(i, ((precise) ? enigma::ct_precise : enigma::ct_bbox), i.pxdata, mipmap);
     }
   }

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -87,6 +87,17 @@ void image_swap_color(RawImage& in, Color oldColor, Color newColor) {
   }
 }
 
+void image_swap_color(RawImage& in, Color oldColor) {
+  Color newColor = oldColor;
+  newColor.a = 0;
+  image_swap_color(in, oldColor, newColor);
+}
+
+void image_swap_color(RawImage& in) {
+  const Color bottom_left = enigma::image_get_pixel_color(in, 0, in.h - 1);
+  image_swap_color(in, bottom_left);
+}
+
 std::vector<RawImage> image_split(const RawImage& in, unsigned imgcount) {
   std::vector<RawImage> imgs(imgcount);
   unsigned splitWidth = in.w / imgcount;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -60,6 +60,8 @@ enum {
 
 Color image_get_pixel_color(const RawImage& in, unsigned x, unsigned y);
 void image_swap_color(RawImage& in, Color oldColor, Color newColor);
+void image_swap_color(RawImage& in, Color oldColor);
+void image_swap_color(RawImage& in);
 /// Note splits horizontally
 std::vector<RawImage> image_split(const RawImage& in, unsigned imgcount);
 RawImage image_pad(const RawImage& in, unsigned newWidth, unsigned newHeight);


### PR DESCRIPTION
Added some overloads so you don't have to specify so many parameters everywhere you call the swap color utility. This also corrects a subtle change in behavior introduced by #1937 which was replacing the transparent color with black instead of the same color with transparent alpha.