### PR TITLE
Nearest Neighbor Color Removal

### DIFF
--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSscreen.cpp
@@ -73,10 +73,7 @@ RawImage create_from_screen_helper(int x, int y, int w, int h, bool removeback, 
   if (flipped)
     enigma::image_flip(i);
     
-  if (removeback) {
-    Color c = enigma::image_get_pixel_color(i, 0, h - 1);
-    enigma::image_swap_color(i, c, Color {0, 0, 0, 0});
-  }
+  if (removeback) enigma::image_remove_color(i);
   
   return i;
 }

--- a/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
+++ b/ENIGMAsystem/SHELL/Graphics_Systems/General/GSsurface.cpp
@@ -378,10 +378,7 @@ int background_create_from_surface(int id, int x, int y, int w, int h, bool remo
 
   enigma::RawImage s(enigma::graphics_copy_texture_pixels(base.texture,x,y,w,h), w, h);
   
-  if (removeback) {
-    enigma::Color c = enigma::image_get_pixel_color(s, 0, h - 1);
-    enigma::image_swap_color(s, c, enigma::Color {0, 0, 0, 0});
-  }
+  if (removeback) enigma::image_remove_color(s);
   
   unsigned fullwidth, fullheight;
   int texID = enigma::graphics_create_texture(s, false, &fullwidth, &fullheight);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/backgrounds.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/backgrounds.cpp
@@ -54,10 +54,7 @@ Background background_add_helper(std::string filename, bool transparent, bool sm
 
   // If background is transparent, set the alpha to zero for pixels that should be
   // transparent from lower left pixel color
-  if (transparent) {
-    Color c = enigma::image_get_pixel_color(imgs[0], 0, imgs[0].h - 1);
-    enigma::image_swap_color(imgs[0], c, Color {0, 0, 0, 0});
-  }
+  if (transparent) enigma::image_remove_color(imgs[0]);
 
   nb.textureID = graphics_create_texture(imgs[0], mipmap, &fullwidth, &fullheight);
   nb.textureBounds = TexRect(0, 0, static_cast<gs_scalar>(imgs[0].w) / fullwidth, static_cast<gs_scalar>(imgs[0].h) / fullheight);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
@@ -45,10 +45,6 @@ Sprite sprite_add_helper(std::string filename, int imgnumb, bool precise, bool t
   unsigned cellwidth = ((imgs.size() > 1) ? imgs[0].w : imgs[0].w / imgnumb);
   Sprite ns(cellwidth, imgs[0].h, x_offset, y_offset);
   ns.SetBBox(0, 0, cellwidth, imgs[0].h);
-
-  // If sprite transparent, set the alpha to zero for pixels that should be
-  // transparent from lower left pixel color
-  Color c = enigma::image_get_pixel_color(imgs[0], 0, imgs[0].h - 1);
   
   if (imgs.size() == 1 && imgnumb > 1) {
     if (transparent) enigma::image_remove_color(imgs[0]);

--- a/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Resources/sprites.cpp
@@ -51,9 +51,7 @@ Sprite sprite_add_helper(std::string filename, int imgnumb, bool precise, bool t
   Color c = enigma::image_get_pixel_color(imgs[0], 0, imgs[0].h - 1);
   
   if (imgs.size() == 1 && imgnumb > 1) {
-    if (transparent) {      
-      enigma::image_swap_color(imgs[0], c, Color {0, 0, 0, 0});
-    }
+    if (transparent) enigma::image_remove_color(imgs[0]);
   
     std::vector<RawImage> rawSubimages = enigma::image_split(imgs[0], imgnumb);
     for (const RawImage& i : rawSubimages) {
@@ -61,9 +59,7 @@ Sprite sprite_add_helper(std::string filename, int imgnumb, bool precise, bool t
     }
   } else {
     for (RawImage& i : imgs) {
-      if (transparent) {
-        enigma::image_swap_color(i, c, Color {0, 0, 0, 0});
-      }
+      if (transparent) enigma::image_remove_color(i);
       ns.AddSubimage(i, ((precise) ? enigma::ct_precise : enigma::ct_bbox), i.pxdata, mipmap);
     }
   }

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -133,8 +133,8 @@ void image_remove_color(RawImage& in, Color oldColor) {
 }
 
 void image_remove_color(RawImage& in) {
-  Color c = image_get_pixel_color(in, 0, in.h - 1);
-  image_remove_color(in, c);
+  Color bottom_left = image_get_pixel_color(in, 0, in.h - 1);
+  image_remove_color(in, bottom_left);
 }
 
 std::vector<RawImage> image_split(const RawImage& in, unsigned imgcount) {

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -114,7 +114,6 @@ void image_remove_color(RawImage& in, Color oldColor) {
         float neighbors = 0, counted = 0;
         for (; nh <= ih + 1 && nh < in.h; ++nh) {
           for (; nw <= iw + 1 && nw < in.w; ++nw) {
-            if (nw == iw && nh == ih) continue;
             ++counted;
             int ni = (nh * in.w + nw) * 4;
             if (

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -111,8 +111,8 @@ void image_remove_color(RawImage& in, Color oldColor) {
       } else {
         unsigned int nw, nh;
         float neighbors = 0, counted = 0;
-        for (nh = ih - 1; nh <= ih + 1; ++nh) {
-          for (nw = iw - 1; nw <= iw + 1; ++nw) {
+        for (nh = ih - 1; nh <= ih + 1 && nh < in.h; ++nh) {
+          for (nw = iw - 1; nw <= iw + 1 && nw < in.w; ++nw) {
             if (nw < 0 || nh < 0 || (nw == iw && nh == ih)) continue;
             ++counted;
             int ni = (nh * in.w + nw) * 4;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -109,11 +109,12 @@ void image_remove_color(RawImage& in, Color oldColor) {
         ) {
           in.pxdata[index + 3] = 0;
       } else {
-        unsigned int nw, nh;
+        unsigned int nw = (iw <= 0 ? iw : iw - 1),
+                     nh = (ih <= 0 ? ih : ih - 1);
         float neighbors = 0, counted = 0;
-        for (nh = ih - 1; nh <= ih + 1 && nh < in.h; ++nh) {
-          for (nw = iw - 1; nw <= iw + 1 && nw < in.w; ++nw) {
-            if (nw < 0 || nh < 0 || (nw == iw && nh == ih)) continue;
+        for (; nh <= ih + 1 && nh < in.h; ++nh) {
+          for (; nw <= iw + 1 && nw < in.w; ++nw) {
+            if (nw == iw && nh == ih) continue;
             ++counted;
             int ni = (nh * in.w + nw) * 4;
             if (

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.cpp
@@ -87,6 +87,56 @@ void image_swap_color(RawImage& in, Color oldColor, Color newColor) {
   }
 }
 
+void image_remove_color(RawImage& in, Color oldColor) {
+  #ifdef DEBUG_MODE
+  if (in.pxdata == nullptr) {
+    in.pxdata = new unsigned char[in.w * in.h * 4];
+    std::fill(in.pxdata, in.pxdata + (in.w * in.h * 4), 255);
+    DEBUG_MESSAGE("Attempt to access a null pointer" , MESSAGE_TYPE::M_ERROR);
+    return;
+  }
+  #endif
+
+  unsigned int ih, iw;
+  for (ih = 0; ih < in.h; ih++) {
+    int index = ih * in.w * 4;
+    
+    for (iw = 0; iw < in.w; iw++) {
+      if (
+           in.pxdata[index]     == oldColor.b
+        && in.pxdata[index + 1] == oldColor.g
+        && in.pxdata[index + 2] == oldColor.r
+        ) {
+          in.pxdata[index + 3] = 0;
+      } else {
+        unsigned int nw, nh;
+        float neighbors = 0, counted = 0;
+        for (nh = ih - 1; nh <= ih + 1; ++nh) {
+          for (nw = iw - 1; nw <= iw + 1; ++nw) {
+            if (nw < 0 || nh < 0 || (nw == iw && nh == ih)) continue;
+            ++counted;
+            int ni = (nh * in.w + nw) * 4;
+            if (
+                 in.pxdata[ni]     != oldColor.b
+              || in.pxdata[ni + 1] != oldColor.g
+              || in.pxdata[ni + 2] != oldColor.r
+              )
+              ++neighbors;
+          }
+        }
+        in.pxdata[index + 3] = static_cast<unsigned char>((neighbors/counted) * 255.0f);
+      }
+
+      index += 4;
+    }
+  }
+}
+
+void image_remove_color(RawImage& in) {
+  Color c = image_get_pixel_color(in, 0, in.h - 1);
+  image_remove_color(in, c);
+}
+
 std::vector<RawImage> image_split(const RawImage& in, unsigned imgcount) {
   std::vector<RawImage> imgs(imgcount);
   unsigned splitWidth = in.w / imgcount;

--- a/ENIGMAsystem/SHELL/Universal_System/image_formats.h
+++ b/ENIGMAsystem/SHELL/Universal_System/image_formats.h
@@ -60,6 +60,8 @@ enum {
 
 Color image_get_pixel_color(const RawImage& in, unsigned x, unsigned y);
 void image_swap_color(RawImage& in, Color oldColor, Color newColor);
+void image_remove_color(RawImage& in, Color oldColor);
+void image_remove_color(RawImage& in);
 /// Note splits horizontally
 std::vector<RawImage> image_split(const RawImage& in, unsigned imgcount);
 RawImage image_pad(const RawImage& in, unsigned newWidth, unsigned newHeight);


### PR DESCRIPTION
Fixes #353 using nearest neighbors to remove the target color from the image. This is close to what GameMaker itself does in that it's not destructive to the color channels, only the alpha channels. It addresses an issue introduced by #1937 whereby the color channel is not replaced by black now which further worsened texture interpolation.

| Master | Pull |
|--------|------|
|![Master Image Color Swap](https://user-images.githubusercontent.com/3212801/141053390-b3213512-5852-46ca-a024-e4993601ced0.png)|![Pull Request Nearest Neighbor Image Color Removal](https://user-images.githubusercontent.com/3212801/141234680-94371ec2-da10-4c8c-aa8e-47162d3f168d.png)|

This also fixes another issue with sprite transparency where we're only using the bottom-left pixel of the first frame for the entire sprite. GameMaker never did this and gave each frame its own individual pixel.
![GameMaker 8.1 Transparent Sprite Import](https://user-images.githubusercontent.com/3212801/141227287-7f5d8f27-3811-420f-b3ba-9c2dc0933b05.png)
