### PR TITLE
Cleanup None Platform Includes

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/None/fillin.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/None/fillin.cpp
@@ -25,16 +25,8 @@
 #include "Universal_System/roomsystem.h"
 #include "Universal_System/var4.h"
 
-#include <stdio.h>
-#include <stdlib.h>  //malloc
 #include <stdlib.h>  //getenv and system
-#include <sys/resource.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <cstdlib>
-#include <map>
 #include <string>
-#include <time.h>
 
 namespace enigma {
   bool initGameWindow() { return true; }


### PR DESCRIPTION
Some of the POSIX headers don't even exist on Windows and they weren't even being used in there anyway. This fixes #2219 specifically but does not fully fix the issue of building the None Platform on Windows as for some reason somebody also linked POSIX in the None system makefile.