### PR TITLE
Fix 'folder replaces resource' egm-read issue

### DIFF
--- a/CommandLine/libEGM/egm-read.cpp
+++ b/CommandLine/libEGM/egm-read.cpp
@@ -523,6 +523,9 @@ bool EGMFileFormat::LoadDirectory(const fs::path& fPath, buffers::TreeNode* n,
 }
 
 void RecursiveResourceSanityCheck(buffers::TreeNode* n, std::map<Type, std::map<int, std::string>>& IDmap) {
+  // check if folder is present otherwise mutable_folder creates an unwanted folder
+  if(!n->has_folder())
+    return;
 
   for (int i = 0; i < n->mutable_folder()->children_size(); ++i) {
     buffers::TreeNode* c = n->mutable_folder()->mutable_children(i);


### PR DESCRIPTION
This is a small fix for the issue in which on loading egm projects in RGM, folders appears in place of actual resources.

The issue is a side effect of calling `mutable_folder` before checking if node contains `folder` or not, as a call to `mutable_folder` creates an unwanted `folder` which was happening in `void RecursiveResourceSanityCheck(...)` of `egm-read.cpp`.