### PR TITLE
Fix checking return code of build_game function in testharness

### DIFF
--- a/CommandLine/testing/Platform/TestHarness-X11.cpp
+++ b/CommandLine/testing/Platform/TestHarness-X11.cpp
@@ -307,7 +307,7 @@ unique_ptr<TestHarness>
 TestHarness::launch_and_attach(const string &game, const TestConfig &tc) {
   string out = "/tmp/test-game";
   if (int retcode = build_game(game, tc, out)) {
-    if (retcode != -1) {
+    if (retcode == -1) {
       std::cerr << "Failed to run emake." << std::endl;
     } else {
       std::cerr << "emake returned " << retcode << "; abort" << std::endl;
@@ -343,7 +343,7 @@ constexpr int operator"" _million(unsigned long long x) {
 int TestHarness::run_to_completion(const string &game, const TestConfig &tc) {
   string out = "/tmp/test-game";
   if (int retcode = build_game(game, tc, out)) {
-    if (retcode != -1) {
+    if (retcode == -1) {
       std::cerr << "Failed to run emake." << std::endl;
     } else {
       std::cerr << "emake returned " << retcode << "; abort" << std::endl;


### PR DESCRIPTION
`build_game` returns with the following codes:

- `0` if `execvp` successfully launches `emake`.
- A value `>0` if `emake` launches but exits with non zero return code.
- `-1` if `execvp` fails to launch `emake`.

These return codes are checked by `launch_and_attach` and `run_to_completion` here:
```
if (int retcode = build_game(game, tc, out)) {
    if (retcode != -1) {
      std::cerr << "Failed to run emake." << std::endl;
    } else {
      std::cerr << "emake returned " << retcode << "; abort" << std::endl;
    }
    return nullptr;
  }
```
When `build_game` fails to launch `emake` then `retcode` holds `-1` which gets compared with `-1`  using `!=` evaluating to `false` hence `Failed to run emake` never gets into cerr. Replacing `!=` with `==` ensures correct behavior.