### PR TITLE
Fix more build errors with JDI update

### DIFF
--- a/CompilerSource/compiler/jdi_utility.cpp
+++ b/CompilerSource/compiler/jdi_utility.cpp
@@ -132,6 +132,8 @@ bool lang_CPP::global_exists(string n) const {
 void lang_CPP::quickmember_variable(jdi::definition_scope* scope, jdi::definition* type, string name) {
   scope->members[name] = std::make_unique<jdi::definition_typed>(name,scope,type);
 }
+
+enigma::parsing::StdErrorHandler hackybaby;  // TODO: FIXME: This should be using a central error handler...
 void lang_CPP::quickmember_script(jdi::definition_scope* scope, string name) {
   jdi::ref_stack rfs;
   jdi::ref_stack::parameter_ct params;
@@ -142,5 +144,5 @@ void lang_CPP::quickmember_script(jdi::definition_scope* scope, string name) {
     params.throw_on(p);
   }
   rfs.push_func(params);
-  scope->members[name] = std::make_unique<jdi::definition_function>(name,enigma_type__var,scope,rfs,0,0);
+  scope->members[name] = std::make_unique<jdi::definition_function>(name,enigma_type__var,scope,rfs,0,0, SourceLocation{name, 0, 0}, (ErrorHandler*)&hackybaby);
 }

--- a/CompilerSource/gcc_interface/gcc_backend.cpp
+++ b/CompilerSource/gcc_interface/gcc_backend.cpp
@@ -204,7 +204,7 @@ const char* establish_bearings(const char *compiler)
     if (!macro_reader.is_open())
       return "Call to `defines' toolchain executable returned no data.\n";
 
-    int res = builtin.parse_stream(macro_reader, (codegen_directory/"enigma_defines.txt").u8string().c_str());
+    int res = builtin.parse_stream(macro_reader);
     builtin.add_macro("_GLIBCXX_USE_CXX11_ABI", "0");
     if (res)
       return "Highly unlikely error: Compiler builtins failed to parse. But stupid things can happen when working with files.";

--- a/CompilerSource/languages/lang_CPP.cpp
+++ b/CompilerSource/languages/lang_CPP.cpp
@@ -169,11 +169,11 @@ enigma::parsing::Macro TranslateMacro(const jdi::macro_type &macro,
   using namespace enigma::parsing;
   if (macro.is_function) {
     std::vector<std::string> arg_list =
-        ((const jdi::macro_function*) &macro)->args;
+        macro.params;
     return enigma::parsing::Macro(macro.name, std::move(arg_list),
-          macro.is_variadic(), macro.valueString(), herr);
+          macro.is_variadic, macro.toString(), herr);
   }
-  return enigma::parsing::Macro(macro.name, macro.valueString(), herr);
+  return enigma::parsing::Macro(macro.name, macro.toString(), herr);
 }
 
 }  // namespace
@@ -187,7 +187,7 @@ syntax_error *lang_CPP::definitionsModified(const char* wscode,
 
   cout << "Creating swap." << endl;
   delete main_context;
-  main_context = new jdi::context();
+  main_context = new jdi::Context();
 
   cout << "Dumping whiteSpace definitions..." << endl;
   FILE *of = wscode ? fopen((codegen_directory/"Preprocessor_Environment_Editable/IDE_EDIT_whitespace.h").u8string().c_str(),"wb") : NULL;
@@ -200,7 +200,7 @@ syntax_error *lang_CPP::definitionsModified(const char* wscode,
   DECLARE_TIME_TYPE ts, te;
   if (f.is_open()) {
     CURRENT_TIME(ts);
-    res = main_context->parse_C_stream(f, "SHELLmain.cpp");
+    res = main_context->parse_stream(f);
     CURRENT_TIME(te);
   }
 
@@ -252,7 +252,7 @@ syntax_error *lang_CPP::definitionsModified(const char* wscode,
 
   cout << "Creating dummy primitives for old ENIGMA" << endl;
   for (jdi::tf_iter it = jdi::builtin_declarators.begin(); it != jdi::builtin_declarators.end(); ++it) {
-    main_context->get_global()->members[it->first] = new jdi::definition(it->first, main_context->get_global(), jdi::DEF_TYPENAME);
+    main_context->get_global()->members[it->first] = std::make_unique<jdi::definition>(it->first, main_context->get_global(), jdi::DEF_TYPENAME);
   }
 
   enigma::parsing::StdErrorHandler hack;  // TODO: FIXME: This should be using a central error handler...

--- a/CompilerSource/languages/language_adapter.cpp
+++ b/CompilerSource/languages/language_adapter.cpp
@@ -27,4 +27,4 @@ map<string,language_adapter*> languages;
 language_adapter *current_language;
 string current_language_name;
 
-jdi::context *main_context = NULL;
+jdi::Context *main_context = nullptr;

--- a/CompilerSource/main.cpp
+++ b/CompilerSource/main.cpp
@@ -109,7 +109,7 @@ DLLEXPORT const char* libInit_path(EnigmaCallbacks* ecs, const char* enigma_path
   current_language = languages[current_language_name] = new lang_CPP();
 
   cout << "Creating parse context" << endl;
-  main_context = new jdi::context;
+  main_context = new jdi::Context;
 
   return 0;
 }

--- a/CompilerSource/parser/parser_components.cpp
+++ b/CompilerSource/parser/parser_components.cpp
@@ -59,19 +59,20 @@ int dropscope()
 int quickscope()
 {
   jdi::definition_scope* ns = new jdi::definition_scope("{}",current_scope,jdi::DEF_NAMESPACE);
-  current_scope->members["{}"+tostring(scope_braceid++)] = ns;
+  current_scope->members["{}"+tostring(scope_braceid++)].reset(ns);
   current_scope = ns;
   return 0;
 }
 int initscope(string name)
 {
   scope_braceid = 0;
-  main_context->get_global()->members[name] = current_scope = new jdi::definition_scope(name,main_context->get_global(),jdi::DEF_NAMESPACE);
+  main_context->get_global()->members[name] = std::make_unique<jdi::definition_scope>(name,main_context->get_global(),jdi::DEF_NAMESPACE);
+  current_scope = reinterpret_cast<jdi::definition_scope*>(main_context->get_global()->members[name].get());
   return 0;
 }
 int quicktype(unsigned flags, string name)
 {
-  current_scope->members[name] = new jdi::definition(name,current_scope,flags | jdi::DEF_TYPENAME);
+  current_scope->members[name] = std::make_unique<jdi::definition>(name,current_scope,flags | jdi::DEF_TYPENAME);
   return 0;
 }
 


### PR DESCRIPTION
This fixes the build errors which showed up when running `make all`

NOTE: The changes in `jdi_utility.cpp` should be reviewed, as they are just a hack to get the build to finish