### PR TITLE
Fix the 'ouble' bug

### DIFF
--- a/CompilerSource/parser/collect_variables.cpp
+++ b/CompilerSource/parser/collect_variables.cpp
@@ -150,7 +150,7 @@ void collect_variables(const LanguageFrontend *lang, enigma::parsing::AST *ast,
               cout << "ERASE FROM CODE: " << code.substr(dec_start_pos,dec_equals_at-dec_start_pos) << endl;
               code.replace(dec_start_pos,dec_equals_at-dec_start_pos, dec_name);
               synt.replace(dec_start_pos,dec_equals_at-dec_start_pos, string(dec_name.length(),'n'));
-              pos -= dec_equals_at - dec_start_pos - 1 - dec_name.length();
+              pos -= dec_equals_at - dec_start_pos - dec_name.length();
             }
             dec_start_pos = pos;
           }


### PR DESCRIPTION
Adding onto the commit message, here is the relevant state of the compiler when parsing the following code, where the `^` represents the variable `pos` in `collect_variables()` and `code` is printed before `synt` each time:

```gml
buf = buffer_create(32000, buffer_grow, 4);
local double i = 0.0;
local double j = 0.5;
```

```gml
FOUND LOCAL/GLOBAL KEYWORD:
{buf=buffer_create(32000,buffer_grow,4);localdoublei=0.0;localdoublej=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);LLLLLttttttn=000;LLLLLttttttn=000;};
                                        ^
Declared double i as local
WHILE DECLARING:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;localdoublej=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;LLLLLttttttn=000;};
                                             ^
ERASE FROM CODE: i
dec_name: i
AFTER ERASING INIT:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;localdoublej=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;LLLLLttttttn=000;};
                                              ^
FOUND LOCAL/GLOBAL KEYWORD:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;localdoublej=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;LLLLLttttttn=000;};
                                               ^
Declared ouble j as local
WHILE DECLARING:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;lj=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;Ln=000;};
                                                    ^
ERASE FROM CODE: j
dec_name: j
AFTER ERASING INIT:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;lj=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;Ln=000;};
                                                     ^
```

After erasing the initializer of the variable `i`, the `pos` is set at the first `l` of `local` instead of the semicolon, because of which it skips to the `o` of `local` when it starts parsing `j` because of the `pos++` at the end of the loop. Therefore, by setting `pos` to be one character behind, it leads to the following state:

```gml
FOUND LOCAL/GLOBAL KEYWORD:
{buf=buffer_create(32000,buffer_grow,4);localdoublei=0.0;localdoublej=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);LLLLLttttttn=000;LLLLLttttttn=000;};
                                        ^
Declared double i as local
WHILE DECLARING:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;localdoublej=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;LLLLLttttttn=000;};
                                             ^
ERASE FROM CODE: i
dec_name: i
AFTER ERASING INIT:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;localdoublej=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;LLLLLttttttn=000;};
                                             ^
FOUND LOCAL/GLOBAL KEYWORD:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;localdoublej=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;LLLLLttttttn=000;};
                                              ^
Declared double j as local
WHILE DECLARING:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;j=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;n=000;};
                                                   ^
ERASE FROM CODE: j
dec_name: j
AFTER ERASING INIT:
{buf=buffer_create(32000,buffer_grow,4);i=0.0;j=0.5;};
{nnn=nnnnnnnnnnnnn(00000,nnnnnnnnnnn,0);n=000;n=000;};
                                                   ^
```

Thus `pos` points to the right character at the end of parsing the initializer and the bug is fixed.