### PR TITLE
WIP: Fixes for macros in EDL lexer

### DIFF
--- a/CommandLine/emake-tests/Parsing/lexer-test.cpp
+++ b/CommandLine/emake-tests/Parsing/lexer-test.cpp
@@ -151,3 +151,16 @@ TEST(LexerTest, HexThenComment) {
   EXPECT_EQ(lex->ReadToken().type, TT_ENDBRACE);
   EXPECT_EQ(lex->ReadToken().type, TT_ENDOFCODE);
 }
+
+TEST(LexerTest, PreProcessorMacroExpansion) {
+  LexerTester lex("MACRO_FUNC(ident);", true);
+
+  const_cast<MacroMap*>(&const_cast<ParseContext*>(lex.context)->macro_map)->insert({"MACRO_FUNC", Macro("MACRO_FUNC", {"arg"}, false, "(arg)", &lex.herr)});
+
+  EXPECT_EQ(lex->ReadToken().type, TT_BEGINPARENTH);
+  EXPECT_EQ(lex->ReadToken().type, TT_IDENTIFIER);
+  EXPECT_EQ(lex->ReadToken().type, TT_ENDPARENTH);
+  EXPECT_EQ(lex->ReadToken().type, TT_SEMICOLON);
+  EXPECT_EQ(lex->ReadToken().type, TT_ENDOFCODE);
+}
+

--- a/CompilerSource/parsing/lexer.cpp
+++ b/CompilerSource/parsing/lexer.cpp
@@ -432,7 +432,7 @@ bool Lexer::HandleMacro(std::string_view name) {
         for (size_t i = 0; i < args.size(); ++i)
           args_evald[i] = PreprocessBuffer(args[i]);
         PushMacro(macro.name,
-                  macro.SubstituteAndUnroll(args, args_evald, errc));
+                  macro.SubstituteAndUnroll(args, args_evald, errc, stringified_macros));
       } else {
         errc.Error() << "No closing parenthesis for arguments to `"
                      << name << '`';

--- a/CompilerSource/parsing/lexer.cpp
+++ b/CompilerSource/parsing/lexer.cpp
@@ -422,7 +422,7 @@ bool Lexer::HandleMacro(std::string_view name) {
         else if (t.type == TT_ENDPARENTH) --paren;
         if (t.type == TT_COMMA && paren == 1) {
           args.emplace_back();
-        } else {
+        } else if (paren != 0) {
           args.back().push_back(t);
         }
       } while (paren && t.type != TT_ENDOFCODE);

--- a/CompilerSource/parsing/lexer.h
+++ b/CompilerSource/parsing/lexer.h
@@ -127,6 +127,17 @@ class Lexer {
   const ParseContext *context;
   std::deque<OpenMacro> open_macros;
   ErrorHandler *herr;
+
+  /// Store the stringified versions of macros in a set so that they can be safely referred to by `std::string_view`.
+  ///
+  /// As `CodeSnippet`s point inside the source itself, it is not possible to make one that points to the `std::string`
+  /// created on stringifying a macro as that string doesn't exist within the source and can only be referred to within
+  /// the function it is created in and therefore when trying to access this string outside, it can cause a segfault.
+  ///
+  /// Thus, this set "extends" the lifetime of the stringified forms of macros by promoting their lifetimes to the
+  /// lifetime of the lexer itself. The reason a `std::unordered_set` is used is to deduplicate macros which stringify
+  /// to the same string.
+  Macro::StringifiedSet stringified_macros;
   
   struct Options {
     bool use_escapes;  ///< Use C++-like escape sequences.

--- a/CompilerSource/parsing/macros.cpp
+++ b/CompilerSource/parsing/macros.cpp
@@ -257,9 +257,8 @@ TokenVector Macro::SubstituteAndUnroll(const vector<TokenVector> &args, const ve
             str += tok.content;
           str = QuoteString(str);
 
-          stringified_macros.insert(str);
           CodeSnippet snr;
-          snr.content = *stringified_macros.find(str);
+          snr.content = *stringified_macros.insert(str).first;
 
           TokenVector vec{Token(TT_STRINGLIT, snr)};
           AppendOrPaste(res, vec.begin(), vec.end(), paste_next, errc);

--- a/CompilerSource/parsing/macros.cpp
+++ b/CompilerSource/parsing/macros.cpp
@@ -204,9 +204,8 @@ static void AppendOrPaste(TokenVector &dest,
   dest.insert(dest.end(), begin, end);
 }
 
-TokenVector Macro::SubstituteAndUnroll(
-    const vector<TokenVector> &args, const vector<TokenVector> &args_evald,
-    ErrorContext errc) const {
+TokenVector Macro::SubstituteAndUnroll(const vector<TokenVector> &args, const vector<TokenVector> &args_evald,
+                                       ErrorContext errc, StringifiedSet &stringified_macros) const {
   TokenVector res;
   bool paste_next = false;
   if (args.size() != parameters->size()) {
@@ -257,7 +256,12 @@ TokenVector Macro::SubstituteAndUnroll(
           for (const Token &tok : args[ind])
             str += tok.content;
           str = QuoteString(str);
-          TokenVector vec{Token(TT_STRINGLIT, errc.snippet)};
+
+          stringified_macros.insert(str);
+          CodeSnippet snr;
+          snr.content = *stringified_macros.find(str);
+
+          TokenVector vec{Token(TT_STRINGLIT, snr)};
           AppendOrPaste(res, vec.begin(), vec.end(), paste_next, errc);
           paste_next = false;
           break;

--- a/CompilerSource/parsing/macros.h
+++ b/CompilerSource/parsing/macros.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace enigma {
@@ -105,10 +106,11 @@ struct Macro {
       const TokenVector &tokens, const std::vector<std::string> &params,
       ErrorHandler *herr);
 
+  using StringifiedSet = std::unordered_set<std::string>;
+
   /// Expand this macro function, given arguments.
-  TokenVector SubstituteAndUnroll(const std::vector<TokenVector> &args,
-                                  const std::vector<TokenVector> &args_evald,
-                                  ErrorContext errc) const;
+  TokenVector SubstituteAndUnroll(const std::vector<TokenVector> &args, const std::vector<TokenVector> &args_evald,
+                                  ErrorContext errc, StringifiedSet &stringified_macros) const;
 
   /// Convert this macro to a string
   std::string ToString() const;


### PR DESCRIPTION
These series of commits:
1. Adds a test to check macro expansion
2. Fixes the closing parenthesis of macros being considered as a macro argument
3. Fixes incorrect strings being used when stringifying a macro argument