### PR TITLE
emake: add -j flags to specify compile jobs

### DIFF
--- a/CommandLine/emake/OptionsParser.cpp
+++ b/CommandLine/emake/OptionsParser.cpp
@@ -131,6 +131,7 @@ OptionsParser::OptionsParser() : _desc("Options")
     ("enigma-root", opt::value<std::string>()->default_value(fs::current_path().string()), "Path to ENIGMA's sources")
     ("codegen-only", opt::bool_switch()->default_value(false), "Only generate code and exit")
     ("run,r", opt::bool_switch()->default_value(false), "Automatically run the game after it is built")
+    ("jobs,j", opt::value<int>()->default_value(1), "The number of compile jobs to run simultaneously")
   ;
 
   _positional.add("input", 1);
@@ -245,6 +246,7 @@ std::string OptionsParser::APIyaml(const buffers::resources::Settings* currentCo
   std::string widgets = _rawArgs["widgets"].as<std::string>();
   std::string collision = _rawArgs["collision"].as<std::string>();
   std::string network = _rawArgs["network"].as<std::string>();
+  std::string jobs = std::to_string(_rawArgs["jobs"].as<int>());
   
   std::string eobjs_directory = fs::absolute(_rawArgs["workdir"].as<std::string>()).string();
   std::string codegen_directory = fs::absolute(_rawArgs["codegen"].as<std::string>()).string(); 
@@ -306,6 +308,7 @@ std::string OptionsParser::APIyaml(const buffers::resources::Settings* currentCo
   yaml += "extensions: " + _extensions + "\n";
   yaml += std::string("codegen-only: ") + (_rawArgs["codegen-only"].as<bool>() ? "true" : "false") + "\n";
   yaml += "enigma-root: " + _enigmaRoot + "\n";
+  yaml += "jobs: " + jobs + "\n";
 
   return yaml;
 }

--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -364,6 +364,7 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
   	make += "COMPILEPATH=\"" + unixfy_path(compilepath) + "\" ";
   	make += "WORKDIR=\"" + unixfy_path(eobjs_directory) + "\" ";
     make += "CODEGEN=\"" + unixfy_path(codegen_directory) + "\" ";
+    make += "-j" + jobs + " ";
 
   	edbg << "Full command line: " << compilerInfo.MAKE_location << " " << make << flushl;
     e_execs(compilerInfo.MAKE_location,make);
@@ -725,6 +726,7 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
   make += "NETWORKING=\""  + extensions::targetAPI.networkSys + "\" ";
   make += "PLATFORM=\"" + extensions::targetAPI.windowSys + "\" ";
   make += "TARGET-PLATFORM=\"" + compilerInfo.target_platform + "\" ";
+  make += "-j" + jobs + " ";
 
   for (const auto& key : compilerInfo.make_vars) {
     if (key.second != "")

--- a/CompilerSource/compiler/compile.cpp
+++ b/CompilerSource/compiler/compile.cpp
@@ -364,7 +364,7 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
   	make += "COMPILEPATH=\"" + unixfy_path(compilepath) + "\" ";
   	make += "WORKDIR=\"" + unixfy_path(eobjs_directory) + "\" ";
     make += "CODEGEN=\"" + unixfy_path(codegen_directory) + "\" ";
-    make += "-j" + jobs + " ";
+    make += "-j" + num_make_jobs + " ";
 
   	edbg << "Full command line: " << compilerInfo.MAKE_location << " " << make << flushl;
     e_execs(compilerInfo.MAKE_location,make);
@@ -726,7 +726,7 @@ int lang_CPP::compile(const GameData &game, const char* exe_filename, int mode) 
   make += "NETWORKING=\""  + extensions::targetAPI.networkSys + "\" ";
   make += "PLATFORM=\"" + extensions::targetAPI.windowSys + "\" ";
   make += "TARGET-PLATFORM=\"" + compilerInfo.target_platform + "\" ";
-  make += "-j" + jobs + " ";
+  make += "-j" + num_make_jobs + " ";
 
   for (const auto& key : compilerInfo.make_vars) {
     if (key.second != "")

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -25,6 +25,7 @@
 **  or programs made in the environment.                                        **
 **                                                                              **
 \********************************************************************************/
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -141,7 +142,16 @@ void parse_ide_settings(const char* eyaml)
   setting::keyword_blacklist = settree.get("keyword-blacklist").toString();
 
   // The number of compile jobs
-  num_make_jobs = settree.get("jobs").toString();
+  if (settree.exists("jobs")) {
+    const std::string &jobs = settree.get("jobs");
+    if (std::all_of(jobs.begin(), jobs.end(), [](char c) { return std::isdigit(c); })) {
+      num_make_jobs = settree.get("jobs").toString();
+    } else {
+      num_make_jobs = "1";
+    }
+  } else {
+    num_make_jobs = "1";
+  }
 
   // Path to enigma sources
   enigma_root = settree.get("enigma-root").toString();

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -107,6 +107,7 @@ bool codegen_only = false;
 std::filesystem::path enigma_root;
 std::filesystem::path eobjs_directory;
 std::filesystem::path codegen_directory;
+std::string jobs;
 
 void parse_ide_settings(const char* eyaml)
 {
@@ -138,6 +139,9 @@ void parse_ide_settings(const char* eyaml)
   }
   setting::automatic_semicolons   = settree.get("automatic-semicolons").toBool();
   setting::keyword_blacklist = settree.get("keyword-blacklist").toString();
+
+  // The number of compile jobs
+  jobs = settree.get("jobs").toString();
 
   // Path to enigma sources
   enigma_root = settree.get("enigma-root").toString();

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -142,15 +142,12 @@ void parse_ide_settings(const char* eyaml)
   setting::keyword_blacklist = settree.get("keyword-blacklist").toString();
 
   // The number of compile jobs
+  num_make_jobs = "1";
   if (settree.exists("jobs")) {
     const std::string &jobs = settree.get("jobs");
     if (std::all_of(jobs.begin(), jobs.end(), [](char c) { return std::isdigit(c); })) {
       num_make_jobs = settree.get("jobs").toString();
-    } else {
-      num_make_jobs = "1";
     }
-  } else {
-    num_make_jobs = "1";
   }
 
   // Path to enigma sources

--- a/CompilerSource/settings-parse/parse_ide_settings.cpp
+++ b/CompilerSource/settings-parse/parse_ide_settings.cpp
@@ -107,7 +107,7 @@ bool codegen_only = false;
 std::filesystem::path enigma_root;
 std::filesystem::path eobjs_directory;
 std::filesystem::path codegen_directory;
-std::string jobs;
+std::string num_make_jobs;
 
 void parse_ide_settings(const char* eyaml)
 {
@@ -141,7 +141,7 @@ void parse_ide_settings(const char* eyaml)
   setting::keyword_blacklist = settree.get("keyword-blacklist").toString();
 
   // The number of compile jobs
-  jobs = settree.get("jobs").toString();
+  num_make_jobs = settree.get("jobs").toString();
 
   // Path to enigma sources
   enigma_root = settree.get("enigma-root").toString();

--- a/CompilerSource/settings.h
+++ b/CompilerSource/settings.h
@@ -104,7 +104,7 @@ extern bool codegen_only;
 extern std::filesystem::path enigma_root;
 extern std::filesystem::path eobjs_directory;
 extern std::filesystem::path codegen_directory;
-extern std::string jobs;
+extern std::string num_make_jobs;
 
 inline std::string escapeEnv(std::string str) {
   size_t i = str.find_first_of('%');

--- a/CompilerSource/settings.h
+++ b/CompilerSource/settings.h
@@ -104,6 +104,7 @@ extern bool codegen_only;
 extern std::filesystem::path enigma_root;
 extern std::filesystem::path eobjs_directory;
 extern std::filesystem::path codegen_directory;
+extern std::string jobs;
 
 inline std::string escapeEnv(std::string str) {
   size_t i = str.find_first_of('%');


### PR DESCRIPTION
add a `-j` flag to emake for that yoinky sploinky