### PR TITLE
GSoC Part 1: Binary Buffer functions 

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/buffers.h
+++ b/ENIGMAsystem/SHELL/Universal_System/buffers.h
@@ -80,7 +80,7 @@ int buffer_get_type(int buffer);
 void buffer_get_surface(int buffer, int surface, int mode, unsigned offset = 0, int modulo = 0);
 void buffer_set_surface(int buffer, int surface, int mode, unsigned offset = 0, int modulo = 0);
 void buffer_resize(int buffer, unsigned size);
-void buffer_seek(int buffer, int base, unsigned offset);
+void buffer_seek(int buffer, int base, long long offset);
 unsigned buffer_sizeof(int type);
 int buffer_tell(int buffer);
 

--- a/ENIGMAsystem/SHELL/Universal_System/buffers.h
+++ b/ENIGMAsystem/SHELL/Universal_System/buffers.h
@@ -58,6 +58,9 @@ enum {
   buffer_text = 13,
 };
 
+std::vector<std::byte> serialize_to_type(variant &value, int type);
+variant deserialize_from_type(std::vector<std::byte>::iterator first, std::vector<std::byte>::iterator last, int type);
+
 int buffer_create(unsigned size, int type, unsigned alignment);
 bool buffer_exists(int buffer);
 void buffer_delete(int buffer);

--- a/ENIGMAsystem/SHELL/Universal_System/buffers_internal.h
+++ b/ENIGMAsystem/SHELL/Universal_System/buffers_internal.h
@@ -28,18 +28,20 @@ namespace enigma
 {
   struct BinaryBuffer
   {
-    std::vector<unsigned char> data;
-    unsigned position;
-    unsigned alignment;
+    std::vector<std::byte> data;
+    std::size_t position;
+    std::size_t alignment;
     int type;
     
-    BinaryBuffer(unsigned size);
+    BinaryBuffer(std::size_t size);
     ~BinaryBuffer() = default;
-    unsigned GetSize();
-    void Resize(unsigned size);
-    void Seek(unsigned offset);  
-    unsigned char ReadByte();
-    void WriteByte(unsigned char byte);
+
+    std::size_t GetSize();
+    void Resize(std::size_t size);
+    void Seek(long long offset);
+
+    std::byte ReadByte();
+    void WriteByte(std::byte byte);
   };
   
   extern std::vector<BinaryBuffer*> buffers;

--- a/ENIGMAsystem/SHELL/Universal_System/var4.h
+++ b/ENIGMAsystem/SHELL/Universal_System/var4.h
@@ -269,6 +269,15 @@ std::string toString(double);
 using std::string;
 
 }
+#include <iostream>
+namespace {
+template <typename T, typename U>
+T bit_cast(const U &value) {
+  T result;
+  std::memcpy(reinterpret_cast<void*>(&result), reinterpret_cast<const void*>(&value), sizeof(T));
+  return result;
+}
+}
 
 //▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚▞▚
 //██▛▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▜██████████████████████████████
@@ -562,24 +571,24 @@ struct variant : enigma::variant_real_union, enigma::variant_string_wrapper {
   // ===========================================================================
 
   template<typename T>
-  decltype(0LL << (int)*(T*)nullptr) operator<<(T x) const {
-    return (long long) rval.d << (int) x;
+  decltype(0ULL << (int)*(T*)nullptr) operator<<(T x) const {
+    return bit_cast<unsigned long long>(rval.d) << (int) x;
   }
   template<typename T>
-  decltype(0LL >> (int)*(T*)nullptr) operator>>(T x) const {
-    return (long long) rval.d >> (int) x;
+  decltype(0ULL >> (int)*(T*)nullptr) operator>>(T x) const {
+    return bit_cast<unsigned long long>(rval.d) >> (int) x;
   }
   template<typename T>
-  decltype(0LL & (long long)*(T*)nullptr) operator&(T x) const {
-    return (long long) rval.d & (long long) x;
+  decltype(0ULL & (long long)*(T*)nullptr) operator&(T x) const {
+    return bit_cast<unsigned long long>(rval.d) & (long long) x;
   }
   template<typename T>
-  decltype(0LL | (long long)*(T*)nullptr) operator|(T x) const {
-    return (long long) rval.d | (long long) x;
+  decltype(0ULL | (long long)*(T*)nullptr) operator|(T x) const {
+    return bit_cast<unsigned long long>(rval.d) | (long long) x;
   }
   template<typename T>
-  decltype(0LL | (long long)*(T*)nullptr) operator^(T x) const {
-    return (long long) rval.d ^ (long long) x;
+  decltype(0ULL | (long long)*(T*)nullptr) operator^(T x) const {
+    return bit_cast<unsigned long long>(rval.d) ^ (long long) x;
   }
 
   // Miscellanea


### PR DESCRIPTION
This series of commits forms part 1 of my GSoC project, wherein I finish implementing and cleaning up the binary buffer functions.

Done:
- Fix `variant`'s bitwise operators
- Switch `BinaryBuffer` to use `std::byte` and `std::size_t`
- Add serialization and deserialization (big-endian, pretty sure) for the various types supported
- Fix `buffer_fill`, refactor a few other functions