### PR TITLE
feat: add ability for Lexer to add macros to ParseContext

### DIFF
--- a/CommandLine/emake-tests/Parsing/lexer-test.cpp
+++ b/CommandLine/emake-tests/Parsing/lexer-test.cpp
@@ -153,15 +153,9 @@ TEST(LexerTest, HexThenComment) {
   EXPECT_EQ(lex->ReadToken().type, TT_ENDOFCODE);
 }
 
-void AddMacro(LexerTester &lex, Macro macro) {
-  // FIXME: this is a horrible hack
-  const_cast<MacroMap&>(lex.context->macro_map)
-      .insert({macro.name, macro});
-}
-
 TEST(LexerTest, MacroFunctions) {
   LexerTester lex("MACRO_FUNC(ident);", true);
-  AddMacro(lex, Macro("MACRO_FUNC", {"arg"}, false, "(arg)", &lex.herr));
+  lex->AddMacro(Macro{"MACRO_FUNC", {"arg"}, false, "(arg)", &lex.herr});
   EXPECT_EQ(lex->ReadToken().type, TT_BEGINPARENTH);
   EXPECT_EQ(lex->ReadToken().type, TT_IDENTIFIER);
   EXPECT_EQ(lex->ReadToken().type, TT_ENDPARENTH);
@@ -171,7 +165,7 @@ TEST(LexerTest, MacroFunctions) {
 
 TEST(LexerTest, VariadicMacroFunctions) {
   LexerTester lex("VAR_FUNC(ident, 123);", true);
-  AddMacro(lex, Macro("VAR_FUNC", {"arg"}, true, "(arg)", &lex.herr));
+  lex->AddMacro(Macro{"VAR_FUNC", {"arg"}, true, "(arg)", &lex.herr});
   EXPECT_EQ(lex->ReadToken().type, TT_BEGINPARENTH);
   EXPECT_EQ(lex->ReadToken().type, TT_IDENTIFIER);
   EXPECT_EQ(lex->ReadToken().type, TT_COMMA);

--- a/CompilerSource/parsing/lexer.cpp
+++ b/CompilerSource/parsing/lexer.cpp
@@ -217,6 +217,16 @@ const ParseContext &ParseContext::ForPreprocessorEvaluation() {
   return kEmptyContextCpp;
 }
 
+void ParseContext::AddMacro(Macro macro) {
+  macro_map.insert({macro.name, macro});
+}
+
+void Lexer::AddMacro(Macro macro) {
+  // TODO: This is a horrible, horrible, atrocious, despicable hack to get this to work, namely because everywhere
+  // context is passed as a const pointer so its easier to have one @c const_cast versus changing many call sites
+  const_cast<ParseContext *>(context)->AddMacro(macro);
+}
+
 bool Lexer::MacroRecurses(std::string_view name) const {
   for (const auto &macro : open_macros) if (macro.name == name) return true;
   return false;

--- a/CompilerSource/parsing/lexer.h
+++ b/CompilerSource/parsing/lexer.h
@@ -38,7 +38,7 @@ struct ParseContext {
   /// implements pretty-printing.
   const LanguageFrontend *language_fe;
   /// All macros built-in or declared in user's Definitions pages.
-  const MacroMap macro_map;
+  MacroMap macro_map;
   /// Variables that are inherited by all objects.
   const NameSet *shared_locals;
   /// Scripts that are available for execution.
@@ -58,6 +58,8 @@ struct ParseContext {
       shared_locals(&lang->shared_object_locals()),
       script_names(std::move(script_names)),
       compatibility_opts(lang->compatibility_opts()) {}
+
+  void AddMacro(Macro macro);
 };
 
 class Lexer {
@@ -84,6 +86,8 @@ class Lexer {
       owned_code(code_), code(*owned_code), context(ctx), herr(herr_),
       options(ctx) {}
   Lexer(TokenVector tokens, const ParseContext *ctx, ErrorHandler *herr_);
+
+  void AddMacro(Macro macro);
 
  private:
   struct OpenMacro {


### PR DESCRIPTION
This relies on a horrible `const_cast` hack, as the `ParseContext` is always a const pointer however `AddMacro` requires modifying its state in `macro_map`.
