### PR TITLE
emake doesn't show error finding input file bug fix

### DIFF
--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
 
   std::unique_ptr<buffers::Project> project;
   
-  if (input_file.empty()) {
+  if (!fs::exists(input_file)) {
     project = std::make_unique<buffers::Project>();
     std::cerr << "Warning: No game file specified. "
                 "Building an empty game." << std::endl;

--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -46,6 +46,11 @@ int main(int argc, char* argv[])
   if (result == OPTIONS_ERROR || result == OPTIONS_HELP)
     return result;
 
+  std::string input_file = options.GetOption("input").as<std::string>();
+  if (!input_file.empty() && !fs::exists(input_file)) {
+    std::cerr << "File: " + input_file + " does not exists" << std::endl;
+    return result;
+  }
   EnigmaPlugin plugin;
   plugin.Load();
   CallBack ecb;
@@ -117,12 +122,9 @@ int main(int argc, char* argv[])
     std::cerr << "Invalid game mode: " << _mode << " aborting!" << std::endl;
     return OPTIONS_ERROR;
   }
-  
-  std::string input_file = options.GetOption("input").as<std::string>();
-
   std::unique_ptr<buffers::Project> project;
   
-  if (!fs::exists(input_file)) {
+  if (input_file.empty()) {
     project = std::make_unique<buffers::Project>();
     std::cerr << "Warning: No game file specified. "
                 "Building an empty game." << std::endl;

--- a/CommandLine/emake/Main.cpp
+++ b/CommandLine/emake/Main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[])
 
   std::string input_file = options.GetOption("input").as<std::string>();
   if (!input_file.empty() && !fs::exists(input_file)) {
-    std::cerr << "File: " + input_file + " does not exists" << std::endl;
+    std::cerr << "File: " + input_file + " does not exist" << std::endl;
     return result;
   }
   EnigmaPlugin plugin;


### PR DESCRIPTION
Fixes issue #2296
Fixed the issue by making a condition checking if the file name is not empty and that it doesn't exist.