### PR TITLE
Fix GTest extension build fails on installing it by building from source on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@
 /CompilerSource/stupidity-buffer/obj
 /ENIGMAsystem/SHELL/.vs/*
 /ENIGMAsystem/SHELL/.vscode/*
+/.vscode/*
+/CMakeFiles/*
+/ENIGMAsystem/SHELL/.build/*
+CMakeCache
 .DS_Store
 
 enigma-launch.bat

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/Makefile
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/Makefile
@@ -1,10 +1,6 @@
 SOURCES += Universal_System/Extensions/GTest/GTest.cpp
 
-ifeq ($(TARGET-PLATFORM), Windows)
-	override LDLIBS += -lgtest.dll
-else
-	override LDLIBS += -lgtest
-endif
+override LDLIBS += -lgtest
 
 ifeq ($(TARGET-PLATFORM), Android)
   override CXXFLAGS += -I$(ENIGMA_ROOT)/android/external/gtest/googletest/include


### PR DESCRIPTION
Fix #2338 

GTest extension must be installed using ``pacman -S mingw-w64-x86_64-gtest`` to be working correctly with the current ``ENIGMAsystem/SHELL/Universal_System/Extensions/GTest/Makefile``, but if you installed GTest with another way (building it from source and copy-paste files), it won't work because you will need the ``.dll`` file for linking it dynamically which is not provided when you build gtest from source, you only got ``.a`` files.

Using pacman or building from source gives you ``.a`` files, which you can link statically to your exe and this PR provides that change.