### PR TITLE
fix for emake build error on windows

### DIFF
--- a/CommandLine/libEGM/serialization-helpers.h
+++ b/CommandLine/libEGM/serialization-helpers.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <sstream>
 #include <iostream>
+#include <cstdint>
 
 namespace egm {
 namespace serialization {


### PR DESCRIPTION
When running ``make emake`` on windows it gives an error:

<https://gist.github.com/k0T0z/82a0454fd99070d54143492d5d0e10ae>

this PR contains a fix for this error.