### PR TITLE
Async Event Constants

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/actions.h
@@ -531,6 +531,24 @@ enum
     ev_step_end     = 2
 };
 
+enum
+{
+    ev_async_web_image_load = 60,
+    ev_async_web = 62,
+    ev_async_dialog = 63,
+    ev_async_web_iap = 66,
+    ev_async_web_cloud = 67,
+    ev_async_web_networking = 68,
+    ev_async_web_steam = 69,
+    ev_async_social = 70,
+    ev_async_push_notification = 71,
+    ev_async_save_load = 72,
+    ev_async_audio_recording = 73,
+    ev_async_audio_playback = 74,
+    ev_async_audio_playback_ended = 80,
+    ev_async_system_event = 75
+};
+
 inline variant event_perform(int type, int numb) {
     return enigma::ev_perf(type, numb);
 }

--- a/ENIGMAsystem/SHELL/Universal_System/actions.h
+++ b/ENIGMAsystem/SHELL/Universal_System/actions.h
@@ -490,7 +490,7 @@ enum
     ev_global_middle_release    = 58,
     ev_mouse_wheel_up           = 60,
     ev_mouse_wheel_down         = 61,
-	ev_gui                      = 64
+    ev_gui                      = 64
 };
 
 enum
@@ -533,20 +533,20 @@ enum
 
 enum
 {
-    ev_async_web_image_load = 60,
-    ev_async_web = 62,
-    ev_async_dialog = 63,
-    ev_async_web_iap = 66,
-    ev_async_web_cloud = 67,
-    ev_async_web_networking = 68,
-    ev_async_web_steam = 69,
-    ev_async_social = 70,
-    ev_async_push_notification = 71,
-    ev_async_save_load = 72,
-    ev_async_audio_recording = 73,
-    ev_async_audio_playback = 74,
-    ev_async_audio_playback_ended = 80,
-    ev_async_system_event = 75
+    ev_async_web_image_load        = 60,
+    ev_async_web                   = 62,
+    ev_async_dialog                = 63,
+    ev_async_web_iap               = 66,
+    ev_async_web_cloud             = 67,
+    ev_async_web_networking        = 68,
+    ev_async_web_steam             = 69,
+    ev_async_social                = 70,
+    ev_async_push_notification     = 71,
+    ev_async_save_load             = 72,
+    ev_async_audio_recording       = 73,
+    ev_async_audio_playback        = 74,
+    ev_async_audio_playback_ended  = 80,
+    ev_async_system_event          = 75
 };
 
 inline variant event_perform(int type, int numb) {


### PR DESCRIPTION
Added all the event constants for the newer async events, which can later be used to implement `event_perform_async`