### PR TITLE
Exclude vk_enter from adding to keyboard_string on Enter Press

### DIFF
--- a/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
+++ b/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp
@@ -68,7 +68,7 @@ int handleEvents() {
             enigma_user::keyboard_lastchar = string(1, str[0]);
             if (actualKey == enigma_user::vk_backspace) {
               if (!enigma_user::keyboard_string.empty()) enigma_user::keyboard_string.pop_back();
-            } else {
+            } else if(actualKey != enigma_user::vk_enter) {
               enigma_user::keyboard_string += enigma_user::keyboard_lastchar;
             }
           }


### PR DESCRIPTION
**Issue:**
The current implementation appends vk_enter to keyboard_string on Enter key press, leading to unexpected behavior.

**Changes Made:**
Modified the code to exclude vk_enter from being appended to keyboard_string when the Enter key is pressed.
in **enigma-dev/ENIGMAsystem/SHELL/Platforms/xlib/XLIBmain.cpp** line:71

```
if (actualKey == enigma_user::vk_backspace) {
    if (!enigma_user::keyboard_string.empty()) enigma_user::keyboard_string.pop_back();
} else if (actualKey != enigma_user::vk_enter) {
    enigma_user::keyboard_string += enigma_user::keyboard_lastchar;
}
```

**Related Issue:**
[#2080 ](https://github.com/enigma-dev/enigma-dev/issues/2080)

Please review the changes and confirm that excluding vk_enter addresses the problem.

Thank you for your review!




