### PR TITLE
Steamworks : UserId from UInt64 to Hex

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/README.md
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/README.md
@@ -120,7 +120,7 @@ Steamworks               <------- 4th layer
 └── *.cpp
 ```
 
-   -  `Steamworks/gameclient/steambinder/SteamvXXX/` and `Steamworks/gameclient/steambinder/SteamFake/` is the 1rd layer of the 
+   -  `Steamworks/gameclient/steambinder/SteamvXXX/` and `Steamworks/gameclient/steambinder/SteamFake/` is the 1st layer of the 
       extension. It is the Steamworks SDK.
    -  `Steamworks/steambinder/` is the 2nd layer of the extension. It contains the code that binds the Steamworks SDK to the extension.
    -  `Steamworks/gameclient/` is the 3rd layer of the extension. It contains the code that is directly calls the Steamworks API functions.

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp
@@ -50,8 +50,8 @@ void get_leaderboard_entries(LeaderboardEntry_t leaderboard_entries[], unsigned 
     leaderboard_entries_buffer << '\"' << "rank" << '\"' << ':';
     leaderboard_entries_buffer << std::to_string(leaderboard_entries[i].m_nGlobalRank) << ',';
     leaderboard_entries_buffer << '\"' << "userID" << '\"' << ':';
-    leaderboard_entries_buffer << '\"' << std::to_string(leaderboard_entries[i].m_steamIDUser.ConvertToUint64())
-                               << '\"';
+    leaderboard_entries_buffer << '\"@i64@' << std::hex << std::to_string(leaderboard_entries[i].m_steamIDUser.ConvertToUint64())
+                               << std::dec << '$i64$\"';
     leaderboard_entries_buffer << '}';
 
     // Add comma if not last entry

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp
@@ -50,8 +50,8 @@ void get_leaderboard_entries(LeaderboardEntry_t leaderboard_entries[], unsigned 
     leaderboard_entries_buffer << '\"' << "rank" << '\"' << ':';
     leaderboard_entries_buffer << std::to_string(leaderboard_entries[i].m_nGlobalRank) << ',';
     leaderboard_entries_buffer << '\"' << "userID" << '\"' << ':';
-    leaderboard_entries_buffer << '\"@i64@' << std::hex << std::to_string(leaderboard_entries[i].m_steamIDUser.ConvertToUint64())
-                               << std::dec << '$i64$\"';
+    leaderboard_entries_buffer << "\"@i64@" << std::hex << std::to_string(leaderboard_entries[i].m_steamIDUser.ConvertToUint64())
+                               << std::dec << "$i64$\"";
     leaderboard_entries_buffer << '}';
 
     // Add comma if not last entry

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp
@@ -26,11 +26,6 @@ namespace steamworks_gc {
 ////////////////////////////////////////////////////////
 
 // TODO: Add data key/value pair (if existed).
-/*
-  TODO: When using the concatenation operator '+' to concatenate strings instead of '<<', the string content blowed up
-  because if something I don't understand.
-*/
-// TODO: The userID is not the same as the steamID.
 // TODO: This function should be modified with https://github.com/enigma-dev/enigma-dev/pull/2358.
 void get_leaderboard_entries(LeaderboardEntry_t leaderboard_entries[], unsigned leaderboard_entries_size,
                              std::stringstream& leaderboard_entries_buffer) {
@@ -50,8 +45,8 @@ void get_leaderboard_entries(LeaderboardEntry_t leaderboard_entries[], unsigned 
     leaderboard_entries_buffer << '\"' << "rank" << '\"' << ':';
     leaderboard_entries_buffer << std::to_string(leaderboard_entries[i].m_nGlobalRank) << ',';
     leaderboard_entries_buffer << '\"' << "userID" << '\"' << ':';
-    leaderboard_entries_buffer << "\"@i64@" << std::hex << leaderboard_entries[i].m_steamIDUser.ConvertToUint64()
-                               << std::dec << "$i64$\"";
+    leaderboard_entries_buffer << '\"' <<"@i64@" << std::hex << leaderboard_entries[i].m_steamIDUser.ConvertToUint64()
+                               << std::dec << "$i64$" << '\"';
     leaderboard_entries_buffer << '}';
 
     // Add comma if not last entry

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp
@@ -50,7 +50,7 @@ void get_leaderboard_entries(LeaderboardEntry_t leaderboard_entries[], unsigned 
     leaderboard_entries_buffer << '\"' << "rank" << '\"' << ':';
     leaderboard_entries_buffer << std::to_string(leaderboard_entries[i].m_nGlobalRank) << ',';
     leaderboard_entries_buffer << '\"' << "userID" << '\"' << ':';
-    leaderboard_entries_buffer << "\"@i64@" << std::hex << std::to_string(leaderboard_entries[i].m_steamIDUser.ConvertToUint64())
+    leaderboard_entries_buffer << "\"@i64@" << std::hex << leaderboard_entries[i].m_steamIDUser.ConvertToUint64()
                                << std::dec << "$i64$\"";
     leaderboard_entries_buffer << '}';
 


### PR DESCRIPTION
Fixes #2370.

Previously the userId of the steam users was shown as it is in integer form.

Since this is not desirable, this PR converts the integer into a **hexadecimal number** , prepends it with `@i64@` and appends it with `$i64$` before getting output on the leaderboard.

changed lines 53/54 in the [file](https://github.com/enigma-dev/enigma-dev/blob/3918af3dc40734465b355a7d52cb9f9f93f5a8d6/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_score_downloaded_cookies.cpp#L53) to handle hex conversion.