### PR TITLE
fix #2365 about leaderboards functions

### DIFF
--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/gc_leaderboards.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/gc_leaderboards.h
@@ -71,8 +71,11 @@ class GCLeaderboards {
    *           AssetArray @c add() function.
    * 
    * @param leaderboard_name the name of the leaderboard.
+   * @return true If the leaderboard is successfully found.
    */
-  void find_leaderboard(const int& id, const std::string& leaderboard_name);
+  bool find_leaderboard(const int& id, const std::string& leaderboard_name);
+
+  bool match_leaderboard_name(const std::string& leaderboard_name);
 
   /**
    * @brief Uploads a user score to a specified leaderboard.

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_find_result_cookies.cpp
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/gameclient/utils/gc_leaderboards_find_result_cookies.cpp
@@ -51,8 +51,6 @@ void GCLeaderboardsFindResultCookies::on_find_leaderboard(LeaderboardFindResult_
   GCLeaderboardsFindResultCookies::gc_leaderboards_->set_current_leaderboard(
       pFindLeaderboardResult->m_hSteamLeaderboard);
 
-  DEBUG_MESSAGE("Calling FindOrCreateLeaderboard succeeded.", M_INFO);
-
   // Success? Let's save it.
   // SOGs are failing because of this line but LGM is not.
   // enigma::leaderboards_array.get(GCLeaderboardsFindResultCookies::id_) = pFindLeaderboardResult;
@@ -60,6 +58,12 @@ void GCLeaderboardsFindResultCookies::on_find_leaderboard(LeaderboardFindResult_
   enigma::push_create_leaderboard_steam_async_event(GCLeaderboardsFindResultCookies::id_, *pFindLeaderboardResult);
 
   GCLeaderboardsFindResultCookies::is_done_ = true;
+
+  // send download-waiting request
+  enigma::SendLBRequest();
+
+  DEBUG_MESSAGE("Calling FindOrCreateLeaderboard succeeded.", M_INFO);
+  
 }
 
 }  // namespace steamworks_gc

--- a/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/leaderboards.h
+++ b/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/leaderboards.h
@@ -34,6 +34,7 @@
 #include "Universal_System/Resources/AssetArray.h"
 #include "gameclient/gc_leaderboards.h"
 #include "gameclient/gc_main.h"
+#include <list>
 
 namespace enigma {
 
@@ -114,6 +115,40 @@ void push_leaderboard_upload_steam_async_event(const int& id, const LeaderboardS
  */
 void push_leaderboard_download_steam_async_event(const int& id, const std::string& entries_buffer,
                                                  const LeaderboardScoresDownloaded_t& pLeaderboardScoresDownloaded);
+
+
+struct LeaderboardRequest {
+
+    std::string m_pszName;                    // get name of the leaderboards to use
+    int m_postId;                             // request id
+    int m_score;
+    int m_method;                             // get method
+    int m_rangeStart;						  // get range
+	int m_rangeEnd;							  // get range
+    bool m_sign_post;                         // upload(post) or download(get)
+
+    LeaderboardRequest(const std::string& pLBName, int postId, int method, int rangeStart, int rangeEnd)
+        : m_pszName(pLBName), m_postId(postId), m_method(method), m_rangeStart(rangeStart), m_rangeEnd(rangeEnd), m_sign_post(false) {}
+
+    LeaderboardRequest(const std::string& pLBName, int postId, int score, int method)
+        : m_pszName(pLBName), m_postId(postId), m_score(score), m_method(method), m_sign_post(true) {}
+};
+
+/**
+ * @brief the STL List of Leaderboard Request
+ * 
+*/
+extern std::list<LeaderboardRequest> LBRequestList;
+
+/**
+ * @brief send the request from queue to the steam API 
+ */
+void SendLBRequest();
+
+void PerformLBRequest(LeaderboardRequest* pRequest);
+
+bool LookupLeaderboardHandle(const std::string& pszName);
+
 }  // namespace enigma
 
 namespace enigma_user {


### PR DESCRIPTION
## A Solution for #2365 :
### Description
Create `std::list<LeaderboardRequest> LBRequestList` for all download or upload leaderboards requests, and a `LeaderboardRequest` structure object to store the relevant parameters for the calls. 
### Example:
Take the `steam_download_scores` function [leaderboards.cpp](https://github.com/enigma-dev/enigma-dev/blob/master/ENIGMAsystem/SHELL/Universal_System/Extensions/Steamworks/leaderboards.cpp) as an example, first add the leaderboard request of `download_scores` func to `LBRequestList`. When `find_leaderboard` func completes the find operation, the list will release the download request for execution. Therefore, the "download" of the leaderboard entry always follows the operation of finding the leaderboard, and the two remain synchronized.
@k0T0z 