### PR TITLE
fix #2400 : Removed direct inclusion of source files in the Makefile in emake directory #2400

### DIFF
--- a/CommandLine/emake-tests/Emake_Tests_Config.mk
+++ b/CommandLine/emake-tests/Emake_Tests_Config.mk
@@ -1,0 +1,2 @@
+EMAKE_TESTS_SRC := $(call rwildcard,.,.cpp)
+export EMAKE_TESTS_SRC

--- a/CommandLine/emake/Makefile
+++ b/CommandLine/emake/Makefile
@@ -14,10 +14,11 @@ endif
 
 CXXFLAGS  += -I../../CompilerSource -I$(PROTO_DIR) -I../libEGM -I../libEGM -I../../ENIGMAsystem/SHELL
 LDFLAGS   += $(OS_LIBS) -L../../ -lcompileEGMf -lEGM -lProtocols -lENIGMAShared -lgrpc++ -lprotobuf -lyaml-cpp -lpng 
+include ../emake-tests/Emake_Tests_Config.mk
 
 ifeq ($(TESTS), TRUE)
 	TARGET=../../emake-tests
-	SOURCES := $(call rwildcard, ../emake-tests,*.cpp) $(call rwildcard, ../emake-tests/Extensions/Json,*.cpp)
+	SOURCES := $(EMAKE_TESTS_SRC)
 	LDFLAGS += -lpthread -lgtest_main -lgtest
 else
 	TARGET = ../../emake


### PR DESCRIPTION
Created `Emake_Tests_Config.mk` file in the `emake-tests` directory which exports `EMAKE_TESTS_SRC` variable. This variable is then used in the Makefile, removing the need to directly include source files.