### PR TITLE
Fix Building emake on Linux

### DIFF
--- a/CommandLine/emake/Makefile
+++ b/CommandLine/emake/Makefile
@@ -16,7 +16,6 @@ CXXFLAGS  += -I../../CompilerSource -I$(PROTO_DIR) -I../libEGM -I../libEGM -I../
 LDFLAGS   += $(OS_LIBS) -L../../ -lcompileEGMf -lEGM -lENIGMAShared -lProtocols -lgrpc++ -lgpr -lprotobuf -lyaml-cpp -lpng
 
 ifeq ($(CUSTOM_LIB_SEARCH_PRIORITY), system)
-	LDFLAGS += -labsl_log_internal_message -labsl_log_internal_check_op
 else
 	LDFLAGS += -labseil_dll
 endif

--- a/CommandLine/emake/Makefile
+++ b/CommandLine/emake/Makefile
@@ -15,8 +15,7 @@ endif
 CXXFLAGS  += -I../../CompilerSource -I$(PROTO_DIR) -I../libEGM -I../libEGM -I../../ENIGMAsystem/SHELL
 LDFLAGS   += $(OS_LIBS) -L../../ -lcompileEGMf -lEGM -lENIGMAShared -lProtocols -lgrpc++ -lgpr -lprotobuf -lyaml-cpp -lpng
 
-ifeq ($(CUSTOM_LIB_SEARCH_PRIORITY), system)
-else
+ifneq ($(CUSTOM_LIB_SEARCH_PRIORITY), system)
 	LDFLAGS += -labseil_dll
 endif
 


### PR DESCRIPTION
Fixes the following error building emake on Linux...

> /usr/bin/ld: cannot find -labsl_log_internal_message: No such file or directory
/usr/bin/ld: cannot find -labsl_log_internal_check_op: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [../../Default.mk:23: ../../emake] Error 1
make[1]: Leaving directory '/home/ubuntu/enigma-dev/CommandLine/emake'
make: *** [Makefile:51: emake] Error 2

...and just like that, it builds again!